### PR TITLE
Wire chat paths through Wiii turn contracts

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/runtime_contracts.py
+++ b/maritime-ai-service/app/engine/multi_agent/runtime_contracts.py
@@ -114,9 +114,18 @@ class WiiiStreamEvent:
 
     event_type: str
     payload: Any = None
+    raw_event: Any = None
 
     @classmethod
     def from_legacy_tuple(cls, event: Any) -> "WiiiStreamEvent":
+        if isinstance(event, cls):
+            return event
+        if hasattr(event, "type") and hasattr(event, "content"):
+            return cls(
+                event_type=str(event.type),
+                payload=getattr(event, "content", None),
+                raw_event=event,
+            )
         if isinstance(event, tuple) and event:
             payload = event[1] if len(event) > 1 else None
             return cls(event_type=str(event[0]), payload=payload)
@@ -130,6 +139,34 @@ class WiiiStreamEvent:
         if self.event_type != "graph" or not isinstance(self.payload, dict):
             return ""
         return str(next(iter(self.payload), ""))
+
+    @property
+    def type(self) -> str:
+        return self.event_type
+
+    @property
+    def content(self) -> Any:
+        return getattr(self.raw_event, "content", self.payload)
+
+    @property
+    def node(self) -> str | None:
+        return getattr(self.raw_event, "node", None)
+
+    @property
+    def step(self) -> str | None:
+        return getattr(self.raw_event, "step", None)
+
+    @property
+    def confidence(self) -> float | None:
+        return getattr(self.raw_event, "confidence", None)
+
+    @property
+    def details(self) -> dict[str, Any] | None:
+        return getattr(self.raw_event, "details", None)
+
+    @property
+    def subtype(self) -> str | None:
+        return getattr(self.raw_event, "subtype", None)
 
 
 __all__ = [

--- a/maritime-ai-service/app/services/chat_orchestrator_runtime.py
+++ b/maritime-ai-service/app/services/chat_orchestrator_runtime.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from app.core.constants import MAX_CONTENT_SNIPPET_LENGTH
 from app.engine.llm_runtime_metadata import resolve_runtime_llm_metadata
+from app.engine.multi_agent.runtime_contracts import WiiiRunContext, WiiiTurnRequest
 from app.models.schemas import ChatRequest, Source
 
 
@@ -128,6 +129,28 @@ async def prepare_turn_impl(
     )
 
 
+def build_wiii_turn_request(
+    *,
+    execution_input: Any,
+    organization_id: str | None = None,
+) -> WiiiTurnRequest:
+    """Build the native WiiiRunner turn request from service execution input."""
+
+    return WiiiTurnRequest(
+        query=execution_input.query,
+        run_context=WiiiRunContext(
+            user_id=execution_input.user_id,
+            session_id=execution_input.session_id,
+            domain_id=execution_input.domain_id,
+            organization_id=organization_id,
+            context=execution_input.context,
+            thinking_effort=execution_input.thinking_effort,
+            provider=execution_input.provider,
+            model=getattr(execution_input, "model", None),
+        ),
+    )
+
+
 async def process_with_multi_agent_impl(
     *,
     context: Any,
@@ -143,7 +166,7 @@ async def process_with_multi_agent_impl(
     agent_type_map: dict[str, Any],
     default_agent_type: Any,
 ) -> Any:
-    from app.engine.multi_agent.runtime import process_with_multi_agent
+    from app.engine.multi_agent.runtime import run_wiii_turn
 
     prepared_turn = prepared_turn_cls(
         request_scope=request_scope_cls(
@@ -170,16 +193,13 @@ async def process_with_multi_agent_impl(
         provider=provider,
     )
 
-    result = await process_with_multi_agent(
-        query=execution_input.query,
-        user_id=execution_input.user_id,
-        session_id=execution_input.session_id,
-        context=execution_input.context,
-        domain_id=execution_input.domain_id,
-        thinking_effort=execution_input.thinking_effort,
-        provider=execution_input.provider,
-        model=getattr(execution_input, "model", None),
+    turn_result = await run_wiii_turn(
+        build_wiii_turn_request(
+            execution_input=execution_input,
+            organization_id=getattr(context, "organization_id", None),
+        )
     )
+    result = dict(turn_result.payload)
 
     response_text = result.get("response", "")
     sources = result.get("sources", [])

--- a/maritime-ai-service/app/services/chat_stream_coordinator.py
+++ b/maritime-ai-service/app/services/chat_stream_coordinator.py
@@ -1,6 +1,7 @@
 """Service-level coordinator for chat streaming event orchestration."""
 
 import asyncio
+import inspect
 import logging
 import time
 from typing import AsyncGenerator, Mapping
@@ -26,6 +27,24 @@ def _source_to_payload(source):
     if hasattr(source, "dict"):
         return source.dict(exclude_none=True)
     return source
+
+
+def _expects_native_turn_request(stream_fn) -> bool:
+    """Return true when an injected stream function expects one turn request."""
+
+    try:
+        parameters = list(inspect.signature(stream_fn).parameters.values())
+    except (TypeError, ValueError):
+        return False
+
+    return (
+        len(parameters) == 1
+        and parameters[0].kind
+        in {
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        }
+    )
 
 
 async def generate_stream_v3_events(
@@ -94,6 +113,8 @@ async def generate_stream_v3_events(
             )
 
             stream_fn = stream_wiii_turn
+        else:
+            uses_native_turn_stream = _expects_native_turn_request(stream_fn)
 
         if orchestrator is None:
             from app.services.chat_service import get_chat_service

--- a/maritime-ai-service/app/services/chat_stream_coordinator.py
+++ b/maritime-ai-service/app/services/chat_stream_coordinator.py
@@ -9,6 +9,7 @@ from app.core.config import settings
 from app.core.exceptions import ProviderUnavailableError
 from app.engine.llm_runtime_metadata import resolve_runtime_llm_metadata
 from app.services.llm_runtime_audit_service import record_llm_runtime_observation
+from app.services.chat_orchestrator_runtime import build_wiii_turn_request
 from app.services.model_switch_prompt_service import (
     build_model_switch_prompt_for_failover,
     build_model_switch_prompt_for_unavailable,
@@ -86,12 +87,13 @@ async def generate_stream_v3_events(
 
             ensure_provider_is_selectable(requested_provider)
 
+        uses_native_turn_stream = stream_fn is None
         if stream_fn is None:
             from app.engine.multi_agent.streaming_runtime import (
-                process_with_multi_agent_streaming,
+                stream_wiii_turn,
             )
 
-            stream_fn = process_with_multi_agent_streaming
+            stream_fn = stream_wiii_turn
 
         if orchestrator is None:
             from app.services.chat_service import get_chat_service
@@ -293,16 +295,17 @@ async def generate_stream_v3_events(
         accumulated_answer: list[str] = []
         saw_done_event = False
 
-        async for event in stream_fn(
-            query=execution_input.query,
-            user_id=execution_input.user_id,
-            session_id=execution_input.session_id,
-            context=execution_input.context,
-            domain_id=execution_input.domain_id,
-            thinking_effort=execution_input.thinking_effort,
-            provider=execution_input.provider,
-            model=getattr(execution_input, "model", None),
-        ):
+        turn_request = build_wiii_turn_request(
+            execution_input=execution_input,
+            organization_id=resolved_org_id,
+        )
+        stream_events = (
+            stream_fn(turn_request)
+            if uses_native_turn_stream
+            else stream_fn(**turn_request.to_runtime_kwargs())
+        )
+
+        async for event in stream_events:
             if event.type == "answer":
                 accumulated_answer.append(event.content)
             elif event.type == "done":

--- a/maritime-ai-service/tests/unit/test_chat_request_flow.py
+++ b/maritime-ai-service/tests/unit/test_chat_request_flow.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.models.schemas import UserRole
+from app.engine.multi_agent.runtime_contracts import WiiiTurnRequest, WiiiTurnResult
 from app.services.chat_orchestrator import ChatOrchestrator, RequestScope
 from app.services.input_processor import ChatContext
 
@@ -736,3 +737,64 @@ async def test_process_with_multi_agent_preserves_runtime_provider_metadata():
 
     assert result.metadata["provider"] == "zhipu"
     assert str(result.metadata["model"]).startswith("glm-")
+
+
+@pytest.mark.asyncio
+async def test_process_with_multi_agent_uses_native_wiii_turn_request():
+    orchestrator = _make_orchestrator()
+    context = _make_chat_context()
+    session = _make_session()
+    execution_input = SimpleNamespace(
+        query=context.message,
+        user_id=context.user_id,
+        session_id=str(context.session_id),
+        context={"history": [], "organization_id": "org-1"},
+        domain_id="maritime",
+        thinking_effort="medium",
+        provider="nvidia",
+        model="deepseek-ai/deepseek-v3.1",
+    )
+
+    orchestrator.build_multi_agent_execution_input = AsyncMock(
+        return_value=execution_input
+    )
+
+    with patch(
+        "app.engine.multi_agent.runtime.run_wiii_turn",
+        new=AsyncMock(
+            return_value=WiiiTurnResult.from_payload(
+                {
+                    "response": "Native turn ok.",
+                    "sources": [],
+                    "tools_used": [],
+                    "grader_score": 0.0,
+                    "agent_outputs": {},
+                    "current_agent": "direct",
+                    "next_agent": "direct",
+                    "provider": "nvidia",
+                    "model": "deepseek-ai/deepseek-v3.1",
+                }
+            )
+        ),
+    ) as run_turn:
+        result = await orchestrator._process_with_multi_agent(
+            context=context,
+            session=session,
+            domain_id="maritime",
+            thinking_effort="medium",
+            provider="nvidia",
+            model="deepseek-ai/deepseek-v3.1",
+        )
+
+    turn_request = run_turn.await_args.args[0]
+    assert isinstance(turn_request, WiiiTurnRequest)
+    assert turn_request.query == "Explain COLREG Rule 5"
+    assert turn_request.run_context.user_id == "user-1"
+    assert turn_request.run_context.session_id == str(context.session_id)
+    assert turn_request.run_context.domain_id == "maritime"
+    assert turn_request.run_context.organization_id == "org-1"
+    assert turn_request.run_context.thinking_effort == "medium"
+    assert turn_request.run_context.provider == "nvidia"
+    assert turn_request.run_context.model == "deepseek-ai/deepseek-v3.1"
+    assert result.message == "Native turn ok."
+    assert result.metadata["provider"] == "nvidia"

--- a/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
@@ -189,6 +189,62 @@ async def test_generate_stream_v3_events_defaults_to_native_wiii_turn_stream():
     assert turn_request.run_context.model == "deepseek-ai/deepseek-v3.1"
     assert any("Native hello" in chunk for chunk in chunks)
     orchestrator.finalize_response_turn.assert_called_once()
+    assert (
+        orchestrator.finalize_response_turn.call_args.kwargs["response_text"]
+        == "Native hello"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_v3_events_accepts_injected_native_wiii_turn_stream():
+    orchestrator = MagicMock()
+    prepared_turn = SimpleNamespace(
+        request_scope=RequestScope("org-1", "maritime"),
+        session_id="session-1",
+        validation=SimpleNamespace(blocked=False),
+        chat_context=SimpleNamespace(user_name="Minh"),
+    )
+    orchestrator.prepare_turn = AsyncMock(return_value=prepared_turn)
+    orchestrator.build_multi_agent_execution_input = AsyncMock(
+        return_value=SimpleNamespace(
+            query="Explain Rule 5",
+            user_id="user-1",
+            session_id="session-1",
+            context={"conversation_history": ""},
+            domain_id="maritime",
+            thinking_effort=None,
+            provider=None,
+            model=None,
+        )
+    )
+
+    captured = {}
+
+    async def fake_native_stream_fn(request):
+        captured["request"] = request
+        yield WiiiStreamEvent(event_type="answer", payload="Injected native")
+        yield WiiiStreamEvent(
+            event_type="done",
+            payload={"status": "complete", "total_time": 0.5},
+        )
+
+    chunks = []
+    async for chunk in generate_stream_v3_events(
+        chat_request=_make_request(),
+        request_headers={},
+        background_save=MagicMock(),
+        start_time=0.0,
+        orchestrator=orchestrator,
+        stream_fn=fake_native_stream_fn,
+    ):
+        chunks.append(chunk)
+
+    assert isinstance(captured["request"], WiiiTurnRequest)
+    assert any("Injected native" in chunk for chunk in chunks)
+    assert (
+        orchestrator.finalize_response_turn.call_args.kwargs["response_text"]
+        == "Injected native"
+    )
 
 
 @pytest.mark.asyncio

--- a/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
@@ -156,6 +156,10 @@ async def test_generate_stream_v3_events_defaults_to_native_wiii_turn_stream():
 
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(
+            "app.services.llm_selectability_service.ensure_provider_is_selectable",
+            lambda _provider: None,
+        )
+        mp.setattr(
             "app.engine.multi_agent.streaming_runtime.stream_wiii_turn",
             fake_stream_wiii_turn,
         )

--- a/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
@@ -5,6 +5,7 @@ import pytest
 
 from app.models.schemas import UserRole
 from app.core.exceptions import ProviderUnavailableError
+from app.engine.multi_agent.runtime_contracts import WiiiStreamEvent, WiiiTurnRequest
 from app.services.chat_orchestrator import AgentType
 from app.services.chat_orchestrator import RequestScope
 from app.services.output_processor import ProcessingResult
@@ -118,6 +119,72 @@ async def test_generate_stream_v3_events_finalizes_answer_after_stream():
         ]
         == "stream"
     )
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_v3_events_defaults_to_native_wiii_turn_stream():
+    orchestrator = MagicMock()
+    prepared_turn = SimpleNamespace(
+        request_scope=RequestScope("org-1", "maritime"),
+        session_id="session-1",
+        validation=SimpleNamespace(blocked=False),
+        chat_context=SimpleNamespace(user_name="Minh"),
+    )
+    orchestrator.prepare_turn = AsyncMock(return_value=prepared_turn)
+    orchestrator.build_multi_agent_execution_input = AsyncMock(
+        return_value=SimpleNamespace(
+            query="Explain Rule 5",
+            user_id="user-1",
+            session_id="session-1",
+            context={"conversation_history": ""},
+            domain_id="maritime",
+            thinking_effort="medium",
+            provider="nvidia",
+            model="deepseek-ai/deepseek-v3.1",
+        )
+    )
+
+    captured = {}
+
+    async def fake_stream_wiii_turn(request):
+        captured["request"] = request
+        yield WiiiStreamEvent(event_type="answer", payload="Native hello")
+        yield WiiiStreamEvent(
+            event_type="done",
+            payload={"status": "complete", "total_time": 0.5},
+        )
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "app.engine.multi_agent.streaming_runtime.stream_wiii_turn",
+            fake_stream_wiii_turn,
+        )
+        chunks = []
+        async for chunk in generate_stream_v3_events(
+            chat_request=_make_request(
+                provider="nvidia",
+                model="deepseek-ai/deepseek-v3.1",
+                thinking_effort="medium",
+            ),
+            request_headers={},
+            background_save=MagicMock(),
+            start_time=0.0,
+            orchestrator=orchestrator,
+        ):
+            chunks.append(chunk)
+
+    turn_request = captured["request"]
+    assert isinstance(turn_request, WiiiTurnRequest)
+    assert turn_request.query == "Explain Rule 5"
+    assert turn_request.run_context.user_id == "user-1"
+    assert turn_request.run_context.session_id == "session-1"
+    assert turn_request.run_context.domain_id == "maritime"
+    assert turn_request.run_context.organization_id == "org-1"
+    assert turn_request.run_context.thinking_effort == "medium"
+    assert turn_request.run_context.provider == "nvidia"
+    assert turn_request.run_context.model == "deepseek-ai/deepseek-v3.1"
+    assert any("Native hello" in chunk for chunk in chunks)
+    orchestrator.finalize_response_turn.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/maritime-ai-service/tests/unit/test_wiii_runtime_contracts.py
+++ b/maritime-ai-service/tests/unit/test_wiii_runtime_contracts.py
@@ -92,6 +92,7 @@ def test_wiii_stream_event_preserves_stream_event_shape():
 
     event = WiiiStreamEvent.from_legacy_tuple(raw_event)
 
+    assert event.raw_event is raw_event
     assert event.type == "answer"
     assert event.content == "Xin chao."
     assert event.node == "direct"

--- a/maritime-ai-service/tests/unit/test_wiii_runtime_contracts.py
+++ b/maritime-ai-service/tests/unit/test_wiii_runtime_contracts.py
@@ -11,6 +11,7 @@ from app.engine.multi_agent.runtime_contracts import (
     WiiiTurnResult,
     WiiiTurnState,
 )
+from app.engine.multi_agent.stream_utils import StreamEvent
 
 
 def test_wiii_turn_request_adapts_to_existing_runtime_kwargs():
@@ -78,6 +79,24 @@ def test_wiii_stream_event_wraps_existing_tuple_contract():
     assert event.event_type == "graph"
     assert event.node_name == "direct"
     assert event.to_legacy_tuple() == ("graph", {"direct": {"response": "ok"}})
+
+
+def test_wiii_stream_event_preserves_stream_event_shape():
+    raw_event = StreamEvent(
+        type="answer",
+        content="Xin chao.",
+        node="direct",
+        step="direct_response",
+        details={"visibility": "answer"},
+    )
+
+    event = WiiiStreamEvent.from_legacy_tuple(raw_event)
+
+    assert event.type == "answer"
+    assert event.content == "Xin chao."
+    assert event.node == "direct"
+    assert event.step == "direct_response"
+    assert event.details == {"visibility": "answer"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Route the sync chat multi-agent service path through `WiiiTurnRequest` and `run_wiii_turn`.
- Route the default SSE V3 multi-agent stream path through `stream_wiii_turn` while preserving the injectable legacy `stream_fn` seam.
- Make `WiiiStreamEvent` preserve StreamEvent-like shape so the existing SSE presenter contract remains unchanged.
- Add focused regression coverage for sync provider/model/org propagation and native streaming turn wiring.

## Risk
- Backend runtime/pipeline surface. The patch is intentionally service-boundary only and does not remove LangGraph internals, change route schemas, or change SSE payload serialization.
- Compatibility is preserved for existing graph patch paths and explicit test-injected legacy stream functions.

## Rollback
- Revert this PR to return sync/stream callers to direct legacy kwargs invocation. No migration or persisted data changes are included.

## Verification
- `cd maritime-ai-service && python -m pytest tests/unit/test_wiii_runtime_contracts.py tests/unit/test_chat_request_flow.py tests/unit/test_chat_stream_coordinator.py -q` -> 32 passed
- `cd maritime-ai-service && python -m pytest tests/unit/test_multi_agent_runtime_surface.py tests/unit/test_graph_stream_runtime.py tests/unit/test_thinking_lifecycle.py -q` -> 45 passed
- `cd maritime-ai-service && python -m ruff check app/ tests/unit/test_wiii_runtime_contracts.py tests/unit/test_chat_request_flow.py tests/unit/test_chat_stream_coordinator.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

Closes #179
Refs #170, #177, #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated multi-agent runtime integration to enhance event handling and streaming coordination.
  * Improved stream event preservation to maintain original event data throughout the processing pipeline.

* **Tests**
  * Added test coverage for runtime integration and native streaming functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->