### PR TITLE
fix(runtime): align streaming guardrails with sync runner

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/runner.py
+++ b/maritime-ai-service/app/engine/multi_agent/runner.py
@@ -228,6 +228,15 @@ class WiiiRunner:
 
         # 1. Guardian
         state = await self._run_step(_NODE_GUARDIAN, state)
+
+        # Keep streaming semantics aligned with run(): extended input
+        # guardrails are part of the active runtime contract, not only sync API.
+        guardian_passed = state.get("guardian_passed", True)
+        passed, reason = await run_input_guardrails(state, guardian_passed=guardian_passed)
+        if not passed:
+            state["guardian_passed"] = False
+            state["final_response"] = reason or "Nội dung không phù hợp."
+
         self._push_queue(merged_queue, _NODE_GUARDIAN, state)
 
         # 2. Guardian route
@@ -239,6 +248,7 @@ class WiiiRunner:
         if route == _NODE_SYNTHESIZER:
             state["current_agent"] = _NODE_SYNTHESIZER
             state = await self._run_step(_NODE_SYNTHESIZER, state)
+            await run_output_guardrails(state)
             self._push_queue(merged_queue, _NODE_SYNTHESIZER, state)
             elapsed = (time.perf_counter() - t_start) * 1000
             await self._emit_run_end(state, elapsed)
@@ -278,6 +288,7 @@ class WiiiRunner:
 
         # Synthesize
         state = await self._run_step(_NODE_SYNTHESIZER, state)
+        await run_output_guardrails(state)
         self._push_queue(merged_queue, _NODE_SYNTHESIZER, state)
 
         elapsed = (time.perf_counter() - t_start) * 1000

