### PR TITLE
feat(auth): one-click "Local Dev" button on LoginScreen

### DIFF
--- a/wiii-desktop/src/__tests__/login-screen-dev-login.test.tsx
+++ b/wiii-desktop/src/__tests__/login-screen-dev-login.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Issue #88: Local dev-login button on LoginScreen.
+ *
+ * Verifies:
+ *   - The button renders only when running on localhost AND backend reports
+ *     enable_dev_login=true.
+ *   - The button is hidden when the backend probe returns enabled=false.
+ *   - Clicking the button POSTs to /auth/dev-login and pipes the response
+ *     through loginWithTokens() — same flow Google OAuth uses.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+
+
+// jsdom does not implement matchMedia; the avatar hook reads it on mount.
+if (typeof window !== "undefined" && !window.matchMedia) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+// Stub the avatar before LoginScreen imports it — its real implementation
+// pulls in IntersectionObserver / animation hooks that are out of scope
+// for this dev-login flow test.
+vi.mock("@/components/common/WiiiAvatar", () => ({
+  WiiiAvatar: () => null,
+}));
+
+import { LoginScreen } from "@/components/auth/LoginScreen";
+import { useSettingsStore } from "@/stores/settings-store";
+import { useAuthStore } from "@/stores/auth-store";
+
+
+function _setLocalhostHost() {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      ...window.location,
+      hostname: "localhost",
+      origin: "http://localhost:1420",
+      search: "",
+      hash: "",
+    },
+  });
+}
+
+
+function _resetSettings() {
+  useSettingsStore.setState({
+    settings: {
+      ...useSettingsStore.getState().settings,
+      server_url: "http://localhost:8080",
+      api_key: "",
+      user_id: "",
+      user_role: "student",
+    },
+    isLoaded: true,
+  });
+}
+
+
+describe("LoginScreen — dev-login button (Issue #88)", () => {
+  beforeEach(() => {
+    _setLocalhostHost();
+    _resetSettings();
+    // Reset auth-store's loginWithTokens spy if previously stubbed.
+    useAuthStore.setState({
+      isAuthenticated: false,
+      user: null,
+      tokens: null,
+      authMode: "legacy",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not render the dev button when backend reports enabled=false", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes("/auth/dev-login/status")) {
+          return new Response(JSON.stringify({ enabled: false }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response("{}", { status: 200 });
+      }),
+    );
+
+    await act(async () => {
+      render(<LoginScreen />);
+    });
+
+    // After the probe resolves, the button must not be in the DOM.
+    await waitFor(() => {
+      expect(screen.queryByTestId("dev-login-button")).toBeNull();
+    });
+  });
+
+  it("renders the dev button when backend reports enabled=true", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes("/auth/dev-login/status")) {
+          return new Response(JSON.stringify({ enabled: true }), {
+            status: 200,
+          });
+        }
+        return new Response("{}", { status: 200 });
+      }),
+    );
+
+    await act(async () => {
+      render(<LoginScreen />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dev-login-button")).toBeTruthy();
+    });
+    // Sanity: the badge + Vietnamese label are present
+    expect(screen.getByText("DEV")).toBeTruthy();
+    expect(screen.getByText(/Đăng nhập nhanh/)).toBeTruthy();
+  });
+
+  it("clicking the button POSTs to /auth/dev-login and stores tokens", async () => {
+    const tokenPayload = {
+      access_token: "ACCESS",
+      refresh_token: "REFRESH",
+      expires_in: 1800,
+      organization_id: "default",
+      user: {
+        id: "dev-user-1",
+        email: "dev@localhost",
+        name: "Dev User",
+        avatar_url: null,
+        role: "admin",
+        legacy_role: "admin",
+        platform_role: "platform_admin",
+        role_source: "platform",
+        active_organization_id: "default",
+      },
+    };
+
+    let postCalled = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        if (url.includes("/auth/dev-login/status")) {
+          return new Response(JSON.stringify({ enabled: true }), {
+            status: 200,
+          });
+        }
+        if (
+          url.endsWith("/api/v1/auth/dev-login") &&
+          init?.method === "POST"
+        ) {
+          postCalled = true;
+          return new Response(JSON.stringify(tokenPayload), { status: 200 });
+        }
+        return new Response("{}", { status: 200 });
+      }),
+    );
+
+    const loginSpy = vi.fn(async () => {});
+    useAuthStore.setState({ loginWithTokens: loginSpy } as any);
+
+    await act(async () => {
+      render(<LoginScreen />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dev-login-button")).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("dev-login-button"));
+    });
+
+    await waitFor(() => {
+      expect(postCalled).toBe(true);
+      expect(loginSpy).toHaveBeenCalledTimes(1);
+      const [accessTok, refreshTok, expiresIn, user] = loginSpy.mock.calls[0];
+      expect(accessTok).toBe("ACCESS");
+      expect(refreshTok).toBe("REFRESH");
+      expect(expiresIn).toBe(1800);
+      // buildAuthUserFromPayload normalises user_id→id; the AuthUser carries
+      // the canonical id field plus the legacy user_id field.
+      expect(user.id).toBe("dev-user-1");
+    });
+  });
+});

