### PR TITLE
docs: align architecture with WiiiRunner runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ To work as a different agent:
 
 ## Project Overview
 
-**Wiii** by **The Wiii Lab** — a multi-domain agentic RAG platform with plugin architecture, long-term memory, product search across 5 platforms, browser scraping (Playwright+Crawl4AI+Scrapling), Google OAuth + LMS integration (production-connected), multi-tenant data isolation, org-level customization, two-tier admin (system + org), Living Agent autonomy system (Soul AGI — all coding phases complete), spaced repetition skill learning, cross-platform memory sync, unified skill architecture, MCP tool exposure, Universal Context Engine (7-phase: host-agnostic context, bidirectional actions, YAML skills, browser agent), and cross-platform conversation sync. Built with FastAPI, LangGraph, Google Gemini, PostgreSQL (pgvector), and Neo4j. 385+ Python files, 70+ API endpoints, 110 feature flags, 10250+ backend tests, 1905 desktop tests. Connection pool: min=10, max=50 (Sprint 173).
+**Wiii** by **The Wiii Lab** — a multi-domain agentic RAG platform with plugin architecture, long-term memory, product search across 5 platforms, browser scraping (Playwright+Crawl4AI+Scrapling), Google OAuth + LMS integration (production-connected), multi-tenant data isolation, org-level customization, two-tier admin (system + org), Living Agent autonomy system (Soul AGI — all coding phases complete), spaced repetition skill learning, cross-platform memory sync, unified skill architecture, MCP tool exposure, Universal Context Engine (7-phase: host-agnostic context, bidirectional actions, YAML skills, browser agent), and cross-platform conversation sync. Built with FastAPI, WiiiRunner custom orchestration, Google Gemini, PostgreSQL (pgvector), and Neo4j. 385+ Python files, 70+ API endpoints, 110 feature flags, 10250+ backend tests, 1905 desktop tests. Connection pool: min=10, max=50 (Sprint 173).
 
 ### Domain Plugin System (Feb 2026)
 - **Plugin architecture**: `app/domains/*/domain.yaml` — add new domains by creating a folder + YAML config
@@ -77,7 +77,7 @@ To work as a different agent:
 ### Unified Provider Layer (Sprint 55, simplified Sprint 226)
 - **UnifiedLLMClient**: `enable_unified_client=True` (default) — `AsyncOpenAI` SDK for non-graph code paths
 - **Unified Providers**: `enable_unified_providers=False` — when enabled, all LLM providers use `ChatOpenAI` via OpenAI-compatible endpoints (eliminates `langchain-google-genai` + `langchain-ollama` dependencies)
-- **Two-path architecture**: Graph nodes → `LLMPool` → `BaseChatModel` (LangGraph compat); New code → `UnifiedLLMClient` → `AsyncOpenAI` (raw SDK)
+- **Two-path architecture**: Runner nodes → `LLMPool` → `BaseChatModel` for existing node code; new code → `UnifiedLLMClient` → `AsyncOpenAI` (raw SDK)
 - **Provider configs**: Google Gemini, OpenAI, Ollama — all via OpenAI-compatible endpoints
 - **Singleton**: `UnifiedLLMClient` with `get_client(provider)` → `AsyncOpenAI`
 - **Tier mapping**: `get_model(provider, tier)` → deep/moderate/light model names
@@ -166,7 +166,7 @@ External MCP Servers (filesystem, web, custom)
          ↓ stdio/http transport
     MCPToolManager (langchain-mcp-adapters)  ←── MCP Client: consumes tools
          ↓
-    AgenticLoop / LangGraph Nodes
+    AgenticLoop / WiiiRunner nodes
 ```
 
 ### Domain Plugin System
@@ -182,18 +182,18 @@ app/domains/
 └── _template/       # Skeleton for creating new domains
 ```
 
-### Multi-Agent System (LangGraph)
+### Multi-Agent System (WiiiRunner)
 - **Guardian Agent**: Content safety and relevance filtering (entry point, fail-open)
 - **Supervisor**: LLM-first routing via `RoutingDecision` structured output (Sprint 103). Keyword guardrails (social→DIRECT, personal→MEMORY) as fallback only. Intents: lookup, learning, personal, social, off_topic, web_search
 - **RAG Agent**: Knowledge retrieval with Corrective RAG (hybrid search)
 - **Tutor Agent**: Teaching/explanation with pedagogical approach
 - **Memory Agent**: Cross-session user context and facts
 - **Direct Response**: General queries + web/news/legal search tools (8 tools bound)
-- **Grader Agent**: Quality control (score-based re-routing)
+- **Quality Signals**: Runner-level self-correction can consume `grader_score` when present, but the old grader node is not a default runtime step
 - **Synthesizer**: Final response formatting, Vietnamese output
 
 ### Virtual Agent-per-User (Sprints 16-20)
-- **Thread System**: Composite IDs (`user_{uid}__session_{sid}` or `org_{org}__user_{uid}__session_{sid}`), per-user LangGraph checkpoints
+- **Thread System**: Composite IDs (`user_{uid}__session_{sid}` or `org_{org}__user_{uid}__session_{sid}`), per-user thread views and chat history
 - **Session Manager**: lifecycle, anti-repetition, pronoun tracking, auto-summarize
 - **Cross-Platform Conversation Sync** (Sprint 225): `thread_views` populated after every chat via `upsert_thread()`. Frontend `syncFromServer()` merges server thread list with local conversations on login. `GET /threads/{id}/messages` for lazy loading. Metadata event includes `thread_id` for local→server mapping
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository is optimized for ongoing product engineering, not as a minimal s
 - `docs/`: repository-level documentation, plans, diagrams, screenshots, and doc indexes
 - `Documents/`: supporting reference material and vendor research
 - `tools/`: utilities, fixtures, and one-off helpers
-- `.claude/`: agent workflows, reports, and internal project knowledge
+- `.claude/`: legacy Claude-era agent workflows and project knowledge kept for reference; GitHub issues/PRs and `docs/operations/` are the current coordination surface
 
 ## Architecture At A Glance
 
