### PR TITLE
[codex] add canonical WiiiRunner runtime surfaces

### DIFF
--- a/maritime-ai-service/app/api/v1/messenger_webhook.py
+++ b/maritime-ai-service/app/api/v1/messenger_webhook.py
@@ -219,7 +219,7 @@ async def _check_otp_linking(text: str, channel_type: str, sender_id: str) -> st
 
 
 async def _process_and_reply(sender_id: str, text: str) -> str:
-    """Process user message through multi-agent graph and return answer.
+    """Process user message through the multi-agent runtime and return answer.
 
     Sprint 174: Uses IdentityResolver for canonical user ID and
     PersonalityMode for soul/professional switching.
@@ -232,7 +232,7 @@ async def _process_and_reply(sender_id: str, text: str) -> str:
 
     from app.auth.identity_resolver import resolve_user_id
     from app.engine.personality_mode import resolve_personality_mode
-    from app.engine.multi_agent.graph import process_with_multi_agent
+    from app.engine.multi_agent.runtime import process_with_multi_agent
 
     canonical_user_id = await resolve_user_id("messenger", sender_id)
     personality_mode = resolve_personality_mode("messenger")

--- a/maritime-ai-service/app/api/v1/zalo_webhook.py
+++ b/maritime-ai-service/app/api/v1/zalo_webhook.py
@@ -174,7 +174,7 @@ async def _check_otp_linking(text: str, channel_type: str, sender_id: str) -> st
 
 
 async def _process_and_reply(sender_id: str, text: str) -> str:
-    """Process user message through multi-agent graph and return answer.
+    """Process user message through the multi-agent runtime and return answer.
 
     Sprint 174b: Checks OTP linking before multi-agent processing.
     """
@@ -185,7 +185,7 @@ async def _process_and_reply(sender_id: str, text: str) -> str:
 
     from app.auth.identity_resolver import resolve_user_id
     from app.engine.personality_mode import resolve_personality_mode
-    from app.engine.multi_agent.graph import process_with_multi_agent
+    from app.engine.multi_agent.runtime import process_with_multi_agent
 
     canonical_user_id = await resolve_user_id("zalo", sender_id)
     personality_mode = resolve_personality_mode("zalo")

--- a/maritime-ai-service/app/engine/multi_agent/__init__.py
+++ b/maritime-ai-service/app/engine/multi_agent/__init__.py
@@ -27,9 +27,9 @@ def __getattr__(name: str):
         from app.engine.multi_agent import supervisor
         return getattr(supervisor, name)
     if name == "process_with_multi_agent":
-        from app.engine.multi_agent import graph
-        return getattr(graph, name)
+        from app.engine.multi_agent.runtime import process_with_multi_agent
+        return process_with_multi_agent
     if name == "process_with_multi_agent_streaming":
-        from app.engine.multi_agent.graph_streaming import process_with_multi_agent_streaming
+        from app.engine.multi_agent.streaming_runtime import process_with_multi_agent_streaming
         return process_with_multi_agent_streaming
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/maritime-ai-service/app/engine/multi_agent/runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/runtime.py
@@ -1,0 +1,18 @@
+"""Canonical WiiiRunner-backed multi-agent runtime surface."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+async def process_with_multi_agent(*args: Any, **kwargs: Any) -> dict:
+    """Dispatch to the runner-backed sync entrypoint.
+
+    The lazy import preserves legacy test patch paths while production callers
+    move to the canonical runtime module name.
+    """
+    from app.engine.multi_agent.graph import process_with_multi_agent as process
+
+    return await process(*args, **kwargs)
+
+__all__ = ["process_with_multi_agent"]

--- a/maritime-ai-service/app/engine/multi_agent/streaming_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/streaming_runtime.py
@@ -1,0 +1,26 @@
+"""Canonical streaming surface for the WiiiRunner-backed runtime."""
+
+from __future__ import annotations
+
+from typing import Any, AsyncGenerator
+
+from app.engine.multi_agent.stream_utils import StreamEvent
+
+
+async def process_with_multi_agent_streaming(
+    *args: Any,
+    **kwargs: Any,
+) -> AsyncGenerator[StreamEvent, None]:
+    """Dispatch to the runner-backed streaming entrypoint.
+
+    The lazy import preserves legacy test patch paths while production callers
+    move to the canonical streaming module name.
+    """
+    from app.engine.multi_agent.graph_streaming import (
+        process_with_multi_agent_streaming as stream,
+    )
+
+    async for event in stream(*args, **kwargs):
+        yield event
+
+__all__ = ["process_with_multi_agent_streaming"]

--- a/maritime-ai-service/app/services/chat_orchestrator_runtime.py
+++ b/maritime-ai-service/app/services/chat_orchestrator_runtime.py
@@ -143,7 +143,7 @@ async def process_with_multi_agent_impl(
     agent_type_map: dict[str, Any],
     default_agent_type: Any,
 ) -> Any:
