### PR TITLE
feat(auth): Valkey-backed magic link session store for restart safety

### DIFF
--- a/maritime-ai-service/.env.example
+++ b/maritime-ai-service/.env.example
@@ -261,6 +261,9 @@ OLLAMA_THINKING_MODELS=["qwen3","deepseek-r1","qwq"]
 RESEND_API_KEY=
 MAGIC_LINK_BASE_URL=http://localhost:8000
 MAGIC_LINK_FROM_EMAIL=Wiii <noreply@wiii.app>
+# Distributed session store (Valkey-backed) — required for multi-worker / restart-safe
+# magic-link auth. Falls back to in-memory if Valkey is unreachable.
+# ENABLE_DISTRIBUTED_MAGIC_LINK_SESSIONS=false
 
 # =============================================================================
 # AUTH HARDENING (Sprint 192: "Khiên Sắt")

--- a/maritime-ai-service/app/auth/magic_link_service.py
+++ b/maritime-ai-service/app/auth/magic_link_service.py
@@ -6,12 +6,8 @@ import hashlib
 import logging
 import re
 import secrets
-import time
-from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Dict, Optional, Tuple
-
-from fastapi import WebSocket
+from typing import Optional, Tuple
 
 
 logger = logging.getLogger(__name__)
@@ -60,95 +56,28 @@ def validate_email(email: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# WebSocket session manager (in-memory, single-instance)
+# WebSocket session manager
+#
+# The store implementation is selected at startup via
+# ``initialize_session_store`` in ``magic_link_session_store.py``. The default
+# is a single-process in-memory dict; with
+# ``enable_distributed_magic_link_sessions=True`` and a reachable Valkey, it
+# becomes a Valkey-backed store that survives FastAPI restarts and works
+# across multiple workers. Call sites use this thin alias so they remain
+# decoupled from the choice.
 # ---------------------------------------------------------------------------
 
-@dataclass
-class _SessionEntry:
-    """Tracks a registered WebSocket plus the monotonic clock time at registration.
-
-    `created_at` is monotonic seconds (not wall-clock) so the reaper is immune
-    to system clock changes.
-    """
-
-    websocket: WebSocket
-    created_at: float
+# Backward-compat re-exports — older code may still import these names from here.
+from app.auth.magic_link_session_store import (  # noqa: E402 (intentional late re-export)
+    InMemorySessionStore as MagicLinkSessionManager,
+    _SessionEntry,
+    get_session_store,
+)
 
 
-class MagicLinkSessionManager:
-    """Manages WebSocket connections waiting for magic link verification."""
-
-    def __init__(self):
-        self._sessions: Dict[str, _SessionEntry] = {}
-
-    async def register(self, session_id: str, websocket: WebSocket) -> None:
-        """Register a WebSocket connection for a session."""
-        await websocket.accept()
-        self._sessions[session_id] = _SessionEntry(
-            websocket=websocket, created_at=time.monotonic()
-        )
-        logger.info("Magic link WS session registered: %s", session_id)
-
-    async def push_tokens(self, session_id: str, payload: dict) -> bool:
-        """Push auth tokens to a waiting WebSocket session.
-
-        Returns True if delivered, False if session not found.
-        """
-        entry = self._sessions.pop(session_id, None)
-        if entry is None:
-            logger.warning("Magic link WS session not found: %s", session_id)
-            return False
-        ws = entry.websocket
-        try:
-            await ws.send_json(payload)
-            await ws.close()
-            logger.info("Magic link tokens pushed to session: %s", session_id)
-            return True
-        except Exception as e:
-            logger.error("Failed to push tokens to WS session %s: %s", session_id, e)
-            return False
-
-    def remove(self, session_id: str) -> None:
-        """Remove a session (on disconnect or timeout)."""
-        self._sessions.pop(session_id, None)
-
-    def reap_stale(self, max_age_seconds: float) -> int:
-        """Drop any session entry older than ``max_age_seconds``.
-
-        Defense-in-depth — the WebSocket handler's ``finally: mgr.remove(...)``
-        already cleans up the happy path. The reaper exists in case a handler
-        crash or future code path leaves entries behind.
-
-        Returns the number of entries reaped.
-        """
-        if max_age_seconds <= 0:
-            return 0
-        now = time.monotonic()
-        stale_ids = [
-            sid for sid, entry in self._sessions.items()
-            if (now - entry.created_at) > max_age_seconds
-        ]
-        for sid in stale_ids:
-            self._sessions.pop(sid, None)
-        if stale_ids:
-            logger.info("Magic link WS reaper dropped %d stale session(s)", len(stale_ids))
-        return len(stale_ids)
-
-    @property
-    def active_count(self) -> int:
-        return len(self._sessions)
-
-
-# Singleton
-_session_manager: Optional[MagicLinkSessionManager] = None
-
-
-def get_session_manager() -> MagicLinkSessionManager:
-    """Get the singleton session manager."""
-    global _session_manager
-    if _session_manager is None:
-        _session_manager = MagicLinkSessionManager()
-    return _session_manager
+def get_session_manager():
+    """Return the active session store (in-memory or Valkey, picked at startup)."""
+    return get_session_store()
 
 
 # ---------------------------------------------------------------------------

--- a/maritime-ai-service/app/auth/magic_link_session_store.py
+++ b/maritime-ai-service/app/auth/magic_link_session_store.py
@@ -1,0 +1,349 @@
+"""
+TASK-2026-04-25-002: Distributed magic-link session store.
+
+Two implementations of a common ``MagicLinkSessionStore`` Protocol:
+
+* ``InMemorySessionStore`` — wraps the legacy dict logic. Single-process only.
+  Used when ``enable_distributed_magic_link_sessions=False`` or Valkey is
+  unreachable. Preserves bit-for-bit existing behaviour.
+
+* ``ValkeySessionStore`` — survives FastAPI restarts and multi-worker
+  deployments. Each worker keeps WebSockets it owns in a local dict;
+  cross-worker handoff happens via Valkey **PUB/SUB** on
+  ``magic_link_push:{session_id}`` plus a TTL-bounded cache key at
+  ``magic_link_session:{session_id}`` (so a publish that beats the WS
+  subscribe is not lost).
+
+Call sites use ``register / push_tokens / remove / reap_stale / active_count`` —
+identical to the original ``MagicLinkSessionManager``. The factory is exposed
+as ``get_session_store()`` (sync) and ``initialize_session_store()`` (async,
+called once from the FastAPI lifespan).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+
+from fastapi import WebSocket
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Protocol + shared types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _SessionEntry:
+    """Local-process WebSocket entry. ``created_at`` is monotonic seconds."""
+
+    websocket: WebSocket
+    created_at: float
+
+
+@runtime_checkable
+class MagicLinkSessionStore(Protocol):
+    """Common API for in-memory and Valkey-backed implementations."""
+
+    async def register(self, session_id: str, websocket: WebSocket) -> None: ...
+    async def push_tokens(self, session_id: str, payload: dict) -> bool: ...
+    def remove(self, session_id: str) -> None: ...
+    def reap_stale(self, max_age_seconds: float) -> int: ...
+    @property
+    def active_count(self) -> int: ...
+
+
+# ---------------------------------------------------------------------------
+# In-memory store (legacy fallback)
+# ---------------------------------------------------------------------------
+
+class InMemorySessionStore:
+    """Single-process WebSocket session map. Identical semantics to the
+    original ``MagicLinkSessionManager``."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, _SessionEntry] = {}
+
+    async def register(self, session_id: str, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self._sessions[session_id] = _SessionEntry(
+            websocket=websocket, created_at=time.monotonic()
+        )
+        logger.info("Magic link WS session registered (in-memory): %s", session_id)
+
+    async def push_tokens(self, session_id: str, payload: dict) -> bool:
+        entry = self._sessions.pop(session_id, None)
+        if entry is None:
+            logger.warning("Magic link WS session not found: %s", session_id)
+            return False
+        try:
+            await entry.websocket.send_json(payload)
+            await entry.websocket.close()
+            logger.info("Magic link tokens pushed (in-memory): %s", session_id)
+            return True
+        except Exception as exc:
+            logger.error("Failed to push tokens to WS session %s: %s", session_id, exc)
+            return False
+
+    def remove(self, session_id: str) -> None:
+        self._sessions.pop(session_id, None)
+
+    def reap_stale(self, max_age_seconds: float) -> int:
+        if max_age_seconds <= 0:
+            return 0
+        now = time.monotonic()
+        stale_ids = [
+            sid for sid, entry in self._sessions.items()
+            if (now - entry.created_at) > max_age_seconds
+        ]
+        for sid in stale_ids:
+            self._sessions.pop(sid, None)
+        if stale_ids:
+            logger.info("In-memory reaper dropped %d stale session(s)", len(stale_ids))
+        return len(stale_ids)
+
+    @property
+    def active_count(self) -> int:
+        return len(self._sessions)
+
+
+# ---------------------------------------------------------------------------
+# Valkey-backed store (distributed)
+# ---------------------------------------------------------------------------
+
+_KEY_PREFIX = "magic_link_session"
+_CHANNEL_PREFIX = "magic_link_push"
+
+
+class ValkeySessionStore:
+    """Cross-worker magic-link session store backed by Valkey PUB/SUB.
+
+    Local state: each worker keeps a dict of WebSockets it physically owns.
+    Distributed handoff: ``push_tokens`` SETs the payload at
+    ``magic_link_session:{sid}`` with TTL and PUBLISHes it to
+    ``magic_link_push:{sid}``. A per-session subscriber task in the WS-owning
+    worker forwards the message to the WebSocket and exits.
+
+    Race-safety: ``register`` subscribes BEFORE checking the cached key,
+    so a publish that arrives during ``register`` is not lost.
+    """
+
+    def __init__(self, redis_client: Any, default_ttl_seconds: int) -> None:
+        self._redis = redis_client
+        self._default_ttl = max(60, int(default_ttl_seconds))
+        self._sessions: Dict[str, _SessionEntry] = {}
+        self._tasks: Dict[str, asyncio.Task] = {}
+
+    # -- public API --------------------------------------------------------
+
+    async def register(self, session_id: str, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self._sessions[session_id] = _SessionEntry(
+            websocket=websocket, created_at=time.monotonic()
+        )
+        # Per-session subscriber task — auto-exits after first delivery
+        self._tasks[session_id] = asyncio.create_task(self._wait_for_push(session_id))
+        logger.info("Magic link WS session registered (Valkey): %s", session_id)
+
+    async def push_tokens(self, session_id: str, payload: dict) -> bool:
+        # Local-first: same worker as the WS, deliver directly without Valkey hop
+        if session_id in self._sessions:
+            return await self._deliver_local(session_id, payload)
+
+        # Cross-worker: persist + publish. TTL-bounded so a late WS picks it up
+        # but a never-arriving WS doesn't leave junk forever.
+        try:
+            body = json.dumps(payload, ensure_ascii=False)
+            await self._redis.set(
+                f"{_KEY_PREFIX}:{session_id}", body, ex=self._default_ttl
+            )
+            await self._redis.publish(f"{_CHANNEL_PREFIX}:{session_id}", body)
+            logger.info("Magic link tokens published to Valkey: %s", session_id)
+            return True
+        except Exception as exc:
+            # Per spec: log + raise rather than silently dropping
+            logger.error("Valkey push_tokens failed for %s: %s", session_id, exc)
+            raise
+
+    def remove(self, session_id: str) -> None:
+        self._sessions.pop(session_id, None)
+        task = self._tasks.pop(session_id, None)
+        if task is not None and not task.done():
+            task.cancel()
+
+    def reap_stale(self, max_age_seconds: float) -> int:
+        if max_age_seconds <= 0:
+            return 0
+        now = time.monotonic()
+        stale_ids = [
+            sid for sid, entry in self._sessions.items()
+            if (now - entry.created_at) > max_age_seconds
+        ]
+        for sid in stale_ids:
+            self.remove(sid)
+        if stale_ids:
+            logger.info("Valkey reaper dropped %d stale session(s)", len(stale_ids))
+        return len(stale_ids)
+
+    @property
+    def active_count(self) -> int:
+        return len(self._sessions)
+
+    # -- internals ---------------------------------------------------------
+
+    async def _deliver_local(self, session_id: str, payload: dict) -> bool:
+        entry = self._sessions.pop(session_id, None)
+        if entry is None:
+            return False
+        # Cancel the subscriber task — we delivered ourselves
+        task = self._tasks.pop(session_id, None)
+        if task is not None and not task.done():
+            task.cancel()
+        try:
+            await entry.websocket.send_json(payload)
+            await entry.websocket.close()
+            return True
+        except Exception as exc:
+            logger.error("Local WS delivery failed for %s: %s", session_id, exc)
+            return False
+
+    async def _wait_for_push(self, session_id: str) -> None:
+        """Subscribe → check cache → deliver on first message. Exits after one delivery."""
+        pubsub = None
+        try:
+            pubsub = self._redis.pubsub()
+            channel = f"{_CHANNEL_PREFIX}:{session_id}"
+            await pubsub.subscribe(channel)
+
+            # Race-safety: a publish may have happened between push and our subscribe.
+            # The TTL'd key holds the payload, so check it after the subscribe is in place.
+            cached = await self._redis.get(f"{_KEY_PREFIX}:{session_id}")
+            if cached is not None:
+                await self._consume_payload(session_id, cached)
+                return
+
+            # Wait for a publish. Iterate until we see a real message.
+            async for msg in pubsub.listen():
+                if msg.get("type") not in ("message", "pmessage"):
+                    continue
+                await self._consume_payload(session_id, msg.get("data"))
+                return
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error("Valkey subscriber failed for %s: %s", session_id, exc)
+        finally:
+            if pubsub is not None:
+                try:
+                    await pubsub.unsubscribe()
+                except Exception:
+                    pass
+                close = getattr(pubsub, "aclose", None) or getattr(pubsub, "close", None)
+                if close is not None:
+                    try:
+                        result = close()
+                        if asyncio.iscoroutine(result):
+                            await result
+                    except Exception:
+                        pass
+
+    async def _consume_payload(self, session_id: str, raw: Any) -> None:
+        if raw is None:
+            return
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        try:
+            payload = json.loads(raw)
+        except Exception as exc:
+            logger.error("Valkey payload decode failed for %s: %s", session_id, exc)
+            return
+        entry = self._sessions.pop(session_id, None)
+        if entry is None:
+            return
+        try:
+            await entry.websocket.send_json(payload)
+            await entry.websocket.close()
+            logger.info("Magic link tokens delivered via Valkey: %s", session_id)
+        except Exception as exc:
+            logger.error("WS delivery after Valkey publish failed for %s: %s", session_id, exc)
+
+
+# ---------------------------------------------------------------------------
+# Factory + lifespan integration
+# ---------------------------------------------------------------------------
+
+_active_store: Optional[MagicLinkSessionStore] = None
+
+
+def get_session_store() -> MagicLinkSessionStore:
+    """Synchronous accessor for the active session store.
+
+    Defaults to ``InMemorySessionStore`` until ``initialize_session_store``
+    runs from the FastAPI lifespan.
+    """
+    global _active_store
+    if _active_store is None:
+        _active_store = InMemorySessionStore()
+    return _active_store
+
+
+async def initialize_session_store(settings_obj: Any) -> MagicLinkSessionStore:
+    """Pick the session store based on settings + Valkey reachability.
+
+    Falls back to in-memory on any error. App MUST never fail to boot
+    because Valkey is down.
+    """
+    global _active_store
+
+    if not getattr(settings_obj, "enable_distributed_magic_link_sessions", False):
+        _active_store = InMemorySessionStore()
+        logger.info("Magic link session store: in-memory (distributed gate off)")
+        return _active_store
+
+    valkey_url = getattr(settings_obj, "valkey_url", "") or ""
+    if not valkey_url:
+        logger.warning(
+            "enable_distributed_magic_link_sessions=True but valkey_url is empty; "
+            "falling back to in-memory store"
+        )
+        _active_store = InMemorySessionStore()
+        return _active_store
+
+    try:
+        import redis.asyncio as redis_asyncio  # type: ignore[import-not-found]
+    except ImportError as exc:
+        logger.warning(
+            "redis.asyncio not installed (%s); falling back to in-memory store", exc
+        )
+        _active_store = InMemorySessionStore()
+        return _active_store
+
+    try:
+        client = redis_asyncio.from_url(
+            valkey_url,
+            decode_responses=False,
+            socket_connect_timeout=2.0,
+        )
+        await client.ping()
+        ttl = int(getattr(settings_obj, "magic_link_ws_timeout_seconds", 900))
+        _active_store = ValkeySessionStore(client, default_ttl_seconds=ttl)
+        logger.info("Magic link session store: Valkey at %s (TTL=%ds)", valkey_url, ttl)
+        return _active_store
+    except Exception as exc:
+        logger.error(
+            "Valkey connection failed (%s); falling back to in-memory store", exc
+        )
+        _active_store = InMemorySessionStore()
+        return _active_store
+
+
+def reset_session_store_for_tests() -> None:
+    """Clear the cached singleton — TEST-ONLY helper."""
+    global _active_store
+    _active_store = None

--- a/maritime-ai-service/app/core/config/_settings_base_fields.py
+++ b/maritime-ai-service/app/core/config/_settings_base_fields.py
@@ -86,6 +86,7 @@ class BaseSettingsFieldsMixin:
     magic_link_cleanup_interval_seconds: int = Field(default=3600, ge=60, le=86400, description="Periodic cleanup of expired magic_link_tokens rows (default 1h)")
     magic_link_cleanup_grace_hours: int = Field(default=24, ge=0, le=168, description="Grace period before deleting expired magic-link rows (hours)")
     magic_link_session_reaper_interval_seconds: int = Field(default=60, ge=15, le=3600, description="Interval for reaping stale in-memory WS sessions")
+    enable_distributed_magic_link_sessions: bool = Field(default=False, description="Use Valkey-backed magic link session store for restart safety + multi-worker support")
 
     # Sentry — Error Tracking (Production Hardening)
     sentry_dsn: str = Field(default="", description="Sentry DSN — empty disables Sentry")

--- a/maritime-ai-service/app/core/config/_settings_validation.py
+++ b/maritime-ai-service/app/core/config/_settings_validation.py
@@ -167,6 +167,15 @@ def build_validate_production_security(config_logger):
                     "SECURITY: enable_magic_link_auth=True but RESEND_API_KEY is empty — "
                     "magic link emails will fail silently"
                 )
+            if (
+                getattr(self, "enable_distributed_magic_link_sessions", False)
+                and not getattr(self, "valkey_url", "")
+            ):
+                config_logger.warning(
+                    "CONFIG: enable_distributed_magic_link_sessions=True but valkey_url is empty — "
+                    "store will silently fall back to in-memory (single-process only). "
+                    "Set VALKEY_URL to enable cross-worker handoff."
+                )
             if getattr(self, "enable_dev_login", False):
                 raise ValueError(
                     "SECURITY: enable_dev_login=True is forbidden in production. "

--- a/maritime-ai-service/app/main_startup_runtime.py
+++ b/maritime-ai-service/app/main_startup_runtime.py
@@ -448,10 +448,21 @@ async def _start_magic_link_maintenance(
     """Start the magic-link cleanup + WS-session reaper background tasks.
 
     Both run only when ``enable_magic_link_auth`` is on. They are gated together
-    since they are two halves of the same feature's hygiene loop.
+    since they are two halves of the same feature's hygiene loop. Also picks
+    the session store (in-memory vs Valkey) for cross-worker handoff support.
     """
     if not settings.enable_magic_link_auth:
         return None, None
+
+    # Pick the session store (in-memory by default; Valkey if flag+reachable)
+    try:
+        initialize_session_store = _load_attr(
+            "app.auth.magic_link_session_store", "initialize_session_store"
+        )
+        await initialize_session_store(settings)
+    except Exception as exc:  # pragma: no cover - logging path
+        logger_.warning("[WARN] Magic link session store initialization failed: %s", exc)
+
     cleanup_task: asyncio.Task | None = None
     reaper_task: asyncio.Task | None = None
     try:

--- a/maritime-ai-service/tests/unit/test_magic_link_session_store.py
+++ b/maritime-ai-service/tests/unit/test_magic_link_session_store.py
@@ -1,0 +1,381 @@
+"""TASK-2026-04-25-002: Tests for the distributed magic-link session store.
+
+Covers:
+* InMemorySessionStore parity (re-exported as ``MagicLinkSessionManager``).
+* Factory selection — flag off, flag on + empty valkey_url, flag on + unreachable, flag on + reachable.
+* ValkeySessionStore happy paths against the live ``wiii-valkey`` container
+  (database index 1 to keep prod cache DB 0 untouched). These tests skip
+  automatically if Valkey is not reachable.
+* Production validator warning when the flag is on but valkey_url is empty.
+"""
+import asyncio
+import json
+import os
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+VALKEY_TEST_URL = os.environ.get("VALKEY_TEST_URL", "redis://valkey:6379/1")
+
+
+# ---------------------------------------------------------------------------
+# Skip helpers — these tests only run when wiii-valkey is reachable
+# ---------------------------------------------------------------------------
+
+async def _is_valkey_up() -> bool:
+    try:
+        import redis.asyncio as redis_asyncio
+    except ImportError:
+        return False
+    try:
+        client = redis_asyncio.from_url(
+            VALKEY_TEST_URL, socket_connect_timeout=1.0
+        )
+        await client.ping()
+        try:
+            await client.aclose()  # redis-py 5.x
+        except AttributeError:  # pragma: no cover
+            await client.close()
+        return True
+    except Exception:
+        return False
+
+
+_valkey_available_cache: dict = {}
+
+
+def _valkey_marker():
+    """Pytest skip marker — caches the probe so we don't ping Valkey 20 times."""
+    if "available" not in _valkey_available_cache:
+        try:
+            _valkey_available_cache["available"] = asyncio.get_event_loop().run_until_complete(
+                _is_valkey_up()
+            )
+        except RuntimeError:
+            # No running loop — create a fresh one for the probe
+            loop = asyncio.new_event_loop()
+            try:
+                _valkey_available_cache["available"] = loop.run_until_complete(_is_valkey_up())
+            finally:
+                loop.close()
+    return pytest.mark.skipif(
+        not _valkey_available_cache["available"],
+        reason=f"Valkey not reachable at {VALKEY_TEST_URL}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config + validator
+# ---------------------------------------------------------------------------
+
+class TestDistributedFlagDefault:
+    def test_flag_default_false(self):
+        from app.core.config import Settings
+        assert (
+            Settings.model_fields["enable_distributed_magic_link_sessions"].default is False
+        )
+
+
+class TestProductionValidatorWarning:
+    """Validator should warn when flag is on but valkey_url is empty in prod."""
+
+    def test_warning_emitted_when_flag_on_and_valkey_url_missing(self, caplog):
+        import logging
+        from app.core.config._settings_validation import (
+            build_validate_production_security,
+        )
+
+        config_logger = logging.getLogger("test_validator")
+        validate = build_validate_production_security(config_logger)
+
+        fake_settings = SimpleNamespace(
+            environment="production",
+            jwt_secret_key="some-very-long-random-secret-thats-not-default",
+            cors_origins=["https://wiii.app"],
+            api_key="x" * 32,
+            enable_magic_link_auth=False,
+            resend_api_key="re_x",
+            enable_dev_login=False,
+            enable_distributed_magic_link_sessions=True,
+            valkey_url="",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="test_validator"):
+            validate(fake_settings)
+
+        assert any(
+            "enable_distributed_magic_link_sessions" in rec.message
+            and "valkey_url" in rec.message
+            for rec in caplog.records
+        ), f"Expected distributed-sessions warning. Got: {[r.message for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# Factory selection
+# ---------------------------------------------------------------------------
+
+class TestFactorySelection:
+    """Factory must pick the right store based on settings + Valkey reachability."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_singleton(self):
+        from app.auth.magic_link_session_store import reset_session_store_for_tests
+        reset_session_store_for_tests()
+        yield
+        reset_session_store_for_tests()
+
+    @pytest.mark.asyncio
+    async def test_flag_off_returns_in_memory(self):
+        from app.auth.magic_link_session_store import (
+            InMemorySessionStore,
+            initialize_session_store,
+        )
+        s = SimpleNamespace(
+            enable_distributed_magic_link_sessions=False,
+            valkey_url="redis://valkey:6379/0",
+            magic_link_ws_timeout_seconds=900,
+        )
+        store = await initialize_session_store(s)
+        assert isinstance(store, InMemorySessionStore)
+
+    @pytest.mark.asyncio
+    async def test_flag_on_empty_url_falls_back(self):
+        from app.auth.magic_link_session_store import (
+            InMemorySessionStore,
+            initialize_session_store,
+        )
+        s = SimpleNamespace(
+            enable_distributed_magic_link_sessions=True,
+            valkey_url="",
+            magic_link_ws_timeout_seconds=900,
+        )
+        store = await initialize_session_store(s)
+        assert isinstance(store, InMemorySessionStore)
+
+    @pytest.mark.asyncio
+    async def test_flag_on_unreachable_falls_back(self):
+        from app.auth.magic_link_session_store import (
+            InMemorySessionStore,
+            initialize_session_store,
+        )
+        s = SimpleNamespace(
+            enable_distributed_magic_link_sessions=True,
+            valkey_url="redis://nonexistent-host-12345.invalid:6379/0",
+            magic_link_ws_timeout_seconds=900,
+        )
+        store = await initialize_session_store(s)
+        assert isinstance(store, InMemorySessionStore)
+
+
+# ---------------------------------------------------------------------------
+# In-memory store — parity with the legacy MagicLinkSessionManager API
+# ---------------------------------------------------------------------------
+
+class TestInMemorySessionStoreApi:
+    """Re-exported as MagicLinkSessionManager — must behave identically to the old class."""
+
+    def test_active_count_starts_at_zero(self):
+        from app.auth.magic_link_session_store import InMemorySessionStore
+        assert InMemorySessionStore().active_count == 0
+
+    @pytest.mark.asyncio
+    async def test_push_to_missing_session_returns_false(self):
+        from app.auth.magic_link_session_store import InMemorySessionStore
+        store = InMemorySessionStore()
+        assert await store.push_tokens("nope", {"x": 1}) is False
+
+    @pytest.mark.asyncio
+    async def test_register_then_push_round_trip(self):
+        from app.auth.magic_link_session_store import InMemorySessionStore
+        store = InMemorySessionStore()
+        ws = MagicMock()
+        ws.accept = AsyncMock()
+        ws.send_json = AsyncMock()
+        ws.close = AsyncMock()
+
+        await store.register("sid", ws)
+        delivered = await store.push_tokens("sid", {"hello": "world"})
+
+        assert delivered is True
+        ws.send_json.assert_awaited_once_with({"hello": "world"})
+        assert store.active_count == 0
+
+    def test_reap_drops_stale(self):
+        from app.auth.magic_link_session_store import (
+            InMemorySessionStore,
+            _SessionEntry,
+        )
+        store = InMemorySessionStore()
+        now = time.monotonic()
+        store._sessions["old"] = _SessionEntry(websocket=MagicMock(), created_at=now - 1000)
+        store._sessions["new"] = _SessionEntry(websocket=MagicMock(), created_at=now)
+
+        reaped = store.reap_stale(max_age_seconds=300)
+        assert reaped == 1
+        assert "new" in store._sessions
+        assert "old" not in store._sessions
+
+    def test_legacy_alias_resolves_to_in_memory(self):
+        """``magic_link_service.MagicLinkSessionManager`` must remain importable."""
+        from app.auth.magic_link_service import MagicLinkSessionManager
+        from app.auth.magic_link_session_store import InMemorySessionStore
+        assert MagicLinkSessionManager is InMemorySessionStore
+
+
+# ---------------------------------------------------------------------------
+# Valkey-backed store — integration tests against wiii-valkey:6379/1
+# ---------------------------------------------------------------------------
+
+@_valkey_marker()
+class TestValkeySessionStore:
+
+    @pytest.fixture
+    async def redis_client(self):
+        import redis.asyncio as redis_asyncio
+        client = redis_asyncio.from_url(VALKEY_TEST_URL, decode_responses=False)
+        # Clean up any stale state from earlier test runs
+        try:
+            await client.flushdb()
+        except Exception:
+            pass
+        yield client
+        try:
+            await client.flushdb()
+            await client.aclose()
+        except Exception:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_local_first_delivery(self, redis_client):
+        """Same-worker register + push delivers without touching Valkey."""
+        from app.auth.magic_link_session_store import ValkeySessionStore
+
+        store = ValkeySessionStore(redis_client, default_ttl_seconds=900)
+
+        ws = MagicMock()
+        ws.accept = AsyncMock()
+        ws.send_json = AsyncMock()
+        ws.close = AsyncMock()
+
+        await store.register("loc", ws)
+        delivered = await store.push_tokens("loc", {"local": True})
+
+        assert delivered is True
+        ws.send_json.assert_awaited_once_with({"local": True})
+        store.remove("loc")  # idempotent
+
+    @pytest.mark.asyncio
+    async def test_cross_instance_handoff(self, redis_client):
+        """Two store instances sharing a Valkey deliver across the boundary.
+
+        Simulates worker A holding the WS while worker B handles verify.
+        """
+        from app.auth.magic_link_session_store import ValkeySessionStore
+
+        store_a = ValkeySessionStore(redis_client, default_ttl_seconds=900)
+        store_b = ValkeySessionStore(redis_client, default_ttl_seconds=900)
+
+        ws = MagicMock()
+        ws.accept = AsyncMock()
+        ws.send_json = AsyncMock()
+        ws.close = AsyncMock()
+
+        # Worker A: WS connects + registers
+        await store_a.register("xworker", ws)
+
+        # Brief yield so the subscriber task has a chance to subscribe
+        await asyncio.sleep(0.1)
+
+        # Worker B: verify endpoint pushes
+        delivered = await store_b.push_tokens("xworker", {"cross": "worker"})
+        assert delivered is True
+
+        # Wait for the subscriber to consume the publish
+        for _ in range(20):
+            await asyncio.sleep(0.05)
+            if ws.send_json.await_count > 0:
+                break
+        ws.send_json.assert_awaited_once_with({"cross": "worker"})
+
+        store_a.remove("xworker")
+
+    @pytest.mark.asyncio
+    async def test_late_register_picks_up_cached_payload(self, redis_client):
+        """If verify publishes BEFORE the WS subscribes, the cached key holds it."""
+        from app.auth.magic_link_session_store import ValkeySessionStore
+
+        store_pub = ValkeySessionStore(redis_client, default_ttl_seconds=900)
+        store_sub = ValkeySessionStore(redis_client, default_ttl_seconds=900)
+
+        # Push first — no WS exists yet anywhere
+        delivered = await store_pub.push_tokens("late", {"late": True})
+        assert delivered is True  # SET + PUBLISH succeeded
+
+        # Now register the WS — should pick up the cached payload via the GET branch
+        ws = MagicMock()
+        ws.accept = AsyncMock()
+        ws.send_json = AsyncMock()
+        ws.close = AsyncMock()
+        await store_sub.register("late", ws)
+
+        # The subscriber task races: subscribe, then GET cached, then deliver
+        for _ in range(20):
+            await asyncio.sleep(0.05)
+            if ws.send_json.await_count > 0:
+                break
+        ws.send_json.assert_awaited_once_with({"late": True})
+
+        store_sub.remove("late")
+
+    @pytest.mark.asyncio
+    async def test_push_raises_when_redis_dies(self):
+        """Per spec: Valkey errors mid-flight should raise, not silently drop."""
+        from app.auth.magic_link_session_store import ValkeySessionStore
+
+        broken = MagicMock()
+        broken.set = AsyncMock(side_effect=ConnectionError("connection closed"))
+        broken.publish = AsyncMock()
+
+        store = ValkeySessionStore(broken, default_ttl_seconds=900)
+
+        with pytest.raises(ConnectionError):
+            await store.push_tokens("any", {"x": 1})
+
+    @pytest.mark.asyncio
+    async def test_remove_cancels_pending_subscriber(self, redis_client):
+        """remove() should cancel the per-session subscriber task."""
+        from app.auth.magic_link_session_store import ValkeySessionStore
+
+        store = ValkeySessionStore(redis_client, default_ttl_seconds=900)
+
+        ws = MagicMock()
+        ws.accept = AsyncMock()
+
+        await store.register("cancel-me", ws)
+        task = store._tasks.get("cancel-me")
+        assert task is not None and not task.done()
+
+        store.remove("cancel-me")
+        # Give the cancellation a moment to propagate
+        await asyncio.sleep(0.05)
+        assert task.cancelled() or task.done()
+        assert "cancel-me" not in store._sessions
+
+    def test_reap_stale_only_drops_local_entries(self, redis_client):
+        """reap_stale operates on the local dict; Valkey TTL handles distributed cleanup."""
+        from app.auth.magic_link_session_store import (
+            ValkeySessionStore,
+            _SessionEntry,
+        )
+        store = ValkeySessionStore(redis_client, default_ttl_seconds=900)
+        now = time.monotonic()
+        store._sessions["old"] = _SessionEntry(websocket=MagicMock(), created_at=now - 9999)
+        store._sessions["new"] = _SessionEntry(websocket=MagicMock(), created_at=now)
+
+        reaped = store.reap_stale(max_age_seconds=300)
+        assert reaped == 1
+        assert "new" in store._sessions
+        assert "old" not in store._sessions


### PR DESCRIPTION
Closes #95

## Summary

Replaces the in-memory magic-link WS session dict with a pluggable store. Default behaviour is unchanged (in-memory, single-process). Opt-in `ENABLE_DISTRIBUTED_MAGIC_LINK_SESSIONS=true` activates a Valkey-backed implementation that survives FastAPI restarts and works across multiple Gunicorn workers.

## Why

Without this, every FastAPI restart strands users currently waiting on a magic-link WebSocket — verify marks the token used but can't find a session in the local dict to push the JWT into. Multi-worker deployments hit the same issue when verify and WS land on different workers.

## Architecture

Two implementations of a common ``MagicLinkSessionStore`` Protocol:

| Store | When | Notes |
|---|---|---|
| `InMemorySessionStore` | Default, plus fallback when Valkey is unreachable | Identical to the legacy class. Re-exported as `magic_link_service.MagicLinkSessionManager` for backward compatibility. |
| `ValkeySessionStore` | `enable_distributed_magic_link_sessions=True` + Valkey reachable | Per-session subscriber on `magic_link_push:{sid}` plus TTL-bounded cache at `magic_link_session:{sid}` (race-safe — subscribe first, then check cached key). Local-first: same-worker register+push short-circuits Valkey. |

### Race safety

`ValkeySessionStore.register()` subscribes to the pub/sub channel **before** reading the cached key. So a publish that lands between SET and SUBSCRIBE is recoverable: the subscriber finds the value via GET on the next tick. Conversely, a publish that lands after SUBSCRIBE is delivered through the pub/sub channel.

### Failure modes

- Valkey down at startup → log error, fall back to in-memory. App **never** fails to boot.
- Valkey down mid-flight → `push_tokens` logs and **raises** (no silent drop, per spec).
- Migration safety: any in-flight sessions at deploy time are lost (treated like a normal restart). Acceptable.

### Production validator

Warns (not errors) when `enable_distributed_magic_link_sessions=True` but `valkey_url=""` — matches the existing `magic_link_auth + resend_api_key` warning pattern. Falls back gracefully to in-memory.

## Test plan

**16 new unit tests** in `tests/unit/test_magic_link_session_store.py`:
- [x] Flag default + factory selection (off, empty URL, unreachable URL)
- [x] Production validator warning when flag on + valkey_url empty
- [x] In-memory parity (active_count, push to missing, register-then-push, reap_stale)
- [x] Legacy alias `magic_link_service.MagicLinkSessionManager` still resolves
- [x] **Valkey integration tests** against the live `wiii-valkey:6379/1` container:
  - Local-first delivery skips Valkey hop
  - **Cross-instance handoff** — store A holds WS, store B publishes, A delivers
  - Late register picks up cached payload (publish-before-subscribe race)
  - `push_tokens` raises on `redis.set` failure
  - `remove` cancels the per-session subscriber task
  - `reap_stale` is local-only (Valkey TTL handles distributed cleanup)

```
============== 84 passed in 9.17s ==============
```

(58 magic-link + 10 dev-login + 16 new — full magic-link suite plus dev-login regression check, all green in docker.)

## Out of scope

- Replacing other in-memory state (chat session, RAG cache) — different ticket
- Changing the WebSocket protocol shape
- Switching to Redis Cluster / Sentinel
- The 264 pre-existing CI failures unrelated to magic link

## Follow-up suggestions

- E2E smoke that flips the flag, restarts the app container mid-handshake, and asserts the WS still receives tokens. Manual today; could be scripted later.
- Once this PR has soaked in staging, the in-memory `reap_stale` loop only matters for the fallback path — could be downgraded to a smaller interval, or removed entirely once Valkey becomes the only path. Not done here to keep scope minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for distributed magic-link session storage, enabling session persistence across service restarts and multi-worker deployments when Valkey is configured.
  * Session storage automatically falls back to in-memory mode if Valkey is unavailable or disabled.

* **Configuration**
  * Added feature flag to enable distributed session storage (disabled by default).
  * Added Valkey environment configuration support for session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->