@@ -20,14 +20,14 @@ Primary runtime flow:
 1. Client request enters the backend through REST, SSE, WebSocket, or LMS/embed integration.
 2. Middleware applies request correlation, organization context, auth, and rate limiting.
 3. `ChatOrchestrator` resolves session state, domain context, and request normalization.
-4. The LangGraph-based multi-agent pipeline routes work to RAG, tutor, memory, direct-response, or search/tooling paths.
+4. The WiiiRunner multi-agent pipeline routes work to RAG, tutor, memory, direct-response, Code Studio, product search, or other feature-gated tool paths.
 5. Retrieval, tools, LMS data, semantic memory, and optional browser or MCP integrations contribute context.
 6. The response is synthesized back to JSON or SSE V3 events for the desktop app and embed clients.
 
 Core subsystems:
 
 - FastAPI API layer with organization-aware middleware and auth
-- LangGraph multi-agent orchestration with RAG, tutor, memory, and direct-response paths
+- WiiiRunner multi-agent orchestration with RAG, tutor, memory, direct-response, and feature-gated tool paths
 - Retrieval stack built on PostgreSQL, pgvector, sparse search, and optional Neo4j graph context
 - LMS bridge with HMAC token exchange, webhook ingestion, and dashboard/data pull tools
 - Tauri desktop client with Zustand state, SSE V3 streaming, full-page admin surfaces, and embed mode

--- a/docs/WIII_PROJECT_MENTAL_MODEL.md
+++ b/docs/WIII_PROJECT_MENTAL_MODEL.md
@@ -30,7 +30,7 @@ In practical terms, Wiii Core is made of:
 
 - FastAPI entrypoints and middleware
 - ChatOrchestrator
-- LangGraph multi-agent routing
+- WiiiRunner multi-agent routing
 - RAG, tutor, memory, direct-response, and tool paths
 - streaming response assembly for desktop and embed clients
 

--- a/maritime-ai-service/README.md
+++ b/maritime-ai-service/README.md
@@ -9,7 +9,7 @@ Use this README as the backend entry point. For full architecture detail, defer 
 - FastAPI API surface for chat, streaming, threads, auth, organizations, admin, LMS, and health endpoints
 - request middleware for request IDs, organization context, auth, and rate limiting
 - `ChatOrchestrator` pipeline, session handling, domain routing, and output shaping
-- LangGraph multi-agent execution across RAG, tutor, memory, direct-response, and tool-assisted flows
+- WiiiRunner multi-agent execution across RAG, tutor, memory, direct-response, Code Studio, product search, and tool-assisted flows
 - retrieval and memory subsystems backed by PostgreSQL, pgvector, sparse search, and optional Neo4j context
 - LMS token exchange, webhook ingestion, dashboard/data pull endpoints, and tool exposure
 - production packaging, runtime config validation, and Docker Compose deployment assets
@@ -28,7 +28,7 @@ The main request path is:
 1. HTTP or SSE request enters the API router.
 2. Middleware applies request correlation, organization context, rate limiting, and auth.
 3. `ChatOrchestrator` resolves session state and domain/plugin context.
-4. The multi-agent graph routes work into retrieval, tutoring, memory, direct response, or external tools.
+4. `WiiiRunner` routes work into retrieval, tutoring, memory, direct response, Code Studio, product search, or external tools.
 5. The output layer formats the final response as JSON or SSE V3 events.
 6. Background tasks update facts, insights, or other post-response state.
 

--- a/maritime-ai-service/app/engine/multi_agent/agent_config.py
+++ b/maritime-ai-service/app/engine/multi_agent/agent_config.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class AgentNodeConfig:
-    """Configuration for a single LangGraph node."""
+    """Configuration for a single WiiiRunner node."""
 
     node_id: str
     provider: str = ""

--- a/maritime-ai-service/app/engine/multi_agent/agent_nodes.py
+++ b/maritime-ai-service/app/engine/multi_agent/agent_nodes.py
@@ -1,4 +1,4 @@
-"""Agent node wrappers for LangGraph multi-agent graph.
+"""Agent node wrappers for the WiiiRunner multi-agent runtime.
 
 Extracted from graph.py — thin delegation wrappers that call
 external agent implementations (rag_node, tutor_node, etc.).

--- a/maritime-ai-service/app/engine/multi_agent/agents/product_search_node.py
+++ b/maritime-ai-service/app/engine/multi_agent/agents/product_search_node.py
@@ -1,7 +1,7 @@
 """
 Product Search Agent Node — Sprint 148→150→200: "Săn Hàng" → "Tìm Sâu" → "Mắt Sản Phẩm"
 
-Specialized LangGraph node for multi-platform e-commerce product search.
+Specialized WiiiRunner node for multi-platform e-commerce product search.
 Uses ReAct loop (LLM→tools→observe→decide) pattern from tutor_node.py.
 
 Sprint 150 enhancements:
@@ -147,7 +147,7 @@ class ProductSearchAgentNode:
         init_llm_impl(self)
 
     async def process(self, state: AgentState) -> AgentState:
-        """Main entry point from LangGraph."""
+        """Main entry point from WiiiRunner."""
         query = state.get("query", "")
         context = state.get("context", {})
 

--- a/maritime-ai-service/app/engine/multi_agent/agents/tutor_node.py
+++ b/maritime-ai-service/app/engine/multi_agent/agents/tutor_node.py
@@ -691,7 +691,7 @@ class TutorAgentNode:
                     state.pop("thinking_provenance", None)
             
             # CHỈ THỊ SỐ 31 v3 SOTA: Propagate CRAG trace for synthesizer merge
-            # This follows LangGraph shared state pattern
+            # This follows the shared AgentState pattern used by WiiiRunner
             crag_trace = get_last_reasoning_trace()
             if crag_trace:
                 state["reasoning_trace"] = crag_trace

--- a/maritime-ai-service/app/engine/multi_agent/stream_utils.py
+++ b/maritime-ai-service/app/engine/multi_agent/stream_utils.py
@@ -1,11 +1,11 @@
 """
-Stream Utilities for Multi-Agent Graph Streaming
+Stream utilities for WiiiRunner multi-agent streaming
 
-SOTA Dec 2025: LangGraph 1.0 astream_events() pattern
+SOTA Dec 2025: evented agent streaming pattern
 Pattern: OpenAI Responses API + Claude Extended Thinking + Gemini astream
 