-    from app.engine.multi_agent.graph import process_with_multi_agent
+    from app.engine.multi_agent.runtime import process_with_multi_agent
 
     prepared_turn = prepared_turn_cls(
         request_scope=request_scope_cls(

--- a/maritime-ai-service/app/services/chat_stream_coordinator.py
+++ b/maritime-ai-service/app/services/chat_stream_coordinator.py
@@ -87,7 +87,7 @@ async def generate_stream_v3_events(
             ensure_provider_is_selectable(requested_provider)
 
         if stream_fn is None:
-            from app.engine.multi_agent.graph import (
+            from app.engine.multi_agent.streaming_runtime import (
                 process_with_multi_agent_streaming,
             )
 

--- a/maritime-ai-service/app/services/scheduled_task_executor.py
+++ b/maritime-ai-service/app/services/scheduled_task_executor.py
@@ -128,8 +128,8 @@ class ScheduledTaskExecutor:
         extra = task.get("extra_data") or {}
 
         if extra.get("agent_invoke"):
-            # Agent mode: invoke multi-agent graph
-            from app.engine.multi_agent.graph import process_with_multi_agent
+            # Agent mode: invoke the WiiiRunner-backed multi-agent runtime.
+            from app.engine.multi_agent.runtime import process_with_multi_agent
 
             result = await asyncio.wait_for(
                 process_with_multi_agent(

--- a/maritime-ai-service/tests/unit/test_multi_agent_runtime_surface.py
+++ b/maritime-ai-service/tests/unit/test_multi_agent_runtime_surface.py
@@ -1,0 +1,47 @@
+"""Guards for canonical WiiiRunner runtime import surfaces."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.engine.multi_agent.runtime import process_with_multi_agent
+from app.engine.multi_agent.streaming_runtime import process_with_multi_agent_streaming
+from app.engine.multi_agent.stream_utils import create_status_event
+
+
+@pytest.mark.asyncio
+async def test_runtime_surface_delegates_to_sync_entrypoint():
+    process = AsyncMock(return_value={"response": "ok"})
+
+    with patch("app.engine.multi_agent.graph.process_with_multi_agent", new=process):
+        result = await process_with_multi_agent(
+            query="hello",
+            user_id="user-1",
+            session_id="session-1",
+        )
+
+    assert result == {"response": "ok"}
+    process.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_streaming_runtime_surface_delegates_to_streaming_entrypoint():
+    expected_event = await create_status_event("ok")
+
+    async def stream(*_args, **_kwargs):
+        yield expected_event
+
+    with patch(
+        "app.engine.multi_agent.graph_streaming.process_with_multi_agent_streaming",
+        new=stream,
+    ):
+        events = [
+            event
+            async for event in process_with_multi_agent_streaming(
+                query="hello",
+                user_id="user-1",
+                session_id="session-1",
+            )
+        ]
+
+    assert events == [expected_event]


### PR DESCRIPTION
## Summary

Closes #152.

Adds canonical import surfaces for the active WiiiRunner runtime so new production code no longer needs to import through LangGraph-era `graph`/`graph_streaming` module names.

## What changed

- Added `app.engine.multi_agent.runtime.process_with_multi_agent` as the sync runtime surface.
- Added `app.engine.multi_agent.streaming_runtime.process_with_multi_agent_streaming` as the SSE runtime surface.
- Moved production edge callers in chat orchestration, stream coordination, scheduled tasks, Messenger, and Zalo onto the canonical surfaces.
- Updated package-level lazy exports to resolve through the new canonical modules.
- Added unit guards proving the canonical surfaces lazily delegate to the legacy compatibility entrypoints, preserving existing patch behavior during migration.

## Why

This is the next safe #130 slice after #151: move callers toward WiiiRunner-native naming without deleting compatibility shells or forcing broad test rewrites in one PR.

## Validation

- `python -m compileall -q maritime-ai-service\app\engine\multi_agent\runtime.py maritime-ai-service\app\engine\multi_agent\streaming_runtime.py maritime-ai-service\app\engine\multi_agent\__init__.py maritime-ai-service\app\api\v1\messenger_webhook.py maritime-ai-service\app\api\v1\zalo_webhook.py maritime-ai-service\app\services\chat_orchestrator_runtime.py maritime-ai-service\app\services\chat_stream_coordinator.py maritime-ai-service\app\services\scheduled_task_executor.py maritime-ai-service\tests\unit\test_multi_agent_runtime_surface.py`
- `python -m pytest maritime-ai-service\tests\unit\test_multi_agent_runtime_surface.py maritime-ai-service\tests\unit\test_chat_request_flow.py maritime-ai-service\tests\unit\test_chat_stream_coordinator.py -q -p no:capture --tb=short` (`23 passed`)
- `git diff --check`

## Related

- Parent architecture issue: #130
- Runtime metadata guardrail: #151