### PR TITLE
[codex] route WiiiRunner outside graph shell

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/runner.py
+++ b/maritime-ai-service/app/engine/multi_agent/runner.py
@@ -157,7 +157,7 @@ class WiiiRunner:
             state["final_response"] = reason or "Nội dung không phù hợp."
 
         # 2. Guardian route
-        from app.engine.multi_agent.graph import guardian_route
+        from app.engine.multi_agent.runtime_routes import guardian_route
 
         route = guardian_route(state)
         await self._emit_route(_NODE_GUARDIAN, route, state)
@@ -240,7 +240,7 @@ class WiiiRunner:
         self._push_queue(merged_queue, _NODE_GUARDIAN, state)
 
         # 2. Guardian route
-        from app.engine.multi_agent.graph import guardian_route
+        from app.engine.multi_agent.runtime_routes import guardian_route
 
         route = guardian_route(state)
         await self._emit_route(_NODE_GUARDIAN, route, state)

--- a/maritime-ai-service/app/engine/multi_agent/runtime_routes.py
+++ b/maritime-ai-service/app/engine/multi_agent/runtime_routes.py
@@ -1,0 +1,16 @@
+"""Route helpers used directly by the WiiiRunner runtime."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from app.engine.multi_agent.guardian_runtime import guardian_route_impl
+from app.engine.multi_agent.state import AgentState
+
+
+def guardian_route(state: AgentState) -> Literal["supervisor", "synthesizer"]:
+    """Route after guardian validation without depending on the legacy graph shell."""
+    return guardian_route_impl(state)
+
+
+__all__ = ["guardian_route"]

--- a/maritime-ai-service/tests/unit/test_runner_hooks.py
+++ b/maritime-ai-service/tests/unit/test_runner_hooks.py
@@ -354,7 +354,7 @@ class TestWiiiRunnerHooks:
         runner.set_hooks(dispatcher)
 
         # Patch guardian_route and route_decision
-        with patch("app.engine.multi_agent.graph.guardian_route", return_value="supervisor"), \
+        with patch("app.engine.multi_agent.runtime_routes.guardian_route", return_value="supervisor"), \
              patch("app.engine.multi_agent.graph_support.route_decision", return_value="rag_agent"):
             result = await runner.run({"query": "test"})
 
@@ -395,7 +395,7 @@ class TestWiiiRunnerHooks:
         dispatcher.add_run_hooks(hooks)
         runner.set_hooks(dispatcher)
 
-        with patch("app.engine.multi_agent.graph.guardian_route", return_value="supervisor"), \
+        with patch("app.engine.multi_agent.runtime_routes.guardian_route", return_value="supervisor"), \
              patch("app.engine.multi_agent.graph_support.route_decision", return_value="rag_agent"):
             result = await runner.run({"query": "test"})
 
@@ -420,7 +420,7 @@ class TestWiiiRunnerHooks:
         runner.register_node("guardian", mock_guardian)
         runner.register_node("synthesizer", mock_synthesizer)
 
-        with patch("app.engine.multi_agent.graph.guardian_route", return_value="synthesizer"):
+        with patch("app.engine.multi_agent.runtime_routes.guardian_route", return_value="synthesizer"):
             result = await runner.run({"query": "blocked"})
 
         assert result["final_response"] == "ok"
@@ -461,7 +461,7 @@ class TestWiiiRunnerHooks:
         dispatcher.add_agent_hooks("rag_agent", rag_hooks)
         runner.set_hooks(dispatcher)
 
-        with patch("app.engine.multi_agent.graph.guardian_route", return_value="supervisor"), \
+        with patch("app.engine.multi_agent.runtime_routes.guardian_route", return_value="supervisor"), \
              patch("app.engine.multi_agent.graph_support.route_decision", return_value="rag_agent"):
             await runner.run({"query": "test"})
 

--- a/maritime-ai-service/tests/unit/test_sprint75_latency.py
+++ b/maritime-ai-service/tests/unit/test_sprint75_latency.py
@@ -168,7 +168,7 @@ class TestGraderRemovedFromPipeline:
         for name in ("guardian", "supervisor", agent_name, "synthesizer"):
             runner.register_node(name, lambda state, _name=name: _node(_name, state))
 
-        with patch("app.engine.multi_agent.graph.guardian_route", return_value="supervisor"), \
+        with patch("app.engine.multi_agent.runtime_routes.guardian_route", return_value="supervisor"), \
              patch("app.engine.multi_agent.graph_support.route_decision", return_value=agent_name), \
              patch("app.engine.multi_agent.runner.run_input_guardrails", new=AsyncMock(return_value=(True, None))), \
              patch("app.engine.multi_agent.runner.run_output_guardrails", new=AsyncMock()):

--- a/maritime-ai-service/tests/unit/test_wiii_runner_golden_parity.py
+++ b/maritime-ai-service/tests/unit/test_wiii_runner_golden_parity.py
@@ -84,7 +84,7 @@ async def test_sync_and_streaming_share_core_step_contract():
     input_guardrails = AsyncMock(return_value=(True, None))
     output_guardrails = AsyncMock(return_value=(True, None))
 
-    with patch("app.engine.multi_agent.graph.guardian_route", return_value="supervisor"), patch(
+    with patch("app.engine.multi_agent.runtime_routes.guardian_route", return_value="supervisor"), patch(
         "app.engine.multi_agent.graph_support.route_decision", return_value="direct"
     ), patch(
         "app.engine.multi_agent.runner.run_input_guardrails", input_guardrails
@@ -123,7 +123,7 @@ async def test_streaming_applies_input_guardrail_before_routing():
     def guardian_route(state):
         return "synthesizer" if not state.get("guardian_passed", True) else "supervisor"
 
-    with patch("app.engine.multi_agent.graph.guardian_route", side_effect=guardian_route), patch(
+    with patch("app.engine.multi_agent.runtime_routes.guardian_route", side_effect=guardian_route), patch(
         "app.engine.multi_agent.graph_support.route_decision", return_value="direct"
     ), patch(
         "app.engine.multi_agent.runner.run_input_guardrails", input_guardrails


### PR DESCRIPTION
## Summary

Closes #156.

Moves WiiiRunner guardian routing off the legacy `multi_agent.graph` shell and onto a small runtime-native route surface.

## What changed

- Added `app.engine.multi_agent.runtime_routes.guardian_route` backed by `guardian_route_impl`.
- Updated `WiiiRunner.run()` and `WiiiRunner.run_streaming()` to import guardian routing from `runtime_routes`.
- Updated runner/hook/golden/latency tests to patch the route dependency the runner now uses.
- Left legacy `graph.guardian_route` intact for compatibility tests and existing direct imports.

## Why

This continues #130 after #155 by reducing `runner.py`'s internal dependency on the LangGraph-era `graph.py` shell without touching node registration yet. It keeps the migration small, reversible, and easy to validate.

## Validation

- `python -m compileall -q maritime-ai-service\app\engine\multi_agent\runtime_routes.py maritime-ai-service\app\engine\multi_agent\runner.py maritime-ai-service\tests\unit\test_wiii_runner_golden_parity.py maritime-ai-service\tests\unit\test_runner_hooks.py maritime-ai-service\tests\unit\test_sprint75_latency.py`
- `python -m pytest maritime-ai-service\tests\unit\test_wiii_runner_golden_parity.py maritime-ai-service\tests\unit\test_runner_hooks.py maritime-ai-service\tests\unit\test_guardian_graph_node.py -q -p no:capture --tb=short` (`38 passed`)
- `python -m pytest maritime-ai-service\tests\unit\test_sprint75_latency.py -q -p no:capture --tb=short` (`12 passed, 10 skipped`)
- `git diff --check`

## Related

- Parent architecture issue: #130
- Streaming decouple PR: #155