--- a/maritime-ai-service/tests/unit/test_wiii_runner_golden_parity.py
+++ b/maritime-ai-service/tests/unit/test_wiii_runner_golden_parity.py
@@ -1,0 +1,147 @@
+"""Golden parity tests for WiiiRunner sync and streaming execution.
+
+These tests intentionally avoid real providers and agent nodes. They lock the
+runtime contract that must survive the de-LangGraph migration before any
+runner-backed ``graph_*`` compatibility shells are renamed or removed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.engine.multi_agent.runner import WiiiRunner
+
+
+def _build_runner(step_log: list[str]) -> WiiiRunner:
+    runner = WiiiRunner()
+
+    async def guardian(state):
+        step_log.append("guardian")
+        state.setdefault("guardian_passed", True)
+        return state
+
+    async def supervisor(state):
+        step_log.append("supervisor")
+        state["next_agent"] = "direct"
+        return state
+
+    async def direct(state):
+        step_log.append("direct")
+        state["current_agent"] = "direct"
+        state["final_response"] = "Direct answer long enough for parity checks."
+        state["sources"] = [{"title": "golden-source"}]
+        state["_execution_provider"] = "zhipu"
+        state["_execution_model"] = "glm-5"
+        return state
+
+    async def synthesizer(state):
+        step_log.append("synthesizer")
+        state["current_agent"] = "synthesizer"
+        state.setdefault("final_response", "Synthesized fallback.")
+        state.setdefault("sources", [])
+        return state
+
+    runner.register_node("guardian", guardian)
+    runner.register_node("supervisor", supervisor)
+    runner.register_node("direct", direct)
+    runner.register_node("synthesizer", synthesizer)
+    return runner
+
+
+def _node_names(events: list[tuple]) -> list[str]:
+    names = []
+    for event_type, payload in events:
+        if event_type == "graph" and isinstance(payload, dict):
+            names.extend(payload.keys())
+    return names
+
+
+async def _run_streaming(runner: WiiiRunner, state: dict) -> tuple[dict, list[tuple]]:
+    queue: asyncio.Queue = asyncio.Queue()
+    result = await runner.run_streaming(dict(state), merged_queue=queue)
+    events = []
+    while not queue.empty():
+        events.append(queue.get_nowait())
+    return result, events
+
+
+@pytest.mark.asyncio
+async def test_sync_and_streaming_share_core_step_contract():
+    """Sync and streaming lanes must execute the same WiiiRunner core path."""
+    base_state = {
+        "query": "hello",
+        "user_id": "user-1",
+        "session_id": "session-1",
+    }
+    sync_log: list[str] = []
+    stream_log: list[str] = []
+    sync_runner = _build_runner(sync_log)
+    stream_runner = _build_runner(stream_log)
+
+    input_guardrails = AsyncMock(return_value=(True, None))
+    output_guardrails = AsyncMock(return_value=(True, None))
+
+    with patch("app.engine.multi_agent.graph.guardian_route", return_value="supervisor"), patch(
+        "app.engine.multi_agent.graph_support.route_decision", return_value="direct"
+    ), patch(
+        "app.engine.multi_agent.runner.run_input_guardrails", input_guardrails
+    ), patch(
+        "app.engine.multi_agent.runner.run_output_guardrails", output_guardrails
+    ):
+        sync_result = await sync_runner.run(dict(base_state))
+        stream_result, stream_events = await _run_streaming(stream_runner, base_state)
+
+    assert sync_log == ["guardian", "supervisor", "direct", "synthesizer"]
+    assert stream_log == sync_log
+    assert _node_names(stream_events) == ["guardian", "direct", "synthesizer"]
+
+    for key in (
+        "final_response",
+        "sources",
+        "_execution_provider",
+        "_execution_model",
+        "user_id",
+        "session_id",
+    ):
+        assert stream_result[key] == sync_result[key]
+
+    assert input_guardrails.await_count == 2
+    assert output_guardrails.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_streaming_applies_input_guardrail_before_routing():
+    """Streaming must not bypass guardrails that the sync lane already enforces."""
+    step_log: list[str] = []
+    runner = _build_runner(step_log)
+    input_guardrails = AsyncMock(return_value=(False, "blocked by golden parity test"))
+    output_guardrails = AsyncMock(return_value=(True, None))
+
+    def guardian_route(state):
+        return "synthesizer" if not state.get("guardian_passed", True) else "supervisor"
+
+    with patch("app.engine.multi_agent.graph.guardian_route", side_effect=guardian_route), patch(
+        "app.engine.multi_agent.graph_support.route_decision", return_value="direct"
+    ), patch(
+        "app.engine.multi_agent.runner.run_input_guardrails", input_guardrails
+    ), patch(
+        "app.engine.multi_agent.runner.run_output_guardrails", output_guardrails
+    ):
+        result, stream_events = await _run_streaming(
+            runner,
+            {
+                "query": "blocked",
+                "user_id": "user-1",
+                "session_id": "session-1",
+            },
+        )
+
+    assert step_log == ["guardian", "synthesizer"]
+    assert _node_names(stream_events) == ["guardian", "synthesizer"]
+    assert result["guardian_passed"] is False
+    assert result["final_response"] == "blocked by golden parity test"
+    input_guardrails.assert_awaited_once()
+    output_guardrails.assert_awaited_once()


### PR DESCRIPTION
## Summary

Fixes a WiiiRunner parity gap found while preparing the next #130 migration step: the sync lane applied runtime guardrails, but the streaming lane did not. Because FE chat uses streaming, this should be corrected before any `graph_*` compatibility shells are renamed or retired.

## Changes

- Applies extended input guardrails in `WiiiRunner.run_streaming()` immediately after `guardian` and before routing.
- Applies output guardrails after streaming synthesizer execution before the final synthesizer graph event is emitted.
- Adds golden parity tests that compare sync and streaming WiiiRunner core path behavior without real providers or agent nodes.
- Adds a regression test proving streaming guardrails can block before the supervisor/agent path runs.

## Validation

- `python -m compileall -q maritime-ai-service/app/engine/multi_agent/runner.py maritime-ai-service/tests/unit/test_wiii_runner_golden_parity.py`
- `python -m pytest maritime-ai-service/tests/unit/test_wiii_runner_golden_parity.py maritime-ai-service/tests/unit/test_graph_thread_id.py maritime-ai-service/tests/unit/test_graph_stream_merge_runtime.py maritime-ai-service/tests/unit/test_graph_stream_runtime.py maritime-ai-service/tests/unit/test_sprint54_graph_streaming.py -q -p no:capture --tb=short` -> 56 passed
- `git diff --check`

Note: local Python 3.13 emits an existing `requests` dependency warning about urllib3/charset_normalizer version compatibility; tests still pass.

## Risk

Runtime behavior change is intentionally narrow: streaming now enforces the same guardrail calls as sync. This may block unsafe streaming requests earlier, which is desired parity. No provider routing, memory persistence, public SSE event names, or frontend code changed.

Fixes #148
Refs #130.