### PR TITLE
docs(governance): record second 2026-04-24 bypass event

### DIFF
--- a/docs/operations/BYPASS_LOG.md
+++ b/docs/operations/BYPASS_LOG.md
@@ -30,6 +30,21 @@ Every bypass event is appended here within 24 hours. Format:
   - Added **@wiiiii123** as `write` collaborator (invitation ID 316160239, sent 2026-04-24 15:49 UTC). @wiiiii123 is an existing second GitHub account belonging to the same maintainer; using it as a second code owner avoided the overhead of provisioning a new bot identity.
   - Updated `.github/CODEOWNERS` to list `@meiiie @wiiiii123` on every path — OR semantics means either can approve any PR they are not the author of.
   - Updated `docs/operations/WIII_BRANCH_PROTECTION.md` with a dedicated "Second code owner — avoiding the self-approval deadlock" section describing the pattern.
-  - Pending: @wiiiii123 must **accept** the invitation at https://github.com/meiiie/wiii/invitations and then configure GPG/SSH signing so future commits from that account are verified. Until accepted, the CODEOWNERS entry for that login is inert and the next @meiiie-authored PR would still need a bypass.
+  - @wiiiii123 accepted the collaborator invitation later the same day and is now listed with `write` role.
+
+---
+
+## 2026-04-24 (second event) — @meiiie — main
+
+- **Reason**: Even after @wiiiii123 accepted the collaborator invitation, GitHub's "require review from Code Owners" gate reads `CODEOWNERS` from the **base branch** (main). Until the updated CODEOWNERS (listing @wiiiii123) was actually present on main, an approval from @wiiiii123 on PR #25 would not satisfy the gate — only @meiiie's would, and @meiiie cannot self-approve. A second bypass was needed to land the CODEOWNERS update itself.
+- **Linked incident / ticket**: PR #26 (`docs(governance): bring @wiiiii123 code-owner + bypass log onto main`).
+- **Protection change applied**: same procedure as the first event — `GET` current protection, `DELETE`, merge, `PUT` original config back.
+- **Merged PR / commit produced**: PR #26 merged as squash commit `a14757d`. Contains: `.github/CODEOWNERS` (adds @wiiiii123), `docs/operations/WIII_BRANCH_PROTECTION.md` (adds "Second code owner" section), `docs/operations/BYPASS_LOG.md` (initial file with the first event recorded).
+- **Re-enable confirmation**: Protection restored from the pre-bypass snapshot. All fields verbatim: `enforce_admins: true`, `require_code_owner_reviews: true`, `required_approving_review_count: 1`, `require_last_push_approval: true`, `required_status_checks.contexts: ["CodeRabbit"]`, `required_conversation_resolution: true`.
+- **Follow-up**:
+  - Every subsequent PR (including the still-open PR #25 for CI stabilization and the Dependabot queue) can now merge via the normal workflow: @wiiiii123 approves PRs authored by @meiiie, and vice versa. No more bypass required for the self-approval reason.
+  - A third bypass this quarter triggers a protection-policy review per `WIII_BRANCH_PROTECTION.md`. Two out of three used today — any subsequent bypass in Q2 2026 must be for a genuinely different reason (production incident, security patch window, etc.).
+
+---
 
 ---


### PR DESCRIPTION
## Summary

Records the second branch-protection bypass that was executed on 2026-04-24 to merge PR #26 (the CODEOWNERS update itself). One file changed: `docs/operations/BYPASS_LOG.md` gains a new entry.

## Why a second bypass was needed

PR #26 moved \`.github/CODEOWNERS\` from single-owner (@meiiie) to two-owner (@meiiie @wiiiii123). Until that update actually landed on \`main\`, GitHub's "require review from Code Owners" gate still treated @meiiie as the only recognized code owner — meaning @wiiiii123's approval of any PR could not satisfy the gate, and @meiiie could not self-approve.

This PR is the **first** that goes through the normal review workflow (no bypass required): @wiiiii123 is now a recognized code owner on \`main\`, so they can approve this.

## Risk

Documentation-only. One file, 16 lines added. Zero runtime impact.

## Verification

```
$ git log --oneline main..codex/demo-followup-2026-04-24
cd5f6fe docs(governance): log 2026-04-24 main branch protection bypass #2

$ git diff --stat main
docs/operations/BYPASS_LOG.md | 17 ++++++++++++++++-
1 file changed, 16 insertions(+), 1 deletion(-)
```

## Reviewer Focus

- The new entry format matches the template at the top of `BYPASS_LOG.md`.
- It is accurate about what happened — the two bypasses this quarter are now recorded, leaving one remaining before a policy review is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)