### PR TITLE
fix(admin): system admin auto-picks first org so Knowledge UI is reachable

### DIFF
--- a/wiii-desktop/src/App.tsx
+++ b/wiii-desktop/src/App.tsx
@@ -170,12 +170,23 @@ export default function App() {
       detectSubdomainOrg();
 
       // Sprint 156: Fetch organizations + restore saved org
-      fetchOrganizations().then(() => {
-        // Sprint 181: Fetch admin context after auth/org init
-        fetchAdminContext();
+      fetchOrganizations().then(async () => {
+        // Sprint 181: Fetch admin context after auth/org init.
+        // Issue #112: await it so the auto-pick branch below can rely on
+        // isSystemAdmin() being populated.
+        await fetchAdminContext();
         // Sprint 175: If subdomain detected, use it (skip saved org)
         const subdomainOrg = useOrgStore.getState().subdomainOrgId;
-        const orgToActivate = subdomainOrg || settings.organization_id;
+        let orgToActivate = subdomainOrg || settings.organization_id;
+        // Issue #112: System admin without an active org cannot reach the
+        // "Quản lý tổ chức" sidebar button (gated on activeOrgId !== "personal"),
+        // so the Knowledge upload + visual knowledge graph/scatter UI is
+        // unreachable. Auto-pick the first non-personal org as a starting point.
+        if (!orgToActivate && useOrgStore.getState().isSystemAdmin()) {
+          const orgs = useOrgStore.getState().organizations;
+          const firstRealOrg = orgs.find((o) => o.id && o.id !== "personal");
+          if (firstRealOrg) orgToActivate = firstRealOrg.id;
+        }
         if (orgToActivate) {
           setActiveOrg(orgToActivate);
           const org = useOrgStore.getState().organizations.find((o) => o.id === orgToActivate);


### PR DESCRIPTION
## Symptom

After dev-login (or any system admin sign-in), the Sidebar's **"Quản lý tổ chức" 🏢 button is invisible**. The button gates on:

```tsx
{(isOrgAdmin() || isSystemAdmin()) && activeOrgId && activeOrgId !== "personal" && (
  <button>...</button>
)}
```

Backend correctly reports `is_system_admin: true` for the dev user, but `active_organization_id: null` → `activeOrgId` is null → button hidden. System admin has no path to discover the org-management UI, including the entire **Knowledge upload + visual knowledge graph/scatter** surface.

User intuition was correct: a system admin should be able to manage the default org out of the box.

## Fix

In `App.tsx`'s post-login init block:

1. **Await** `fetchAdminContext()` (was fire-and-forget) so `isSystemAdmin()` is resolvable when picking the active org.
2. After the existing subdomain / saved-settings resolution, if no org was selected AND the user is system admin, pick the first non-personal org from the loaded organizations list. Apply the same `setOrgFilter`.

Non-admin users unchanged — still default to personal workspace if no org is saved.

## End-to-end smoke verified

```
POST /organizations/maritime-lms/knowledge/upload   → 200  (1-page PDF, ~13s ingest)
GET  /organizations/maritime-lms/knowledge/documents → status=ready, chunk_count=1
GET  /organizations/maritime-lms/knowledge/visualize/graph
       → 2 nodes (document + chunk), 1 "contains" edge
GET  /organizations/maritime-lms/knowledge/visualize/scatter
       → 1 point with embedding coords + content preview
```

So after merge + hard-refresh:
1. Dev login → Sidebar shows 🏢 immediately
2. Click → enters Org Manager for `maritime-lms` (or first available)
3. Tab "Knowledge" → drag-drop PDF → status flips uploading → processing → ready
4. KnowledgeVisualizer renders graph + scatter with real embedding data

Closes #112

## Test plan

- [x] `tsc --noEmit` clean
- [x] curl-driven E2E for upload + list + graph + scatter all returned 200 with correct payloads
- [ ] After merge + hard-refresh: user sees button + uploads PDF + sees viz

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization initialization during app startup to ensure an organization is properly activated for system administrators, particularly when no organization is selected via subdomain or saved settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->