-This module provides utilities to stream events from LangGraph execution,
-transforming internal graph events into user-friendly SSE events.
+This module provides utilities to stream events from WiiiRunner execution,
+transforming internal runtime events into user-friendly SSE events.
 
 **Feature: v3-full-graph-streaming**
 """

--- a/maritime-ai-service/app/engine/multi_agent/subagents/aggregator.py
+++ b/maritime-ai-service/app/engine/multi_agent/subagents/aggregator.py
@@ -7,10 +7,10 @@ Pattern inspired by Claude Code hub-and-spoke:
 - Results come back as structured SubagentReport
 - Aggregator reads all reports, picks best strategy
 
-Usage in LangGraph::
+Usage in WiiiRunner::
 
-    workflow.add_node("aggregator", aggregator_node)
-    workflow.add_conditional_edges("aggregator", aggregator_route, {...})
+    runner.register_feature_node("aggregator", aggregator_node, gate_fn)
+    aggregator_route(state) decides synthesizer vs supervisor follow-up.
 """
 
 from __future__ import annotations
@@ -188,7 +188,7 @@ def _fallback_decision(reports: List[SubagentReport]) -> AggregatorDecision:
 
 
 async def aggregator_node(state: Dict[str, Any]) -> Dict[str, Any]:
-    """LangGraph node: reads subagent_reports, produces aggregator decision.
+    """WiiiRunner node: reads subagent_reports, produces aggregator decision.
 
     Writes:
     - state["_aggregator_action"]

--- a/maritime-ai-service/app/engine/multi_agent/supervisor.py
+++ b/maritime-ai-service/app/engine/multi_agent/supervisor.py
@@ -3,7 +3,7 @@ Supervisor Agent - Phase 8.2 + Sprint 71 + Sprint 103
 
 Coordinator agent that routes queries to specialized agents.
 
-Pattern: LangGraph Supervisor with tool-based handoffs
+Pattern: WiiiRunner supervisor with tool-based handoffs
 
 Sprint 103: LLM-First Routing (SOTA 2026)
 - Structured output (_route_structured) is now the PRIMARY and ONLY LLM path

--- a/maritime-ai-service/app/engine/workflows/__init__.py
+++ b/maritime-ai-service/app/engine/workflows/__init__.py
@@ -1,1 +1,1 @@
-"""LangGraph workflows for multi-step AI operations."""
+"""Framework-free workflows for multi-step AI operations."""

--- a/maritime-ai-service/app/engine/workflows/course_generation.py
+++ b/maritime-ai-service/app/engine/workflows/course_generation.py
@@ -1,5 +1,5 @@
 """
-Course Generation Workflow — 3-Node LangGraph Pipeline
+Course Generation Workflow — 3-stage framework-free pipeline
 
 CONVERT (Docling) → OUTLINE (DEEP tier) → EXPAND (LIGHT tier, parallel)
 

--- a/maritime-ai-service/app/services/chat_orchestrator.py
+++ b/maritime-ai-service/app/services/chat_orchestrator.py
@@ -601,7 +601,7 @@ class ChatOrchestrator:
         model: str | None = None,
     ) -> ProcessingResult:
         """
