### PR TITLE
Harden provider runtime health, fallback, and SSE finalization

### DIFF
--- a/maritime-ai-service/app/api/v1/admin_schemas.py
+++ b/maritime-ai-service/app/api/v1/admin_schemas.py
@@ -316,12 +316,16 @@ class LlmTimeoutProfilesConfig(BaseModel):
     stream_idle_timeout_seconds: float = Field(ge=0, le=3600)
 
 
-class LlmTimeoutProviderOverride(BaseModel):
+class LlmTimeoutModelOverride(BaseModel):
     light_seconds: Optional[float] = Field(default=None, ge=0, le=600)
     moderate_seconds: Optional[float] = Field(default=None, ge=0, le=900)
     deep_seconds: Optional[float] = Field(default=None, ge=0, le=1800)
     structured_seconds: Optional[float] = Field(default=None, ge=0, le=1800)
     background_seconds: Optional[float] = Field(default=None, ge=0, le=3600)
+
+
+class LlmTimeoutProviderOverride(LlmTimeoutModelOverride):
+    models: dict[str, LlmTimeoutModelOverride] = Field(default_factory=dict)
 
 
 class LlmRuntimeConfigResponse(BaseModel):

--- a/maritime-ai-service/app/core/config/_settings_base_fields.py
+++ b/maritime-ai-service/app/core/config/_settings_base_fields.py
@@ -348,7 +348,11 @@ class BaseSettingsFieldsMixin:
     )
     llm_timeout_provider_overrides: str = Field(
         default="{}",
-        description='JSON provider-specific timeout overrides: {"google": {"light_seconds": 12}}',
+        description=(
+            "JSON provider/model timeout overrides: "
+            '{"google": {"light_seconds": 12}, '
+            '"nvidia": {"models": {"deepseek-ai/deepseek-v4-flash": {"moderate_seconds": 8}}}}'
+        ),
     )
     llm_runtime_audit_refresh_interval_seconds: float = Field(
         default=300.0,
@@ -688,4 +692,3 @@ class BaseSettingsFieldsMixin:
     enable_multi_tenant: bool = Field(default=False, description="Enable multi-organization support")
     default_organization_id: str = Field(default="default", description="Default org for unauthenticated users")
     enable_rls: bool = Field(default=False, description="Enable PostgreSQL Row-Level Security (requires enable_multi_tenant)")
-

--- a/maritime-ai-service/app/core/config/llm.py
+++ b/maritime-ai-service/app/core/config/llm.py
@@ -1,5 +1,5 @@
 """LLMConfig — LLM provider settings (Gemini, OpenAI, Ollama)."""
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel
 
@@ -31,7 +31,7 @@ class LLMConfig(BaseModel):
     primary_timeout_background_seconds: float = 0.0
     stream_keepalive_interval_seconds: float = 15.0
     stream_idle_timeout_seconds: float = 0.0
-    timeout_provider_overrides: dict[str, dict[str, float]] = {}
+    timeout_provider_overrides: dict[str, dict[str, Any]] = {}
     google_api_key: Optional[str] = None
     google_model: str = GOOGLE_DEFAULT_MODEL
     google_model_advanced: str = GOOGLE_DEEP_MODEL

--- a/maritime-ai-service/app/engine/llm_failover_runtime.py
+++ b/maritime-ai-service/app/engine/llm_failover_runtime.py
@@ -9,7 +9,9 @@ from typing import Any, Callable, Optional
 from langchain_core.language_models import BaseChatModel
 
 from app.core.exceptions import ProviderUnavailableError
+from app.engine.llm_model_health import record_model_failure, record_model_success
 from app.engine.llm_same_provider_runtime import extract_runtime_model_name_impl
+from app.engine.llm_timeout_policy import resolve_timeout_override
 
 
 def is_rate_limit_error_impl(error: Exception) -> bool:
@@ -41,6 +43,7 @@ def resolve_primary_timeout_seconds_impl(
     pool_cls,
     timeout_profile_structured: str,
     timeout_profile_background: str,
+    model_name: Optional[str] = None,
 ) -> float | None:
     """Resolve the first-response timeout for one invocation."""
     normalized_profile = str(timeout_profile or "").strip().lower()
@@ -58,7 +61,12 @@ def resolve_primary_timeout_seconds_impl(
         overrides = loads_timeout_provider_overrides_fn(
             getattr(settings_obj, "llm_timeout_provider_overrides", "{}")
         )
-        override_value = overrides.get(normalized_provider, {}).get(profile_key)
+        override_value = resolve_timeout_override(
+            overrides=overrides,
+            provider=normalized_provider,
+            profile_key=profile_key,
+            model_name=model_name,
+        )
         if override_value is not None:
             return override_value if override_value > 0 else None
 
@@ -303,6 +311,7 @@ async def ainvoke_with_failover_impl(
     elif getattr(llm, "_wiii_provider_name", None) == route.provider or route.provider is None:
         primary_llm = llm
 
+    primary_model_name = extract_runtime_model_name_impl(primary_llm)
     timeout = (
         primary_timeout
         if primary_timeout is not None
@@ -310,6 +319,7 @@ async def ainvoke_with_failover_impl(
             tier=tier,
             timeout_profile=timeout_profile,
             provider=route.provider,
+            model_name=primary_model_name,
         )
     )
 
@@ -322,11 +332,10 @@ async def ainvoke_with_failover_impl(
         return fallback_llm
 
     def _prepare_same_provider_fallback():
-        current_model_name = extract_runtime_model_name_impl(primary_llm)
         plan = resolve_same_provider_model_fallback_fn(
             route.provider,
             tier,
-            current_model_name=current_model_name,
+            current_model_name=primary_model_name,
         )
         if not plan:
             return None, None
@@ -437,6 +446,7 @@ async def ainvoke_with_failover_impl(
             result = await asyncio.wait_for(primary_llm.ainvoke(messages), timeout=timeout)
         else:
             result = await primary_llm.ainvoke(messages)
+        record_model_success(route.provider, primary_model_name)
         await asyncio.shield(pool_cls.record_success_for_provider(route.provider))
         return result
     except (asyncio.TimeoutError, Exception) as exc:
@@ -450,6 +460,17 @@ async def ainvoke_with_failover_impl(
             raise
 
         await asyncio.shield(pool_cls.record_failure_for_provider(route.provider))
+        classified_primary_failure = classify_failover_reason_impl(
+            error=exc,
+            timeout_seconds=timeout if is_timeout else None,
+        )
+        record_model_failure(
+            route.provider,
+            primary_model_name,
+            reason_code=classified_primary_failure["reason_code"],
+            error=exc,
+            timeout_seconds=timeout if is_timeout else None,
+        )
 
         same_provider_plan = None
         same_provider_llm = None
@@ -461,6 +482,7 @@ async def ainvoke_with_failover_impl(
                 tier=same_provider_plan["to_tier"],
                 timeout_profile=timeout_profile,
                 provider=route.provider,
+                model_name=same_provider_plan["to_model"],
             )
             reason = f"timeout_{timeout}s" if is_timeout else type(exc).__name__
             await _emit_same_provider_switch(
@@ -477,10 +499,26 @@ async def ainvoke_with_failover_impl(
                     )
                 else:
                     result = await same_provider_llm.ainvoke(messages)
+                record_model_success(
+                    same_provider_plan["provider"],
+                    same_provider_plan["to_model"],
+                )
                 await asyncio.shield(pool_cls.record_success_for_provider(route.provider))
                 return result
             except Exception as same_exc:
                 same_provider_error = same_exc
+                same_is_timeout = isinstance(same_exc, asyncio.TimeoutError)
+                classified_same_failure = classify_failover_reason_impl(
+                    error=same_exc,
+                    timeout_seconds=same_timeout if same_is_timeout else None,
+                )
+                record_model_failure(
+                    same_provider_plan["provider"],
+                    same_provider_plan["to_model"],
+                    reason_code=classified_same_failure["reason_code"],
+                    error=same_exc,
+                    timeout_seconds=same_timeout if same_is_timeout else None,
+                )
                 logger_obj.warning(
                     "[LLM_MODEL_FALLBACK] Same-provider fallback failed: provider=%s model=%s detail=%s",
                     same_provider_plan["provider"],
@@ -506,6 +544,11 @@ async def ainvoke_with_failover_impl(
         reason = f"timeout_{timeout}s" if is_timeout else type(exc).__name__
         await _emit_switch(reason=reason, error=exc)
         fallback_timeout = timeout * 2 if (timeout and timeout > 0) else None
+        fallback_model_name = extract_runtime_model_name_impl(fb)
         if fallback_timeout:
-            return await asyncio.wait_for(fb.ainvoke(messages), timeout=fallback_timeout)
-        return await fb.ainvoke(messages)
+            result = await asyncio.wait_for(fb.ainvoke(messages), timeout=fallback_timeout)
+        else:
+            result = await fb.ainvoke(messages)
+        record_model_success(route.fallback_provider, fallback_model_name)
+        await asyncio.shield(pool_cls.record_success_for_provider(route.fallback_provider))
+        return result

--- a/maritime-ai-service/app/engine/llm_failover_runtime.py
+++ b/maritime-ai-service/app/engine/llm_failover_runtime.py
@@ -545,10 +545,31 @@ async def ainvoke_with_failover_impl(
         await _emit_switch(reason=reason, error=exc)
         fallback_timeout = timeout * 2 if (timeout and timeout > 0) else None
         fallback_model_name = extract_runtime_model_name_impl(fb)
-        if fallback_timeout:
-            result = await asyncio.wait_for(fb.ainvoke(messages), timeout=fallback_timeout)
-        else:
-            result = await fb.ainvoke(messages)
+        try:
+            if fallback_timeout:
+                result = await asyncio.wait_for(
+                    fb.ainvoke(messages),
+                    timeout=fallback_timeout,
+                )
+            else:
+                result = await fb.ainvoke(messages)
+        except Exception as fallback_exc:
+            fallback_is_timeout = isinstance(fallback_exc, asyncio.TimeoutError)
+            classified_fallback_failure = classify_failover_reason_impl(
+                error=fallback_exc,
+                timeout_seconds=fallback_timeout if fallback_is_timeout else None,
+            )
+            record_model_failure(
+                route.fallback_provider,
+                fallback_model_name,
+                reason_code=classified_fallback_failure["reason_code"],
+                error=fallback_exc,
+                timeout_seconds=fallback_timeout if fallback_is_timeout else None,
+            )
+            await asyncio.shield(
+                pool_cls.record_failure_for_provider(route.fallback_provider)
+            )
+            raise
         record_model_success(route.fallback_provider, fallback_model_name)
         await asyncio.shield(pool_cls.record_success_for_provider(route.fallback_provider))
         return result

--- a/maritime-ai-service/app/engine/llm_model_health.py
+++ b/maritime-ai-service/app/engine/llm_model_health.py
@@ -8,6 +8,7 @@ model immediately without waiting for a full provider-level probe cycle.
 
 from __future__ import annotations
 
+import threading
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -38,6 +39,7 @@ class ModelHealthRecord:
 
 
 _MODEL_HEALTH: dict[tuple[str, str], ModelHealthRecord] = {}
+_MODEL_HEALTH_LOCK = threading.RLock()
 
 
 def _normalize_provider(provider: str | None) -> str | None:
@@ -64,12 +66,13 @@ def _compact_detail(value: Any, *, max_length: int = 180) -> str | None:
 
 
 def _get_record(provider: str, model: str) -> ModelHealthRecord:
-    key = (provider, model)
-    record = _MODEL_HEALTH.get(key)
-    if record is None:
-        record = ModelHealthRecord(provider=provider, model=model, state="healthy")
-        _MODEL_HEALTH[key] = record
-    return record
+    with _MODEL_HEALTH_LOCK:
+        key = (provider, model)
+        record = _MODEL_HEALTH.get(key)
+        if record is None:
+            record = ModelHealthRecord(provider=provider, model=model, state="healthy")
+            _MODEL_HEALTH[key] = record
+        return record
 
 
 def _is_still_degraded(record: ModelHealthRecord, *, now: float) -> bool:
@@ -90,10 +93,11 @@ def record_model_success(provider: str | None, model: str | None) -> None:
     normalized_model = _normalize_model(model)
     if not normalized_provider or not normalized_model:
         return
-    record = _get_record(normalized_provider, normalized_model)
-    record.state = "healthy"
-    record.last_success_at = time.time()
-    record.degraded_until = None
+    with _MODEL_HEALTH_LOCK:
+        record = _get_record(normalized_provider, normalized_model)
+        record.state = "healthy"
+        record.last_success_at = time.time()
+        record.degraded_until = None
 
 
 def record_model_failure(
@@ -103,7 +107,7 @@ def record_model_failure(
     reason_code: str | None = None,
     error: Exception | None = None,
     timeout_seconds: float | None = None,
-    degraded_for_seconds: float = DEFAULT_DEGRADED_TTL_SECONDS,
+    degraded_for_seconds: float | None = DEFAULT_DEGRADED_TTL_SECONDS,
 ) -> None:
     """Record a model failure and temporarily degrade retry-worthy failures."""
     normalized_provider = _normalize_provider(provider)
@@ -111,28 +115,29 @@ def record_model_failure(
     if not normalized_provider or not normalized_model:
         return
 
-    now = time.time()
-    normalized_reason = (reason_code or "").strip().lower() or None
-    record = _get_record(normalized_provider, normalized_model)
-    record.last_reason_code = normalized_reason
-    record.last_error_type = type(error).__name__ if error is not None else None
-    record.last_error_detail = _compact_detail(error)
-    record.last_timeout_seconds = timeout_seconds
-    record.last_failure_at = now
+    with _MODEL_HEALTH_LOCK:
+        now = time.time()
+        normalized_reason = (reason_code or "").strip().lower() or None
+        record = _get_record(normalized_provider, normalized_model)
+        record.last_reason_code = normalized_reason
+        record.last_error_type = type(error).__name__ if error is not None else None
+        record.last_error_detail = _compact_detail(error)
+        record.last_timeout_seconds = timeout_seconds
+        record.last_failure_at = now
 
-    should_degrade = (
-        timeout_seconds is not None
-        or normalized_reason in _DEGRADING_REASON_CODES
-    )
-    if not should_degrade:
-        return
+        should_degrade = (
+            degraded_for_seconds is not None
+            and degraded_for_seconds > 0
+            and (
+                timeout_seconds is not None
+                or normalized_reason in _DEGRADING_REASON_CODES
+            )
+        )
+        if not should_degrade:
+            return
 
-    record.state = "degraded"
-    record.degraded_until = (
-        now + degraded_for_seconds
-        if degraded_for_seconds and degraded_for_seconds > 0
-        else None
-    )
+        record.state = "degraded"
+        record.degraded_until = now + degraded_for_seconds
 
 
 def is_model_degraded(provider: str | None, model: str | None) -> bool:
@@ -141,32 +146,35 @@ def is_model_degraded(provider: str | None, model: str | None) -> bool:
     normalized_model = _normalize_model(model)
     if not normalized_provider or not normalized_model:
         return False
-    record = _MODEL_HEALTH.get((normalized_provider, normalized_model))
-    if record is None:
-        return False
-    return _is_still_degraded(record, now=time.time())
+    with _MODEL_HEALTH_LOCK:
+        record = _MODEL_HEALTH.get((normalized_provider, normalized_model))
+        if record is None:
+            return False
+        return _is_still_degraded(record, now=time.time())
 
 
 def get_model_health_snapshot() -> dict[str, dict[str, dict[str, Any]]]:
     """Expose model health for diagnostics and LLMPool stats."""
-    now = time.time()
-    snapshot: dict[str, dict[str, dict[str, Any]]] = {}
-    for record in list(_MODEL_HEALTH.values()):
-        _is_still_degraded(record, now=now)
-        provider_bucket = snapshot.setdefault(record.provider, {})
-        provider_bucket[record.model] = {
-            "state": record.state,
-            "last_reason_code": record.last_reason_code,
-            "last_error_type": record.last_error_type,
-            "last_error_detail": record.last_error_detail,
-            "last_timeout_seconds": record.last_timeout_seconds,
-            "last_failure_at": record.last_failure_at,
-            "last_success_at": record.last_success_at,
-            "degraded_until": record.degraded_until,
-        }
-    return snapshot
+    with _MODEL_HEALTH_LOCK:
+        now = time.time()
+        snapshot: dict[str, dict[str, dict[str, Any]]] = {}
+        for record in list(_MODEL_HEALTH.values()):
+            _is_still_degraded(record, now=now)
+            provider_bucket = snapshot.setdefault(record.provider, {})
+            provider_bucket[record.model] = {
+                "state": record.state,
+                "last_reason_code": record.last_reason_code,
+                "last_error_type": record.last_error_type,
+                "last_error_detail": record.last_error_detail,
+                "last_timeout_seconds": record.last_timeout_seconds,
+                "last_failure_at": record.last_failure_at,
+                "last_success_at": record.last_success_at,
+                "degraded_until": record.degraded_until,
+            }
+        return snapshot
 
 
 def reset_model_health_state() -> None:
     """Clear health state, primarily for tests."""
-    _MODEL_HEALTH.clear()
+    with _MODEL_HEALTH_LOCK:
+        _MODEL_HEALTH.clear()

--- a/maritime-ai-service/app/engine/llm_model_health.py
+++ b/maritime-ai-service/app/engine/llm_model_health.py
@@ -165,7 +165,6 @@ def get_model_health_snapshot() -> dict[str, dict[str, dict[str, Any]]]:
                 "state": record.state,
                 "last_reason_code": record.last_reason_code,
                 "last_error_type": record.last_error_type,
-                "last_error_detail": record.last_error_detail,
                 "last_timeout_seconds": record.last_timeout_seconds,
                 "last_failure_at": record.last_failure_at,
                 "last_success_at": record.last_success_at,

--- a/maritime-ai-service/app/engine/llm_model_health.py
+++ b/maritime-ai-service/app/engine/llm_model_health.py
@@ -1,0 +1,172 @@
+"""In-memory per-provider/model health state for LLM routing.
+
+This is intentionally process-local. Persistent provider audit remains the
+source of truth for admin UI/history, while this module protects the hot path:
+when a concrete model times out or rate-limits, the next request can avoid that
+model immediately without waiting for a full provider-level probe cycle.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_DEGRADED_TTL_SECONDS = 300.0
+_DEGRADING_REASON_CODES = {
+    "timeout",
+    "rate_limit",
+    "server_error",
+    "provider_unavailable",
+    "host_down",
+}
+
+
+@dataclass
+class ModelHealthRecord:
+    provider: str
+    model: str
+    state: str
+    last_reason_code: str | None = None
+    last_error_type: str | None = None
+    last_error_detail: str | None = None
+    last_timeout_seconds: float | None = None
+    last_failure_at: float | None = None
+    last_success_at: float | None = None
+    degraded_until: float | None = None
+
+
+_MODEL_HEALTH: dict[tuple[str, str], ModelHealthRecord] = {}
+
+
+def _normalize_provider(provider: str | None) -> str | None:
+    if not isinstance(provider, str):
+        return None
+    normalized = provider.strip().lower()
+    return normalized or None
+
+
+def _normalize_model(model: str | None) -> str | None:
+    if not isinstance(model, str):
+        return None
+    normalized = model.strip()
+    return normalized or None
+
+
+def _compact_detail(value: Any, *, max_length: int = 180) -> str | None:
+    text = " ".join(str(value or "").split()).strip()
+    if not text:
+        return None
+    if len(text) <= max_length:
+        return text
+    return f"{text[: max_length - 3].rstrip()}..."
+
+
+def _get_record(provider: str, model: str) -> ModelHealthRecord:
+    key = (provider, model)
+    record = _MODEL_HEALTH.get(key)
+    if record is None:
+        record = ModelHealthRecord(provider=provider, model=model, state="healthy")
+        _MODEL_HEALTH[key] = record
+    return record
+
+
+def _is_still_degraded(record: ModelHealthRecord, *, now: float) -> bool:
+    if record.state != "degraded":
+        return False
+    if record.degraded_until is None:
+        return True
+    if record.degraded_until > now:
+        return True
+    record.state = "healthy"
+    record.degraded_until = None
+    return False
+
+
+def record_model_success(provider: str | None, model: str | None) -> None:
+    """Mark a concrete model healthy after a successful invocation."""
+    normalized_provider = _normalize_provider(provider)
+    normalized_model = _normalize_model(model)
+    if not normalized_provider or not normalized_model:
+        return
+    record = _get_record(normalized_provider, normalized_model)
+    record.state = "healthy"
+    record.last_success_at = time.time()
+    record.degraded_until = None
+
+
+def record_model_failure(
+    provider: str | None,
+    model: str | None,
+    *,
+    reason_code: str | None = None,
+    error: Exception | None = None,
+    timeout_seconds: float | None = None,
+    degraded_for_seconds: float = DEFAULT_DEGRADED_TTL_SECONDS,
+) -> None:
+    """Record a model failure and temporarily degrade retry-worthy failures."""
+    normalized_provider = _normalize_provider(provider)
+    normalized_model = _normalize_model(model)
+    if not normalized_provider or not normalized_model:
+        return
+
+    now = time.time()
+    normalized_reason = (reason_code or "").strip().lower() or None
+    record = _get_record(normalized_provider, normalized_model)
+    record.last_reason_code = normalized_reason
+    record.last_error_type = type(error).__name__ if error is not None else None
+    record.last_error_detail = _compact_detail(error)
+    record.last_timeout_seconds = timeout_seconds
+    record.last_failure_at = now
+
+    should_degrade = (
+        timeout_seconds is not None
+        or normalized_reason in _DEGRADING_REASON_CODES
+    )
+    if not should_degrade:
+        return
+
+    record.state = "degraded"
+    record.degraded_until = (
+        now + degraded_for_seconds
+        if degraded_for_seconds and degraded_for_seconds > 0
+        else None
+    )
+
+
+def is_model_degraded(provider: str | None, model: str | None) -> bool:
+    """Return True while a model is inside its temporary degraded window."""
+    normalized_provider = _normalize_provider(provider)
+    normalized_model = _normalize_model(model)
+    if not normalized_provider or not normalized_model:
+        return False
+    record = _MODEL_HEALTH.get((normalized_provider, normalized_model))
+    if record is None:
+        return False
+    return _is_still_degraded(record, now=time.time())
+
+
+def get_model_health_snapshot() -> dict[str, dict[str, dict[str, Any]]]:
+    """Expose model health for diagnostics and LLMPool stats."""
+    now = time.time()
+    snapshot: dict[str, dict[str, dict[str, Any]]] = {}
+    for record in list(_MODEL_HEALTH.values()):
+        _is_still_degraded(record, now=now)
+        provider_bucket = snapshot.setdefault(record.provider, {})
+        provider_bucket[record.model] = {
+            "state": record.state,
+            "last_reason_code": record.last_reason_code,
+            "last_error_type": record.last_error_type,
+            "last_error_detail": record.last_error_detail,
+            "last_timeout_seconds": record.last_timeout_seconds,
+            "last_failure_at": record.last_failure_at,
+            "last_success_at": record.last_success_at,
+            "degraded_until": record.degraded_until,
+        }
+    return snapshot
+
+
+def reset_model_health_state() -> None:
+    """Clear health state, primarily for tests."""
+    _MODEL_HEALTH.clear()

--- a/maritime-ai-service/app/engine/llm_pool.py
+++ b/maritime-ai-service/app/engine/llm_pool.py
@@ -21,6 +21,7 @@ from langchain_core.language_models import BaseChatModel
 
 from app.core.config import settings
 from app.core.exceptions import ProviderUnavailableError
+from app.engine.llm_model_health import is_model_degraded, reset_model_health_state
 from app.engine.llm_runtime_state import register_llm_runtime_access
 from app.engine.llm_provider_registry import create_provider, is_supported_provider
 from app.engine.llm_timeout_policy import (
@@ -649,6 +650,7 @@ class LLMPool:
             settings_obj=settings,
             thinking_tier_cls=ThinkingTier,
             normalize_provider=cls._normalize_provider,
+            is_model_degraded_fn=is_model_degraded,
         )
 
     @classmethod
@@ -667,6 +669,7 @@ class LLMPool:
         cls._initialized = False
         cls._active_provider = None
         cls._fallback_provider = None
+        reset_model_health_state()
 
 
 # ============================================================================
@@ -754,6 +757,7 @@ def resolve_primary_timeout_seconds(
     tier: str = "moderate",
     timeout_profile: Optional[str] = None,
     provider: Optional[str] = None,
+    model_name: Optional[str] = None,
 ) -> float | None:
     return resolve_primary_timeout_seconds_impl(
         tier=tier,
@@ -767,6 +771,7 @@ def resolve_primary_timeout_seconds(
         pool_cls=LLMPool,
         timeout_profile_structured=TIMEOUT_PROFILE_STRUCTURED,
         timeout_profile_background=TIMEOUT_PROFILE_BACKGROUND,
+        model_name=model_name,
     )
 
 

--- a/maritime-ai-service/app/engine/llm_pool_bootstrap_runtime.py
+++ b/maritime-ai-service/app/engine/llm_pool_bootstrap_runtime.py
@@ -6,6 +6,22 @@ from typing import Optional
 
 from langchain_core.language_models import BaseChatModel
 
+from app.engine.llm_model_health import is_model_degraded
+from app.engine.llm_same_provider_runtime import extract_runtime_model_name_impl
+
+
+def _cached_llm_is_degraded(provider_name: str, llm: BaseChatModel | None) -> bool:
+    model_name = extract_runtime_model_name_impl(llm)
+    return is_model_degraded(provider_name, model_name)
+
+
+def _drop_cached_tier(cls_ref, provider_name: str, tier_key: str) -> None:
+    cls_ref._provider_pools.get(provider_name, {}).pop(tier_key, None)
+    if provider_name == cls_ref._active_provider:
+        cls_ref._pool.pop(tier_key, None)
+    if provider_name == cls_ref._fallback_provider:
+        cls_ref._fallback_pool.pop(tier_key, None)
+
 
 def create_provider_instance_impl(
     *,
@@ -21,7 +37,11 @@ def create_provider_instance_impl(
 
     provider_cache = cls_ref._provider_pools.setdefault(provider_name, {})
     if tier_key in provider_cache:
-        return provider_cache[tier_key]
+        cached_llm = provider_cache[tier_key]
+        if not _cached_llm_is_degraded(provider_name, cached_llm):
+            return cached_llm
+        _drop_cached_tier(cls_ref, provider_name, tier_key)
+        provider_cache = cls_ref._provider_pools.setdefault(provider_name, {})
 
     thinking_budget, include_thoughts = cls_ref._thinking_budget_for_tier(tier_key)
     llm = provider.create_instance(
@@ -64,23 +84,41 @@ def get_provider_instance_impl(
 
     if normalized_provider == cls_ref._active_provider and tier_key in cls_ref._pool:
         llm = cls_ref._pool[tier_key]
-        cls_ref._provider_pools.setdefault(normalized_provider, {})[tier_key] = llm
-        return cls_ref._tag_runtime_metadata(
-            llm,
-            provider_name=normalized_provider,
-            tier_key=tier_key,
-            requested_provider=requested_provider,
-        )
+        if _cached_llm_is_degraded(normalized_provider, llm):
+            _drop_cached_tier(cls_ref, normalized_provider, tier_key)
+        else:
+            cls_ref._provider_pools.setdefault(normalized_provider, {})[tier_key] = llm
+            return cls_ref._tag_runtime_metadata(
+                llm,
+                provider_name=normalized_provider,
+                tier_key=tier_key,
+                requested_provider=requested_provider,
+            )
 
     if normalized_provider == cls_ref._fallback_provider and tier_key in cls_ref._fallback_pool:
         llm = cls_ref._fallback_pool[tier_key]
-        cls_ref._provider_pools.setdefault(normalized_provider, {})[tier_key] = llm
-        return cls_ref._tag_runtime_metadata(
-            llm,
-            provider_name=normalized_provider,
-            tier_key=tier_key,
-            requested_provider=requested_provider,
-        )
+        if _cached_llm_is_degraded(normalized_provider, llm):
+            _drop_cached_tier(cls_ref, normalized_provider, tier_key)
+        else:
+            cls_ref._provider_pools.setdefault(normalized_provider, {})[tier_key] = llm
+            return cls_ref._tag_runtime_metadata(
+                llm,
+                provider_name=normalized_provider,
+                tier_key=tier_key,
+                requested_provider=requested_provider,
+            )
+
+    provider_cache = cls_ref._provider_pools.get(normalized_provider, {})
+    if tier_key in provider_cache:
+        llm = provider_cache[tier_key]
+        if not _cached_llm_is_degraded(normalized_provider, llm):
+            return cls_ref._tag_runtime_metadata(
+                llm,
+                provider_name=normalized_provider,
+                tier_key=tier_key,
+                requested_provider=requested_provider,
+            )
+        _drop_cached_tier(cls_ref, normalized_provider, tier_key)
 
     try:
         return cls_ref._create_provider_instance(
@@ -132,7 +170,12 @@ def create_primary_instance_impl(*, cls_ref, tier, settings_obj, logger_obj, thi
     tier_key = cls_ref._resolve_tier(tier)
 
     if tier_key in cls_ref._pool:
-        return cls_ref._pool[tier_key]
+        cached_llm = cls_ref._pool[tier_key]
+        cached_provider = getattr(cached_llm, "_wiii_provider_name", None) or cls_ref._active_provider
+        if cached_provider and _cached_llm_is_degraded(cached_provider, cached_llm):
+            _drop_cached_tier(cls_ref, cached_provider, tier_key)
+        else:
+            return cached_llm
 
     thinking_budget = thinking_budgets.get(tier_key, 1024)
     include_thoughts = thinking_budget > 0

--- a/maritime-ai-service/app/engine/llm_pool_custom_models.py
+++ b/maritime-ai-service/app/engine/llm_pool_custom_models.py
@@ -23,11 +23,11 @@ def create_llm_with_model_for_provider_impl(
     if not normalized_provider:
         return None
 
-    cache_key = f"_custom_{normalized_provider}_{model_name}_{tier.value}"
-    if cache_key in pool:
+    requested_cache_key = f"_custom_{normalized_provider}_{model_name}_{tier.value}"
+    if requested_cache_key in pool:
         if not is_model_degraded(normalized_provider, model_name):
-            return pool[cache_key]
-        pool.pop(cache_key, None)
+            return pool[requested_cache_key]
+        pool.pop(requested_cache_key, None)
 
     thinking_budget = thinking_budgets.get(tier.value, 4096)
     include_thoughts = tier in (
@@ -40,12 +40,44 @@ def create_llm_with_model_for_provider_impl(
         if provider is None or not provider.is_configured():
             return None
 
+        selected_model_name = model_name
+        if is_model_degraded(normalized_provider, model_name):
+            model_selector = getattr(provider, "_select_healthy_model", None)
+            if callable(model_selector):
+                selected = model_selector(tier=tier.value, model=model_name)
+                if isinstance(selected, str) and selected.strip():
+                    selected_model_name = selected.strip()
+
+            if (
+                selected_model_name == model_name
+                or is_model_degraded(normalized_provider, selected_model_name)
+            ):
+                logger_obj.warning(
+                    "[LLM_POOL] Refusing degraded custom model without healthy "
+                    "alternative: provider=%s model=%s tier=%s",
+                    normalized_provider,
+                    model_name,
+                    tier.value,
+                )
+                return None
+
+            logger_obj.info(
+                "[LLM_POOL] Custom model %s/%s is degraded; using healthy alternative %s",
+                normalized_provider,
+                model_name,
+                selected_model_name,
+            )
+
+        cache_key = f"_custom_{normalized_provider}_{selected_model_name}_{tier.value}"
+        if cache_key in pool:
+            return pool[cache_key]
+
         llm = provider.create_instance(
             tier=tier.value,
             thinking_budget=thinking_budget,
             include_thoughts=include_thoughts,
             temperature=0.5,
-            model_name=model_name,
+            model_name=selected_model_name,
         )
         attach_tracking_callback(llm, cache_key)
         llm = tag_runtime_metadata(
@@ -58,7 +90,7 @@ def create_llm_with_model_for_provider_impl(
         logger_obj.info(
             "[LLM_POOL] Created custom model LLM: provider=%s model=%s tier=%s budget=%d",
             normalized_provider,
-            model_name,
+            selected_model_name,
             tier.value,
             thinking_budget,
         )

--- a/maritime-ai-service/app/engine/llm_pool_custom_models.py
+++ b/maritime-ai-service/app/engine/llm_pool_custom_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from app.engine.llm_model_health import is_model_degraded
+
 
 def create_llm_with_model_for_provider_impl(
     *,
@@ -23,7 +25,9 @@ def create_llm_with_model_for_provider_impl(
 
     cache_key = f"_custom_{normalized_provider}_{model_name}_{tier.value}"
     if cache_key in pool:
-        return pool[cache_key]
+        if not is_model_degraded(normalized_provider, model_name):
+            return pool[cache_key]
+        pool.pop(cache_key, None)
 
     thinking_budget = thinking_budgets.get(tier.value, 4096)
     include_thoughts = tier in (

--- a/maritime-ai-service/app/engine/llm_pool_monitoring.py
+++ b/maritime-ai-service/app/engine/llm_pool_monitoring.py
@@ -65,6 +65,14 @@ def get_stats_impl(
         stats["circuit_breakers"] = circuit_breakers
     if gemini_cb is not None and "circuit_breakers" not in stats:
         stats["circuit_breaker"] = gemini_cb.get_stats()
+    try:
+        from app.engine.llm_model_health import get_model_health_snapshot
+
+        model_health = get_model_health_snapshot()
+        if model_health:
+            stats["model_health"] = model_health
+    except Exception:
+        pass
     return stats
 
 

--- a/maritime-ai-service/app/engine/llm_pool_monitoring.py
+++ b/maritime-ai-service/app/engine/llm_pool_monitoring.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
 
 
 def get_request_selectable_providers_impl(
@@ -71,8 +74,9 @@ def get_stats_impl(
         model_health = get_model_health_snapshot()
         if model_health:
             stats["model_health"] = model_health
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("[LLM_POOL] Could not collect model health snapshot: %s", exc)
+        stats["model_health_error"] = str(exc)
     return stats
 
 

--- a/maritime-ai-service/app/engine/llm_pool_public.py
+++ b/maritime-ai-service/app/engine/llm_pool_public.py
@@ -108,6 +108,7 @@ def resolve_primary_timeout_seconds(
     tier: str = "moderate",
     timeout_profile: Optional[str] = None,
     provider: Optional[str] = None,
+    model_name: Optional[str] = None,
 ) -> float | None:
     from app.engine import llm_pool as pool_mod
 
@@ -123,6 +124,7 @@ def resolve_primary_timeout_seconds(
         pool_cls=pool_mod.LLMPool,
         timeout_profile_structured=TIMEOUT_PROFILE_STRUCTURED,
         timeout_profile_background=TIMEOUT_PROFILE_BACKGROUND,
+        model_name=model_name,
     )
 
 
@@ -134,6 +136,7 @@ async def ainvoke_with_failover(
     provider: Optional[str] = None,
     failover_mode: str = "auto",
     prefer_selectable_fallback: bool = False,
+    allowed_fallback_providers: set[str] | list[str] | tuple[str, ...] | None = None,
     on_primary: Optional[Callable[[BaseChatModel], BaseChatModel]] = None,
     on_fallback: Optional[Callable[[BaseChatModel], BaseChatModel]] = None,
     on_switch: Optional[Callable[[str, str, str], Any]] = None,
@@ -150,6 +153,7 @@ async def ainvoke_with_failover(
         provider=provider,
         failover_mode=failover_mode,
         prefer_selectable_fallback=prefer_selectable_fallback,
+        allowed_fallback_providers=allowed_fallback_providers,
         on_primary=on_primary,
         on_fallback=on_fallback,
         on_switch=on_switch,
@@ -163,4 +167,7 @@ async def ainvoke_with_failover(
         logger_obj=pool_mod.logger,
         failover_mode_pinned=pool_mod.FAILOVER_MODE_PINNED,
         provider_unavailable_error_cls=pool_mod.ProviderUnavailableError,
+        resolve_same_provider_model_fallback_fn=pool_mod.LLMPool.resolve_same_provider_model_fallback,
+        create_llm_with_model_for_provider_fn=pool_mod.LLMPool.create_llm_with_model_for_provider,
+        thinking_tier_cls=pool_mod.ThinkingTier,
     )

--- a/maritime-ai-service/app/engine/llm_providers/openai_provider.py
+++ b/maritime-ai-service/app/engine/llm_providers/openai_provider.py
@@ -12,6 +12,7 @@ from typing import Any
 from langchain_core.language_models import BaseChatModel
 
 from app.core.config import settings
+from app.engine.llm_model_health import is_model_degraded
 from app.engine.llm_providers.base import LLMProvider
 from app.engine.llm_providers.wiii_chat_model import WiiiChatModel
 from app.engine.openai_compatible_credentials import (
@@ -35,13 +36,26 @@ from app.engine.openrouter_routing import (
 
 logger = logging.getLogger(__name__)
 
-# Circuit breaker for OpenAI API
-_openai_cb = None
-try:
-    from app.core.resilience import get_circuit_breaker
-    _openai_cb = get_circuit_breaker("openai", failure_threshold=3, recovery_timeout=30)
-except Exception:
-    pass
+_openai_compatible_cbs: dict[str, Any] = {}
+
+
+def _get_openai_compatible_circuit_breaker(provider_alias: str):
+    """Return a provider-specific breaker for OpenAI-compatible transports."""
+    normalized_alias = str(provider_alias or "openai").strip().lower() or "openai"
+    if normalized_alias in _openai_compatible_cbs:
+        return _openai_compatible_cbs[normalized_alias]
+    try:
+        from app.core.resilience import get_circuit_breaker
+
+        circuit_breaker = get_circuit_breaker(
+            normalized_alias,
+            failure_threshold=3,
+            recovery_timeout=30,
+        )
+        _openai_compatible_cbs[normalized_alias] = circuit_breaker
+        return circuit_breaker
+    except Exception:
+        return None
 
 # o-series models that support reasoning_effort parameter
 _O_SERIES_PREFIXES = ("o1", "o3-mini", "o3", "o4-mini")
@@ -59,6 +73,9 @@ class OpenAIProvider(LLMProvider):
 
     def __init__(self, provider_alias: str = "openai"):
         self._provider_alias = str(provider_alias or "openai").strip().lower()
+        self._circuit_breaker = _get_openai_compatible_circuit_breaker(
+            self._provider_alias
+        )
 
     @property
     def name(self) -> str:
@@ -74,9 +91,38 @@ class OpenAIProvider(LLMProvider):
     def is_available(self) -> bool:
         if not self.is_configured():
             return False
-        if _openai_cb is not None:
-            return _openai_cb.is_available()
+        if self._circuit_breaker is not None:
+            return self._circuit_breaker.is_available()
         return True
+
+    def _select_healthy_model(self, *, tier: str, model: str) -> str:
+        if self._provider_alias != "nvidia":
+            return model
+
+        base = str(resolve_nvidia_model(settings) or "").strip()
+        advanced = str(resolve_nvidia_model_advanced(settings) or "").strip()
+        if not base or not advanced or base == advanced:
+            return model
+
+        if model == base and is_model_degraded("nvidia", base):
+            if not is_model_degraded("nvidia", advanced):
+                logger.warning(
+                    "[OPENAI] NVIDIA model %s is degraded; selecting %s for %s tier",
+                    base,
+                    advanced,
+                    tier,
+                )
+                return advanced
+        if model == advanced and is_model_degraded("nvidia", advanced):
+            if not is_model_degraded("nvidia", base):
+                logger.warning(
+                    "[OPENAI] NVIDIA model %s is degraded; selecting %s for %s tier",
+                    advanced,
+                    base,
+                    tier,
+                )
+                return base
+        return model
 
     def create_instance(
         self,
@@ -102,6 +148,8 @@ class OpenAIProvider(LLMProvider):
             model = resolve_openai_model_advanced(settings)
         else:
             model = resolve_openai_model(settings)
+        if not model_name:
+            model = self._select_healthy_model(tier=tier, model=model)
 
         # Detect o-series reasoning models
         is_o_series = any(model.startswith(prefix) for prefix in _O_SERIES_PREFIXES)
@@ -162,16 +210,13 @@ class OpenAIProvider(LLMProvider):
         )
         return llm
 
-    @staticmethod
-    def get_circuit_breaker():
-        return _openai_cb
+    def get_circuit_breaker(self):
+        return self._circuit_breaker
 
-    @staticmethod
-    async def record_success():
-        if _openai_cb is not None:
-            await _openai_cb.record_success()
+    async def record_success(self):
+        if self._circuit_breaker is not None:
+            await self._circuit_breaker.record_success()
 
-    @staticmethod
-    async def record_failure():
-        if _openai_cb is not None:
-            await _openai_cb.record_failure()
+    async def record_failure(self):
+        if self._circuit_breaker is not None:
+            await self._circuit_breaker.record_failure()

--- a/maritime-ai-service/app/engine/llm_runtime_metadata.py
+++ b/maritime-ai-service/app/engine/llm_runtime_metadata.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from app.core.config import settings
 from app.engine.openai_compatible_credentials import (
+    resolve_nvidia_model,
     resolve_openai_model,
     resolve_openrouter_model,
 )
@@ -21,6 +22,8 @@ def _configured_model_for_provider(provider: str) -> str:
         return resolve_openai_model(settings)
     if normalized == "openrouter":
         return resolve_openrouter_model(settings)
+    if normalized == "nvidia":
+        return resolve_nvidia_model(settings)
     if normalized == "zhipu":
         return getattr(settings, "zhipu_model", "glm-5")
     if normalized == "ollama":

--- a/maritime-ai-service/app/engine/llm_same_provider_runtime.py
+++ b/maritime-ai-service/app/engine/llm_same_provider_runtime.py
@@ -22,25 +22,34 @@ def resolve_same_provider_model_fallback_impl(
     settings_obj,
     thinking_tier_cls,
     normalize_provider,
+    is_model_degraded_fn=None,
 ) -> dict[str, str] | None:
-    """Resolve a lower-latency same-provider model fallback plan.
-
-    V1 keeps this intentionally conservative:
-    - only applies to `deep` turns
-    - only when provider exposes distinct `advanced` and base models
-    - returns a moderate-tier fallback to bias for lower latency
-    """
+    """Resolve a safe same-provider model fallback plan."""
     provider = normalize_provider(provider_name)
-    if not provider or tier_key != thinking_tier_cls.DEEP.value:
+    if not provider:
         return None
 
     if provider == "google":
+        if tier_key != thinking_tier_cls.DEEP.value:
+            return None
         advanced = getattr(settings_obj, "google_model_advanced", None)
         base = getattr(settings_obj, "google_model", None)
-    elif provider in {"openai", "openrouter"}:
+    elif provider == "openai":
+        if tier_key != thinking_tier_cls.DEEP.value:
+            return None
         advanced = getattr(settings_obj, "openai_model_advanced", None)
         base = getattr(settings_obj, "openai_model", None)
+    elif provider == "openrouter":
+        if tier_key != thinking_tier_cls.DEEP.value:
+            return None
+        advanced = getattr(settings_obj, "openrouter_model_advanced", None)
+        base = getattr(settings_obj, "openrouter_model", None)
+    elif provider == "nvidia":
+        advanced = getattr(settings_obj, "nvidia_model_advanced", None)
+        base = getattr(settings_obj, "nvidia_model", None)
     elif provider == "zhipu":
+        if tier_key != thinking_tier_cls.DEEP.value:
+            return None
         advanced = getattr(settings_obj, "zhipu_model_advanced", None)
         base = getattr(settings_obj, "zhipu_model", None)
     else:
@@ -52,15 +61,37 @@ def resolve_same_provider_model_fallback_impl(
 
     if not advanced or not base or advanced == base:
         return None
-    if current == base:
-        return None
-    if current is not None and current != advanced:
+
+    if provider == "nvidia":
+        if current == base or (current is None and tier_key != thinking_tier_cls.DEEP.value):
+            from_model = base
+            to_model = advanced
+            from_tier = tier_key
+            to_tier = thinking_tier_cls.DEEP.value
+        elif current == advanced or (current is None and tier_key == thinking_tier_cls.DEEP.value):
+            from_model = advanced
+            to_model = base
+            from_tier = thinking_tier_cls.DEEP.value
+            to_tier = thinking_tier_cls.MODERATE.value
+        else:
+            return None
+    else:
+        if current == base:
+            return None
+        if current is not None and current != advanced:
+            return None
+        from_model = advanced
+        to_model = base
+        from_tier = thinking_tier_cls.DEEP.value
+        to_tier = thinking_tier_cls.MODERATE.value
+
+    if is_model_degraded_fn is not None and is_model_degraded_fn(provider, to_model):
         return None
 
     return {
         "provider": provider,
-        "from_model": advanced,
-        "to_model": base,
-        "from_tier": thinking_tier_cls.DEEP.value,
-        "to_tier": thinking_tier_cls.MODERATE.value,
+        "from_model": from_model,
+        "to_model": to_model,
+        "from_tier": from_tier,
+        "to_tier": to_tier,
     }

--- a/maritime-ai-service/app/engine/llm_timeout_policy.py
+++ b/maritime-ai-service/app/engine/llm_timeout_policy.py
@@ -77,10 +77,43 @@ def build_timeout_profiles_snapshot(source: Any) -> dict[str, float]:
     return snapshot
 
 
-def sanitize_timeout_provider_overrides(
+def _sanitize_profile_values(provider_overrides: Mapping[str, Any]) -> dict[str, float]:
+    normalized_overrides: dict[str, float] = {}
+    for public_name, raw_value in provider_overrides.items():
+        if public_name not in TIMEOUT_PROFILE_SETTINGS:
+            continue
+        numeric = _coerce_float(
+            raw_value,
+            field_name=TIMEOUT_PROFILE_SETTINGS[public_name],
+        )
+        if numeric is None:
+            continue
+        normalized_overrides[public_name] = numeric
+    return normalized_overrides
+
+
+def _sanitize_model_overrides(
     value: Any,
 ) -> dict[str, dict[str, float]]:
-    """Keep only supported provider timeout overrides."""
+    if not isinstance(value, Mapping):
+        return {}
+    clean: dict[str, dict[str, float]] = {}
+    for model_name, model_overrides in value.items():
+        if not isinstance(model_name, str):
+            continue
+        normalized_model = model_name.strip()
+        if not normalized_model or not isinstance(model_overrides, Mapping):
+            continue
+        normalized_overrides = _sanitize_profile_values(model_overrides)
+        if normalized_overrides:
+            clean[normalized_model] = normalized_overrides
+    return clean
+
+
+def sanitize_timeout_provider_overrides(
+    value: Any,
+) -> dict[str, dict[str, Any]]:
+    """Keep only supported provider and model timeout overrides."""
     payload = value
     if isinstance(payload, str):
         raw = payload.strip()
@@ -96,7 +129,7 @@ def sanitize_timeout_provider_overrides(
         return {}
 
     supported_providers = set(get_supported_provider_names())
-    clean: dict[str, dict[str, float]] = {}
+    clean: dict[str, dict[str, Any]] = {}
     for provider_name, provider_overrides in payload.items():
         if not isinstance(provider_name, str):
             continue
@@ -110,17 +143,10 @@ def sanitize_timeout_provider_overrides(
         if not isinstance(provider_overrides, Mapping):
             continue
 
-        normalized_overrides: dict[str, float] = {}
-        for public_name, raw_value in provider_overrides.items():
-            if public_name not in TIMEOUT_PROFILE_SETTINGS:
-                continue
-            numeric = _coerce_float(
-                raw_value,
-                field_name=TIMEOUT_PROFILE_SETTINGS[public_name],
-            )
-            if numeric is None:
-                continue
-            normalized_overrides[public_name] = numeric
+        normalized_overrides: dict[str, Any] = _sanitize_profile_values(provider_overrides)
+        model_overrides = _sanitize_model_overrides(provider_overrides.get("models"))
+        if model_overrides:
+            normalized_overrides["models"] = model_overrides
 
         if normalized_overrides:
             clean[normalized_provider] = normalized_overrides
@@ -136,5 +162,35 @@ def dumps_timeout_provider_overrides(value: Any) -> str:
     )
 
 
-def loads_timeout_provider_overrides(value: Any) -> dict[str, dict[str, float]]:
+def loads_timeout_provider_overrides(value: Any) -> dict[str, dict[str, Any]]:
     return sanitize_timeout_provider_overrides(value)
+
+
+def resolve_timeout_override(
+    *,
+    overrides: Mapping[str, Mapping[str, Any]],
+    provider: str | None,
+    profile_key: str,
+    model_name: str | None = None,
+) -> float | None:
+    """Resolve a provider/model timeout override for one profile key."""
+    if not provider:
+        return None
+    provider_overrides = overrides.get(provider)
+    if not isinstance(provider_overrides, Mapping):
+        return None
+
+    normalized_model = str(model_name or "").strip()
+    if normalized_model:
+        raw_models = provider_overrides.get("models")
+        if isinstance(raw_models, Mapping):
+            model_overrides = raw_models.get(normalized_model)
+            if isinstance(model_overrides, Mapping):
+                model_value = model_overrides.get(profile_key)
+                if isinstance(model_value, (int, float)):
+                    return float(model_value)
+
+    provider_value = provider_overrides.get(profile_key)
+    if isinstance(provider_value, (int, float)):
+        return float(provider_value)
+    return None

--- a/maritime-ai-service/app/services/chat_stream_coordinator.py
+++ b/maritime-ai-service/app/services/chat_stream_coordinator.py
@@ -291,6 +291,7 @@ async def generate_stream_v3_events(
             )
 
         accumulated_answer: list[str] = []
+        saw_done_event = False
 
         async for event in stream_fn(
             query=execution_input.query,
@@ -304,6 +305,8 @@ async def generate_stream_v3_events(
         ):
             if event.type == "answer":
                 accumulated_answer.append(event.content)
+            elif event.type == "done":
+                saw_done_event = True
 
             chunks, event_counter, should_stop = (
                 serialize_stream_event(
@@ -356,6 +359,16 @@ async def generate_stream_v3_events(
             "[STREAM-V3] Completed in %.3fs (full graph)",
             processing_time,
         )
+        if not saw_done_event:
+            done_event = await create_done_event(processing_time)
+            done_chunks, event_counter, _ = serialize_stream_event(
+                event=done_event,
+                event_counter=event_counter,
+                enable_artifacts=settings.enable_artifacts,
+                presentation_state=presentation_state,
+            )
+            for chunk in done_chunks:
+                yield chunk
 
     except ProviderUnavailableError as exc:
         logger.warning(

--- a/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
@@ -121,6 +121,46 @@ async def test_generate_stream_v3_events_finalizes_answer_after_stream():
 
 
 @pytest.mark.asyncio
+async def test_generate_stream_v3_events_emits_done_when_stream_omits_final_event():
+    orchestrator = MagicMock()
+    prepared_turn = SimpleNamespace(
+        request_scope=RequestScope("org-1", "maritime"),
+        session_id="session-1",
+        validation=SimpleNamespace(blocked=False),
+        chat_context=SimpleNamespace(user_name="Minh"),
+    )
+    orchestrator.prepare_turn = AsyncMock(return_value=prepared_turn)
+    orchestrator.build_multi_agent_execution_input = AsyncMock(return_value=(
+        SimpleNamespace(
+            query="Explain Rule 5",
+            user_id="user-1",
+            session_id="session-1",
+            context={"conversation_history": ""},
+            domain_id="maritime",
+            thinking_effort=None,
+            provider=None,
+        )
+    ))
+
+    async def fake_stream_fn(**_kwargs):
+        yield SimpleNamespace(type="answer", content="Hello without explicit done")
+
+    chunks = []
+    async for chunk in generate_stream_v3_events(
+        chat_request=_make_request(),
+        request_headers={},
+        background_save=MagicMock(),
+        start_time=0.0,
+        orchestrator=orchestrator,
+        stream_fn=fake_stream_fn,
+    ):
+        chunks.append(chunk)
+
+    assert sum(1 for chunk in chunks if "event: done" in chunk) == 1
+    orchestrator.finalize_response_turn.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_generate_stream_v3_events_uses_sync_fallback_when_multi_agent_disabled():
     orchestrator = MagicMock()
     orchestrator._use_multi_agent = False

--- a/maritime-ai-service/tests/unit/test_llm_failover.py
+++ b/maritime-ai-service/tests/unit/test_llm_failover.py
@@ -476,6 +476,23 @@ class TestModelHealthRuntime:
             is_model_degraded("nvidia", "deepseek-ai/deepseek-v4-flash") is False
         )
 
+    def test_model_health_snapshot_omits_raw_error_detail(self):
+        from app.engine.llm_model_health import (
+            get_model_health_snapshot,
+            record_model_failure,
+        )
+
+        record_model_failure(
+            "nvidia",
+            "deepseek-ai/deepseek-v4-pro",
+            reason_code="server_error",
+            error=RuntimeError("provider payload with secret-token"),
+        )
+
+        entry = get_model_health_snapshot()["nvidia"]["deepseek-ai/deepseek-v4-pro"]
+        assert entry["last_error_type"] == "RuntimeError"
+        assert "last_error_detail" not in entry
+
     def test_create_custom_model_uses_provider_healthy_alternative(self):
         from app.engine.llm_model_health import record_model_failure
 

--- a/maritime-ai-service/tests/unit/test_llm_failover.py
+++ b/maritime-ai-service/tests/unit/test_llm_failover.py
@@ -9,7 +9,7 @@ Sprint 11: Tests failover logic in LLMPool._create_instance():
 """
 
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, MagicMock, AsyncMock, call
 
 from langchain_core.language_models import BaseChatModel
 
@@ -455,6 +455,53 @@ class TestPrimaryTimeoutProfiles:
             )
 
         assert result == "ok"
+
+
+class TestModelHealthRuntime:
+    def test_model_failure_with_non_positive_window_does_not_degrade(self):
+        from app.engine.llm_model_health import (
+            is_model_degraded,
+            record_model_failure,
+        )
+
+        record_model_failure(
+            "nvidia",
+            "deepseek-ai/deepseek-v4-flash",
+            reason_code="timeout",
+            timeout_seconds=0.01,
+            degraded_for_seconds=0,
+        )
+
+        assert (
+            is_model_degraded("nvidia", "deepseek-ai/deepseek-v4-flash") is False
+        )
+
+    def test_create_custom_model_uses_provider_healthy_alternative(self):
+        from app.engine.llm_model_health import record_model_failure
+
+        provider = _make_mock_provider("nvidia")
+        provider._select_healthy_model = MagicMock(
+            return_value="deepseek-ai/deepseek-v4-flash"
+        )
+        LLMPool._providers = {"nvidia": provider}
+        record_model_failure(
+            "nvidia",
+            "deepseek-ai/deepseek-v4-pro",
+            reason_code="timeout",
+            timeout_seconds=0.01,
+        )
+
+        result = LLMPool.create_llm_with_model_for_provider(
+            "nvidia",
+            "deepseek-ai/deepseek-v4-pro",
+            ThinkingTier.DEEP,
+        )
+
+        assert result is provider.create_instance.return_value
+        provider.create_instance.assert_called_once()
+        assert provider.create_instance.call_args.kwargs["model_name"] == (
+            "deepseek-ai/deepseek-v4-flash"
+        )
 
 
 class TestRequestScopedRouting:
@@ -940,6 +987,40 @@ class TestRequestScopedRouting:
         assert failover_events[0]["timeout_seconds"] == pytest.approx(0.001)
 
     @pytest.mark.asyncio
+    async def test_ainvoke_with_failover_records_cross_provider_fallback_failure(self):
+        from app.engine.llm_model_health import is_model_degraded
+
+        google_llm = _FakeAsyncLLM(error=RuntimeError("503 google unavailable"))
+        nvidia_llm = _FakeAsyncLLM(error=RuntimeError("503 nvidia unavailable"))
+        setattr(nvidia_llm, "model_name", "deepseek-ai/deepseek-v4-pro")
+
+        route = ResolvedLLMRoute(
+            provider="google",
+            llm=google_llm,
+            circuit_breaker=None,
+            fallback_provider="nvidia",
+            fallback_llm=nvidia_llm,
+        )
+        mock_failure = AsyncMock()
+
+        with (
+            patch.object(LLMPool, "resolve_runtime_route", return_value=route),
+            patch.object(LLMPool, "record_failure_for_provider", new=mock_failure),
+            patch.object(LLMPool, "record_success_for_provider", new=AsyncMock()),
+        ):
+            with pytest.raises(RuntimeError, match="nvidia unavailable"):
+                await ainvoke_with_failover(
+                    google_llm,
+                    ["hello"],
+                    tier="moderate",
+                    provider="google",
+                    primary_timeout=None,
+                )
+
+        mock_failure.assert_has_awaits([call("google"), call("nvidia")])
+        assert is_model_degraded("nvidia", "deepseek-ai/deepseek-v4-pro") is True
+
+    @pytest.mark.asyncio
     async def test_ainvoke_with_failover_uses_same_provider_model_fallback_before_cross_provider(self):
         zhipu_primary = _FakeAsyncLLM(sleep_seconds=0.05, result="slow-glm5")
         setattr(zhipu_primary, "model_name", "glm-5")
@@ -1152,22 +1233,28 @@ class TestRequestScopedRouting:
 
     @patch("app.engine.llm_pool.settings")
     def test_nvidia_same_provider_fallback_skips_degraded_target(self, mock_settings):
-        from app.engine.llm_model_health import record_model_failure
+        from app.engine.llm_model_health import (
+            record_model_failure,
+            reset_model_health_state,
+        )
 
         mock_settings.nvidia_model = "deepseek-ai/deepseek-v4-flash"
         mock_settings.nvidia_model_advanced = "deepseek-ai/deepseek-v4-pro"
-        record_model_failure(
-            "nvidia",
-            "deepseek-ai/deepseek-v4-pro",
-            reason_code="timeout",
-            timeout_seconds=0.01,
-        )
-
-        assert (
-            LLMPool.resolve_same_provider_model_fallback(
+        try:
+            record_model_failure(
                 "nvidia",
-                "moderate",
-                current_model_name="deepseek-ai/deepseek-v4-flash",
+                "deepseek-ai/deepseek-v4-pro",
+                reason_code="timeout",
+                timeout_seconds=0.01,
             )
-            is None
-        )
+
+            assert (
+                LLMPool.resolve_same_provider_model_fallback(
+                    "nvidia",
+                    "moderate",
+                    current_model_name="deepseek-ai/deepseek-v4-flash",
+                )
+                is None
+            )
+        finally:
+            reset_model_health_state()

--- a/maritime-ai-service/tests/unit/test_llm_failover.py
+++ b/maritime-ai-service/tests/unit/test_llm_failover.py
@@ -386,6 +386,25 @@ class TestPrimaryTimeoutProfiles:
             provider="google",
         ) == 88.0
 
+    @patch("app.engine.llm_pool.settings")
+    def test_resolve_primary_timeout_seconds_honors_model_override(self, mock_settings):
+        mock_settings.llm_primary_timeout_moderate_seconds = 25.0
+        mock_settings.llm_timeout_provider_overrides = (
+            '{"nvidia":{"moderate_seconds":22,'
+            '"models":{"deepseek-ai/deepseek-v4-flash":{"moderate_seconds":7}}}}'
+        )
+
+        assert resolve_primary_timeout_seconds(
+            tier="moderate",
+            provider="nvidia",
+            model_name="deepseek-ai/deepseek-v4-flash",
+        ) == 7.0
+        assert resolve_primary_timeout_seconds(
+            tier="moderate",
+            provider="nvidia",
+            model_name="deepseek-ai/deepseek-v4-pro",
+        ) == 22.0
+
     @pytest.mark.asyncio
     @patch("app.engine.llm_pool.settings")
     async def test_ainvoke_with_failover_uses_structured_timeout_profile(self, mock_settings):
@@ -1071,3 +1090,84 @@ class TestRequestScopedRouting:
                     provider="zhipu",
                     primary_timeout=0.001,
                 )
+
+    @pytest.mark.asyncio
+    @patch("app.engine.llm_pool.settings")
+    async def test_nvidia_flash_timeout_marks_model_degraded_and_falls_back_to_pro(
+        self,
+        mock_settings,
+    ):
+        from app.engine.llm_model_health import is_model_degraded
+
+        mock_settings.nvidia_model = "deepseek-ai/deepseek-v4-flash"
+        mock_settings.nvidia_model_advanced = "deepseek-ai/deepseek-v4-pro"
+        mock_settings.llm_primary_timeout_deep_seconds = 45.0
+        mock_settings.llm_timeout_provider_overrides = "{}"
+
+        nvidia_flash = _FakeAsyncLLM(sleep_seconds=0.05, result="slow-flash")
+        setattr(nvidia_flash, "model_name", "deepseek-ai/deepseek-v4-flash")
+        nvidia_pro = _FakeAsyncLLM(result="pro-ok")
+        route = ResolvedLLMRoute(
+            provider="nvidia",
+            llm=nvidia_flash,
+            circuit_breaker=None,
+            fallback_provider=None,
+            fallback_llm=None,
+        )
+        failover_events: list[dict[str, object]] = []
+
+        async def _capture_failover(event: dict[str, object]) -> None:
+            failover_events.append(event)
+
+        with (
+            patch.object(LLMPool, "resolve_runtime_route", return_value=route),
+            patch.object(
+                LLMPool,
+                "create_llm_with_model_for_provider",
+                return_value=nvidia_pro,
+            ) as mock_create_fallback,
+            patch.object(LLMPool, "record_failure_for_provider", new=AsyncMock()),
+            patch.object(LLMPool, "record_success_for_provider", new=AsyncMock()),
+        ):
+            result = await ainvoke_with_failover(
+                nvidia_flash,
+                ["hello"],
+                tier="moderate",
+                provider="nvidia",
+                on_failover=_capture_failover,
+                primary_timeout=0.001,
+            )
+
+        assert result == "pro-ok"
+        assert is_model_degraded("nvidia", "deepseek-ai/deepseek-v4-flash") is True
+        assert is_model_degraded("nvidia", "deepseek-ai/deepseek-v4-pro") is False
+        mock_create_fallback.assert_called_once_with(
+            "nvidia",
+            "deepseek-ai/deepseek-v4-pro",
+            ThinkingTier.DEEP,
+        )
+        assert failover_events[0]["fallback_scope"] == "same_provider_model"
+        assert failover_events[0]["from_model"] == "deepseek-ai/deepseek-v4-flash"
+        assert failover_events[0]["to_model"] == "deepseek-ai/deepseek-v4-pro"
+
+    @patch("app.engine.llm_pool.settings")
+    def test_nvidia_same_provider_fallback_skips_degraded_target(self, mock_settings):
+        from app.engine.llm_model_health import record_model_failure
+
+        mock_settings.nvidia_model = "deepseek-ai/deepseek-v4-flash"
+        mock_settings.nvidia_model_advanced = "deepseek-ai/deepseek-v4-pro"
+        record_model_failure(
+            "nvidia",
+            "deepseek-ai/deepseek-v4-pro",
+            reason_code="timeout",
+            timeout_seconds=0.01,
+        )
+
+        assert (
+            LLMPool.resolve_same_provider_model_fallback(
+                "nvidia",
+                "moderate",
+                current_model_name="deepseek-ai/deepseek-v4-flash",
+            )
+            is None
+        )

--- a/maritime-ai-service/tests/unit/test_llm_providers.py
+++ b/maritime-ai-service/tests/unit/test_llm_providers.py
@@ -301,9 +301,12 @@ class TestOpenAIProvider:
         p = OpenAIProvider()
         assert p.is_configured() is False
 
-    @patch("app.engine.llm_providers.openai_provider._openai_cb", None)
+    @patch(
+        "app.engine.llm_providers.openai_provider._get_openai_compatible_circuit_breaker",
+        return_value=None,
+    )
     @patch("app.engine.llm_providers.openai_provider.settings")
-    def test_is_available_no_circuit_breaker(self, mock_settings):
+    def test_is_available_no_circuit_breaker(self, mock_settings, _mock_cb_factory):
         mock_settings.openai_api_key = "sk-test"
         p = OpenAIProvider()
         assert p.is_available() is True

--- a/maritime-ai-service/tests/unit/test_llm_runtime_policy_service.py
+++ b/maritime-ai-service/tests/unit/test_llm_runtime_policy_service.py
@@ -204,6 +204,45 @@ def test_get_persisted_llm_runtime_policy_sanitizes_timeout_overrides():
     }
 
 
+def test_get_persisted_llm_runtime_policy_keeps_model_timeout_overrides():
+    from app.services.llm_runtime_policy_service import get_persisted_llm_runtime_policy
+
+    repo = MagicMock()
+    repo.get_settings.return_value = AdminRuntimeSettingsRecord(
+        key="llm_runtime",
+        settings={
+            "timeout_provider_overrides": {
+                "nvidia": {
+                    "moderate_seconds": 20,
+                    "models": {
+                        "deepseek-ai/deepseek-v4-flash": {"moderate_seconds": 7},
+                        "bad-empty": {"unknown": 99},
+                    },
+                },
+            }
+        },
+        description="Persisted runtime policy",
+        created_at=datetime(2026, 3, 22, 1, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 3, 22, 2, 0, tzinfo=timezone.utc),
+    )
+
+    with patch(
+        "app.services.llm_runtime_policy_service.get_admin_runtime_settings_repository",
+        return_value=repo,
+    ):
+        record = get_persisted_llm_runtime_policy()
+
+    assert record is not None
+    assert record.payload["timeout_provider_overrides"] == {
+        "nvidia": {
+            "moderate_seconds": 20.0,
+            "models": {
+                "deepseek-ai/deepseek-v4-flash": {"moderate_seconds": 7.0},
+            },
+        },
+    }
+
+
 def test_persist_current_llm_runtime_policy_uses_repo_snapshot():
     from app.core.config import settings
     from app.services.llm_runtime_policy_service import persist_current_llm_runtime_policy

--- a/maritime-ai-service/tests/unit/test_nvidia_provider.py
+++ b/maritime-ai-service/tests/unit/test_nvidia_provider.py
@@ -283,6 +283,59 @@ class TestOpenAIProviderWithNvidiaAlias:
         model_kwargs = captured.get("model_kwargs", {})
         assert "extra_body" not in model_kwargs
 
+    def test_create_instance_avoids_degraded_flash_model(self):
+        from app.engine.llm_model_health import (
+            record_model_failure,
+            reset_model_health_state,
+        )
+        from app.engine.llm_providers import OpenAIProvider
+
+        captured: dict = {}
+
+        def _fake_chat_model(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        try:
+            record_model_failure(
+                "nvidia",
+                "deepseek-ai/deepseek-v4-flash",
+                reason_code="timeout",
+                timeout_seconds=0.01,
+            )
+            with patch.object(
+                __import__("app.engine.llm_providers.openai_provider", fromlist=["settings"]),
+                "settings",
+                SimpleNamespace(
+                    nvidia_api_key="nvapi",
+                    nvidia_base_url=None,
+                    nvidia_model="deepseek-ai/deepseek-v4-flash",
+                    nvidia_model_advanced="deepseek-ai/deepseek-v4-pro",
+                    openai_api_key=None,
+                    openai_base_url=None,
+                ),
+            ), patch(
+                "app.engine.llm_providers.openai_provider.WiiiChatModel",
+                new=_fake_chat_model,
+            ):
+                provider = OpenAIProvider(provider_alias="nvidia")
+                provider.create_instance(tier="moderate")
+
+            assert captured["model"] == "deepseek-ai/deepseek-v4-pro"
+        finally:
+            reset_model_health_state()
+
+    def test_openai_compatible_aliases_use_distinct_circuit_breakers(self):
+        from app.engine.llm_providers import OpenAIProvider
+
+        with patch(
+            "app.engine.llm_providers.openai_provider._get_openai_compatible_circuit_breaker",
+            side_effect=lambda alias: f"cb:{alias}",
+        ):
+            assert OpenAIProvider(provider_alias="openai").get_circuit_breaker() == "cb:openai"
+            assert OpenAIProvider(provider_alias="openrouter").get_circuit_breaker() == "cb:openrouter"
+            assert OpenAIProvider(provider_alias="nvidia").get_circuit_breaker() == "cb:nvidia"
+
 
 # ---------------------------------------------------------------------------
 # Cross-cutting safety


### PR DESCRIPTION
## Summary
- Add process-local per-provider/model health so timed-out models are marked degraded and skipped on subsequent cached/pool selections.
- Extend timeout policy to support provider-level and model-level overrides, including NVIDIA Flash/Pro profiles.
- Add same-provider NVIDIA fallback in both directions (Flash -> Pro, Pro -> Flash) while avoiding degraded fallback targets.
- Split OpenAI/OpenRouter/NVIDIA circuit breakers by provider alias instead of sharing the OpenAI breaker.
- Add an SSE finalization guard so FE receives `done` even if the inner stream exits without an explicit final event.
- Address CodeRabbit follow-up review: thread-safe health registry, non-permanent non-positive TTL behavior, fallback-provider failure recording, healthy custom-model replacement, and visible model-health stats errors.

Closes #171

## Verification
- `cd maritime-ai-service && python -m pytest tests/unit/test_llm_failover.py tests/unit/test_nvidia_provider.py tests/unit/test_llm_providers.py -q` -> 106 passed
- `cd maritime-ai-service && python -m pytest tests/unit/test_admin_llm_runtime.py tests/unit/test_llm_selectability_service.py tests/unit/test_llm_runtime_audit_service.py -q` -> 33 passed
- `cd maritime-ai-service && python -m pytest tests/unit/test_chat_stream_coordinator.py tests/unit/test_llm_runtime_policy_service.py -q` -> 14 passed
- `cd maritime-ai-service && python -m pytest tests/unit/test_direct_execution_answer_replay.py -q` -> 1 passed
- `cd maritime-ai-service && python -m pytest tests/unit/test_chat_stream_transport.py -q` -> 6 passed
- `cd maritime-ai-service && python -m pytest tests/unit/test_sprint40_streaming_timeout.py -q` -> 23 passed
- `cd maritime-ai-service && python -m ruff check app/ tests/unit/test_llm_failover.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed
- `cd maritime-ai-service && python -m pytest tests/unit/ -p no:capture --tb=short -q` -> attempted locally before this follow-up commit, timed out after 244s before reporting a final result

## Risk / Rollback
- Risk: provider routing, model selection, timeout resolution, and SSE finalization are high-risk runtime surfaces. Changes are covered by focused failover, NVIDIA provider, admin policy, audit/selectability, provider abstraction, and stream tests.
- Rollback: revert this PR to restore provider-level-only health, previous timeout override shape, previous same-provider fallback behavior, shared OpenAI-compatible circuit breaker behavior, and prior SSE finalization behavior.