### PR TITLE
[codex] delegate graph sync entrypoint to runtime

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/graph.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph.py
@@ -25,7 +25,6 @@ from app.engine.multi_agent.graph_support import (
     _get_domain_greetings,
     _generate_session_summary_bg,
 )
-from app.engine.multi_agent.graph_process import process_with_multi_agent_impl
 from app.engine.multi_agent.graph_trace_store import (
     _TRACERS,
     _cleanup_tracer,
@@ -471,8 +470,10 @@ async def process_with_multi_agent(
     provider: Optional[str] = None,
     model: Optional[str] = None,
 ) -> dict:
-    """High-level function to process query with the multi-agent system."""
-    return await process_with_multi_agent_impl(
+    """Compatibility wrapper for legacy graph imports."""
+    from app.engine.multi_agent.runtime import process_with_multi_agent as process
+
+    return await process(
         query=query,
         user_id=user_id,
         session_id=session_id,
@@ -481,20 +482,6 @@ async def process_with_multi_agent(
         thinking_effort=thinking_effort,
         provider=provider,
         model=model,
-        build_domain_config=_build_domain_config,
-        build_turn_local_state_defaults=_build_turn_local_state_defaults,
-        cleanup_tracer=_cleanup_tracer,
-        resolve_public_thinking_content=_resolve_public_thinking_content,
-        generate_session_summary_bg=_generate_session_summary_bg,
-        inject_host_context=_inject_host_context,
-        inject_host_session=_inject_host_session,
-        inject_operator_context=_inject_operator_context,
-        inject_living_context=_inject_living_context,
-        inject_visual_context=_inject_visual_context,
-        inject_visual_cognition_context=_inject_visual_cognition_context,
-        inject_widget_feedback_context=_inject_widget_feedback_context,
-        inject_code_studio_context=_inject_code_studio_context,
-        summary_milestones=_SUMMARY_MILESTONES,
     )
 
 

--- a/maritime-ai-service/tests/unit/test_multi_agent_runtime_surface.py
+++ b/maritime-ai-service/tests/unit/test_multi_agent_runtime_surface.py
@@ -52,6 +52,24 @@ async def test_runtime_surface_skips_unpatched_legacy_graph_module():
 
 
 @pytest.mark.asyncio
+async def test_graph_surface_delegates_to_runtime_entrypoint():
+    from app.engine.multi_agent import graph
+
+    process = AsyncMock(return_value={"response": "runtime-ok"})
+
+    with patch("app.engine.multi_agent.runtime.process_with_multi_agent", new=process):
+        result = await graph.process_with_multi_agent(
+            query="hello",
+            user_id="user-1",
+            session_id="session-1",
+        )
+
+    assert result == {"response": "runtime-ok"}
+    process.assert_awaited_once()
+    assert process.call_args.kwargs["query"] == "hello"
+
+
+@pytest.mark.asyncio
 async def test_runtime_surface_preserves_legacy_graph_patch_path():
     from app.engine.multi_agent.runtime import process_with_multi_agent
 


### PR DESCRIPTION
## Summary

- Convert legacy `graph.process_with_multi_agent()` into a thin compatibility wrapper over the canonical `runtime.process_with_multi_agent()` path.
- Remove the direct `graph_process.process_with_multi_agent_impl` wiring from `graph.py`.
- Add a focused runtime-surface test proving legacy graph callers delegate through runtime.

## Why

PR #163 made `runtime.py` the canonical sync entrypoint, but `graph.py` still had a second sync wiring path. This keeps #130 moving in small, reversible slices without touching the broader legacy graph re-export/patchability surface yet.

Closes #164.
Parent: #130.

## Validation

- `python -m compileall -q maritime-ai-service\app\engine\multi_agent\graph.py maritime-ai-service\tests\unit\test_multi_agent_runtime_surface.py`
- `python -m ruff check maritime-ai-service\app\engine\multi_agent\graph.py maritime-ai-service\tests\unit\test_multi_agent_runtime_surface.py --select=E9,F63,F7`
- `python -m pytest maritime-ai-service\tests\unit\test_multi_agent_runtime_surface.py -q -p no:capture --tb=short`
- `python -m pytest maritime-ai-service\tests\unit\test_chat_request_flow.py::test_process_with_multi_agent_preserves_runtime_provider_metadata maritime-ai-service\tests\unit\test_scheduled_task_executor.py maritime-ai-service\tests\unit\test_sprint174_cross_platform.py maritime-ai-service\tests\unit\test_graph_thread_id.py -q -p no:capture --tb=short`
- `python -m pytest maritime-ai-service\tests\unit\test_wiii_runner_golden_parity.py maritime-ai-service\tests\unit\test_runner_hooks.py maritime-ai-service\tests\unit\test_runner_node_surface.py maritime-ai-service\tests\unit\test_guardian_graph_node.py maritime-ai-service\tests\unit\test_graph_process_thinking_lifecycle.py -q -p no:capture --tb=short`
- `git diff --check`