### PR TITLE
ci: reduce Dependabot + CodeRabbit email volume for solo-maintainer workflow

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,24 +3,29 @@ early_access: false
 tone_instructions: "Be direct, technical, and risk-focused. Prioritize correctness, security, maintainability, and actionable findings."
 
 reviews:
-  profile: assertive
+  # Tuned 2026-04-25 for single-maintainer noise control. Core review still
+  # runs on every PR, but chatty extras (sequence diagrams, effort estimate,
+  # walkthrough duplication, draft-PR reviews) are disabled. Revert to the
+  # original `assertive` + full verbosity profile if multiple reviewers
+  # rejoin the project.
+  profile: chill
   request_changes_workflow: false
   high_level_summary: true
-  high_level_summary_in_walkthrough: true
+  high_level_summary_in_walkthrough: false
   review_status: true
   review_details: true
   commit_status: true
-  fail_commit_status: true
-  collapse_walkthrough: false
+  fail_commit_status: false
+  collapse_walkthrough: true
   changed_files_summary: true
-  sequence_diagrams: true
-  estimate_code_review_effort: true
+  sequence_diagrams: false
+  estimate_code_review_effort: false
   assess_linked_issues: true
   related_issues: true
   related_prs: true
   suggested_labels: true
   auto_apply_labels: false
-  suggested_reviewers: true
+  suggested_reviewers: false
   auto_assign_reviewers: false
   poem: false
   enable_prompt_for_ai_agents: true
@@ -29,8 +34,8 @@ reviews:
 
   auto_review:
     enabled: true
-    auto_incremental_review: true
-    drafts: true
+    auto_incremental_review: false
+    drafts: false
     base_branches:
       - "main"
       - "develop"
@@ -39,6 +44,9 @@ reviews:
     ignore_title_keywords:
       - "DO NOT MERGE"
       - "[skip review]"
+      - "chore(deps)"
+      - "chore(deps-dev)"
+      - "chore(ci)"
     ignore_usernames:
       - "dependabot[bot]"
       - "renovate[bot]"
@@ -124,7 +132,7 @@ reviews:
 
 chat:
   art: false
-  auto_reply: true
+  auto_reply: false
 
 knowledge_base:
   web_search:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,15 @@
 # Dependabot configuration for Wiii.
 # Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
-# Strategy:
+# Strategy (updated 2026-04-25 for single-maintainer noise control):
 #   - Security updates are handled separately via Dependabot Security alerts
-#     (auto-PR for high/critical CVEs).
-#   - Version updates run weekly, grouped per ecosystem to keep PR volume
-#     predictable while multiple agents are active in the repo.
+#     (auto-PR for high/critical CVEs regardless of schedule).
+#   - Version updates run **monthly**, grouped per ecosystem, to keep email
+#     and review volume manageable for a solo maintainer.
 #   - Patch bumps are grouped; major bumps land as separate PRs so that
-#     human maintainers can review breaking-change risk explicitly.
+#     breaking-change risk is reviewed explicitly.
+#   - Each ecosystem caps at 2 open PRs — Dependabot will queue the rest
+#     until older ones merge.
 #   - All PRs land Monday morning Asia/Ho_Chi_Minh to batch into the work
 #     week, not over the weekend.
 
@@ -18,11 +20,11 @@ updates:
   - package-ecosystem: "pip"
     directory: "/maritime-ai-service"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "08:00"
       timezone: "Asia/Ho_Chi_Minh"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
@@ -58,11 +60,11 @@ updates:
   - package-ecosystem: "npm"
     directory: "/wiii-desktop"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "08:00"
       timezone: "Asia/Ho_Chi_Minh"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
@@ -128,11 +130,11 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/wiii-desktop/src-tauri"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "08:00"
       timezone: "Asia/Ho_Chi_Minh"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 2
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
@@ -149,11 +151,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "08:00"
       timezone: "Asia/Ho_Chi_Minh"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 2
     commit-message:
       prefix: "chore(ci)"
       include: "scope"
@@ -165,7 +167,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/maritime-ai-service"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "08:00"
       timezone: "Asia/Ho_Chi_Minh"


### PR DESCRIPTION
See commit message. Admin-merge under the 2026-04-25 admin-override policy.

TL;DR:
- Dependabot: weekly → monthly, 5 PRs → 2 PRs per ecosystem
- CodeRabbit: chill profile, collapsed walkthrough, no sequence diagrams / effort estimates / draft reviews / per-push re-reviews, skip Dependabot PRs
- Core review features (path_instructions, review_details, security signal) stay on