### PR TITLE
feat(llm): add NVIDIA NIM as OpenAI-compatible provider

### DIFF
--- a/maritime-ai-service/.env.example
+++ b/maritime-ai-service/.env.example
@@ -81,6 +81,14 @@ LLM_FAILOVER_CHAIN=["openrouter","ollama","google"]
 # OPENROUTER_REQUIRE_PARAMETERS=true
 # OPENROUTER_PROVIDER_SORT=latency
 
+# NVIDIA NIM (Issue #110) — OpenAI-compatible endpoint with free tier
+# Get an NGC API key at https://build.nvidia.com/explore/discover
+# Default models: meta/llama-3.1-70b-instruct (light/moderate), 405B (deep)
+# NVIDIA_API_KEY=nvapi-...
+# NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
+# NVIDIA_MODEL=meta/llama-3.1-70b-instruct
+# NVIDIA_MODEL_ADVANCED=meta/llama-3.1-405b-instruct
+
 # Google Gemini
 # Get your API key from: https://aistudio.google.com/app/apikey
 GOOGLE_API_KEY=your-google-gemini-api-key-here

--- a/maritime-ai-service/app/core/config/_settings_base_fields.py
+++ b/maritime-ai-service/app/core/config/_settings_base_fields.py
@@ -21,6 +21,9 @@ from app.engine.model_catalog import (
     OPENROUTER_DEFAULT_BASE_URL,
     OPENROUTER_DEFAULT_MODEL,
     OPENROUTER_DEFAULT_MODEL_ADVANCED,
+    NVIDIA_DEFAULT_BASE_URL,
+    NVIDIA_DEFAULT_MODEL,
+    NVIDIA_DEFAULT_MODEL_ADVANCED,
     ZHIPU_DEFAULT_MODEL,
     ZHIPU_DEFAULT_MODEL_ADVANCED,
     get_embedding_dimensions,
@@ -204,6 +207,13 @@ class BaseSettingsFieldsMixin:
     openai_model_advanced: str = Field(default=OPENAI_DEFAULT_MODEL_ADVANCED, description="OpenAI model for complex tasks")
     openrouter_model: str = Field(default=OPENROUTER_DEFAULT_MODEL, description="OpenRouter model for general tasks")
     openrouter_model_advanced: str = Field(default=OPENROUTER_DEFAULT_MODEL_ADVANCED, description="OpenRouter model for complex tasks")
+
+    # NVIDIA NIM (Issue #110) — OpenAI-compatible endpoint at integrate.api.nvidia.com.
+    # NGC API key from build.nvidia.com unlocks Llama 3.1 405B, Nemotron 70B, etc.
+    nvidia_api_key: Optional[str] = Field(default=None, description="NVIDIA NIM (NGC) API key")
+    nvidia_base_url: Optional[str] = Field(default=NVIDIA_DEFAULT_BASE_URL, description="NVIDIA NIM API base URL")
+    nvidia_model: str = Field(default=NVIDIA_DEFAULT_MODEL, description="NVIDIA model for general tasks")
+    nvidia_model_advanced: str = Field(default=NVIDIA_DEFAULT_MODEL_ADVANCED, description="NVIDIA model for complex tasks")
     openrouter_model_fallbacks: list[str] = Field(
         default_factory=list,
         description="Ordered fallback models for OpenRouter requests",

--- a/maritime-ai-service/app/engine/llm_provider_registry.py
+++ b/maritime-ai-service/app/engine/llm_provider_registry.py
@@ -7,6 +7,7 @@ SUPPORTED_PROVIDER_NAMES: tuple[str, ...] = (
     "vertex",
     "openai",
     "openrouter",
+    "nvidia",
     "ollama",
     "zhipu",
 )
@@ -39,6 +40,9 @@ def get_provider_class(name: str):
         "vertex": VertexAIProvider,
         "openai": OpenAIProvider,
         "openrouter": OpenAIProvider,
+        # Issue #110: NVIDIA NIM is OpenAI-compatible — same class, different
+        # base_url + key resolved by the alias branch in OpenAIProvider.
+        "nvidia": OpenAIProvider,
         "ollama": OllamaProvider,
         "zhipu": ZhipuProvider,
     }
@@ -48,6 +52,6 @@ def get_provider_class(name: str):
 def create_provider(name: str):
     """Instantiate a provider by canonical provider name."""
     provider_cls = get_provider_class(name)
-    if name in {"openai", "openrouter"}:
+    if name in {"openai", "openrouter", "nvidia"}:
         return provider_cls(provider_alias=name)
     return provider_cls()

--- a/maritime-ai-service/app/engine/llm_providers/openai_provider.py
+++ b/maritime-ai-service/app/engine/llm_providers/openai_provider.py
@@ -1,8 +1,9 @@
 """
-OpenAI / OpenRouter Provider — Secondary LLM backend for Wiii.
+OpenAI / OpenRouter / NVIDIA NIM Provider — Secondary LLM backend for Wiii.
 
 Uses WiiiChatModel (AsyncOpenAI SDK).
 De-LangChaining Phase 1: Removed ChatOpenAI dependency.
+Issue #110: NVIDIA NIM added as alias-based OpenAI-compatible target.
 """
 
 import logging
@@ -14,6 +15,10 @@ from app.core.config import settings
 from app.engine.llm_providers.base import LLMProvider
 from app.engine.llm_providers.wiii_chat_model import WiiiChatModel
 from app.engine.openai_compatible_credentials import (
+    resolve_nvidia_api_key,
+    resolve_nvidia_base_url,
+    resolve_nvidia_model,
+    resolve_nvidia_model_advanced,
     resolve_openai_api_key,
     resolve_openai_base_url,
     resolve_openai_model,
@@ -62,6 +67,8 @@ class OpenAIProvider(LLMProvider):
     def is_configured(self) -> bool:
         if self._provider_alias == "openrouter":
             return bool(resolve_openrouter_api_key(settings))
+        if self._provider_alias == "nvidia":
+            return bool(resolve_nvidia_api_key(settings))
         return bool(resolve_openai_api_key(settings))
 
     def is_available(self) -> bool:
@@ -87,6 +94,10 @@ class OpenAIProvider(LLMProvider):
             model = resolve_openrouter_model_advanced(settings)
         elif self._provider_alias == "openrouter":
             model = resolve_openrouter_model(settings)
+        elif self._provider_alias == "nvidia" and tier == "deep":
+            model = resolve_nvidia_model_advanced(settings)
+        elif self._provider_alias == "nvidia":
+            model = resolve_nvidia_model(settings)
         elif tier == "deep":
             model = resolve_openai_model_advanced(settings)
         else:
@@ -95,11 +106,12 @@ class OpenAIProvider(LLMProvider):
         # Detect o-series reasoning models
         is_o_series = any(model.startswith(prefix) for prefix in _O_SERIES_PREFIXES)
 
-        api_key = (
-            resolve_openrouter_api_key(settings)
-            if self._provider_alias == "openrouter"
-            else resolve_openai_api_key(settings)
-        )
+        if self._provider_alias == "openrouter":
+            api_key = resolve_openrouter_api_key(settings)
+        elif self._provider_alias == "nvidia":
+            api_key = resolve_nvidia_api_key(settings)
+        else:
+            api_key = resolve_openai_api_key(settings)
 
         model_kwargs: dict[str, Any] = {}
 
@@ -112,12 +124,14 @@ class OpenAIProvider(LLMProvider):
         else:
             model_kwargs["temperature"] = temperature
 
-        # Support OpenRouter or custom base URL
+        # Support OpenRouter / NVIDIA NIM / custom base URL
         base_url = ""
         use_openrouter_request = False
         if self._provider_alias == "openrouter":
             base_url = resolve_openrouter_base_url(settings)
             use_openrouter_request = True
+        elif self._provider_alias == "nvidia":
+            base_url = resolve_nvidia_base_url(settings)
         else:
             explicit_openai_base = getattr(settings, "openai_base_url", None)
             if isinstance(explicit_openai_base, str) and explicit_openai_base.strip():

--- a/maritime-ai-service/app/engine/model_catalog.py
+++ b/maritime-ai-service/app/engine/model_catalog.py
@@ -78,6 +78,12 @@ OPENROUTER_DEFAULT_MODEL = "openai/gpt-oss-20b:free"
 OPENROUTER_DEFAULT_MODEL_ADVANCED = "openai/gpt-oss-120b:free"
 ZHIPU_DEFAULT_BASE_URL = "https://open.bigmodel.cn/api/paas/v4"
 
+# NVIDIA NIM — OpenAI-compatible endpoint (Issue #110)
+# Free tier available with NGC API key from build.nvidia.com.
+NVIDIA_DEFAULT_BASE_URL = "https://integrate.api.nvidia.com/v1"
+NVIDIA_DEFAULT_MODEL = "meta/llama-3.1-70b-instruct"
+NVIDIA_DEFAULT_MODEL_ADVANCED = "meta/llama-3.1-405b-instruct"
+
 GOOGLE_CHAT_MODELS: dict[str, ChatModelMetadata] = {
     GOOGLE_DEFAULT_MODEL: ChatModelMetadata(
         provider="google",

--- a/maritime-ai-service/app/engine/openai_compatible_credentials.py
+++ b/maritime-ai-service/app/engine/openai_compatible_credentials.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 from typing import Any
 
 from app.engine.model_catalog import (
+    NVIDIA_DEFAULT_BASE_URL,
+    NVIDIA_DEFAULT_MODEL,
+    NVIDIA_DEFAULT_MODEL_ADVANCED,
     OPENAI_DEFAULT_BASE_URL,
     OPENAI_DEFAULT_MODEL,
     OPENAI_DEFAULT_MODEL_ADVANCED,
@@ -93,6 +96,30 @@ def resolve_openrouter_model_advanced(settings_obj: Any) -> str:
 
 def openrouter_credentials_available(settings_obj: Any) -> bool:
     return bool(resolve_openrouter_api_key(settings_obj))
+
+
+# NVIDIA NIM resolvers (Issue #110) — OpenAI-compatible endpoint at
+# integrate.api.nvidia.com. Each resolver mirrors the OpenAI/OpenRouter
+# pattern: explicit setting first, fall back to the catalogued default.
+
+def resolve_nvidia_api_key(settings_obj: Any) -> str | None:
+    return _normalize_text(getattr(settings_obj, "nvidia_api_key", None))
+
+
+def resolve_nvidia_base_url(settings_obj: Any) -> str:
+    return _normalize_text(getattr(settings_obj, "nvidia_base_url", None)) or NVIDIA_DEFAULT_BASE_URL
+
+
+def resolve_nvidia_model(settings_obj: Any) -> str:
+    return _normalize_text(getattr(settings_obj, "nvidia_model", None)) or NVIDIA_DEFAULT_MODEL
+
+
+def resolve_nvidia_model_advanced(settings_obj: Any) -> str:
+    return _normalize_text(getattr(settings_obj, "nvidia_model_advanced", None)) or NVIDIA_DEFAULT_MODEL_ADVANCED
+
+
+def nvidia_credentials_available(settings_obj: Any) -> bool:
+    return bool(resolve_nvidia_api_key(settings_obj))
 
 
 def is_openrouter_legacy_slot_configured(settings_obj: Any) -> bool:

--- a/maritime-ai-service/tests/unit/test_nvidia_provider.py
+++ b/maritime-ai-service/tests/unit/test_nvidia_provider.py
@@ -1,0 +1,263 @@
+"""Issue #110 — NVIDIA NIM provider wiring.
+
+Verifies the alias-based registration of NVIDIA NIM as an OpenAI-compatible
+target without exercising the live network. Mirrors the OpenRouter alias
+pattern that already ships in the runtime.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+class TestNvidiaRegistry:
+    def test_nvidia_appears_in_supported_provider_names(self):
+        from app.engine.llm_provider_registry import (
+            SUPPORTED_PROVIDER_NAMES,
+            is_supported_provider,
+        )
+        assert "nvidia" in SUPPORTED_PROVIDER_NAMES
+        assert is_supported_provider("nvidia") is True
+
+    def test_create_provider_returns_openai_provider_with_nvidia_alias(self):
+        from app.engine.llm_provider_registry import create_provider
+        from app.engine.llm_providers import OpenAIProvider
+
+        provider = create_provider("nvidia")
+        assert isinstance(provider, OpenAIProvider)
+        assert provider.name == "nvidia"
+
+
+# ---------------------------------------------------------------------------
+# Resolvers
+# ---------------------------------------------------------------------------
+
+class TestNvidiaResolvers:
+    def test_api_key_resolves_from_settings(self):
+        from app.engine.openai_compatible_credentials import resolve_nvidia_api_key
+
+        settings_obj = SimpleNamespace(nvidia_api_key="nvapi-test-key")
+        assert resolve_nvidia_api_key(settings_obj) == "nvapi-test-key"
+
+    def test_api_key_resolves_to_none_when_unset(self):
+        from app.engine.openai_compatible_credentials import resolve_nvidia_api_key
+
+        settings_obj = SimpleNamespace(nvidia_api_key=None)
+        assert resolve_nvidia_api_key(settings_obj) is None
+
+    def test_base_url_default_when_unset(self):
+        from app.engine.model_catalog import NVIDIA_DEFAULT_BASE_URL
+        from app.engine.openai_compatible_credentials import resolve_nvidia_base_url
+
+        settings_obj = SimpleNamespace(nvidia_base_url=None)
+        assert resolve_nvidia_base_url(settings_obj) == NVIDIA_DEFAULT_BASE_URL
+
+    def test_base_url_explicit_override(self):
+        from app.engine.openai_compatible_credentials import resolve_nvidia_base_url
+
+        settings_obj = SimpleNamespace(
+            nvidia_base_url="https://custom.nvidia.example.com/v1"
+        )
+        assert (
+            resolve_nvidia_base_url(settings_obj)
+            == "https://custom.nvidia.example.com/v1"
+        )
+
+    def test_model_defaults(self):
+        from app.engine.model_catalog import (
+            NVIDIA_DEFAULT_MODEL,
+            NVIDIA_DEFAULT_MODEL_ADVANCED,
+        )
+        from app.engine.openai_compatible_credentials import (
+            resolve_nvidia_model,
+            resolve_nvidia_model_advanced,
+        )
+
+        settings_obj = SimpleNamespace(
+            nvidia_model=None, nvidia_model_advanced=None
+        )
+        assert resolve_nvidia_model(settings_obj) == NVIDIA_DEFAULT_MODEL
+        assert (
+            resolve_nvidia_model_advanced(settings_obj)
+            == NVIDIA_DEFAULT_MODEL_ADVANCED
+        )
+
+    def test_credentials_available_helper(self):
+        from app.engine.openai_compatible_credentials import (
+            nvidia_credentials_available,
+        )
+
+        assert nvidia_credentials_available(SimpleNamespace(nvidia_api_key="k")) is True
+        assert nvidia_credentials_available(SimpleNamespace(nvidia_api_key=None)) is False
+
+
+# ---------------------------------------------------------------------------
+# OpenAIProvider — nvidia alias behavior
+# ---------------------------------------------------------------------------
+
+class TestOpenAIProviderWithNvidiaAlias:
+    def test_is_configured_true_with_nvidia_api_key(self):
+        from app.engine.llm_providers import OpenAIProvider
+
+        with patch.object(
+            __import__("app.engine.llm_providers.openai_provider", fromlist=["settings"]),
+            "settings",
+            SimpleNamespace(nvidia_api_key="nvapi-x"),
+        ):
+            provider = OpenAIProvider(provider_alias="nvidia")
+            assert provider.is_configured() is True
+
+    def test_is_configured_false_without_nvidia_api_key(self):
+        from app.engine.llm_providers import OpenAIProvider
+
+        with patch.object(
+            __import__("app.engine.llm_providers.openai_provider", fromlist=["settings"]),
+            "settings",
+            SimpleNamespace(nvidia_api_key=None),
+        ):
+            provider = OpenAIProvider(provider_alias="nvidia")
+            assert provider.is_configured() is False
+
+    def test_is_configured_nvidia_alias_does_not_fall_back_to_openai_key(self):
+        """Nvidia alias must NOT report configured just because openai_api_key is set."""
+        from app.engine.llm_providers import OpenAIProvider
+
+        with patch.object(
+            __import__("app.engine.llm_providers.openai_provider", fromlist=["settings"]),
+            "settings",
+            SimpleNamespace(
+                nvidia_api_key=None,
+                openai_api_key="sk-openai-only",
+                openrouter_api_key=None,
+            ),
+        ):
+            provider = OpenAIProvider(provider_alias="nvidia")
+            assert provider.is_configured() is False
+
+    def test_create_instance_picks_nvidia_endpoint(self):
+        """With alias=nvidia, the WiiiChatModel must be built with the NVIDIA URL + key + model."""
+        from app.engine.llm_providers import OpenAIProvider
+        from app.engine.model_catalog import (
+            NVIDIA_DEFAULT_BASE_URL,
+            NVIDIA_DEFAULT_MODEL,
+        )
+
+        captured: dict = {}
+
+        def _fake_chat_model(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch.object(
+            __import__("app.engine.llm_providers.openai_provider", fromlist=["settings"]),
+            "settings",
+            SimpleNamespace(
+                nvidia_api_key="nvapi-test-key",
+                nvidia_base_url=None,
+                nvidia_model=None,
+                nvidia_model_advanced=None,
+                openai_api_key=None,
+                openai_base_url=None,
+            ),
+        ), patch(
+            "app.engine.llm_providers.openai_provider.WiiiChatModel",
+            new=_fake_chat_model,
+        ):
+            provider = OpenAIProvider(provider_alias="nvidia")
+            provider.create_instance(tier="light")
+
+        assert captured["model"] == NVIDIA_DEFAULT_MODEL
+        assert captured["api_key"] == "nvapi-test-key"
+        assert captured["base_url"] == NVIDIA_DEFAULT_BASE_URL
+
+    def test_create_instance_picks_advanced_model_for_deep_tier(self):
+        from app.engine.llm_providers import OpenAIProvider
+        from app.engine.model_catalog import NVIDIA_DEFAULT_MODEL_ADVANCED
+
+        captured: dict = {}
+
+        def _fake_chat_model(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch.object(
+            __import__("app.engine.llm_providers.openai_provider", fromlist=["settings"]),
+            "settings",
+            SimpleNamespace(
+                nvidia_api_key="nvapi-key",
+                nvidia_base_url=None,
+                nvidia_model=None,
+                nvidia_model_advanced=None,
+                openai_api_key=None,
+                openai_base_url=None,
+            ),
+        ), patch(
+            "app.engine.llm_providers.openai_provider.WiiiChatModel",
+            new=_fake_chat_model,
+        ):
+            provider = OpenAIProvider(provider_alias="nvidia")
+            provider.create_instance(tier="deep")
+
+        assert captured["model"] == NVIDIA_DEFAULT_MODEL_ADVANCED
+
+    def test_create_instance_does_not_emit_openrouter_extra_body(self):
+        """NVIDIA path is plain OpenAI-compatible; openrouter_extra_body must not be added."""
+        from app.engine.llm_providers import OpenAIProvider
+
+        captured: dict = {}
+
+        def _fake_chat_model(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch.object(
+            __import__("app.engine.llm_providers.openai_provider", fromlist=["settings"]),
+            "settings",
+            SimpleNamespace(
+                nvidia_api_key="nvapi",
+                nvidia_base_url=None,
+                nvidia_model=None,
+                nvidia_model_advanced=None,
+                openai_api_key=None,
+                openai_base_url=None,
+            ),
+        ), patch(
+            "app.engine.llm_providers.openai_provider.WiiiChatModel",
+            new=_fake_chat_model,
+        ):
+            provider = OpenAIProvider(provider_alias="nvidia")
+            provider.create_instance(tier="moderate")
+
+        # extra_body is only set for o-series models or openrouter routing
+        model_kwargs = captured.get("model_kwargs", {})
+        assert "extra_body" not in model_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting safety
+# ---------------------------------------------------------------------------
+
+class TestNoRegression:
+    def test_existing_openai_alias_still_works(self):
+        from app.engine.llm_provider_registry import create_provider
+
+        provider = create_provider("openai")
+        assert provider.name == "openai"
+
+    def test_existing_openrouter_alias_still_works(self):
+        from app.engine.llm_provider_registry import create_provider
+
+        provider = create_provider("openrouter")
+        assert provider.name == "openrouter"
+
+    def test_unknown_provider_still_raises(self):
+        from app.engine.llm_provider_registry import get_provider_class
+
+        with pytest.raises(ValueError, match="Unknown provider"):
+            get_provider_class("not-a-real-provider")

--- a/wiii-desktop/src/api/types.ts
+++ b/wiii-desktop/src/api/types.ts
@@ -114,7 +114,7 @@ export interface ChatRequest {
   organization_id?: string;
   images?: ImageInput[];
   user_context?: ChatUserContext;
-  provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
   model?: string;
 }
 
@@ -213,7 +213,7 @@ export interface FailoverMetadata {
 }
 
 export interface ModelSwitchPromptOption {
-  provider: "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  provider: "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
   label: string;
   selected_model?: string | null;
 }
@@ -1267,7 +1267,7 @@ export type ThinkingLevel = "minimal" | "balanced" | "detailed";
 export interface AppSettings {
   server_url: string;
   api_key: string;
-  llm_provider?: "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  llm_provider?: "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
   google_model?: string;
   openai_base_url?: string;
   openai_model?: string;
@@ -1313,11 +1313,11 @@ export interface AppSettings {
   /** Sprint 167: Show interactive artifacts */
   show_artifacts?: boolean;
   /** Per-request model provider selection (persisted across reloads) */
-  model_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  model_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
 }
 
 export interface LlmRuntimeConfig {
-  provider: "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  provider: "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
   use_multi_agent: boolean;
   google_model: string;
   openai_base_url?: string | null;
@@ -1355,12 +1355,12 @@ export interface LlmRuntimeConfig {
   agent_profiles: Record<string, AgentRuntimeProfileConfig>;
   timeout_profiles: LlmTimeoutProfilesConfig;
   timeout_provider_overrides: Record<string, LlmTimeoutProviderOverride>;
-  vision_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "ollama";
-  vision_describe_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  vision_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
+  vision_describe_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
   vision_describe_model?: string | null;
-  vision_ocr_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  vision_ocr_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
   vision_ocr_model?: string | null;
-  vision_grounded_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  vision_grounded_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
   vision_grounded_model?: string | null;
   vision_failover_chain?: string[];
   vision_timeout_seconds: number;
@@ -1369,7 +1369,7 @@ export interface LlmRuntimeConfig {
   vision_last_live_probe_at?: string | null;
   vision_audit_persisted?: boolean;
   vision_audit_warnings?: string[];
-  embedding_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  embedding_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
   embedding_failover_chain?: string[];
   embedding_model: string;
   embedding_dimensions: number;
@@ -1578,7 +1578,7 @@ export interface EmbeddingSpaceMigrationPromoteRequest {
 }
 
 export interface AgentRuntimeProfileConfig {
-  default_provider: "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  default_provider: "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
   tier: "deep" | "moderate" | "light";
   provider_models: Record<string, string>;
 }
@@ -1668,7 +1668,7 @@ export interface ModelCatalogResponse {
 }
 
 export interface LlmRuntimeUpdateBody {
-  provider?: "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  provider?: "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
   use_multi_agent?: boolean;
   google_api_key?: string;
   clear_google_api_key?: boolean;
@@ -1707,16 +1707,16 @@ export interface LlmRuntimeUpdateBody {
   agent_profiles?: Record<string, AgentRuntimeProfileConfig>;
   timeout_profiles?: LlmTimeoutProfilesConfig;
   timeout_provider_overrides?: Record<string, LlmTimeoutProviderOverride>;
-  vision_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "ollama";
-  vision_describe_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  vision_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
+  vision_describe_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
   vision_describe_model?: string;
-  vision_ocr_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  vision_ocr_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
   vision_ocr_model?: string;
-  vision_grounded_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  vision_grounded_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
   vision_grounded_model?: string;
   vision_failover_chain?: string[];
   vision_timeout_seconds?: number;
-  embedding_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "ollama";
+  embedding_provider?: "auto" | "google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama";
   embedding_failover_chain?: string[];
   embedding_model?: string;
 }
@@ -1753,7 +1753,7 @@ export interface LlmStatusResponse {
 }
 
 export interface LlmRuntimeAuditRefreshBody {
-  providers?: Array<"google" | "zhipu" | "openai" | "openrouter" | "ollama">;
+  providers?: Array<"google" | "zhipu" | "openai" | "openrouter" | "nvidia" | "ollama">;
 }
 
 // ===== Sprint 170: Living Agent Types =====

--- a/wiii-desktop/src/components/runtime/LlmRuntimePolicyEditor.tsx
+++ b/wiii-desktop/src/components/runtime/LlmRuntimePolicyEditor.tsx
@@ -198,6 +198,7 @@ function defaultTimeoutProviderOverrides(): Record<RuntimeProvider, TimeoutProvi
     zhipu: {},
     openai: {},
     openrouter: {},
+    nvidia: {},
     ollama: {},
   };
 }


### PR DESCRIPTION
## Summary

NVIDIA NIM exposes top-tier models (Llama 3.1 405B, Nemotron 70B, Mistral Large 2) behind an **OpenAI-compatible** HTTP API at `integrate.api.nvidia.com/v1`, with a free tier for individuals (NGC key from build.nvidia.com). Wiii's existing `OpenAIProvider` already implements the alias-based "one class, multiple endpoints via base_url + key swap" pattern that OpenRouter rides on. NVIDIA is added as a third alias — focused PR, no new orchestration framework needed.

User goal: avoid lock-in on a single LLM provider. With NVIDIA in the rotation alongside Google / OpenAI / OpenRouter / Ollama / Zhipu, Wiii can fail over automatically when one provider is rate-limited, costed-out, or down.

## Wiring touchpoints

**Backend** (-26 / +291)

| File | Change |
|---|---|
| `model_catalog.py` | `NVIDIA_DEFAULT_BASE_URL` + default + advanced models (Llama 3.1 70B / 405B) |
| `_settings_base_fields.py` | `nvidia_api_key`, `nvidia_base_url`, `nvidia_model`, `nvidia_model_advanced` |
| `openai_compatible_credentials.py` | `resolve_nvidia_*` helpers mirroring OpenRouter's exactly |
| `llm_provider_registry.py` | `\"nvidia\"` registered, mapped to `OpenAIProvider`, alias passed through `create_provider` |
| `openai_provider.py` | alias branch in `is_configured` + `create_instance` so `WiiiChatModel` is constructed with the NVIDIA url/key/model triple. NVIDIA does NOT use OpenRouter's `extra_body` routing — it's plain OpenAI-compatible. |
| `.env.example` | NGC key placeholder + URL + default model docs |

**Frontend**

| File | Change |
|---|---|
| `api/types.ts` | All 18 occurrences of the provider union union gain `\"nvidia\"` |
| `LlmRuntimePolicyEditor.tsx` | `nvidia: {}` default in the timeout override map (tsc enforced this) |

## Tests

17 new tests in `test_nvidia_provider.py`, **all pass under --network none**:

```
Registry: nvidia in supported list, create_provider returns aliased OpenAIProvider
Resolvers: api_key, base_url, models, helper — both default and explicit override paths
OpenAIProvider with nvidia alias:
  - is_configured true/false on key presence
  - SECURITY: alias does NOT fall back to openai_api_key
  - create_instance picks NVIDIA url + key + model
  - deep tier uses advanced model
  - no openrouter extra_body emitted (plain OpenAI-compatible)
No regression: openai + openrouter aliases still work, unknown provider still raises
```

Frontend: `tsc --noEmit` clean, vitest **100/100 files / 2062/2062 tests pass**.

## How to use

```
# .env.production (or .env)
NVIDIA_API_KEY=nvapi-...                         # from build.nvidia.com
# NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1   # optional, this is the default
# NVIDIA_MODEL=meta/llama-3.1-70b-instruct        # optional, default light/moderate
# NVIDIA_MODEL_ADVANCED=meta/llama-3.1-405b-instruct  # optional, default deep
```

Then either:
- **Per-request**: send `\"provider\": \"nvidia\"` in the chat body
- **As primary**: set `LLM_PROVIDER=nvidia` and put it first in `LLM_FAILOVER_CHAIN`

Closes #110

## Out of scope

- Bigger Unsloth-style runtime redesign (`RuntimeModelSpec`, `ExecutionLane`, capability probing) — Codex's research doc territory, separate PR
- NVIDIA-specific function-calling tweaks (NVIDIA NIM follows OpenAI tool spec, no special handling needed for current Wiii tools)
- Auto cost / latency-based routing across providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for NVIDIA NIM as an LLM provider option, enabling configuration and use of NVIDIA's inference services alongside existing providers.
  * New configuration fields for NVIDIA NIM including API key, base URL, and model selection with both standard and advanced model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->