### PR TITLE
Add native Wiii runtime contracts

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 from typing import Any
 
+from app.engine.multi_agent.runtime_contracts import WiiiTurnRequest, WiiiTurnResult
 from app.engine.multi_agent.graph_process import process_with_multi_agent_impl
 from app.engine.multi_agent.graph_runtime_bindings import (
     _inject_code_studio_context,
@@ -98,4 +99,11 @@ async def process_with_multi_agent(
     )
 
 
-__all__ = ["process_with_multi_agent"]
+async def run_wiii_turn(request: WiiiTurnRequest) -> WiiiTurnResult:
+    """Run one native Wiii turn through the existing WiiiRunner adapter."""
+
+    payload = await process_with_multi_agent(**request.to_runtime_kwargs())
+    return WiiiTurnResult.from_payload(payload)
+
+
+__all__ = ["process_with_multi_agent", "run_wiii_turn"]

--- a/maritime-ai-service/app/engine/multi_agent/runtime_contracts.py
+++ b/maritime-ai-service/app/engine/multi_agent/runtime_contracts.py
@@ -1,0 +1,141 @@
+"""Native Wiii runtime contracts behind legacy-compatible entrypoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class WiiiRunContext:
+    """Stable runtime context shared by sync and streaming Wiii turns."""
+
+    user_id: str
+    session_id: str = ""
+    domain_id: str | None = None
+    organization_id: str | None = None
+    context: Mapping[str, Any] | None = None
+    thinking_effort: str | None = None
+    provider: str | None = None
+    model: str | None = None
+
+    def context_dict(self) -> dict[str, Any]:
+        """Return a mutable context copy for the active runtime adapter."""
+
+        ctx = dict(self.context or {})
+        if self.organization_id and not ctx.get("organization_id"):
+            ctx["organization_id"] = self.organization_id
+        return ctx
+
+
+@dataclass(frozen=True)
+class WiiiTurnRequest:
+    """One user turn entering the WiiiRunner runtime."""
+
+    query: str
+    run_context: WiiiRunContext
+
+    def to_runtime_kwargs(self) -> dict[str, Any]:
+        """Adapt native Wiii request shape to the current runtime function."""
+
+        return {
+            "query": self.query,
+            "user_id": self.run_context.user_id,
+            "session_id": self.run_context.session_id,
+            "context": self.run_context.context_dict(),
+            "domain_id": self.run_context.domain_id,
+            "thinking_effort": self.run_context.thinking_effort,
+            "provider": self.run_context.provider,
+            "model": self.run_context.model,
+        }
+
+
+@dataclass(frozen=True)
+class WiiiTurnState:
+    """Typed view over WiiiRunner state snapshots."""
+
+    values: Mapping[str, Any]
+
+    @property
+    def final_response(self) -> str:
+        return str(self.values.get("final_response") or self.values.get("response") or "")
+
+    @property
+    def current_agent(self) -> str:
+        return str(self.values.get("current_agent") or "")
+
+    @property
+    def provider(self) -> str | None:
+        provider = self.values.get("_execution_provider") or self.values.get("provider")
+        return str(provider) if provider else None
+
+    @property
+    def model(self) -> str | None:
+        model = self.values.get("_execution_model") or self.values.get("model")
+        return str(model) if model else None
+
+
+@dataclass(frozen=True)
+class WiiiTurnResult:
+    """Result payload returned by a completed Wiii turn."""
+
+    payload: Mapping[str, Any]
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any] | None) -> "WiiiTurnResult":
+        return cls(payload=dict(payload or {}))
+
+    @property
+    def response(self) -> str:
+        return str(self.payload.get("response") or "")
+
+    @property
+    def current_agent(self) -> str:
+        return str(self.payload.get("current_agent") or "")
+
+    @property
+    def error(self) -> Any:
+        return self.payload.get("error")
+
+    @property
+    def provider(self) -> str | None:
+        provider = self.payload.get("_execution_provider") or self.payload.get("provider")
+        return str(provider) if provider else None
+
+    @property
+    def model(self) -> str | None:
+        model = self.payload.get("_execution_model") or self.payload.get("model")
+        return str(model) if model else None
+
+
+@dataclass(frozen=True)
+class WiiiStreamEvent:
+    """Typed wrapper for the existing SSE-compatible stream tuple."""
+
+    event_type: str
+    payload: Any = None
+
+    @classmethod
+    def from_legacy_tuple(cls, event: Any) -> "WiiiStreamEvent":
+        if isinstance(event, tuple) and event:
+            payload = event[1] if len(event) > 1 else None
+            return cls(event_type=str(event[0]), payload=payload)
+        return cls(event_type="unknown", payload=event)
+
+    def to_legacy_tuple(self) -> tuple[str, Any]:
+        return (self.event_type, self.payload)
+
+    @property
+    def node_name(self) -> str:
+        if self.event_type != "graph" or not isinstance(self.payload, dict):
+            return ""
+        return str(next(iter(self.payload), ""))
+
+
+__all__ = [
+    "WiiiRunContext",
+    "WiiiStreamEvent",
+    "WiiiTurnRequest",
+    "WiiiTurnResult",
+    "WiiiTurnState",
+]

--- a/maritime-ai-service/app/engine/multi_agent/streaming_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/streaming_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, AsyncGenerator
 
+from app.engine.multi_agent.runtime_contracts import WiiiStreamEvent, WiiiTurnRequest
 from app.engine.multi_agent.stream_utils import StreamEvent
 
 
@@ -23,4 +24,14 @@ async def process_with_multi_agent_streaming(
     async for event in stream(*args, **kwargs):
         yield event
 
-__all__ = ["process_with_multi_agent_streaming"]
+
+async def stream_wiii_turn(
+    request: WiiiTurnRequest,
+) -> AsyncGenerator[WiiiStreamEvent, None]:
+    """Stream one native Wiii turn while preserving existing wire events."""
+
+    async for event in process_with_multi_agent_streaming(**request.to_runtime_kwargs()):
+        yield WiiiStreamEvent.from_legacy_tuple(event)
+
+
+__all__ = ["process_with_multi_agent_streaming", "stream_wiii_turn"]

--- a/maritime-ai-service/tests/unit/test_wiii_runtime_contracts.py
+++ b/maritime-ai-service/tests/unit/test_wiii_runtime_contracts.py
@@ -1,0 +1,152 @@
+"""Tests for native Wiii runtime contracts and adapters."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.engine.multi_agent.runtime_contracts import (
+    WiiiRunContext,
+    WiiiStreamEvent,
+    WiiiTurnRequest,
+    WiiiTurnResult,
+    WiiiTurnState,
+)
+
+
+def test_wiii_turn_request_adapts_to_existing_runtime_kwargs():
+    context = {"response_language": "vi"}
+    request = WiiiTurnRequest(
+        query="chao Wiii",
+        run_context=WiiiRunContext(
+            user_id="user-1",
+            session_id="session-1",
+            domain_id="maritime",
+            organization_id="org-1",
+            context=context,
+            thinking_effort="low",
+            provider="nvidia",
+            model="deepseek-ai/deepseek-v3.1",
+        ),
+    )
+
+    kwargs = request.to_runtime_kwargs()
+
+    assert kwargs == {
+        "query": "chao Wiii",
+        "user_id": "user-1",
+        "session_id": "session-1",
+        "context": {"response_language": "vi", "organization_id": "org-1"},
+        "domain_id": "maritime",
+        "thinking_effort": "low",
+        "provider": "nvidia",
+        "model": "deepseek-ai/deepseek-v3.1",
+    }
+    assert context == {"response_language": "vi"}
+
+
+def test_wiii_turn_result_and_state_expose_stable_fields():
+    result = WiiiTurnResult.from_payload(
+        {
+            "response": "Xin chao.",
+            "current_agent": "direct",
+            "_execution_provider": "nvidia",
+            "_execution_model": "deepseek-v3.1",
+        }
+    )
+    state = WiiiTurnState(
+        {
+            "final_response": "Xin chao.",
+            "current_agent": "direct",
+            "_execution_provider": "nvidia",
+            "_execution_model": "deepseek-v3.1",
+        }
+    )
+
+    assert result.response == "Xin chao."
+    assert result.current_agent == "direct"
+    assert result.provider == "nvidia"
+    assert result.model == "deepseek-v3.1"
+    assert state.final_response == "Xin chao."
+    assert state.current_agent == "direct"
+    assert state.provider == "nvidia"
+    assert state.model == "deepseek-v3.1"
+
+
+def test_wiii_stream_event_wraps_existing_tuple_contract():
+    event = WiiiStreamEvent.from_legacy_tuple(("graph", {"direct": {"response": "ok"}}))
+
+    assert event.event_type == "graph"
+    assert event.node_name == "direct"
+    assert event.to_legacy_tuple() == ("graph", {"direct": {"response": "ok"}})
+
+
+@pytest.mark.asyncio
+async def test_run_wiii_turn_uses_existing_runtime_adapter(monkeypatch):
+    from app.engine.multi_agent import runtime
+
+    captured = {}
+
+    async def fake_process_with_multi_agent(**kwargs):
+        captured.update(kwargs)
+        return {
+            "response": "Wiii day.",
+            "current_agent": "direct",
+            "provider": kwargs["provider"],
+            "model": kwargs["model"],
+        }
+
+    monkeypatch.setattr(runtime, "process_with_multi_agent", fake_process_with_multi_agent)
+
+    result = await runtime.run_wiii_turn(
+        WiiiTurnRequest(
+            query="hello",
+            run_context=WiiiRunContext(
+                user_id="user-1",
+                session_id="session-1",
+                context={"conversation_summary": "recent"},
+                domain_id="general",
+                provider="nvidia",
+                model="deepseek-v3.1",
+            ),
+        )
+    )
+
+    assert captured["query"] == "hello"
+    assert captured["context"] == {"conversation_summary": "recent"}
+    assert captured["domain_id"] == "general"
+    assert result.response == "Wiii day."
+    assert result.provider == "nvidia"
+
+
+@pytest.mark.asyncio
+async def test_stream_wiii_turn_wraps_existing_stream_events(monkeypatch):
+    from app.engine.multi_agent import streaming_runtime
+
+    captured = {}
+
+    async def fake_process_with_multi_agent_streaming(**kwargs):
+        captured.update(kwargs)
+        yield ("graph", {"guardian": {"guardian_passed": True}})
+        yield ("graph_done", None)
+
+    monkeypatch.setattr(
+        streaming_runtime,
+        "process_with_multi_agent_streaming",
+        fake_process_with_multi_agent_streaming,
+    )
+
+    events = [
+        event
+        async for event in streaming_runtime.stream_wiii_turn(
+            WiiiTurnRequest(
+                query="hello",
+                run_context=WiiiRunContext(user_id="user-1", session_id="session-1"),
+            )
+        )
+    ]
+
+    assert captured["query"] == "hello"
+    assert events[0].event_type == "graph"
+    assert events[0].node_name == "guardian"
+    assert events[0].to_legacy_tuple() == ("graph", {"guardian": {"guardian_passed": True}})
+    assert events[1].event_type == "graph_done"


