### PR TITLE
fix(ci): exclude playwright specs from vitest collection

### DIFF
--- a/wiii-desktop/vitest.config.ts
+++ b/wiii-desktop/vitest.config.ts
@@ -13,6 +13,18 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["src/__tests__/setup.ts"],
+    // Keep vitest's default excludes and add the Playwright spec folder —
+    // playwright/*.spec.ts uses @playwright/test's test.describe(), which
+    // throws when collected by vitest. Those files run via the Playwright
+    // runner in a separate job.
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/cypress/**",
+      "**/.{idea,git,cache,output,temp}/**",
+      "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*",
+      "**/playwright/**",
+    ],
     // Single worker prevents Zustand store leakage between concurrent test files
     // and eliminates 15s dynamic-import timeouts under jsdom load.
     pool: "forks",


### PR DESCRIPTION
## Summary

Vitest default file-glob matches `.spec.ts` anywhere, including the 3 `playwright/*.spec.ts` files that only make sense under the Playwright runner. CI's `test` job kept exiting 1 with:

\`\`\`
Error: Playwright Test did not expect test.describe() to be called here.
\`\`\`

…even when **2053/2053 vitest unit tests passed**.

## Change

Add an explicit `test.exclude` list in `vitest.config.ts`. Preserves vitest's default excludes (node_modules, dist, cypress, config files) and adds `\"**/playwright/**\"`. Playwright specs stay discoverable by the Playwright runner.

## Verification

\`\`\`
Before: Test Files  3 failed | 98 passed (101)   ← 3 Playwright collection errors
        Tests       2053 passed (2053)
        Exit:       1

After:  Test Files  98 passed (98)   ← clean
        Tests       2053 passed (2053)
        Exit:       0
\`\`\`

This is the final piece of the 22-failure greening pass. After this lands, CI's \`test\` check will go green on future PRs without admin bypass.

Closes #84

## Test plan

- [x] \`npx vitest run\` — 98/98 files, 2053/2053 tests, exit 0
- [x] Playwright specs still present at \`wiii-desktop/playwright/*.spec.ts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)