### PR TITLE
fix(auth): demote stale OAuth state to legacy in auth-store

### DIFF
--- a/wiii-desktop/src/__tests__/auth-mode-fallback.test.ts
+++ b/wiii-desktop/src/__tests__/auth-mode-fallback.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Issue #108 — auth-store self-heals when OAuth state goes stale.
+ *
+ * Tests:
+ *   1. loadAuth() keeps oauth+valid-tokens as oauth (no demotion)
+ *   2. loadAuth() demotes oauth+expired-tokens to legacy
+ *   3. loadAuth() demotes oauth+null-tokens to legacy
+ *   4. getAuthHeaders() returns Authorization when tokens are fresh
+ *   5. getAuthHeaders() falls through to X-API-Key when tokens are expired
+ *   6. getAuthHeaders() returns Authorization when token is within 30s grace window
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { useAuthStore } from "@/stores/auth-store";
+import { useSettingsStore } from "@/stores/settings-store";
+
+
+// Reset stores + mocks before each test
+beforeEach(() => {
+  useAuthStore.setState({
+    isAuthenticated: false,
+    isLoaded: false,
+    user: null,
+    tokens: null,
+    authMode: "legacy",
+  });
+  useSettingsStore.setState({
+    settings: {
+      ...useSettingsStore.getState().settings,
+      api_key: "local-dev-key",
+      user_id: "test-user",
+      user_role: "student",
+    },
+    isLoaded: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+
+describe("auth-store loadAuth — self-heal stale OAuth (Issue #108)", () => {
+  it("keeps oauth mode when tokens are valid", async () => {
+    const futureExpiry = Date.now() + 60_000; // 60s from now
+    // Stub loadTokens + loadStore to return oauth state with fresh tokens
+    vi.doMock("@/lib/secure-token-storage", () => ({
+      loadTokens: async () => ({
+        access_token: "valid-access",
+        refresh_token: "refresh",
+        expires_at: futureExpiry,
+      }),
+      storeTokens: async () => {},
+      clearTokens: async () => {},
+    }));
+    vi.doMock("@/lib/storage", () => ({
+      loadStore: async () => ({
+        user: { id: "u1", email: "u@x.com", name: "U" },
+        authMode: "oauth",
+      }),
+      saveStore: async () => {},
+    }));
+    vi.resetModules();
+    const { useAuthStore: mod } = await import("@/stores/auth-store");
+    await mod.getState().loadAuth();
+
+    const s = mod.getState();
+    expect(s.authMode).toBe("oauth");
+    expect(s.tokens?.access_token).toBe("valid-access");
+    expect(s.isAuthenticated).toBe(true);
+  });
+
+  it("demotes oauth to legacy when tokens are expired", async () => {
+    const pastExpiry = Date.now() - 60_000; // 60s ago
+    vi.doMock("@/lib/secure-token-storage", () => ({
+      loadTokens: async () => ({
+        access_token: "expired-access",
+        refresh_token: "refresh",
+        expires_at: pastExpiry,
+      }),
+      storeTokens: async () => {},
+      clearTokens: async () => {},
+    }));
+    let savedPayload: any = null;
+    vi.doMock("@/lib/storage", () => ({
+      loadStore: async () => ({
+        user: { id: "u1", email: "u@x.com", name: "U" },
+        authMode: "oauth",
+      }),
+      saveStore: async (_k: string, _f: string, payload: any) => {
+        savedPayload = payload;
+      },
+    }));
+    vi.resetModules();
+    const { useAuthStore: mod } = await import("@/stores/auth-store");
+    await mod.getState().loadAuth();
+
+    const s = mod.getState();
+    expect(s.authMode).toBe("legacy");
+    expect(s.tokens).toBeNull();
+    expect(s.isAuthenticated).toBe(false);
+    // Persisted demotion so we don't loop on next load
+    expect(savedPayload?.authMode).toBe("legacy");
+  });
+
+  it("demotes oauth to legacy when no tokens are present", async () => {
+    vi.doMock("@/lib/secure-token-storage", () => ({
+      loadTokens: async () => null,
+      storeTokens: async () => {},
+      clearTokens: async () => {},
+    }));
+    let savedPayload: any = null;
+    vi.doMock("@/lib/storage", () => ({
+      loadStore: async () => ({
+        user: { id: "u1", email: "u@x.com", name: "U" },
+        authMode: "oauth",
+        // Note: no `tokens` field either
+      }),
+      saveStore: async (_k: string, _f: string, payload: any) => {
+        savedPayload = payload;
+      },
+    }));
+    vi.resetModules();
+    const { useAuthStore: mod } = await import("@/stores/auth-store");
+    await mod.getState().loadAuth();
+
+    const s = mod.getState();
+    expect(s.authMode).toBe("legacy");
+    expect(s.tokens).toBeNull();
+    expect(savedPayload?.authMode).toBe("legacy");
+  });
+});
+
+
+describe("settings-store getAuthHeaders — runtime stale-token defense (Issue #108)", () => {
+  it("returns Authorization when oauth tokens are fresh", () => {
+    useAuthStore.setState({
+      isAuthenticated: true,
+      authMode: "oauth",
+      tokens: {
+        access_token: "fresh-jwt",
+        refresh_token: "r",
+        expires_at: Date.now() + 60_000, // 60s in future
+      },
+      user: null,
+    });
+
+    const headers = useSettingsStore.getState().getAuthHeaders();
+    expect(headers["Authorization"]).toBe("Bearer fresh-jwt");
+    expect(headers["X-API-Key"]).toBeUndefined();
+  });
+
+  it("falls through to X-API-Key when oauth tokens are expired", () => {
+    useAuthStore.setState({
+      isAuthenticated: true,
+      authMode: "oauth",
+      tokens: {
+        access_token: "stale-jwt",
+        refresh_token: "r",
+        expires_at: Date.now() - 60_000, // 60s in past
+      },
+      user: null,
+    });
+
+    const headers = useSettingsStore.getState().getAuthHeaders();
+    expect(headers["Authorization"]).toBeUndefined();
+    expect(headers["X-API-Key"]).toBe("local-dev-key");
+  });
+
+  it("treats tokens within 30s of expiry as fresh (clock-skew tolerance)", () => {
+    useAuthStore.setState({
+      isAuthenticated: true,
+      authMode: "oauth",
+      tokens: {
+        access_token: "almost-expired",
+        refresh_token: "r",
+        expires_at: Date.now() - 10_000, // 10s past, within 30s grace
+      },
+      user: null,
+    });
+
+    const headers = useSettingsStore.getState().getAuthHeaders();
+    expect(headers["Authorization"]).toBe("Bearer almost-expired");
+  });
+});

--- a/wiii-desktop/src/stores/auth-store.ts
+++ b/wiii-desktop/src/stores/auth-store.ts
@@ -108,7 +108,20 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         }
       }
 
-      if (tokens && saved?.user) {
+      // Issue #108: Treat OAuth state as stale and self-heal when:
+      //   1. Tokens are missing (logout / partial state / secure-store wiped), OR
+      //   2. Tokens have expired by more than 30s (clock-skew tolerance) and no
+      //      refresh has run.
+      // Stale OAuth gets demoted to "legacy" so getAuthHeaders() takes the
+      // X-API-Key path instead of sending a dead Bearer token.
+      const STALE_TOKEN_GRACE_MS = 30_000;
+      const isTokenExpired =
+        !!tokens &&
+        typeof tokens.expires_at === "number" &&
+        tokens.expires_at + STALE_TOKEN_GRACE_MS < Date.now();
+      const hasUsableOAuthTokens = !!tokens && !isTokenExpired;
+
+      if (hasUsableOAuthTokens && saved?.user) {
         set({
           isAuthenticated: true,
           isLoaded: true,
@@ -118,6 +131,24 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         });
       } else if (saved?.authMode === "legacy") {
         set({ authMode: "legacy", isAuthenticated: true, isLoaded: true });
+      } else if (saved?.authMode === "oauth") {
+        // Saved oauth mode but tokens are missing/stale — demote to legacy
+        // and persist the corrected mode so subsequent loads don't loop.
+        set({
+          isAuthenticated: false,
+          isLoaded: true,
+          user: null,
+          tokens: null,
+          authMode: "legacy",
+        });
+        try {
+          await saveStore(AUTH_STORE_KEY, "data", {
+            user: null,
+            authMode: "legacy",
+          });
+        } catch {
+          // Persistence failure is non-fatal; in-memory state is still corrected.
+        }
       } else {
         // Sprint 218: Mark as loaded even if no saved auth found
         set({ isLoaded: true });

--- a/wiii-desktop/src/stores/settings-store.ts
+++ b/wiii-desktop/src/stores/settings-store.ts
@@ -249,11 +249,22 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
 
     // Sprint 157: Try OAuth JWT first, fallback to API key
     // Sprint 218: Uses static import (require() fails in Vite ESM browser mode)
+    // Issue #108: Defensive runtime check — if oauth mode but the token has
+    // already expired, fall through to the legacy api_key path for THIS
+    // request (don't mutate the store; that's loadAuth's job at startup).
+    // Without this, every request between token expiry and the next loadAuth
+    // would silently send a dead Bearer.
+    const STALE_TOKEN_GRACE_MS = 30_000;
     const authState = useAuthStore.getState();
-    if (authState.authMode === "oauth" && authState.tokens?.access_token) {
+    const hasFreshOAuthToken =
+      authState.authMode === "oauth" &&
+      !!authState.tokens?.access_token &&
+      typeof authState.tokens?.expires_at === "number" &&
+      authState.tokens.expires_at + STALE_TOKEN_GRACE_MS >= Date.now();
+    if (hasFreshOAuthToken) {
       // Sprint 194b (H1): OAuth mode — identity from JWT only
       // DO NOT send X-User-ID or X-Role — backend extracts from token
-      headers["Authorization"] = `Bearer ${authState.tokens.access_token}`;
+      headers["Authorization"] = `Bearer ${authState.tokens!.access_token}`;
       // Sprint 156: Include org ID when not personal workspace
       if (settings.organization_id && settings.organization_id !== "personal") {
         headers["X-Organization-ID"] = settings.organization_id;


### PR DESCRIPTION
## Summary

`getAuthHeaders()` in `settings-store.ts` hard-selected between OAuth Bearer and legacy X-API-Key based purely on `authMode`, never checking whether the OAuth token had actually expired. When the access_token went stale but `authMode` was still `\"oauth\"`, every request silently sent a dead Bearer.

PR #87 (backend Bearer-fallback to X-API-Key) made this user-visible behavior functionally OK, but the frontend was still sending a known-stale credential by default — bad hygiene + bad audit signal.

## Two-layer fix

### 1. `auth-store.ts::loadAuth()` — startup self-heal

When reading saved oauth state, demote to legacy if:
- Tokens are missing entirely, OR
- `tokens.expires_at` has passed by more than 30s (clock-skew grace)

Persist the correction so subsequent loads don't loop. A fresh page reload after token expiry now boots straight into legacy mode with the api_key path active.

### 2. `settings-store.ts::getAuthHeaders()` — runtime defensive check

Same 30s grace check, applied per-request. If oauth mode is set but the token has expired, fall through to X-API-Key for THIS request without mutating store state (mutation is loadAuth's job).

This closes the window between token expiry and the next `loadAuth` where every in-flight request would otherwise send a dead Bearer.

## Tests

6 new tests in `auth-mode-fallback.test.ts`:

- `loadAuth` keeps oauth+valid-tokens as oauth
- `loadAuth` demotes oauth+expired-tokens to legacy + persists demotion
- `loadAuth` demotes oauth+null-tokens to legacy + persists demotion
- `getAuthHeaders` returns Authorization when oauth tokens are fresh
- `getAuthHeaders` falls through to X-API-Key when oauth tokens are expired
- `getAuthHeaders` treats tokens within 30s of expiry as fresh (clock-skew tolerance)

## Verification

```
Vitest:  100 files / 2062 tests pass  (was 99/2056 — +6 new tests)
tsc --noEmit:  clean
```

Closes #108

## Test plan

- [x] `npx vitest run src/__tests__/auth-mode-fallback.test.ts` — 6/6 green
- [x] Full vitest suite — no regressions
- [x] `tsc --noEmit` clean
- [ ] Manual smoke: log in via Google OAuth, manually corrupt the secure-store, reload — should boot into legacy mode without 401 cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)