### PR TITLE
[codex] move sync runtime entrypoint off graph shell

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/graph.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph.py
@@ -18,6 +18,7 @@ from typing import Any, Optional, Literal
 from app.core.config import settings
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.graph_support import (
+    _SUMMARY_MILESTONES,
     _build_turn_local_state_defaults,
     route_decision,
     _build_domain_config,
@@ -55,9 +56,6 @@ from app.engine.multi_agent.subagent_dispatch import (
 from app.engine.reasoning_tracer import StepNames
 
 logger = logging.getLogger(__name__)
-
-# Sprint 79: Generate session summary at these message milestones
-_SUMMARY_MILESTONES = {6, 12, 20, 30}
 
 from app.engine.multi_agent.graph_runtime_bindings import (
     get_tool_by_name,

--- a/maritime-ai-service/app/engine/multi_agent/graph_support.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph_support.py
@@ -10,6 +10,9 @@ from app.engine.multi_agent.state import AgentState
 
 logger = logging.getLogger(__name__)
 
+# Sprint 79: Generate session summary at these message milestones.
+_SUMMARY_MILESTONES = {6, 12, 20, 30}
+
 
 def _build_turn_local_state_defaults(context: Optional[dict] = None) -> dict:
     """Reset request-local fields that must never bleed across checkpointed turns."""

--- a/maritime-ai-service/app/engine/multi_agent/runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/runtime.py
@@ -18,13 +18,12 @@ from app.engine.multi_agent.graph_runtime_bindings import (
     _resolve_public_thinking_content,
 )
 from app.engine.multi_agent.graph_support import (
+    _SUMMARY_MILESTONES,
     _build_domain_config,
     _build_turn_local_state_defaults,
     _generate_session_summary_bg,
 )
 from app.engine.multi_agent.graph_trace_store import _cleanup_tracer
-
-_SUMMARY_MILESTONES = {6, 12, 20, 30}
 
 
 def _get_legacy_graph_patch() -> Any | None:
@@ -35,6 +34,8 @@ def _get_legacy_graph_patch() -> Any | None:
 
     legacy_process = getattr(graph_module, "process_with_multi_agent", None)
     if legacy_process is None:
+        return None
+    if legacy_process is process_with_multi_agent:
         return None
 
     is_graph_wrapper = (

--- a/maritime-ai-service/app/engine/multi_agent/runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/runtime.py
@@ -2,17 +2,99 @@
 
 from __future__ import annotations
 
+import sys
 from typing import Any
 
+from app.engine.multi_agent.graph_process import process_with_multi_agent_impl
+from app.engine.multi_agent.graph_runtime_bindings import (
+    _inject_code_studio_context,
+    _inject_host_context,
+    _inject_host_session,
+    _inject_living_context,
+    _inject_operator_context,
+    _inject_visual_cognition_context,
+    _inject_visual_context,
+    _inject_widget_feedback_context,
+    _resolve_public_thinking_content,
+)
+from app.engine.multi_agent.graph_support import (
+    _build_domain_config,
+    _build_turn_local_state_defaults,
+    _generate_session_summary_bg,
+)
+from app.engine.multi_agent.graph_trace_store import _cleanup_tracer
 
-async def process_with_multi_agent(*args: Any, **kwargs: Any) -> dict:
-    """Dispatch to the runner-backed sync entrypoint.
+_SUMMARY_MILESTONES = {6, 12, 20, 30}
 
-    The lazy import preserves legacy test patch paths while production callers
-    move to the canonical runtime module name.
-    """
-    from app.engine.multi_agent.graph import process_with_multi_agent as process
 
-    return await process(*args, **kwargs)
+def _get_legacy_graph_patch() -> Any | None:
+    """Return a monkeypatched legacy graph entrypoint without importing graph.py."""
+    graph_module = sys.modules.get("app.engine.multi_agent.graph")
+    if graph_module is None:
+        return None
+
+    legacy_process = getattr(graph_module, "process_with_multi_agent", None)
+    if legacy_process is None:
+        return None
+
+    is_graph_wrapper = (
+        getattr(legacy_process, "__module__", "") == "app.engine.multi_agent.graph"
+        and getattr(legacy_process, "__name__", "") == "process_with_multi_agent"
+    )
+    if is_graph_wrapper:
+        return None
+
+    return legacy_process
+
+
+async def process_with_multi_agent(
+    query: str,
+    user_id: str,
+    session_id: str = "",
+    context: dict | None = None,
+    domain_id: str | None = None,
+    thinking_effort: str | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+) -> dict:
+    """Process a query through the WiiiRunner-native sync runtime."""
+    legacy_patch = _get_legacy_graph_patch()
+    if legacy_patch is not None:
+        return await legacy_patch(
+            query=query,
+            user_id=user_id,
+            session_id=session_id,
+            context=context,
+            domain_id=domain_id,
+            thinking_effort=thinking_effort,
+            provider=provider,
+            model=model,
+        )
+
+    return await process_with_multi_agent_impl(
+        query=query,
+        user_id=user_id,
+        session_id=session_id,
+        context=context,
+        domain_id=domain_id,
+        thinking_effort=thinking_effort,
+        provider=provider,
+        model=model,
+        build_domain_config=_build_domain_config,
+        build_turn_local_state_defaults=_build_turn_local_state_defaults,
+        cleanup_tracer=_cleanup_tracer,
+        resolve_public_thinking_content=_resolve_public_thinking_content,
+        generate_session_summary_bg=_generate_session_summary_bg,
+        inject_host_context=_inject_host_context,
+        inject_host_session=_inject_host_session,
+        inject_operator_context=_inject_operator_context,
+        inject_living_context=_inject_living_context,
+        inject_visual_context=_inject_visual_context,
+        inject_visual_cognition_context=_inject_visual_cognition_context,
+        inject_widget_feedback_context=_inject_widget_feedback_context,
+        inject_code_studio_context=_inject_code_studio_context,
+        summary_milestones=_SUMMARY_MILESTONES,
+    )
+
 
 __all__ = ["process_with_multi_agent"]

--- a/maritime-ai-service/tests/unit/test_multi_agent_runtime_surface.py
+++ b/maritime-ai-service/tests/unit/test_multi_agent_runtime_surface.py
@@ -2,6 +2,7 @@
 
 import ast
 from pathlib import Path
+import sys
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -12,6 +13,8 @@ from app.engine.multi_agent.stream_utils import create_status_event
 
 @pytest.mark.asyncio
 async def test_runtime_surface_delegates_to_sync_impl():
+    sys.modules.pop("app.engine.multi_agent.graph", None)
+
     from app.engine.multi_agent import runtime
 
     process = AsyncMock(return_value={"response": "ok"})
@@ -28,6 +31,24 @@ async def test_runtime_surface_delegates_to_sync_impl():
     assert process.call_args.kwargs["query"] == "hello"
     assert process.call_args.kwargs["build_domain_config"] is runtime._build_domain_config
     assert process.call_args.kwargs["cleanup_tracer"] is runtime._cleanup_tracer
+
+
+@pytest.mark.asyncio
+async def test_runtime_surface_skips_unpatched_legacy_graph_module():
+    import app.engine.multi_agent.graph  # noqa: F401
+    from app.engine.multi_agent import runtime
+
+    process = AsyncMock(return_value={"response": "ok"})
+
+    with patch.object(runtime, "process_with_multi_agent_impl", new=process):
+        result = await runtime.process_with_multi_agent(
+            query="hello",
+            user_id="user-1",
+            session_id="session-1",
+        )
+
+    assert result == {"response": "ok"}
+    process.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -53,12 +74,39 @@ def test_runtime_surface_has_no_hard_graph_import():
     source = Path(runtime.__file__).read_text(encoding="utf-8")
     tree = ast.parse(source)
 
-    imported_modules = {
+    import_from_modules = {
         node.module
         for node in ast.walk(tree)
         if isinstance(node, ast.ImportFrom)
     }
-    assert "app.engine.multi_agent.graph" not in imported_modules
+    imported_modules = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    dynamic_import_modules = {
+        node.args[0].value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and node.args[0].value == "app.engine.multi_agent.graph"
+        and (
+            (
+                isinstance(node.func, ast.Name)
+                and node.func.id == "__import__"
+            )
+            or (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "import_module"
+            )
+        )
+    }
+    forbidden_module = "app.engine.multi_agent.graph"
+    assert forbidden_module not in import_from_modules
+    assert forbidden_module not in imported_modules
+    assert forbidden_module not in dynamic_import_modules
 
 
 @pytest.mark.asyncio

--- a/maritime-ai-service/tests/unit/test_multi_agent_runtime_surface.py
+++ b/maritime-ai-service/tests/unit/test_multi_agent_runtime_surface.py
@@ -1,17 +1,40 @@
 """Guards for canonical WiiiRunner runtime import surfaces."""
 
+import ast
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.engine.multi_agent.runtime import process_with_multi_agent
 from app.engine.multi_agent.streaming_runtime import process_with_multi_agent_streaming
 from app.engine.multi_agent.stream_utils import create_status_event
 
 
 @pytest.mark.asyncio
-async def test_runtime_surface_delegates_to_sync_entrypoint():
+async def test_runtime_surface_delegates_to_sync_impl():
+    from app.engine.multi_agent import runtime
+
     process = AsyncMock(return_value={"response": "ok"})
+
+    with patch.object(runtime, "process_with_multi_agent_impl", new=process):
+        result = await runtime.process_with_multi_agent(
+            query="hello",
+            user_id="user-1",
+            session_id="session-1",
+        )
+
+    assert result == {"response": "ok"}
+    process.assert_awaited_once()
+    assert process.call_args.kwargs["query"] == "hello"
+    assert process.call_args.kwargs["build_domain_config"] is runtime._build_domain_config
+    assert process.call_args.kwargs["cleanup_tracer"] is runtime._cleanup_tracer
+
+
+@pytest.mark.asyncio
+async def test_runtime_surface_preserves_legacy_graph_patch_path():
+    from app.engine.multi_agent.runtime import process_with_multi_agent
+
+    process = AsyncMock(return_value={"response": "legacy-ok"})
 
     with patch("app.engine.multi_agent.graph.process_with_multi_agent", new=process):
         result = await process_with_multi_agent(
@@ -20,8 +43,22 @@ async def test_runtime_surface_delegates_to_sync_entrypoint():
             session_id="session-1",
         )
 
-    assert result == {"response": "ok"}
+    assert result == {"response": "legacy-ok"}
     process.assert_awaited_once()
+
+
+def test_runtime_surface_has_no_hard_graph_import():
+    from app.engine.multi_agent import runtime
+
+    source = Path(runtime.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    imported_modules = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+    }
+    assert "app.engine.multi_agent.graph" not in imported_modules
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Move `app.engine.multi_agent.runtime.process_with_multi_agent()` onto the runner-native sync implementation instead of lazy-importing `graph.process_with_multi_agent`.
- Wire the extracted graph process dependencies through `runtime.py` using existing runtime binding modules.
- Preserve legacy `graph.process_with_multi_agent` monkeypatch paths without importing `graph.py` from runtime.
- Strengthen runtime surface tests for direct sync impl delegation, legacy patch compatibility, and no hard graph import.

## Notes

This intentionally keeps `graph.py` intact for now. The graph shell still exposes many legacy re-export/patchability symbols, so dọn `graph.py` itself should be a separate cleanup slice under #130 rather than mixed into this runtime entrypoint migration.

Closes #162.
Parent: #130.

## Validation

- `python -m compileall -q maritime-ai-service\app\engine\multi_agent\runtime.py maritime-ai-service\tests\unit\test_multi_agent_runtime_surface.py`
- `python -m ruff check maritime-ai-service\app\engine\multi_agent\runtime.py maritime-ai-service\tests\unit\test_multi_agent_runtime_surface.py`
- `python -m pytest maritime-ai-service\tests\unit\test_multi_agent_runtime_surface.py maritime-ai-service\tests\unit\test_chat_request_flow.py::test_process_with_multi_agent_preserves_runtime_provider_metadata maritime-ai-service\tests\unit\test_scheduled_task_executor.py maritime-ai-service\tests\unit\test_sprint174_cross_platform.py -q -p no:capture --tb=short`
- `python -m pytest maritime-ai-service\tests\unit\test_wiii_runner_golden_parity.py maritime-ai-service\tests\unit\test_runner_hooks.py maritime-ai-service\tests\unit\test_runner_node_surface.py maritime-ai-service\tests\unit\test_guardian_graph_node.py maritime-ai-service\tests\unit\test_graph_process_thinking_lifecycle.py -q -p no:capture --tb=short`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated multi-agent runtime function with explicit typed parameters for improved reliability and parameter validation.

* **Tests**
  * Enhanced test coverage for multi-agent runtime execution, delegation, and backwards compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->