-        Process with Multi-Agent System (LangGraph).
+        Process with the WiiiRunner multi-agent runtime.
         
         Phase 8: SOTA 2025 - Supervisor Agent
         """

--- a/maritime-ai-service/app/services/chat_service.py
+++ b/maritime-ai-service/app/services/chat_service.py
@@ -12,7 +12,7 @@ REFACTORED: This file is now a thin facade that delegates to:
 **Spec:** CHỈ THỊ KỸ THUẬT SỐ 25 - Project Restructure
 
 This service wires together:
-- Multi-Agent System (Phase 8, SOTA 2025) - LangGraph Supervisor
+- Multi-Agent System (Phase 8, SOTA 2025) - WiiiRunner Supervisor
 - Semantic Memory Engine v0.5 (pgvector + Gemini embeddings)
 - Knowledge Graph (Neo4j GraphRAG)
 - Guardrails / Guardian Agent

--- a/maritime-ai-service/docs/architecture/FOLDER_MAP.md
+++ b/maritime-ai-service/docs/architecture/FOLDER_MAP.md
@@ -239,7 +239,7 @@ graph LR
 | **`app/engine/search_platforms/`** | Product Search Platform Adapters | `base.py` (ABC), `registry.py` (singleton), `circuit_breaker.py`, `adapters/` (8 adapters), `oauth/` | SearchPlatformAdapter, SearchPlatformRegistry |
 | **`app/engine/search_platforms/adapters/`** | Individual platform adapters (8 adapters) | `serper_shopping.py`, `serper_site.py`, `websosanh.py`, `apify.py`, `facebook_search.py`, `facebook_group.py`, `tiktok_research.py`, `allweb.py` | Adapter implementations |
 | **`app/engine/search_platforms/adapters/browser_base.py`** | Playwright browser scraping base | `BrowserBaseAdapter` | Browser automation for search |
-| **`app/engine/multi_agent/agents/product_search_node.py`** | Product Search agent node | `product_search_agent()` | LangGraph agent node for product search |
+| **`app/engine/multi_agent/agents/product_search_node.py`** | Product Search agent node | `product_search_agent()` | Feature-gated WiiiRunner node for product search |
 | **`app/integrations/`** | LMS Integration Layer | `lms_client.py`, `lms_enrichment.py` | LMS API client, context enrichment |
 | **`app/repositories/`** | Database access layer (15 repos) | `semantic_memory_repo.py`, `neo4j_repo.py`, `organization_repository.py`, `thread_repository.py`, `scheduler_repository.py` | CRUD operations |
 | **`app/models/`** | Pydantic schemas, DTOs | `schemas.py`, `semantic_memory.py`, `organization.py` | Data models |
@@ -277,7 +277,7 @@ graph LR
 | Subfolder | Chức năng | Key Components |
 |-----------|-----------|----------------|
 | **`agentic_rag/`** | Corrective RAG system (Composition Pattern) | `rag_agent.py`, `corrective_rag.py` (auto-composes RAGAgent), grader, verifier |
-| **`multi_agent/`** | LangGraph orchestration | `supervisor.py`, `graph.py`, `tutor_node.py`, `product_search_node.py` |
+| **`multi_agent/`** | WiiiRunner orchestration | `runner.py`, `graph.py`, `supervisor.py`, `agents/`, `graph_streaming.py` |
 | **`tools/`** | LangChain tools (RAG, Memory, Tutor, Product Search) | `rag_tools.py`, `memory_tools.py`, `tutor_tools.py`, `product_search_tools.py` |
 | **`semantic_memory/`** | Vector-based user memory + cross-platform sync | `core.py`, `extraction.py`, `context.py`, `cross_platform.py` |
 | **`search_platforms/`** | Product search plugin architecture (8 platform adapters) | `base.py` (ABC), `registry.py`, `circuit_breaker.py`, `adapters/`, `oauth/` |
@@ -673,7 +673,7 @@ Audit: All auth events → auth/auth_audit.py → auth_events table (fire-and-fo
 
 ```python
 # app/core/config.py (key flags — see CLAUDE.md for full list)
-use_multi_agent: bool = True            # LangGraph multi-agent (default)
+use_multi_agent: bool = True            # WiiiRunner multi-agent runtime (default)
 enable_corrective_rag: bool = True      # CRAG loop
 deep_reasoning_enabled: bool = True     # <thinking> tags
 enable_multi_tenant: bool = False       # Multi-org data isolation
@@ -710,7 +710,7 @@ prompts/
 | Decision | ReAct (UnifiedAgent) as default |
 |----------|--------------------------------|
 | **Context** | Need flexible agent orchestration |
-| **Decision** | Use manual ReAct loop over LangGraph |
+| **Decision** | Use manual ReAct loop over heavyweight orchestration frameworks |
 | **Rationale** | Simpler, more control, faster iteration |
 | **Status** | ✅ Active |
 
@@ -858,7 +858,7 @@ agentic_rag/
 | Repositories | 15 |
 | Domain plugins | 2 (maritime, traffic_law) |
 | Search platform adapters | 8 |
-| LangGraph agent nodes | 7 (Guardian, Supervisor, RAG, Tutor, Memory, Direct, ProductSearch) |
+| WiiiRunner nodes | 8 core/feature nodes (Guardian, Supervisor, RAG, Tutor, Memory, Direct, Code Studio, ProductSearch) plus optional subagent dispatch |
 
 ### Desktop App (wiii-desktop/) Stats
 

--- a/maritime-ai-service/docs/architecture/SYSTEM_ARCHITECTURE.md
+++ b/maritime-ai-service/docs/architecture/SYSTEM_ARCHITECTURE.md
@@ -16,7 +16,7 @@
 4. [Core Components Deep Dive](#4-core-components-deep-dive)
    - 4.1 [API & Middleware Layer](#41-api--middleware-layer)
    - 4.2 [Chat Processing Pipeline](#42-chat-processing-pipeline)
-   - 4.3 [Multi-Agent System (LangGraph)](#43-multi-agent-system-langgraph)
+   - 4.3 [Multi-Agent Runtime (WiiiRunner)](#43-multi-agent-runtime-wiiirunner)
    - 4.4 [Corrective RAG Pipeline](#44-corrective-rag-pipeline)
    - 4.5 [Search Architecture](#45-search-architecture)
    - 4.6 [LLM Provider Layer](#46-llm-provider-layer)
@@ -82,15 +82,16 @@ graph TB
         DROUTER["DomainRouter<br/>5-priority"]
     end
 
-    subgraph "Multi-Agent System (LangGraph)"
+    subgraph "Multi-Agent Runtime (WiiiRunner)"
         GUARD["Guardian"]
         SUP["Supervisor"]
         RAG_A["RAG Agent"]
         TUTOR_A["Tutor Agent"]
         MEM_A["Memory Agent"]
         DIRECT_A["Direct Response"]
+        CODE_A["Code Studio Agent"]
         PROD_A["Product Search Agent"]
-        GRADE_A["Grader"]
+        PAR_A["Parallel Dispatch / Aggregator"]
         SYNTH["Synthesizer"]
     end
 
@@ -267,22 +268,24 @@ maritime-ai-service/                    # Backend (Python)
 │   │   │   ├── ollama_provider.py      # Ollama (Qwen3/DeepSeek-R1 thinking)
 │   │   │   └── unified_client.py       # AsyncOpenAI SDK (feature-gated)
 │   │   │
-│   │   ├── multi_agent/                # LangGraph Multi-Agent System
-│   │   │   ├── graph.py                # Graph definition + compile
+│   │   ├── multi_agent/                # WiiiRunner multi-agent runtime
+│   │   │   ├── runner.py               # Custom async orchestration loop
+│   │   │   ├── graph.py                # Compatibility shell + node entrypoints
 │   │   │   ├── graph_streaming.py      # SSE event emission + lifecycle + drain
 │   │   │   ├── state.py                # AgentState TypedDict (org_id, tool_events)
-│   │   │   ├── checkpointer.py         # AsyncPostgresSaver singleton
+│   │   │   ├── supervisor.py           # LLM-first routing (RoutingDecision)
+│   │   │   ├── guardian_runtime.py     # Content safety runtime
+│   │   │   ├── direct_node_runtime.py  # General + web/news/legal search tools
+│   │   │   ├── code_studio_node_runtime.py  # Code Studio runtime path
 │   │   │   ├── agent_loop.py           # Generalized ReAct (Path A/B)
-│   │   │   └── agents/                 # Agent nodes (9 agents)
-│   │   │       ├── supervisor.py       # LLM-first routing (RoutingDecision)
-│   │   │       ├── guardian.py         # Content safety (fail-open)
-│   │   │       ├── tutor_node.py       # Teaching + ReAct tool calling
-│   │   │       ├── rag_node.py         # Knowledge retrieval
-│   │   │       ├── memory_node.py      # User memory retrieval
-│   │   │       ├── grader_node.py      # Quality scoring (1-10)
-│   │   │       ├── synthesizer.py      # Final response formatting
-│   │   │       ├── direct_response.py  # General + web/news/legal search tools
-│   │   │       └── product_search_node.py  # Product search (7 tools, 5 platforms)
+│   │   │   ├── agents/                 # Worker agents
+│   │   │   │   ├── tutor_node.py       # Teaching + ReAct tool calling
+│   │   │   │   ├── rag_node.py         # Knowledge retrieval
+│   │   │   │   ├── memory_agent.py     # User memory retrieval
+│   │   │   │   ├── colleague_node.py   # Feature-gated colleague/soul handoff
+│   │   │   │   ├── grader_agent.py     # Optional quality scoring helper
+│   │   │   │   └── product_search_node.py  # Product search (feature-gated)
+│   │   │   └── subagents/              # Feature-gated parallel dispatch workers
 │   │   │
 │   │   ├── search_platforms/           # Product Search Platform (Sprint 148-151)
 │   │   │   ├── base.py                 # SearchPlatformAdapter ABC
@@ -444,7 +447,7 @@ wiii-desktop/                           # Desktop App (Tauri v2)
 | **Framework** | FastAPI | 0.109.2 | Async REST + WebSocket |
 | **Runtime** | Uvicorn | 0.27.1 | ASGI server |
 | **Validation** | Pydantic | >=2.9.0 | Settings + request models |
-| **Orchestration** | LangGraph | >=1.0.0 | Multi-agent state machine |
+| **Orchestration** | WiiiRunner | custom async runner | Multi-agent execution loop without LangGraph dependency |
 | **LLM (primary)** | Google Gemini | 2.0 Flash | via langchain-google-genai >=3.2.0 |
 | **LLM (failover 1)** | OpenAI | GPT-4o | via openai >=1.40.0 |
 | **LLM (failover 2)** | Ollama | Qwen3:8b | via langchain-community >=0.4.0 |
@@ -623,43 +626,39 @@ flowchart TB
 
 ---
 
-### 4.3 Multi-Agent System (LangGraph)
+### 4.3 Multi-Agent Runtime (WiiiRunner)
 
-9 agents in a directed graph with conditional edges, compiled via `StateGraph`.
+The active runtime is `WiiiRunner`, a framework-free async orchestration loop. It preserves the node-style `AgentState` contract while replacing the old `StateGraph` compile/invoke path.
 
 ```mermaid
 stateDiagram-v2
-    [*] --> guardian_agent
+    [*] --> guardian
 
-    guardian_agent --> supervisor: SAFE (or fail-open on error)
-    guardian_agent --> synthesizer_node: BLOCKED (harmful content)
+    guardian --> supervisor: safe or fail-open
+    guardian --> synthesizer: blocked / final response
 
-    supervisor --> direct_response_node: DIRECT
-    supervisor --> memory_agent: MEMORY
-    supervisor --> tutor_agent: TUTOR
-    supervisor --> rag_agent: RAG
-    supervisor --> product_search_agent: PRODUCT_SEARCH
+    supervisor --> direct: social, simple, web/search intent
+    supervisor --> memory_agent: personal context
+    supervisor --> tutor_agent: teaching / explanation
+    supervisor --> rag_agent: retrieval
+    supervisor --> code_studio_agent: generated app / artifact work
+    supervisor --> product_search_agent: feature gate
+    supervisor --> colleague_agent: feature gate
+    supervisor --> parallel_dispatch: subagent feature gate
 
-    direct_response_node --> synthesizer_node
+    direct --> synthesizer
+    memory_agent --> synthesizer
+    tutor_agent --> synthesizer
+    rag_agent --> synthesizer
+    code_studio_agent --> synthesizer
+    product_search_agent --> synthesizer
+    colleague_agent --> synthesizer
 
-    state rag_check <<choice>>
-    rag_agent --> rag_check
-    rag_check --> synthesizer_node: confidence >= 0.85 [EARLY EXIT]
-    rag_check --> quality_check: confidence < 0.85
+    parallel_dispatch --> aggregator
+    aggregator --> synthesizer: enough context
+    aggregator --> supervisor: retry / follow-up route, max 2
 
-    state tutor_check <<choice>>
-    tutor_agent --> tutor_check
-    tutor_check --> synthesizer_node: confidence >= 0.85 [EARLY EXIT]
-    tutor_check --> quality_check: confidence < 0.85
-
-    memory_agent --> quality_check
-
-    product_search_agent --> synthesizer_node
-
-    quality_check --> synthesizer_node: score >= 6 [PASS]
-    quality_check --> tutor_agent: score < 6 [RETRY, max 1]
-
-    synthesizer_node --> [*]
+    synthesizer --> [*]
 ```
 
 | Agent | Responsibility | Key Features |
@@ -670,13 +669,14 @@ stateDiagram-v2
 | **Tutor Agent** | Teaching, explanation | ReAct tool-calling loop with domain tools |
 | **Memory Agent** | User context retrieval | Cross-session semantic memory |
 | **Direct Response** | General queries + tool dispatch | 8 tools: 3 character + datetime + 4 web search (web, news, legal, maritime). Handles off-topic, web_search intents |
-| **Product Search** | Product comparison & pricing | 7 tools across 5 platforms (Serper, WebSosanh, Facebook, TikTok, Apify). Plugin architecture with circuit breakers. Handles product_search intent |
-| **Grader** | Quality control | Score 1-10, early exit at confidence >= 0.85 |
+| **Code Studio** | Generated apps, widgets, and artifacts | Feature-aware app/runtime generation paths |
+| **Product Search** | Product comparison & pricing | Feature-gated tools across Serper, WebSosanh, Facebook, TikTok, Apify, and scraping adapters |
+| **Parallel Dispatch + Aggregator** | Optional subagent fan-out | Feature-gated parallel worker dispatch with bounded aggregator→supervisor loop |
 | **Synthesizer** | Final formatting | Vietnamese output, thinking extraction, citations |
 
 **AgentState** fields: `messages`, `query`, `context`, `domain_id`, `organization_id`, `thinking`, `agent_outputs`, `tool_call_events`, `confidence`, `sources`, `next_agent`, `retry_count`
 
-**Checkpoint persistence:** `AsyncPostgresSaver` — per-user-session LangGraph state stored in PostgreSQL.
+**Persistence:** active conversation continuity uses `thread_views`, `chat_messages`/history repositories, session summaries, and semantic memory. The old LangGraph checkpointer API is no longer part of the active runtime.
 
 ---
 
@@ -931,7 +931,7 @@ sequenceDiagram
     participant C as Client
     participant API as chat_stream.py
     participant GS as graph_streaming.py
-    participant NODES as LangGraph Nodes
+    participant NODES as WiiiRunner nodes
     participant SU as stream_utils.py
 
     C->>API: POST /chat/stream/v3
@@ -940,7 +940,7 @@ sequenceDiagram
         Note over API: _keepalive_generator() wraps stream (15s heartbeat)
     end
 
-    loop For each LangGraph node
+    loop For each WiiiRunner node
         NODES->>SU: create_status_event(label)
         SU-->>GS: StreamEvent(type="status")
         GS-->>API: SSE event: status
@@ -982,7 +982,7 @@ done           {sources: [...]}
 ```
 
 **Status vs Thinking distinction** (Sprint 63):
-- `status` events = pipeline progress (routing decisions, grader scores)
+- `status` events = pipeline progress (routing decisions, node lifecycle, runtime checks)
 - `thinking` events = raw AI reasoning content
 
 **Streaming Timeouts:**
@@ -1100,7 +1100,7 @@ flowchart TB
 
     CV --> DR["DomainRouter<br/>Filter domains by org.allowed_domains"]
     CV --> TID["Thread ID:<br/>org_{org}__user_{uid}__session_{sid}"]
-    TID --> CHECK["LangGraph checkpoints<br/>(per org-user-session)"]
+    TID --> CHECK["thread_views + chat history<br/>(per org-user-session)"]
 
     subgraph Admin["Organization Admin API"]
         CRUD["CRUD organizations"]
@@ -1364,7 +1364,7 @@ flowchart TB
 - **Cache isolation**: Cache key = `"{org_id}:{user_id}"` when org present
 - **Backfill**: Existing rows → `'default'`; knowledge_embeddings → NULL (shared)
 - **B-tree indexes** on `organization_id` for all filtered tables + composite `(user_id, organization_id)` indexes (Migration 017)
-- **Thread isolation**: `build_thread_id()` embeds org_id → cross-org LangGraph checkpoint isolation
+- **Thread isolation**: `build_thread_id()` embeds org_id → cross-org thread/history isolation
 - **86 tests** across `test_sprint160_data_isolation.py` (56) + `test_sprint170c_tenant_hardening.py` (30)
 
 ---
@@ -2027,12 +2027,6 @@ erDiagram
         timestamp updated_at
     }
 
-    langgraph_checkpoints {
-        text thread_id PK
-        bytea checkpoint
-        jsonb metadata
-    }
-
     users ||--o{ federated_identities : has
     users ||--o{ refresh_tokens : has
     users ||--o{ user_organizations : joins
@@ -2046,7 +2040,7 @@ erDiagram
 
 | Database | Tables | Purpose |
 |----------|--------|---------|
-| **PostgreSQL 17** | `knowledge_embeddings`, `semantic_memories`, `conversation_history`, `threads`, `scheduled_tasks`, `organizations`, `user_organizations`, `user_preferences`, `wiii_character_blocks`, `langgraph_checkpoints`, `users`, `federated_identities`, `refresh_tokens`, `org_audit_log`, `learning_profile`, `chat_messages`, `chat_sessions`, `wiii_skills`, `wiii_journal`, `wiii_browsing_log`, `wiii_emotional_snapshots` | Primary OLTP + vector search (HNSW) + FTS |
+| **PostgreSQL 17** | `knowledge_embeddings`, `semantic_memories`, `conversation_history`, `thread_views`, `scheduled_tasks`, `organizations`, `user_organizations`, `user_preferences`, `wiii_character_blocks`, `users`, `federated_identities`, `refresh_tokens`, `org_audit_log`, `learning_profile`, `chat_messages`, `chat_sessions`, `wiii_skills`, `wiii_journal`, `wiii_browsing_log`, `wiii_emotional_snapshots` | Primary OLTP + vector search (HNSW) + FTS |
 | **Neo4j 5** | Nodes: `Regulation`, `Concept`, `Entity`; Rels: `REFERENCES`, `RELATED_TO` | Knowledge graph relationships |
 | **MinIO** | `wiii-docs` bucket | PDF pages, extracted images |
 | **Valkey** | Key-value | Session cache, rate limit counters |
@@ -2247,7 +2241,7 @@ MINIO_ENDPOINT=localhost:9000
 | Flag | Default | Description |
 |------|---------|-------------|
 | **Core** | | |
-| `use_multi_agent` | `True` | LangGraph multi-agent system |
+| `use_multi_agent` | `True` | WiiiRunner multi-agent runtime |
 | `enable_corrective_rag` | `True` | Self-correction loop |
 | `enable_llm_failover` | `True` | Multi-provider chain |
 | `deep_reasoning_enabled` | `True` | `<thinking>` tags |

--- a/maritime-ai-service/docs/architecture/SYSTEM_FLOW.md
+++ b/maritime-ai-service/docs/architecture/SYSTEM_FLOW.md
@@ -42,15 +42,16 @@ flowchart TB
         DOMAIN["DomainRouter<br/>5-priority resolution"]
     end
 
-    subgraph Agents["Multi-Agent System (LangGraph)"]
+    subgraph Agents["Multi-Agent Runtime (WiiiRunner)"]
         GUARD["Guardian Agent<br/>safety + relevance"]
         SUP["Supervisor<br/>intent routing"]
         RAG["RAG Agent<br/>knowledge retrieval"]
         TUTOR["Tutor Agent<br/>pedagogical ReAct"]
         MEM["Memory Agent<br/>user context"]
         DIRECT["Direct Response<br/>greetings, simple"]
-        PRODUCT["Product Search Agent<br/>7 tools, 5 platforms"]
-        GRADE["Grader Agent<br/>quality control"]
+        CODE["Code Studio Agent<br/>apps/artifacts"]
+        PRODUCT["Product Search Agent<br/>feature-gated"]
+        PARALLEL["Parallel Dispatch<br/>feature-gated"]
         SYNTH["Synthesizer<br/>final formatting"]
     end
 
@@ -161,7 +162,7 @@ flowchart LR
 **SSE V3 Event Types** (Desktop uses V3):
 | Event | Source | Content |
 |-------|--------|---------|
-| `status` | Supervisor routing, Grader scores, pipeline steps | Pipeline progress |
+| `status` | Supervisor routing, node lifecycle, runtime checks, pipeline steps | Pipeline progress |
 | `thinking` | AI reasoning from agent nodes | Raw AI thinking |
 | `thinking_start` | Node entry (Guardian, RAG, Tutor, etc.) | Vietnamese node label |
 | `thinking_end` | Node exit | Duration in ms |
@@ -238,7 +239,7 @@ sequenceDiagram
     participant S as SessionManager
     participant I as InputProcessor
     participant DR as DomainRouter
-    participant G as LangGraph
+    participant G as WiiiRunner
     participant OP as OutputProcessor
     participant BG as BackgroundTasks
 
@@ -275,7 +276,7 @@ sequenceDiagram
     rect rgb(255, 245, 230)
         Note over O,G: STAGE 4: Agent Execution
         O->>G: process_with_multi_agent(state)
-        Note right of G: See Section 5: Multi-Agent Graph
+        Note right of G: See Section 5: WiiiRunner Runtime
         G-->>O: {"response": ..., "sources": ..., "thinking": ...}
     end
 
@@ -313,42 +314,39 @@ sequenceDiagram
 
 ---
 
-## 5. Multi-Agent Graph (LangGraph)
+## 5. WiiiRunner Multi-Agent Runtime
 
 ```mermaid
 stateDiagram-v2
-    [*] --> guardian_agent
+    [*] --> guardian
 
-    guardian_agent --> supervisor: SAFE (or fail-open)
-    guardian_agent --> synthesizer_node: BLOCKED (harmful content)
+    guardian --> supervisor: SAFE or fail-open
+    guardian --> synthesizer: BLOCKED / final response
 
-    supervisor --> direct_response_node: DIRECT (greetings, off_topic, web_search)
+    supervisor --> direct: DIRECT (greetings, off_topic, web_search)
     supervisor --> memory_agent: MEMORY (personal questions)
     supervisor --> tutor_agent: TUTOR (teaching, explanation)
     supervisor --> rag_agent: RAG (knowledge retrieval)
-    supervisor --> product_search_agent: PRODUCT_SEARCH (product queries)
+    supervisor --> code_studio_agent: CODE_STUDIO (apps/artifacts)
+    supervisor --> product_search_agent: PRODUCT_SEARCH (feature-gated)
+    supervisor --> colleague_agent: COLLEAGUE (feature-gated)
+    supervisor --> parallel_dispatch: SUBAGENTS (feature-gated)
 
-    direct_response_node --> synthesizer_node
-    product_search_agent --> synthesizer_node
+    direct --> synthesizer
+    memory_agent --> synthesizer
+    tutor_agent --> synthesizer
+    rag_agent --> synthesizer
+    code_studio_agent --> synthesizer
+    product_search_agent --> synthesizer
+    colleague_agent --> synthesizer
 
-    state rag_check <<choice>>
-    rag_agent --> rag_check
-    rag_check --> synthesizer_node: confidence >= 0.85 (EARLY EXIT)
-    rag_check --> quality_check: confidence < 0.85
+    parallel_dispatch --> aggregator
+    aggregator --> synthesizer: enough context
+    aggregator --> supervisor: retry/follow-up route, max 2
 
-    state tutor_check <<choice>>
-    tutor_agent --> tutor_check
-    tutor_check --> synthesizer_node: confidence >= 0.85 (EARLY EXIT)
-    tutor_check --> quality_check: confidence < 0.85
+    synthesizer --> [*]
 
-    memory_agent --> quality_check
-
-    quality_check --> synthesizer_node: score >= 6 (PASS)
-    quality_check --> tutor_agent: score < 6 (RETRY, max 1)
-
-    synthesizer_node --> [*]
-
-    note right of guardian_agent
+    note right of guardian
         Entry point. Fail-open on errors.
         Skip messages < 3 chars.
         Emits thinking_start/thinking_end.
@@ -375,17 +373,17 @@ stateDiagram-v2
         Pedagogical teaching style.
     end note
 
-    note right of quality_check
-        Grader Agent scores 1-10.
-        Pass >= 6, Vietnamese quality.
-        Emits status event with score.
+    note right of aggregator
+        Optional subagent fan-out.
+        Bounded retry to supervisor.
+        Feature-gated by config.
     end note
 ```
 
 **Agent State** (`AgentState` TypedDict):
 | Field | Type | Purpose |
 |-------|------|---------|
-| `messages` | `list[BaseMessage]` | LangGraph message history |
+| `messages` | `list[dict]` | Request and conversation message history |
 | `query` | `str` | Original user query |
 | `context` | `str` | Built context from InputProcessor |
 | `domain_id` | `str` | Resolved domain plugin ID |
@@ -395,7 +393,7 @@ stateDiagram-v2
 | `confidence` | `float` | 0-1 confidence score |
 | `sources` | `list[Citation]` | Retrieved sources |
 | `next_agent` | `str` | Supervisor routing decision |
-| `retry_count` | `int` | Grader retry counter (max 1) |
+| `retry_count` | `int` | Runtime retry counter for bounded self-correction |
 | `organization_id` | `str \| None` | Org context for data isolation (Sprint 160) |
 
 ---
@@ -530,7 +528,7 @@ sequenceDiagram
     participant C as Desktop/Client
     participant API as chat_stream.py
     participant GS as graph_streaming
-    participant G as LangGraph Nodes
+    participant G as WiiiRunner nodes
     participant S as stream_utils
 
     C->>API: POST /chat/stream/v3
@@ -539,7 +537,7 @@ sequenceDiagram
         Note over API,GS: Keepalive wrapper (15s heartbeat)
         API->>GS: stream_graph_response()
 
-        loop For each LangGraph node
+        loop For each WiiiRunner node
             G->>S: create_status_event(node_label)
             S-->>GS: StreamEvent(type="status")
             GS-->>API: SSE event: status
@@ -731,7 +729,7 @@ flowchart LR
     end
 
     Client --> ALOOP["Agentic Loop<br/>Tool calling"]
-    Client --> GRAPH["LangGraph Nodes"]
+    Client --> GRAPH["WiiiRunner nodes"]
 ```
 
 **MCP Transport:** Streamable HTTP (2026 standard). SSE transport deprecated.
@@ -757,7 +755,7 @@ flowchart TB
 
         SEM --> TYPE{"Task Type?"}
         TYPE -->|notification| NOTIFY["Send description<br/>as reminder"]
-        TYPE -->|agent| INVOKE["Invoke multi-agent<br/>graph with prompt"]
+        TYPE -->|agent| INVOKE["Invoke WiiiRunner<br/>with prompt"]
     end
 
     subgraph Dispatch["Notification Dispatcher"]
@@ -806,7 +804,7 @@ flowchart TB
 
     subgraph Isolation["Data Isolation"]
         SET --> THREAD["Thread ID:<br/>org_{org}__user_{uid}__session_{sid}"]
-        THREAD --> CHECKPOINT["LangGraph checkpoints<br/>(per org-user-session)"]
+        THREAD --> CHECKPOINT["thread_views + chat history<br/>(per org-user-session)"]
     end
 
     subgraph Admin["Organization Admin API"]
@@ -1099,7 +1097,7 @@ sequenceDiagram
 | Memory Agent | Active | Semantic memory retrieval |
 | Direct Response | Active | 8 tools (character, datetime, 4x web search) |
 | **Product Search Agent** | Gated | `enable_product_search=False` — 7 tools, 5 platforms, Playwright browser scraping |
-| Grader Agent | Active | Score 1-10, early exit at >= 0.85, structured outputs |
+| Grader score support | Optional/legacy | Runner self-correction can consume `grader_score` when an upstream path provides it |
 | Synthesizer | Active | Vietnamese formatting, thinking extraction |
 | CorrectiveRAG | Active | 6-step with tiered grading |
 | SemanticCache | Active | 3-tier TTL, asyncio.Lock protected, org-isolated cache keys |
@@ -1155,7 +1153,8 @@ sequenceDiagram
 | **Service** | `app/services/hybrid_search_service.py` | Dense + Sparse search |
 | **Service** | `app/services/scheduled_task_executor.py` | Proactive agent |
 | **Service** | `app/services/notification_dispatcher.py` | WS/Telegram dispatch |
-| **Agent** | `app/engine/multi_agent/graph.py` | LangGraph definition |
+| **Agent** | `app/engine/multi_agent/runner.py` | WiiiRunner orchestration loop |
+| **Agent** | `app/engine/multi_agent/graph.py` | Compatibility shell + node entrypoints |
 | **Agent** | `app/engine/multi_agent/graph_streaming.py` | SSE event emission |
 | **Agent** | `app/engine/multi_agent/agents/supervisor.py` | LLM-first routing (RoutingDecision) |
 | **Agent** | `app/engine/multi_agent/agents/tutor_node.py` | Teaching agent |

--- a/maritime-ai-service/docs/integration/LMS_TEAM_GUIDE.md
+++ b/maritime-ai-service/docs/integration/LMS_TEAM_GUIDE.md
@@ -11,7 +11,7 @@
 
 ## 1. Wiii là gì?
 
-Wiii là trợ lý AI giáo dục do **The Wiii Lab** phát triển. Wiii giúp sinh viên tra cứu kiến thức, ôn thi, hỏi đáp bài tập. Cho giảng viên: dashboard phân tích, phát hiện sinh viên nguy cơ, báo cáo AI. Wiii chạy trên FastAPI + LangGraph, giao tiếp qua REST + SSE, bảo mật bằng HMAC-SHA256 + JWT.
+Wiii là trợ lý AI giáo dục do **The Wiii Lab** phát triển. Wiii giúp sinh viên tra cứu kiến thức, ôn thi, hỏi đáp bài tập. Cho giảng viên: dashboard phân tích, phát hiện sinh viên nguy cơ, báo cáo AI. Wiii chạy trên FastAPI + WiiiRunner, giao tiếp qua REST + SSE, bảo mật bằng HMAC-SHA256 + JWT.
 
 ---
 


### PR DESCRIPTION
## Summary
- Align canonical architecture and entrypoint docs with the active WiiiRunner runtime instead of the retired LangGraph/StateGraph model.
- Replace stale checkpoint/database claims with the current `thread_views`, chat history, session summary, and semantic-memory persistence model.
- Refresh active runtime docstrings/comments that still described WiiiRunner nodes as LangGraph nodes.

## Scope
- In scope: repository/backend READMEs, mental model, architecture docs, LMS guide wording, and documentation-only Python docstrings/comments.
- Out of scope: deleting deprecated compatibility modules, removing historical `.claude/` content, changing runtime behavior, or resolving CodeRabbit rate limits.

## Verification
- `git diff --check`
- `python -m py_compile maritime-ai-service/app/engine/multi_agent/agent_config.py maritime-ai-service/app/engine/multi_agent/agent_nodes.py maritime-ai-service/app/engine/multi_agent/agents/product_search_node.py maritime-ai-service/app/engine/multi_agent/agents/tutor_node.py maritime-ai-service/app/engine/multi_agent/stream_utils.py maritime-ai-service/app/engine/multi_agent/subagents/aggregator.py maritime-ai-service/app/engine/multi_agent/supervisor.py maritime-ai-service/app/engine/workflows/__init__.py maritime-ai-service/app/engine/workflows/course_generation.py maritime-ai-service/app/services/chat_orchestrator.py maritime-ai-service/app/services/chat_service.py`

## Reviewer Focus
- Confirm the docs now match the post-LangGraph WiiiRunner runtime direction.
- Confirm remaining LangGraph references are historical/deprecated compatibility references, not active-runtime claims.
- Confirm `.claude/` is treated as legacy reference material, not deleted in this PR.

## Rollback
- Revert this commit to restore the previous documentation wording. Runtime behavior is unchanged.

Refs #130
