### PR TITLE
fix(reasoning-interval): delegate tool_create_visual_code to Code Studio

### DIFF
--- a/wiii-desktop/src/components/chat/ReasoningInterval.tsx
+++ b/wiii-desktop/src/components/chat/ReasoningInterval.tsx
@@ -27,6 +27,7 @@ import type {
 } from "@/api/types";
 import { MarkdownRenderer } from "@/components/common/MarkdownRenderer";
 import { NODE_LABELS } from "@/lib/reasoning-labels";
+import { useCodeStudioStore } from "@/stores/code-studio-store";
 import {
   ToolExecutionStrip,
   summarizeToolExecutionBlock,
@@ -430,6 +431,13 @@ export function ReasoningInterval({
     && typeof interval.durationSeconds === "number"
     && interval.durationSeconds >= 12;
 
+  // Code Studio delegation: when a tool_create_visual_code call targets a
+  // session that Code Studio already owns, skip the inline tool render — the
+  // Code Studio panel is responsible for showing that content. Mirrors
+  // VisualBlock's delegation check so the tool trace and the visual don't
+  // both duplicate into the reasoning timeline.
+  const codeStudioSessions = useCodeStudioStore((s) => s.sessions);
+
   // Phase2: Auto-expand while streaming, auto-collapse when done (Claude pattern)
   const [userToggled, setUserToggled] = useState(false);
   const [userExpanded, setUserExpanded] = useState(false);
@@ -516,6 +524,17 @@ export function ReasoningInterval({
                   </div>
                 );
                 continue;
+              }
+
+              // Delegate to Code Studio panel when it owns the target session.
+              if (
+                item.kind === "tool"
+                && item.block.tool.name === "tool_create_visual_code"
+              ) {
+                const vsid = (item.block.tool.args as Record<string, unknown> | undefined)?.visual_session_id;
+                if (typeof vsid === "string" && codeStudioSessions[vsid]) {
+                  continue;
+                }
               }
 
               // Operation: collect the NEXT thinking item as its expandable body


### PR DESCRIPTION
## Summary

When a `tool_create_visual_code` call targets a session that Code Studio already owns, `ReasoningInterval` was rendering the inline `ToolExecutionStrip` anyway — so the tool title and status appeared twice: once in the reasoning timeline, once in the Code Studio panel.

Mirrors the delegation check already in `VisualBlock.tsx:1114-1118`: subscribe to `useCodeStudioStore.sessions` in `ReasoningInterval`, and skip the inline tool render when `tool.args.visual_session_id` resolves to an existing Code Studio session.

## Changes

- Import `useCodeStudioStore` in `ReasoningInterval.tsx`
- Read `sessions` via hook inside the component
- In the render loop, skip tool items whose `args.visual_session_id` matches an existing session (Code Studio panel owns them)

## Verification

```
Final vitest:   2053 passed (2053)   ← 0 failures
tsc --noEmit:   exit 0
```

This closes the last of the 22 failures identified at the start of this greening pass. Across 6 PRs (#75, #77, #79, #81, #82 plus the Code Studio delegation here) the suite went from **22 failed / 2054 passed** to **0 failed / 2053 passed**, plus ~1870 lines of dead template code removed.

Closes #82

## Test plan

- [x] `reasoning-interval.test.tsx` — all 5 tests green
- [x] Full vitest suite — 2053/2053 pass
- [x] `tsc --noEmit` clean
- [ ] User can manually verify: open a visual via `tool_create_visual_code`, confirm the inline tool strip does not duplicate alongside the Code Studio panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)