### PR TITLE
[codex] include source paths in CodeRabbit review scope

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -47,6 +47,14 @@ reviews:
       - "github-actions[bot]"
 
   path_filters:
+    # Positive filters make CodeRabbit review only matching paths. Keep broad
+    # source/governance includes here so code PRs cannot become skipped-but-green.
+    - ".coderabbit.yaml"
+    - "AGENTS.md"
+    - ".github/**"
+    - "docs/**"
+    - "maritime-ai-service/**"
+    - "wiii-desktop/**"
     # Force-include security-sensitive lockfiles that CodeRabbit skips by
     # default, so dependency PRs do not produce skipped-but-green reviews.
     - "**/package-lock.json"


### PR DESCRIPTION
## Summary

- Fix CodeRabbit `reviews.path_filters` so backend, desktop, GitHub automation, docs, and root governance files are explicitly reviewable.
- Keep existing generated/binary/cache exclusions and lockfile force-includes.

## Why

PR #159 showed a green CodeRabbit status while all changed backend/test files were skipped by path filters. Because positive path filters were limited to lockfiles, normal code changes could become skipped-but-green.

Closes #160.

## Validation

- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.coderabbit.yaml').read_text(encoding='utf-8')); print('coderabbit yaml ok')"`
- `git diff --check`