### PR TITLE
test: retire deprecated graph mocks

### DIFF
--- a/maritime-ai-service/tests/unit/test_phase4_aggregator.py
+++ b/maritime-ai-service/tests/unit/test_phase4_aggregator.py
@@ -901,8 +901,7 @@ class TestGraphIntegration:
             mock_settings.enable_subagent_architecture = True
             mock_settings.quality_skip_threshold = 0.85
 
-            # We can't easily test build_multi_agent_graph without full LangGraph
-            # but we can test the routing map logic
+            # Keep this focused on routing-map behavior without invoking runtime orchestration.
             _routing_map = {
                 "rag_agent": "rag_agent",
                 "tutor_agent": "tutor_agent",

--- a/maritime-ai-service/tests/unit/test_sprint144_progressive_streaming.py
+++ b/maritime-ai-service/tests/unit/test_sprint144_progressive_streaming.py
@@ -42,13 +42,8 @@ if not _had_cs:
 
 if not _had_graph:
     _mock_graph = types.ModuleType(_graph_key)
-    _mock_graph.get_multi_agent_graph_async = AsyncMock()
     _mock_graph._build_domain_config = MagicMock(return_value={})
     _mock_graph._build_turn_local_state_defaults = MagicMock(return_value={})
-    _mock_graph.open_multi_agent_graph = AsyncMock()
-    _mock_graph._inject_host_context = MagicMock(return_value=None)
-    _mock_graph._TRACERS = {}
-    _mock_graph._cleanup_tracer = MagicMock()
     sys.modules[_graph_key] = _mock_graph
 
 from app.engine.agentic_rag.corrective_rag import CorrectiveRAGResult

--- a/maritime-ai-service/tests/unit/test_sprint148_thinking_chain.py
+++ b/maritime-ai-service/tests/unit/test_sprint148_thinking_chain.py
@@ -44,13 +44,8 @@ if not _had_cs:
 
 if not _had_graph:
     _mock_graph = types.ModuleType(_graph_key)
-    _mock_graph.get_multi_agent_graph_async = AsyncMock()
     _mock_graph._build_domain_config = MagicMock(return_value={})
     _mock_graph._build_turn_local_state_defaults = MagicMock(return_value={})
-    _mock_graph.open_multi_agent_graph = AsyncMock()
-    _mock_graph._inject_host_context = MagicMock(return_value=None)
-    _mock_graph._TRACERS = {}
-    _mock_graph._cleanup_tracer = MagicMock()
     sys.modules[_graph_key] = _mock_graph
 
 # Restore sys.modules to avoid polluting later test files

--- a/maritime-ai-service/tests/unit/test_sprint153_browser_screenshots.py
+++ b/maritime-ai-service/tests/unit/test_sprint153_browser_screenshots.py
@@ -30,7 +30,7 @@ for _key in (_graph_key, _cs_key):
         if _key == _graph_key:
             _mod._build_domain_config = MagicMock(return_value={})
             _mod._build_turn_local_state_defaults = MagicMock(return_value={})
-        else:
+        elif _key == _cs_key:
             _mod.ChatService = type("ChatService", (), {})
             _mod.get_chat_service = lambda: None
         sys.modules[_key] = _mod

--- a/maritime-ai-service/tests/unit/test_sprint153_browser_screenshots.py
+++ b/maritime-ai-service/tests/unit/test_sprint153_browser_screenshots.py
@@ -26,11 +26,11 @@ _stubs = {}
 for _key in (_graph_key, _cs_key):
     if _key not in sys.modules:
         _mod = types.ModuleType(_key)
-        # graph module needs these attributes for graph_streaming's import
+        # graph_streaming imports these helper functions from the graph module.
         if _key == _graph_key:
-            _mod.get_multi_agent_graph_async = None
-            _mod._build_domain_config = None
-        elif _key == _cs_key:
+            _mod._build_domain_config = MagicMock(return_value={})
+            _mod._build_turn_local_state_defaults = MagicMock(return_value={})
+        else:
             _mod.ChatService = type("ChatService", (), {})
             _mod.get_chat_service = lambda: None
         sys.modules[_key] = _mod

--- a/maritime-ai-service/tests/unit/test_sprint54_graph_streaming.py
+++ b/maritime-ai-service/tests/unit/test_sprint54_graph_streaming.py
@@ -52,17 +52,11 @@ if not _had_cs:
     _mock_chat_svc.get_chat_service = lambda: None
     sys.modules[_cs_key] = _mock_chat_svc
 
-# Break graph_streaming ↔ graph mutual import: pre-populate graph module
-# Note: get_multi_agent_graph_async is async, so use AsyncMock
+# Break graph_streaming -> graph import by providing the current runner helpers.
 if not _had_graph:
     _mock_graph = types.ModuleType(_graph_key)
-    _mock_graph.get_multi_agent_graph_async = AsyncMock()
     _mock_graph._build_domain_config = MagicMock(return_value={})
     _mock_graph._build_turn_local_state_defaults = MagicMock(return_value={})
-    _mock_graph.open_multi_agent_graph = AsyncMock()
-    _mock_graph._inject_host_context = MagicMock(return_value=None)
-    _mock_graph._TRACERS = {}
-    _mock_graph._cleanup_tracer = MagicMock()
     sys.modules[_graph_key] = _mock_graph
 
 from app.engine.multi_agent.graph_streaming import (

--- a/maritime-ai-service/tests/unit/test_sprint74_streaming_quality.py
+++ b/maritime-ai-service/tests/unit/test_sprint74_streaming_quality.py
@@ -50,17 +50,11 @@ if not _had_cs:
     _mock_chat_svc.get_chat_service = lambda: None
     sys.modules[_cs_key] = _mock_chat_svc
 
-# Break graph_streaming ↔ graph mutual import
-# Note: get_multi_agent_graph_async is async, so use AsyncMock
+# Break graph_streaming -> graph import by providing the current runner helpers.
 if not _had_graph:
     _mock_graph = types.ModuleType(_graph_key)
-    _mock_graph.get_multi_agent_graph_async = AsyncMock()
     _mock_graph._build_domain_config = MagicMock(return_value={})
     _mock_graph._build_turn_local_state_defaults = MagicMock(return_value={})
-    _mock_graph.open_multi_agent_graph = AsyncMock()
-    _mock_graph._inject_host_context = MagicMock(return_value=None)
-    _mock_graph._TRACERS = {}
-    _mock_graph._cleanup_tracer = MagicMock()
     sys.modules[_graph_key] = _mock_graph
 
 from app.engine.multi_agent.graph_streaming import (

--- a/maritime-ai-service/tests/unit/test_sprint75_latency.py
+++ b/maritime-ai-service/tests/unit/test_sprint75_latency.py
@@ -3,9 +3,9 @@ Tests for Sprint 75: Pipeline Latency Elimination — Tier 1.
 
 Tests:
 1. Guardian singleton — _get_guardian() returns same instance, guardian_node uses singleton
-2. Tutor skips grader — graph edges route tutor_agent → synthesizer directly
+2. Tutor skips grader — WiiiRunner lanes route tutor_agent → synthesizer directly
 3. Bulk answer push — _push_answer_bulk() sends large chunks with no delay
-4. Graph structure — verify build_multi_agent_graph() edge configuration
+4. Runner structure — verify WiiiRunner node registration
 """
 
 import sys
@@ -145,57 +145,63 @@ class TestGuardianSingleton:
 # ============================================================================
 
 
-@pytest.mark.skip(reason="De-LangGraphing Phase 3: build_multi_agent_graph deprecated, use WiiiRunner")
 class TestGraderRemovedFromPipeline:
-    """Sprint 233: Grader removed from pipeline. All agents route to synthesizer."""
+    """Sprint 233: Grader removed from WiiiRunner. Agents route to synthesizer."""
 
     @staticmethod
-    def _get_graph_edges():
-        """Build graph and extract edges as (source, target) tuples."""
-        with patch("app.engine.multi_agent.graph.get_agent_registry") as mock_reg:
-            mock_reg.return_value = MagicMock()
-            mock_reg.return_value.tracer = MagicMock()
-            graph = _graph_mod.build_multi_agent_graph(checkpointer=None)
+    async def _run_lane(agent_name: str):
+        """Run a minimal WiiiRunner lane and capture step execution order."""
+        from app.engine.multi_agent.runner import WiiiRunner
 
-        graph_data = graph.get_graph()
+        calls = []
+        runner = WiiiRunner()
 
-        # LangGraph DrawableGraph: nodes may be str or objects with .id
-        nodes = set()
-        for n in graph_data.nodes:
-            nodes.add(n.id if hasattr(n, "id") else str(n))
+        async def _node(name, state):
+            calls.append(name)
+            next_state = dict(state)
+            if name == agent_name:
+                next_state["final_response"] = (
+                    "This is a sufficiently complete response from the selected lane."
+                )
+            return next_state
 
-        edges = []
-        for e in graph_data.edges:
-            src = e.source if hasattr(e, "source") else e[0]
-            tgt = e.target if hasattr(e, "target") else e[1]
-            edges.append((src, tgt))
+        for name in ("guardian", "supervisor", agent_name, "synthesizer"):
+            runner.register_node(name, lambda state, _name=name: _node(_name, state))
 
-        return nodes, edges
+        with patch("app.engine.multi_agent.graph.guardian_route", return_value="supervisor"), \
+             patch("app.engine.multi_agent.graph_support.route_decision", return_value=agent_name), \
+             patch("app.engine.multi_agent.runner.run_input_guardrails", new=AsyncMock(return_value=(True, None))), \
+             patch("app.engine.multi_agent.runner.run_output_guardrails", new=AsyncMock()):
+            await runner.run({"query": "test", "guardian_passed": True})
+
+        return calls
 
     def test_grader_node_not_in_graph(self):
-        """Sprint 233: grader node should no longer exist in compiled graph."""
-        nodes, _edges = self._get_graph_edges()
-        assert "grader" not in nodes, "grader node should be removed (Sprint 233)"
+        """Sprint 233: grader node should no longer exist in WiiiRunner."""
+        from app.engine.multi_agent.runner import get_wiii_runner
 
-    def test_rag_routes_directly_to_synthesizer(self):
-        """Sprint 233: RAG agent routes directly to synthesizer, no grader."""
-        nodes, edges = self._get_graph_edges()
+        runner = get_wiii_runner()
+        assert "grader" not in runner._nodes
+        assert "grader" not in runner._feature_nodes
 
-        assert "rag_agent" in nodes
-        assert "synthesizer" in nodes
-        assert ("rag_agent", "synthesizer") in edges, (
-            f"Expected rag_agent→synthesizer edge, got edges: {edges}"
-        )
+    @pytest.mark.asyncio
+    async def test_rag_routes_directly_to_synthesizer(self):
+        """Sprint 233: RAG agent routes to synthesizer, no grader."""
+        calls = await self._run_lane("rag_agent")
 
-    def test_tutor_routes_to_synthesizer(self):
+        assert calls == ["guardian", "supervisor", "rag_agent", "synthesizer"]
+
+    @pytest.mark.asyncio
+    async def test_tutor_routes_to_synthesizer(self):
         """Tutor agent routes directly to synthesizer."""
-        _nodes, edges = self._get_graph_edges()
-        assert ("tutor_agent", "synthesizer") in edges
+        calls = await self._run_lane("tutor_agent")
+        assert calls == ["guardian", "supervisor", "tutor_agent", "synthesizer"]
 
-    def test_memory_routes_to_synthesizer(self):
+    @pytest.mark.asyncio
+    async def test_memory_routes_to_synthesizer(self):
         """Memory agent routes directly to synthesizer."""
-        _nodes, edges = self._get_graph_edges()
-        assert ("memory_agent", "synthesizer") in edges
+        calls = await self._run_lane("memory_agent")
+        assert calls == ["guardian", "supervisor", "memory_agent", "synthesizer"]
 
 
 # ============================================================================

--- a/maritime-ai-service/tests/unit/test_thinking_lifecycle.py
+++ b/maritime-ai-service/tests/unit/test_thinking_lifecycle.py
@@ -43,18 +43,11 @@ if not _had_cs:
     _mock_chat_svc.get_chat_service = lambda: None
     sys.modules[_cs_key] = _mock_chat_svc
 
-# Break graph_streaming ↔ graph mutual import
-# Note: get_multi_agent_graph_async is async, so use AsyncMock
-from unittest.mock import AsyncMock as _AsyncMock
+# Break graph_streaming -> graph import by providing the current runner helpers.
 if not _had_graph:
     _mock_graph = types.ModuleType(_graph_key)
-    _mock_graph.get_multi_agent_graph_async = _AsyncMock()
     _mock_graph._build_domain_config = MagicMock(return_value={})
     _mock_graph._build_turn_local_state_defaults = MagicMock(return_value={})
-    _mock_graph.open_multi_agent_graph = _AsyncMock()
-    _mock_graph._inject_host_context = MagicMock(return_value=None)
-    _mock_graph._TRACERS = {}
-    _mock_graph._cleanup_tracer = MagicMock()
     sys.modules[_graph_key] = _mock_graph
 
 from app.engine.multi_agent.stream_utils import (
@@ -187,28 +180,6 @@ class TestNodeLabels:
 # Tests: graph_streaming emits lifecycle events
 # =============================================================================
 
-def _make_mock_graph(node_updates):
-    """Create a mock graph that yields the given node state updates."""
-    async def _astream(*args, **kwargs):
-        for update in node_updates:
-            yield update
-    mock_graph = MagicMock()
-    mock_graph.astream = _astream
-    return mock_graph
-
-
-class _MockGraphCM:
-    """Async context manager that returns a mock graph."""
-    def __init__(self, graph):
-        self._graph = graph
-
-    async def __aenter__(self):
-        return self._graph
-
-    async def __aexit__(self, *args):
-        pass
-
-
 def _make_narrator_result(node: str):
     """Create a mock ReasoningRenderResult with predictable labels per node."""
     labels = {
@@ -232,8 +203,7 @@ def _make_narrator_result(node: str):
 
 
 async def _collect_events(node_updates):
-    """Helper to collect all stream events from a graph run."""
-    mock_graph = _make_mock_graph(node_updates)
+    """Helper to collect stream events from a runner-backed streaming run."""
     mock_registry = MagicMock()
     mock_registry.start_request_trace.return_value = "trace-1"
     mock_registry.end_request_trace.return_value = {"span_count": 0}


### PR DESCRIPTION
## Summary

Closes #101.

This PR completes the Phase 3 test-cleanup slice of the de-LangGraph work by removing deprecated `get_multi_agent_graph*` / `open_multi_agent_graph` test stubs from legacy streaming tests and retargeting Sprint 75 grader-removal coverage to `WiiiRunner`.

## In Scope

- Remove deprecated graph API stubs from streaming/thinking unit-test import guards.
- Port `test_sprint75_latency.py` grader-removal checks from skipped graph-edge assertions to active `WiiiRunner` lane-order assertions.
- Keep retired API names only in `test_graph_thread_id.py`, where they are intentionally asserted absent from the public surface.
- Update one aggregator test comment so it no longer describes LangGraph as the expected runtime dependency.

## Out of Scope

- Runtime behavior changes.
- Provider, memory, RAG, or frontend changes.
- Broader documentation cleanup; stale architecture docs remain a follow-up after the RFC lands.

## Verification

- `python -m pytest tests/unit/test_sprint144_progressive_streaming.py tests/unit/test_sprint148_thinking_chain.py tests/unit/test_sprint153_browser_screenshots.py tests/unit/test_sprint54_graph_streaming.py tests/unit/test_sprint74_streaming_quality.py tests/unit/test_thinking_lifecycle.py tests/unit/test_sprint75_latency.py tests/unit/test_phase4_aggregator.py tests/unit/test_graph_thread_id.py -q -p no:capture --tb=short`
  - Result: `262 passed, 10 skipped`
- `git diff --check`
  - Result: passed
- `git grep -n -E "get_multi_agent_graph|open_multi_agent_graph|build_multi_agent_graph" -- maritime-ai-service/tests/unit ':!*.lock'`
  - Result: remaining hits only in `test_graph_thread_id.py` negative public-surface assertions.

## Risk / Rollback

Risk is low because this PR changes tests only. Rollback is to revert this single commit if any CI-only import behavior depends on the older graph-shaped stubs.

## Agent Coordination

- PR owner: Codex / `meiiie`
- Agents involved: Codex only in this branch
- Owned paths: `maritime-ai-service/tests/unit/*`
- Conflict check: branch created from latest `origin/main`; no production files changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test infrastructure by removing unnecessary stubs from mock modules across unit tests.
  * Streamlined circular-import workarounds to reduce dependencies in test mocking layers.
  * Refactored test helpers to eliminate redundant utilities and improve test maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->