### PR DESCRIPTION
## Summary
- Add native Wiii runtime contracts for turn request, run context, state view, turn result, and stream event wrappers.
- Add `run_wiii_turn()` and `stream_wiii_turn()` facades over the existing WiiiRunner-backed adapters.
- Preserve current `process_with_multi_agent` behavior and existing tuple stream wire format.
- Add unit tests for runtime kwargs adaptation, result/state accessors, and stream tuple wrapping.

Closes #177.
Refs #170.

## Risk
- Low runtime risk: this is additive and does not replace existing chat or SSE entrypoints.
- No auth, tenant isolation, provider routing, database, or frontend payload changes.
- Future code can migrate toward Wiii-native names without deleting graph compatibility modules yet.

## Rollback
- Revert this PR to remove the additive contract module and facade exports.
- Existing runtime entrypoints remain unchanged, so rollback has no migration or data impact.

## Verification
- `cd maritime-ai-service && python -m pytest tests/unit/test_wiii_runtime_contracts.py tests/unit/test_wiii_runner_golden_parity.py tests/unit/test_runner_node_surface.py -q` -> 8 passed
- `cd maritime-ai-service && python -m pytest tests/unit/test_chat_request_flow.py tests/unit/test_chat_stream_coordinator.py tests/unit/test_graph_stream_runtime.py -q` -> 29 passed
- `cd maritime-ai-service && python -m ruff check app/ tests/unit/test_wiii_runtime_contracts.py tests/unit/test_wiii_runner_golden_parity.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed