### PR TITLE
chore(deps): remediate remaining desktop dependency alerts

### DIFF
--- a/wiii-desktop/package-lock.json
+++ b/wiii-desktop/package-lock.json
@@ -37,7 +37,7 @@
         "remark-gfm": "^4.0.0",
         "remark-math": "^6.0.0",
         "simplex-noise": "^4.0.3",
-        "uuid": "^9.0.0",
+        "uuid": "^14.0.0",
         "zustand": "^4.5.0"
       },
       "devDependencies": {
@@ -48,7 +48,6 @@
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "@types/react-plotly.js": "^2.6.4",
-        "@types/uuid": "^9.0.0",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.5",
         "autoprefixer": "^10.5.0",
@@ -2881,13 +2880,6 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -4701,11 +4693,10 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -7577,15 +7568,6 @@
         "uuid": "^11.1.0"
       }
     },
-    "node_modules/mermaid/node_modules/dompurify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
     "node_modules/mermaid/node_modules/marked": {
       "version": "16.4.2",
       "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
@@ -7596,19 +7578,6 @@
       },
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/mermaid/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/micromark": {
@@ -10910,16 +10879,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vfile": {

--- a/wiii-desktop/package.json
+++ b/wiii-desktop/package.json
@@ -51,7 +51,7 @@
     "remark-gfm": "^4.0.0",
     "remark-math": "^6.0.0",
     "simplex-noise": "^4.0.3",
-    "uuid": "^9.0.0",
+    "uuid": "^14.0.0",
     "zustand": "^4.5.0"
   },
   "devDependencies": {
@@ -62,7 +62,6 @@
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@types/react-plotly.js": "^2.6.4",
-    "@types/uuid": "^9.0.0",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.5",
     "autoprefixer": "^10.5.0",
@@ -74,5 +73,9 @@
     "typescript": "^5.4.0",
     "vite": "^8.0.10",
     "vitest": "^4.1.5"
+  },
+  "overrides": {
+    "dompurify": "3.4.1",
+    "uuid": "$uuid"
   }
 }

--- a/wiii-desktop/src-tauri/Cargo.lock
+++ b/wiii-desktop/src-tauri/Cargo.lock
@@ -2495,7 +2495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2505,7 +2505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2792,7 +2792,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2849,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2860,9 +2860,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4011,7 +4011,7 @@ checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
 dependencies = [
  "log",
  "notify-rust",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "serde_json",
  "serde_repr",


### PR DESCRIPTION
## Summary

Remediates the remaining desktop dependency-alert work tracked in #129 by tightening the Tauri/desktop dependency graph without broad framework or app changes.

## Changes

- Upgrade the direct `uuid` dependency to `^14.0.0` and remove the obsolete `@types/uuid` package because `uuid` ships its own types.
- Add npm overrides so transitive `dompurify` resolves to `3.4.1` and transitive `uuid` resolves to the direct patched version while upstream packages catch up.
- Update the Rust lockfile from `rand 0.9.2` to `0.9.3` and from `rand 0.8.5` to `0.8.6`.
- Leave the `glib` advisory explicitly tracked as upstream-blocked: `gtk v0.18.2` requires `glib ^0.18` through the current Tauri/GTK stack, so forcing `glib 0.20.0` is not dependency-compatible.

## Validation

- `npm ci`
- `npm ls dompurify uuid`
- `npm audit --json`
- `npm test -- --run`
- `npm run build:embed`
- `npm run build`
- `cargo check --locked`
- `cargo tree -i rand@0.9.3 --locked`
- `cargo tree -i rand@0.8.6 --locked`
- `git diff --check`

## Risk

The `uuid` major update is low-risk in this codebase because the desktop source only imports `v4`; the full Vitest suite and production builds passed. The npm overrides are intentional guardrails for vulnerable transitive packages while waiting on upstream dependency ranges.

Refs #129.