--- a/wiii-desktop/src/components/auth/LoginScreen.tsx
+++ b/wiii-desktop/src/components/auth/LoginScreen.tsx
@@ -59,6 +59,35 @@ export function LoginScreen() {
   // Sprint 193: Detect Tauri vs browser environment
   const isTauri = !!(window as any).__TAURI_INTERNALS__;
 
+  // Issue #88: One-click dev login on localhost. Probe the backend's
+  // /auth/dev-login/status (public, unauthenticated) on mount and only show
+  // the button when both the host is localhost AND the backend opts in.
+  // The probe runs once per mount, so a misconfigured remote backend cannot
+  // surprise-render the button.
+  const [devLoginEnabled, setDevLoginEnabled] = useState(false);
+  useEffect(() => {
+    const isLocalHost =
+      typeof window !== "undefined" &&
+      (window.location.hostname === "localhost" ||
+        window.location.hostname === "127.0.0.1");
+    if (!isLocalHost || !settings.server_url) {
+      setDevLoginEnabled(false);
+      return;
+    }
+    let cancelled = false;
+    fetch(`${settings.server_url}/api/v1/auth/dev-login/status`)
+      .then((res) => (res.ok ? res.json() : { enabled: false }))
+      .then((data) => {
+        if (!cancelled) setDevLoginEnabled(Boolean(data?.enabled));
+      })
+      .catch(() => {
+        if (!cancelled) setDevLoginEnabled(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [settings.server_url]);
+
   const handleGoogleLogin = async () => {
     setError(null);
     setIsLoading(true);
@@ -172,6 +201,58 @@ export function LoginScreen() {
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Đăng nhập thất bại");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Issue #88: One-click local dev login. Calls /auth/dev-login, pipes
+  // the response straight into the existing OAuth-style storage flow.
+  const handleDevLogin = async () => {
+    setError(null);
+    setIsLoading(true);
+    try {
+      const res = await fetch(`${settings.server_url}/api/v1/auth/dev-login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) {
+        const detail = await res.json().catch(() => null);
+        throw new Error(
+          detail?.detail || `Dev login thất bại (${res.status})`,
+        );
+      }
+      const data = await res.json();
+      const user: AuthUser = buildAuthUserFromPayload({
+        user_id: data.user.id,
+        email: data.user.email || "",
+        name: data.user.name || "",
+        avatar_url: data.user.avatar_url || "",
+        role: data.user.role || "admin",
+        legacy_role: data.user.legacy_role || "admin",
+        platform_role: data.user.platform_role || "platform_admin",
+        organization_role: data.user.organization_role || "",
+        host_role: data.user.host_role || "",
+        role_source: data.user.role_source || "platform",
+        active_organization_id: data.user.active_organization_id || "",
+        organization_id: data.organization_id || "",
+        connector_id: "",
+        identity_version: "2",
+      });
+      await loginWithTokens(
+        data.access_token,
+        data.refresh_token,
+        data.expires_in,
+        user,
+      );
+      await updateSettings({
+        user_id: data.user.id,
+        display_name: data.user.name || data.user.email || "Dev User",
+        user_role: toCompatibilitySettingsRole(user),
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Dev login thất bại");
     } finally {
       setIsLoading(false);
     }
@@ -332,6 +413,24 @@ export function LoginScreen() {
         <p className="mt-2 mb-7 text-[15px] text-text-tertiary text-center">
           Trợ lý AI thông minh cho học tập và nghiên cứu
         </p>
+
+        {/* Issue #88: One-click local dev login. Visible only when running
+            on localhost AND the backend has enable_dev_login=true. Styled
+            distinctively (dashed accent border + "DEV" badge) so it is
+            unmistakably a development shortcut, not a production path. */}
+        {devLoginEnabled && (
+          <button
+            data-testid="dev-login-button"
+            onClick={handleDevLogin}
+            disabled={isLoading}
+            className="w-full mb-3 flex items-center justify-center gap-2 h-[44px] px-5 rounded-2xl border-2 border-dashed border-[var(--accent)] bg-[var(--accent)]/5 text-[14px] font-semibold text-[var(--accent)] hover:bg-[var(--accent)]/10 active:scale-[0.97] transition-all disabled:opacity-50"
+          >
+            <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-[var(--accent)] text-white tracking-wider">
+              DEV
+            </span>
+            <span>Đăng nhập nhanh — Local Dev</span>
+          </button>
+        )}
 
         {/* Google login button — primary CTA */}
         <button


### PR DESCRIPTION
## Summary

Pairs with backend PR #89 to remove the last DevTools-snippet workflow for local development. When the browser is on `localhost` AND the backend reports `enable_dev_login=true` (probed via `/auth/dev-login/status` on mount), LoginScreen renders a prominent dashed-bordered \"DEV — Đăng nhập nhanh — Local Dev\" button above the Google login. Click → POST `/auth/dev-login` → pipe tokens through the existing `loginWithTokens()` flow.

## UX

- **Visible only when both gates pass**: `window.location.hostname` is localhost/127.0.0.1 *and* backend probe returns `{enabled: true}`. A misconfigured remote backend cannot surprise-render the button because the host check is local.
- **Distinctive styling**: dashed accent border + \"DEV\" badge so it cannot be confused with a production auth path.
- **Non-blocking probe**: fire-and-forget GET on mount; the button appears asynchronously when the backend responds. Doesn't delay the rest of LoginScreen.

## Code path

```
Click button
  → fetch POST /api/v1/auth/dev-login
  → response = same TokenPair shape as /auth/google/callback
  → buildAuthUserFromPayload(...)            (existing helper)
  → loginWithTokens(...)                     (existing auth-store action)
  → settings updated (display_name, role)
  → app routes to chat
```

No new auth-store branch, no special-case JWT validation — the dev-issued JWT follows exactly the same lifecycle as a Google OAuth token.

## Tests

3 new tests in `login-screen-dev-login.test.tsx`:

- Button hidden when probe returns `enabled=false`
- Button rendered when probe returns `enabled=true` (badge + Vietnamese label asserted)
- Click triggers the POST and pipes tokens through `loginWithTokens` with normalised user identity

```
✓ login-screen-dev-login.test.tsx  (3 tests)
Test Files  99 passed (99)
Tests       2056 passed (2056)        ← +3 from previous green baseline
```

## Defense in depth recap (combined with #89)

| Layer | Owner | Effect |
|---|---|---|
| Backend default `enable_dev_login=False` | #89 | Endpoint unreachable unless explicitly opted in |
| Backend production validator | #89 | App refuses to boot if flag set in `environment=production` |
| Backend 404-when-off | #89 | No fingerprint of endpoint in production |
| Backend source-IP guard | #89 | Refuses non-private IPs at runtime |
| Frontend localhost check | this PR | Button hidden unless host is localhost |
| Frontend probe gate | this PR | Button hidden unless backend opts in |
| Audit log | #89 | Every dev-login captured forensically |

Six independent layers — any one of them sufficient to neuter the path.

Closes #88 (frontend half)

## Test plan

- [x] `npx vitest run src/__tests__/login-screen-dev-login.test.tsx` — 3/3 green
- [x] Full vitest suite — 99/99 files, 2056/2056 tests, 0 regressions
- [x] `tsc --noEmit` clean
- [ ] After merge: a fresh browser at `localhost:1420` with no localStorage state will see the DEV button on first render and reach chat in 1 click

🤖 Generated with [Claude Code](https://claude.com/claude-code)