### PR TITLE
security: harden OpenRouter env template

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -102,10 +102,28 @@ jobs:
           git diff --name-only "$range" | tee /tmp/changed-files.txt
 
           forbidden='(^|/)(node_modules|__pycache__|\.pytest_cache|\.ruff_cache|\.mypy_cache|dist-embed|dist-web|target|coverage|htmlcov)/|(^|/)\.env($|\.|/)|\.(pem|key|p12|pfx|log|tmp)$'
-          if grep -E "$forbidden" /tmp/changed-files.txt; then
+          env_example='(^|/)\.env([^/]*\.)?example$'
+          forbidden_hits="$(grep -E "$forbidden" /tmp/changed-files.txt | grep -Ev "$env_example" || true)"
+          if [[ -n "$forbidden_hits" ]]; then
+            echo "$forbidden_hits"
             echo "Forbidden generated, secret, or local-only artifact detected in the change set." >&2
             exit 1
           fi
+
+          # Env templates are allowed only as examples, and only when they do
+          # not contain provider-shaped keys or non-placeholder secret values.
+          while IFS= read -r env_file; do
+            [[ -n "$env_file" ]] || continue
+            if grep -nE 'sk-or-v1-[A-Za-z0-9_-]{20,}|sk-[A-Za-z0-9_-]{20,}|AIza[0-9A-Za-z_-]{20,}|xox[baprs]-[0-9A-Za-z-]{10,}' "$env_file"; then
+              echo "Provider-shaped secret detected in env example: $env_file" >&2
+              exit 1
+            fi
+            if grep -nE '^[A-Z0-9_]*(SECRET|TOKEN|PASSWORD|API_KEY|ACCESS_KEY)[A-Z0-9_]*=.{12,}$' "$env_file" \
+              | grep -Ev '=(your_|fake-|test-|SET_|REPLACE_|CHANGEME|placeholder|none|null|<|\$\{)'; then
+              echo "Non-placeholder secret-like value detected in env example: $env_file" >&2
+              exit 1
+            fi
+          done < <(grep -E "$env_example" /tmp/changed-files.txt || true)
 
   github-governance:
     name: GitHub Governance Gate

--- a/maritime-ai-service/.env.render.example
+++ b/maritime-ai-service/.env.render.example
@@ -1,4 +1,4 @@
-# Legacy environment template — kept for historical reference only.
+# Legacy environment template - kept for historical reference only.
 # NOT used in production. See .env.production.example for GCP deployment.
 
 PYTHON_VERSION=3.11.4
@@ -20,8 +20,9 @@ NEO4J_PASSWORD=your_neo4j_password_here
 DATABASE_URL=postgresql://postgres:password@db.example.com:5432/postgres
 
 # OpenRouter LLM
-# IMPORTANT: Do NOT commit real API keys to Git!
-OPENAI_API_KEY=sk-or-v1-your_openrouter_key_here
+# IMPORTANT: Do NOT commit real API keys to Git.
+# Keep provider keys only in Render/OpenRouter/GitHub secret stores.
+OPENAI_API_KEY=SET_IN_RENDER_DASHBOARD_DO_NOT_COMMIT
 OPENAI_BASE_URL=https://openrouter.ai/api/v1
 OPENAI_MODEL=x-ai/grok-4.1-fast:free
 


### PR DESCRIPTION
## Summary
- Replaces the OpenRouter-shaped placeholder in `maritime-ai-service/.env.render.example` with a non-secret sentinel value.
- Adds an explicit note that OpenRouter keys must live only in Render/OpenRouter/GitHub secret stores.
- Tightens `Repository Hygiene` so env example templates may be changed only when they do not contain provider-shaped keys or non-placeholder secret-like values.
- Keeps historical secret-scanning alert resolution separate from provider-side key rotation so we do not mark secrets resolved without proof of revocation.

## Linked Issue
Refs #128. This PR intentionally does **not** close #128 because the remaining acceptance criteria require external OpenRouter key revocation/rotation and deployment of the rotated key.

## Verification
- `git grep -l -I -E 'sk-or-v1-[A-Za-z0-9_-]{20,}' -- . ':!*.lock' ':!*.min.*'` returned no matches in the working tree after the template change.
- `git diff --check` passed locally.
- The first CI run correctly showed the previous hygiene rule blocked all `.env.*` changes; commit `f030670` refines that rule to permit env examples only after secret-pattern checks.

## Security Notes
- GitHub secret-scanning alerts #1 and #2 point to historical `.env.render` commits, not this template.
- No secret value was copied into the PR, issue comment, terminal summary, or documentation.
- Local ignored env files were not modified by this PR.
- The hygiene gate still blocks real `.env`, local artifacts, private key formats, logs, tmp files, and generated dependency/build directories.