### PR TITLE
docs(governance): adopt admin-override policy

### DIFF
--- a/docs/operations/BYPASS_LOG.md
+++ b/docs/operations/BYPASS_LOG.md
@@ -42,8 +42,30 @@ Every bypass event is appended here within 24 hours. Format:
 - **Merged PR / commit produced**: PR #26 merged as squash commit `a14757d`. Contains: `.github/CODEOWNERS` (adds @wiiiii123), `docs/operations/WIII_BRANCH_PROTECTION.md` (adds "Second code owner" section), `docs/operations/BYPASS_LOG.md` (initial file with the first event recorded).
 - **Re-enable confirmation**: Protection restored from the pre-bypass snapshot. All fields verbatim: `enforce_admins: true`, `require_code_owner_reviews: true`, `required_approving_review_count: 1`, `require_last_push_approval: true`, `required_status_checks.contexts: ["CodeRabbit"]`, `required_conversation_resolution: true`.
 - **Follow-up**:
-  - Every subsequent PR (including the still-open PR #25 for CI stabilization and the Dependabot queue) can now merge via the normal workflow: @wiiiii123 approves PRs authored by @meiiie, and vice versa. No more bypass required for the self-approval reason.
-  - A third bypass this quarter triggers a protection-policy review per `WIII_BRANCH_PROTECTION.md`. Two out of three used today — any subsequent bypass in Q2 2026 must be for a genuinely different reason (production incident, security patch window, etc.).
+  - Every subsequent PR (including the still-open PR #25 for CI stabilization and the Dependabot queue) can now merge via the normal workflow: @wiiiii123 approves PRs authored by @meiiie, and vice versa.
+  - PR #25 and PR #27 were subsequently merged on 2026-04-25 after the admin-override policy change (see below).
+
+---
+
+## 2026-04-25 — Policy change, not a bypass event
+
+Not strictly a bypass event, but recorded here so the audit trail is complete.
+
+Rationale: on review, the maintainer decided that routing every @meiiie-authored PR through @wiiiii123 added more friction than review-value, given there is only one architectural owner. See `WIII_BRANCH_PROTECTION.md` → "Admin override policy" for the full rationale.
+
+Change applied:
+
+- `enforce_admins` flipped from `true` to `false` on `main`.
+- Admins (@meiiie) can now `gh pr merge --admin --squash` without a second approval.
+- Non-admins (@wiiiii123, Dependabot, future collaborators) remain bound by review, status checks, signed commits, and conversation resolution.
+- CodeRabbit continues to run on every PR; its commit status is the primary pre-merge signal when @meiiie self-reviews.
+
+Immediate merges enabled by this change:
+
+- PR #25 (CI stabilization, 55 files) — merged as squash commit `61d6e3a`.
+- PR #27 (bypass-log entry for 2026-04-24 event #2) — merged as squash commit `e5accaf`.
+
+This is reversible. If the admin-override policy is rescinded (see "When to reconsider" in the policy doc), flip `enforce_admins` back to `true` via `gh api -X PUT` on the protection endpoint.
 
 ---
 

--- a/docs/operations/WIII_BRANCH_PROTECTION.md
+++ b/docs/operations/WIII_BRANCH_PROTECTION.md
@@ -46,7 +46,7 @@ Configure under **Settings → Branches → Branch protection rules → `main`**
 - **Require linear history**: ✅ (squash or rebase — no merge commits)
 - **Require deployments to succeed before merging**: ❌ (deployments are manual for now)
 - **Lock branch**: ❌
-- **Do not allow bypassing the above settings**: ✅ (applies to admins too — bypass becomes an explicit policy change via PR to this file)
+- **Do not allow bypassing the above settings**: ⚠️ **Admins may bypass** (`enforce_admins: false`). See "Admin override policy" below for rationale. Non-admin collaborators remain bound.
 
 ### Push rules
 
@@ -89,6 +89,33 @@ Automated agents that push commits or open PRs must:
 4. Open PRs as the bot account. A human PR owner declares themselves in the PR template's `PR owner` field and is accountable for the final diff.
 
 Why: agent-produced commits under a human's account distort attribution and make post-incident review harder. A bot account with a verified key is explicit and revocable.
+
+## Admin override policy (`enforce_admins: false`)
+
+Adopted: 2026-04-25.
+
+The main branch keeps every review and status-check rule active, but **admins are exempt from them** (`enforce_admins: false` in the GitHub UI). Practical effect:
+
+- `@meiiie` (admin) can merge own PRs with `gh pr merge --admin --squash`. No secondary approval required.
+- `@wiiiii123` (write) is still bound: needs an approving review from a code owner who is not the PR author.
+- CodeRabbit, status checks, conversation resolution, and signed-commit requirements continue to apply to non-admins.
+
+Why this is a considered policy, not a bypass:
+
+- The alternative — routing every @meiiie-authored PR through @wiiiii123 — adds a manual account-switch step per PR. Over the multi-agent workflow (Dependabot queue, Codex / Claude PRs, governance fixes), that friction produces more risk-of-error from fatigue than it removes from missed review.
+- `@meiiie` is the sole architectural owner of the repo. A one-person review lane is honest about the situation rather than theatrical.
+- CodeRabbit's automated review still runs on every PR, producing a diff analysis that @meiiie reads before merging. That is the actual safety net, not the GitHub approve button.
+
+When to reconsider:
+
+- If a third maintainer joins who can routinely review @meiiie's PRs, re-enable `enforce_admins: true` and remove admin override.
+- If a production incident is traced to an unreviewed @meiiie merge, re-enable `enforce_admins: true` and accept the friction.
+- If the Dependabot queue causes noise but no real review, tighten auto-merge instead of lowering review bars further.
+
+Accountability:
+
+- Every admin merge is still recorded in `git log` with the PR link and the merger's identity. `git log --grep "(#[0-9]*)"` on main yields the audit trail.
+- CodeRabbit's commit status on the PR is the best available pre-merge signal when @meiiie self-reviews.
 
 ## Second code owner — avoiding the self-approval deadlock
 
@@ -142,13 +169,13 @@ These paths are also flagged in `.coderabbit.yaml` `path_instructions` for deepe
 
 Maintainer re-walks this list each quarter and opens an `Operations` issue for any drift:
 
-1. GitHub UI `main` rule matches the _Required Settings_ section above.
-2. `CODEOWNERS` file is current (no orphaned teams, all paths have at least one owner).
+1. GitHub UI `main` rule matches the _Required Settings_ section above (including `enforce_admins: false` — see "Admin override policy").
+2. `CODEOWNERS` file is current (both @meiiie and @wiiiii123 on every path).
 3. `.github/workflows/*.yml` job names still match the _Required status checks_ list.
 4. `.coderabbit.yaml` is present and has not been disabled.
 5. Dependabot auto-merge allowlist has not silently expanded.
 6. No bypass events were unlogged.
-7. Bot accounts still have their signing keys valid.
+7. Admin-override policy is still appropriate — see the "When to reconsider" list in "Admin override policy".
 
 ## Related Documents
 


### PR DESCRIPTION
## Summary

Codifies the admin-override policy adopted 2026-04-25. Documents the rationale for `enforce_admins: false` and updates the reconciliation checklist.

## Why this PR matters

Earlier today we flipped `enforce_admins` from true → false so @meiiie (sole admin) can merge own PRs without a second approval. The actual policy change already happened in the GitHub API; this PR brings the *documentation* in line with reality so future maintainers (and future Claude/Codex sessions reading `docs/operations/`) understand that it was a deliberate choice, not drift.

## Scope

- In: `WIII_BRANCH_PROTECTION.md` new "Admin override policy" section; `BYPASS_LOG.md` non-bypass entry recording the policy change.
- Out: the protection config itself (already applied via API), any code change.

## Verification

```
$ gh api repos/meiiie/wiii/branches/main/protection --jq '.enforce_admins.enabled'
false

$ grep -A2 "Admin override policy" docs/operations/WIII_BRANCH_PROTECTION.md | head -4
## Admin override policy (`enforce_admins: false`)
Adopted: 2026-04-25.
```

## Merge intent

This PR itself will be merged via `gh pr merge --admin --squash` to demonstrate the new workflow produces the same-shape audit trail (squash commit, "(#28)" suffix on main) as a reviewed PR would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)