### PR TITLE
[codex] Extract graph tool collection compatibility helpers

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/graph.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph.py
@@ -40,6 +40,12 @@ from app.engine.multi_agent.code_studio_tool_rounds import (
     execute_code_studio_tool_rounds_impl,
 )
 from app.engine.multi_agent.code_studio_node_runtime import code_studio_node_impl
+from app.engine.multi_agent.graph_tool_collection_compat import (
+    collect_code_studio_tools_with_settings,
+    collect_direct_tools_with_settings,
+    code_studio_required_tool_names_with_settings,
+    direct_required_tool_names_with_settings,
+)
 from app.engine.multi_agent.widget_surface import (
     _has_structured_visual_event,
     _inject_widget_blocks_from_tool_results,
@@ -249,46 +255,43 @@ def _collect_direct_tools(
     state: AgentState | None = None,
 ):
     """Preserve graph.settings patch behavior for legacy tests and callers."""
-    original_settings = _tool_collection_module.settings
-    _tool_collection_module.settings = settings
-    try:
-        return _tool_collection_module._collect_direct_tools(
-            query,
-            user_role=user_role,
-            state=state,
-        )
-    finally:
-        _tool_collection_module.settings = original_settings
+    return collect_direct_tools_with_settings(
+        query,
+        user_role=user_role,
+        state=state,
+        settings_obj=settings,
+        tool_collection_module=_tool_collection_module,
+    )
 
 
 def _collect_code_studio_tools(query: str, user_role: str = "student"):
     """Preserve graph.settings patch behavior for legacy tests and callers."""
-    original_settings = _tool_collection_module.settings
-    _tool_collection_module.settings = settings
-    try:
-        return _tool_collection_module._collect_code_studio_tools(query, user_role=user_role)
-    finally:
-        _tool_collection_module.settings = original_settings
+    return collect_code_studio_tools_with_settings(
+        query,
+        user_role=user_role,
+        settings_obj=settings,
+        tool_collection_module=_tool_collection_module,
+    )
 
 
 def _direct_required_tool_names(query: str, user_role: str = "student") -> list[str]:
     """Preserve graph.settings patch behavior for legacy tests and callers."""
-    original_settings = _tool_collection_module.settings
-    _tool_collection_module.settings = settings
-    try:
-        return _tool_collection_module._direct_required_tool_names(query, user_role=user_role)
-    finally:
-        _tool_collection_module.settings = original_settings
+    return direct_required_tool_names_with_settings(
+        query,
+        user_role=user_role,
+        settings_obj=settings,
+        tool_collection_module=_tool_collection_module,
+    )
 
 
 def _code_studio_required_tool_names(query: str, user_role: str = "student") -> list[str]:
     """Preserve graph.settings patch behavior for legacy tests and callers."""
-    original_settings = _tool_collection_module.settings
-    _tool_collection_module.settings = settings
-    try:
-        return _tool_collection_module._code_studio_required_tool_names(query, user_role=user_role)
-    finally:
-        _tool_collection_module.settings = original_settings
+    return code_studio_required_tool_names_with_settings(
+        query,
+        user_role=user_role,
+        settings_obj=settings,
+        tool_collection_module=_tool_collection_module,
+    )
 
 
 async def _execute_code_studio_tool_rounds(

--- a/maritime-ai-service/app/engine/multi_agent/graph_tool_collection_compat.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph_tool_collection_compat.py
@@ -1,0 +1,88 @@
+"""Compatibility helpers for graph-local tool collection wrappers.
+
+These helpers keep the legacy ``app.engine.multi_agent.graph`` patch surface
+small while preserving graph-local ``settings`` monkeypatch behavior.
+"""
+
+from typing import Any
+
+
+def _call_with_tool_collection_settings(
+    tool_collection_module: Any,
+    settings_obj: Any,
+    function_name: str,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    original_settings = tool_collection_module.settings
+    tool_collection_module.settings = settings_obj
+    try:
+        return getattr(tool_collection_module, function_name)(*args, **kwargs)
+    finally:
+        tool_collection_module.settings = original_settings
+
+
+def collect_direct_tools_with_settings(
+    query: str,
+    user_role: str = "student",
+    *,
+    state: Any = None,
+    settings_obj: Any,
+    tool_collection_module: Any,
+) -> Any:
+    return _call_with_tool_collection_settings(
+        tool_collection_module,
+        settings_obj,
+        "_collect_direct_tools",
+        query,
+        user_role=user_role,
+        state=state,
+    )
+
+
+def collect_code_studio_tools_with_settings(
+    query: str,
+    user_role: str = "student",
+    *,
+    settings_obj: Any,
+    tool_collection_module: Any,
+) -> Any:
+    return _call_with_tool_collection_settings(
+        tool_collection_module,
+        settings_obj,
+        "_collect_code_studio_tools",
+        query,
+        user_role=user_role,
+    )
+
+
+def direct_required_tool_names_with_settings(
+    query: str,
+    user_role: str = "student",
+    *,
+    settings_obj: Any,
+    tool_collection_module: Any,
+) -> list[str]:
+    return _call_with_tool_collection_settings(
+        tool_collection_module,
+        settings_obj,
+        "_direct_required_tool_names",
+        query,
+        user_role=user_role,
+    )
+
+
+def code_studio_required_tool_names_with_settings(
+    query: str,
+    user_role: str = "student",
+    *,
+    settings_obj: Any,
+    tool_collection_module: Any,
+) -> list[str]:
+    return _call_with_tool_collection_settings(
+        tool_collection_module,
+        settings_obj,
+        "_code_studio_required_tool_names",
+        query,
+        user_role=user_role,
+    )

--- a/maritime-ai-service/tests/unit/test_multi_agent_runtime_surface.py
+++ b/maritime-ai-service/tests/unit/test_multi_agent_runtime_surface.py
@@ -69,6 +69,84 @@ async def test_graph_surface_delegates_to_runtime_entrypoint():
     assert process.call_args.kwargs["query"] == "hello"
 
 
+def test_graph_tool_collection_wrapper_uses_graph_settings_and_restores(monkeypatch):
+    from app.engine.multi_agent import graph
+
+    calls = []
+    original_settings = object()
+    patched_settings = object()
+    state = {"session_id": "session-1"}
+
+    class FakeToolCollection:
+        settings = original_settings
+
+        def _collect_direct_tools(self, query, *, user_role, state=None):
+            calls.append((self.settings, query, user_role, state))
+            return ["weather_tool"], ["datetime_tool"]
+
+    fake_tools = FakeToolCollection()
+    monkeypatch.setattr(graph, "_tool_collection_module", fake_tools)
+    monkeypatch.setattr(graph, "settings", patched_settings)
+
+    result = graph._collect_direct_tools(
+        "weather now",
+        user_role="teacher",
+        state=state,
+    )
+
+    assert result == (["weather_tool"], ["datetime_tool"])
+    assert calls == [(patched_settings, "weather now", "teacher", state)]
+    assert fake_tools.settings is original_settings
+
+
+def test_graph_tool_collection_wrapper_restores_settings_after_error(monkeypatch):
+    from app.engine.multi_agent import graph
+
+    original_settings = object()
+    patched_settings = object()
+
+    class FakeToolCollection:
+        settings = original_settings
+
+        def _direct_required_tool_names(self, query, *, user_role):
+            assert self.settings is patched_settings
+            raise RuntimeError("tool selection failed")
+
+    fake_tools = FakeToolCollection()
+    monkeypatch.setattr(graph, "_tool_collection_module", fake_tools)
+    monkeypatch.setattr(graph, "settings", patched_settings)
+
+    with pytest.raises(RuntimeError, match="tool selection failed"):
+        graph._direct_required_tool_names("hello", user_role="student")
+
+    assert fake_tools.settings is original_settings
+
+
+def test_graph_code_studio_tool_collection_wrapper_uses_graph_settings(monkeypatch):
+    from app.engine.multi_agent import graph
+
+    calls = []
+    original_settings = object()
+    patched_settings = object()
+
+    class FakeToolCollection:
+        settings = original_settings
+
+        def _collect_code_studio_tools(self, query, *, user_role):
+            calls.append((self.settings, query, user_role))
+            return ["code_studio"], ["render_app"]
+
+    fake_tools = FakeToolCollection()
+    monkeypatch.setattr(graph, "_tool_collection_module", fake_tools)
+    monkeypatch.setattr(graph, "settings", patched_settings)
+
+    result = graph._collect_code_studio_tools("build an app", user_role="teacher")
+
+    assert result == (["code_studio"], ["render_app"])
+    assert calls == [(patched_settings, "build an app", "teacher")]
+    assert fake_tools.settings is original_settings
+
+
 @pytest.mark.asyncio
 async def test_runtime_surface_preserves_legacy_graph_patch_path():
     from app.engine.multi_agent.runtime import process_with_multi_agent


### PR DESCRIPTION
## Summary
This PR continues the LangGraph exit plan by moving the graph-local tool collection settings swap/restore implementation into a dedicated compat module. The legacy `app.engine.multi_agent.graph` wrapper names remain intact, so existing imports and monkeypatch paths keep working while `graph.py` becomes thinner.

## Linked Work
Closes #166
Refs #130

## Scope
- In scope: `graph.py` tool-collection compatibility wrappers, new `graph_tool_collection_compat.py`, runtime-surface regression tests.
- Out of scope: direct/tool selection behavior changes, Code Studio runtime changes, full LangGraph removal.

## Ownership and Coordination
- PR owner: Codex
- Agents involved: Codex
- Owned paths: `maritime-ai-service/app/engine/multi_agent/graph.py`, `maritime-ai-service/app/engine/multi_agent/graph_tool_collection_compat.py`, `maritime-ai-service/tests/unit/test_multi_agent_runtime_surface.py`
- Out-of-scope paths: provider layer, frontend, database migrations, GitHub governance.
- Conflict risk: Low, but any parallel edits to legacy graph wrappers should rebase carefully.
- Merge decision owner: Maintainer

## Change Type
- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation/governance
- [ ] Test-only
- [ ] Build/CI/dependency
- [ ] Security/auth/privacy
- [ ] Database/migration
- [ ] Breaking change

## Risk Checklist
- [x] No unrelated dirty worktree changes were staged.
- [x] No secrets, tokens, private data, or local-only files are committed.
- [x] Multi-agent file ownership was declared when more than one agent contributed.
- [x] CodeRabbit findings are resolved, deferred with rationale, or explicitly not applicable.
- [x] Codex Review was requested for high-risk changes, or explicitly marked not required with rationale.
- [x] Auth, tenant isolation, memory, and user identity behavior were considered.
- [x] Feature flags and default behavior were considered.
- [x] Database migrations are included or explicitly not required.
- [x] Rollback path is clear.

## Verification
```text
Command: python -m compileall -q maritime-ai-service\app\engine\multi_agent\graph.py maritime-ai-service\app\engine\multi_agent\graph_tool_collection_compat.py maritime-ai-service\tests\unit\test_multi_agent_runtime_surface.py
Result: Pass

Command: python -m ruff check maritime-ai-service\app\engine\multi_agent\graph.py maritime-ai-service\app\engine\multi_agent\graph_tool_collection_compat.py maritime-ai-service\tests\unit\test_multi_agent_runtime_surface.py --select=E9,F63,F7
Result: Pass

Command: python -m pytest tests\unit\test_multi_agent_runtime_surface.py -q -p no:capture --tb=short
Result: 9 passed

Command: python -m pytest tests\unit\test_sprint154_tech_debt.py tests\unit\test_graph_routing.py -q -p no:capture --tb=short
Result: 151 passed

Command: python -m pytest tests\unit\test_chat_request_flow.py::test_process_with_multi_agent_preserves_runtime_provider_metadata tests\unit\test_scheduled_task_executor.py tests\unit\test_sprint174_cross_platform.py tests\unit\test_graph_thread_id.py -q -p no:capture --tb=short
Result: 84 passed

Command: git diff --check
Result: Pass
```

## UI Evidence
N/A

## Deployment Notes
- Environment/config changes: None.
- Migration/backfill steps: None.
- Monitoring/logs to watch: Backend CI and graph/direct routing tests.
- Rollback: Revert this PR to move settings swap/restore implementation back into `graph.py`.

## Reviewer Focus
- Critical paths: Legacy `graph._collect_*` and `graph._*_required_tool_names` patch/import compatibility.
- Edge cases: `tool_collection.settings` must be restored even when delegated calls raise.
- Known limitations: This PR intentionally does not remove LangGraph or migrate all graph imports.
- Codex Review focus: Behavioral compatibility around monkeypatchable graph settings and tool collection delegation.