### PR TITLE
[codex] decouple streaming internals from graph shell

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/graph_stream_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph_stream_runtime.py
@@ -84,7 +84,7 @@ async def build_stream_bootstrap_impl(
         **build_turn_local_state_defaults(context),
     }
 
-    from app.engine.multi_agent.graph import (
+    from app.engine.multi_agent.graph_runtime_bindings import (
         _inject_code_studio_context,
         _inject_host_context,
         _inject_host_session,

--- a/maritime-ai-service/app/engine/multi_agent/graph_streaming.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph_streaming.py
@@ -42,7 +42,7 @@ from app.core.exceptions import ProviderUnavailableError
 from app.engine.llm_runtime_metadata import resolve_runtime_llm_metadata
 from app.core.constants import PREVIEW_SNIPPET_MAX_LENGTH
 from app.engine.multi_agent.state import AgentState
-from app.engine.multi_agent.graph import (
+from app.engine.multi_agent.graph_support import (
     _build_domain_config,
     _build_turn_local_state_defaults,
 )
@@ -490,7 +490,7 @@ async def process_with_multi_agent_streaming(
     finally:
         # Sprint 139: Clean up tracer from module-level storage
         if final_state:
-            from app.engine.multi_agent.graph import _cleanup_tracer
+            from app.engine.multi_agent.graph_trace_store import _cleanup_tracer
             _cleanup_tracer(final_state.get("_trace_id"))
         # Sprint 69+153: Clean up event bus (guard against None bus_id)
         if bus_id:

--- a/maritime-ai-service/tests/unit/test_graph_stream_runtime.py
+++ b/maritime-ai-service/tests/unit/test_graph_stream_runtime.py
@@ -23,20 +23,20 @@ class _RegistryStub:
 
 @pytest.mark.asyncio
 async def test_build_stream_bootstrap_matches_sync_context_injection(monkeypatch):
-    import app.engine.multi_agent.graph as graph_module
+    import app.engine.multi_agent.graph_runtime_bindings as runtime_bindings
 
     def _inject_host_context(state):
         state["host_capabilities_prompt"] = "HOST CAPS"
         return "HOST PROMPT"
 
-    monkeypatch.setattr(graph_module, "_inject_host_context", _inject_host_context)
-    monkeypatch.setattr(graph_module, "_inject_host_session", lambda _state: "HOST SESSION")
-    monkeypatch.setattr(graph_module, "_inject_operator_context", lambda _state: "OPERATOR PROMPT")
-    monkeypatch.setattr(graph_module, "_inject_living_context", lambda _state: "LIVING PROMPT")
-    monkeypatch.setattr(graph_module, "_inject_visual_context", lambda _state: "")
-    monkeypatch.setattr(graph_module, "_inject_visual_cognition_context", lambda _state: "")
-    monkeypatch.setattr(graph_module, "_inject_widget_feedback_context", lambda _state: "")
-    monkeypatch.setattr(graph_module, "_inject_code_studio_context", lambda _state: "")
+    monkeypatch.setattr(runtime_bindings, "_inject_host_context", _inject_host_context)
+    monkeypatch.setattr(runtime_bindings, "_inject_host_session", lambda _state: "HOST SESSION")
+    monkeypatch.setattr(runtime_bindings, "_inject_operator_context", lambda _state: "OPERATOR PROMPT")
+    monkeypatch.setattr(runtime_bindings, "_inject_living_context", lambda _state: "LIVING PROMPT")
+    monkeypatch.setattr(runtime_bindings, "_inject_visual_context", lambda _state: "")
+    monkeypatch.setattr(runtime_bindings, "_inject_visual_cognition_context", lambda _state: "")
+    monkeypatch.setattr(runtime_bindings, "_inject_widget_feedback_context", lambda _state: "")
+    monkeypatch.setattr(runtime_bindings, "_inject_code_studio_context", lambda _state: "")
 
     bootstrap = await build_stream_bootstrap_impl(
         query="hello",


### PR DESCRIPTION
## Summary

Closes #154.

Moves streaming/bootstrap internals off direct imports through the legacy `multi_agent.graph` shell where dedicated helper modules already exist.

## What changed

- `graph_stream_runtime.py` now imports context injection helpers from `graph_runtime_bindings`.
- `graph_streaming.py` now imports domain/default-state helpers from `graph_support`.
- `graph_streaming.py` now imports tracer cleanup from `graph_trace_store`.
- Updated the bootstrap test to patch the canonical runtime bindings surface instead of `graph.py`.

## Why

This continues the #130 migration after #153 by shrinking the role of `graph.py` to a compatibility shell. The change is deliberately narrow: no runtime behavior changes, no node registration rewrites, and no compatibility module deletion yet.

## Validation

- `python -m compileall -q maritime-ai-service\app\engine\multi_agent\graph_stream_runtime.py maritime-ai-service\app\engine\multi_agent\graph_streaming.py maritime-ai-service\tests\unit\test_graph_stream_runtime.py`
- `python -m pytest maritime-ai-service\tests\unit\test_graph_stream_runtime.py maritime-ai-service\tests\unit\test_sprint54_graph_streaming.py maritime-ai-service\tests\unit\test_chat_stream_coordinator.py -q -p no:capture --tb=short` (`51 passed`)
- `git grep -n "from app\.engine\.multi_agent\.graph import" -- maritime-ai-service\app\engine\multi_agent\graph_stream_runtime.py maritime-ai-service\app\engine\multi_agent\graph_streaming.py` (no matches)
- `git diff --check`

## Related

- Parent architecture issue: #130
- Canonical runtime surface PR: #153