### PR TITLE
Route auxiliary entrypoints through Wiii turn runtime

### DIFF
--- a/maritime-ai-service/app/api/v1/messenger_webhook.py
+++ b/maritime-ai-service/app/api/v1/messenger_webhook.py
@@ -232,23 +232,29 @@ async def _process_and_reply(sender_id: str, text: str) -> str:
 
     from app.auth.identity_resolver import resolve_user_id
     from app.engine.personality_mode import resolve_personality_mode
-    from app.engine.multi_agent.runtime import process_with_multi_agent
+    from app.engine.multi_agent.runtime import run_wiii_turn
+    from app.engine.multi_agent.runtime_contracts import WiiiRunContext, WiiiTurnRequest
 
     canonical_user_id = await resolve_user_id("messenger", sender_id)
     personality_mode = resolve_personality_mode("messenger")
 
-    result = await process_with_multi_agent(
-        query=text,
-        user_id=canonical_user_id,
-        session_id=f"messenger_{sender_id}",
-        context={
-            "user_role": "student",
-            "conversation_history": "",
-            "semantic_context": "",
-            "personality_mode": personality_mode,
-            "channel_type": "messenger",
-        },
+    turn_result = await run_wiii_turn(
+        WiiiTurnRequest(
+            query=text,
+            run_context=WiiiRunContext(
+                user_id=canonical_user_id,
+                session_id=f"messenger_{sender_id}",
+                context={
+                    "user_role": "student",
+                    "conversation_history": "",
+                    "semantic_context": "",
+                    "personality_mode": personality_mode,
+                    "channel_type": "messenger",
+                },
+            ),
+        )
     )
+    result = turn_result.payload
     return result.get("response", result.get("final_response", "Mình không hiểu câu hỏi."))
 
 

--- a/maritime-ai-service/app/api/v1/zalo_webhook.py
+++ b/maritime-ai-service/app/api/v1/zalo_webhook.py
@@ -185,23 +185,29 @@ async def _process_and_reply(sender_id: str, text: str) -> str:
 
     from app.auth.identity_resolver import resolve_user_id
     from app.engine.personality_mode import resolve_personality_mode
-    from app.engine.multi_agent.runtime import process_with_multi_agent
+    from app.engine.multi_agent.runtime import run_wiii_turn
+    from app.engine.multi_agent.runtime_contracts import WiiiRunContext, WiiiTurnRequest
 
     canonical_user_id = await resolve_user_id("zalo", sender_id)
     personality_mode = resolve_personality_mode("zalo")
 
-    result = await process_with_multi_agent(
-        query=text,
-        user_id=canonical_user_id,
-        session_id=f"zalo_{sender_id}",
-        context={
-            "user_role": "student",
-            "conversation_history": "",
-            "semantic_context": "",
-            "personality_mode": personality_mode,
-            "channel_type": "zalo",
-        },
+    turn_result = await run_wiii_turn(
+        WiiiTurnRequest(
+            query=text,
+            run_context=WiiiRunContext(
+                user_id=canonical_user_id,
+                session_id=f"zalo_{sender_id}",
+                context={
+                    "user_role": "student",
+                    "conversation_history": "",
+                    "semantic_context": "",
+                    "personality_mode": personality_mode,
+                    "channel_type": "zalo",
+                },
+            ),
+        )
     )
+    result = turn_result.payload
     return result.get("response", result.get("final_response", "Mình không hiểu câu hỏi."))
 
 

--- a/maritime-ai-service/app/services/scheduled_task_executor.py
+++ b/maritime-ai-service/app/services/scheduled_task_executor.py
@@ -129,18 +129,26 @@ class ScheduledTaskExecutor:
 
         if extra.get("agent_invoke"):
             # Agent mode: invoke the WiiiRunner-backed multi-agent runtime.
-            from app.engine.multi_agent.runtime import process_with_multi_agent
+            from app.engine.multi_agent.runtime import run_wiii_turn
+            from app.engine.multi_agent.runtime_contracts import (
+                WiiiRunContext,
+                WiiiTurnRequest,
+            )
 
-            result = await asyncio.wait_for(
-                process_with_multi_agent(
-                    query=task["description"],
-                    user_id=task["user_id"],
-                    session_id=f"scheduled_{task['id'][:8]}",
-                    domain_id=task.get("domain_id", "maritime"),
+            turn_result = await asyncio.wait_for(
+                run_wiii_turn(
+                    WiiiTurnRequest(
+                        query=task["description"],
+                        run_context=WiiiRunContext(
+                            user_id=task["user_id"],
+                            session_id=f"scheduled_{task['id'][:8]}",
+                            domain_id=task.get("domain_id", "maritime"),
+                        ),
+                    )
                 ),
                 timeout=settings.scheduler_agent_timeout,
             )
-            # process_with_multi_agent returns {"response": ..., ...}
+            result = turn_result.payload
             return {
                 "mode": "agent",
                 "response": result.get("response", ""),

--- a/maritime-ai-service/tests/unit/test_scheduled_task_executor.py
+++ b/maritime-ai-service/tests/unit/test_scheduled_task_executor.py
@@ -19,6 +19,7 @@ import pytest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from app.engine.multi_agent.runtime_contracts import WiiiTurnRequest, WiiiTurnResult
 from app.services.scheduled_task_executor import (
     ScheduledTaskExecutor,
     _parse_interval,
@@ -239,6 +240,33 @@ class TestExecuteAgentMode:
 
         assert result["mode"] == "agent"
         assert "MARPOL" in result["response"]
+
+    @pytest.mark.asyncio
+    async def test_execute_agent_task_uses_wiii_turn_request(
+        self,
+        executor,
+        sample_task_agent,
+    ):
+        """Agent mode passes a native Wiii turn request to the runtime."""
+        mock_settings = MagicMock()
+        mock_settings.scheduler_agent_timeout = 30
+        mock_result = WiiiTurnResult.from_payload({"response": "Scheduled native ok"})
+
+        with patch("app.core.config.settings", mock_settings), \
+             patch(
+                 "app.engine.multi_agent.runtime.run_wiii_turn",
+                 new_callable=AsyncMock,
+                 return_value=mock_result,
+             ) as mock_run_turn:
+            result = await executor._execute_single_task(sample_task_agent)
+
+        turn_request = mock_run_turn.await_args.args[0]
+        assert isinstance(turn_request, WiiiTurnRequest)
+        assert turn_request.query == sample_task_agent["description"]
+        assert turn_request.run_context.user_id == sample_task_agent["user_id"]
+        assert turn_request.run_context.session_id == "scheduled_task-age"
+        assert turn_request.run_context.domain_id == "maritime"
+        assert result == {"mode": "agent", "response": "Scheduled native ok"}
 
     @pytest.mark.asyncio
     async def test_agent_task_timeout(self, executor, sample_task_agent):

--- a/maritime-ai-service/tests/unit/test_sprint174_cross_platform.py
+++ b/maritime-ai-service/tests/unit/test_sprint174_cross_platform.py
@@ -26,6 +26,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.engine.multi_agent.runtime_contracts import WiiiTurnRequest, WiiiTurnResult
+
 
 # =============================================================================
 # 1. CONFIG TESTS
@@ -405,6 +407,28 @@ class TestMessengerWebhookCrossPlatform:
             await _process_and_reply("sender_x", "Hi")
             assert mock_process.call_args[1]["user_id"] == "canonical-uuid-999"
 
+    @pytest.mark.asyncio
+    async def test_process_uses_native_wiii_turn_request(self):
+        from app.api.v1.messenger_webhook import _process_and_reply
+
+        with patch("app.auth.identity_resolver.resolve_user_id", new_callable=AsyncMock, return_value="canonical-uuid-999"), \
+             patch("app.engine.personality_mode.resolve_personality_mode", return_value="professional"), \
+             patch(
+                 "app.engine.multi_agent.runtime.run_wiii_turn",
+                 new_callable=AsyncMock,
+                 return_value=WiiiTurnResult.from_payload({"response": "OK"}),
+             ) as mock_run_turn:
+            answer = await _process_and_reply("sender_x", "Hi")
+
+        turn_request = mock_run_turn.await_args.args[0]
+        assert isinstance(turn_request, WiiiTurnRequest)
+        assert turn_request.query == "Hi"
+        assert turn_request.run_context.user_id == "canonical-uuid-999"
+        assert turn_request.run_context.session_id == "messenger_sender_x"
+        assert turn_request.run_context.context["personality_mode"] == "professional"
+        assert turn_request.run_context.context["channel_type"] == "messenger"
+        assert answer == "OK"
+
 
 # =============================================================================
 # 6. ZALO WEBHOOK TESTS
@@ -485,6 +509,28 @@ class TestZaloWebhookProcessing:
              patch("app.engine.multi_agent.graph.process_with_multi_agent", new_callable=AsyncMock, return_value={"response": "OK"}) as mock_process:
             await _process_and_reply("zalo_777", "Hi")
             assert mock_process.call_args[1]["session_id"] == "zalo_zalo_777"
+
+    @pytest.mark.asyncio
+    async def test_process_uses_native_wiii_turn_request(self):
+        from app.api.v1.zalo_webhook import _process_and_reply
+
+        with patch("app.auth.identity_resolver.resolve_user_id", new_callable=AsyncMock, return_value="user-z"), \
+             patch("app.engine.personality_mode.resolve_personality_mode", return_value="soul"), \
+             patch(
+                 "app.engine.multi_agent.runtime.run_wiii_turn",
+                 new_callable=AsyncMock,
+                 return_value=WiiiTurnResult.from_payload({"response": "OK"}),
+             ) as mock_run_turn:
+            answer = await _process_and_reply("zalo_777", "Hi")
+
+        turn_request = mock_run_turn.await_args.args[0]
+        assert isinstance(turn_request, WiiiTurnRequest)
+        assert turn_request.query == "Hi"
+        assert turn_request.run_context.user_id == "user-z"
+        assert turn_request.run_context.session_id == "zalo_zalo_777"
+        assert turn_request.run_context.context["personality_mode"] == "soul"
+        assert turn_request.run_context.context["channel_type"] == "zalo"
+        assert answer == "OK"
 
 
 class TestZaloSendReply:


### PR DESCRIPTION
## Summary
- Route Messenger webhook processing through `WiiiTurnRequest` + `run_wiii_turn`.
- Route Zalo webhook processing through `WiiiTurnRequest` + `run_wiii_turn`.
- Route scheduled task `agent_invoke` execution through `WiiiTurnRequest` + `run_wiii_turn`.
- Add unit coverage that webhook and scheduler entrypoints pass native turn request metadata correctly.

## Risk
- Backend runtime entrypoint surface. This does not change webhook schemas, outbound channel delivery, provider selection, or LangGraph internals.
- Existing graph/runtime compatibility patch paths are preserved because `run_wiii_turn` still delegates through the canonical runtime adapter.

## Rollback
- Revert this PR to return Messenger, Zalo, and scheduled task agent execution to direct legacy runtime kwargs invocation. No migration or persisted data changes are included.

## Verification
- `cd maritime-ai-service && python -m pytest tests/unit/test_scheduled_task_executor.py tests/unit/test_sprint174_cross_platform.py -q` -> 78 passed
- `cd maritime-ai-service && python -m pytest tests/unit/test_multi_agent_runtime_surface.py tests/unit/test_wiii_runtime_contracts.py -q` -> 15 passed
- `cd maritime-ai-service && python -m pytest tests/unit/test_chat_request_flow.py tests/unit/test_chat_stream_coordinator.py tests/unit/test_wiii_runtime_contracts.py -q` -> 33 passed
- `cd maritime-ai-service && python -m ruff check app/api/v1/messenger_webhook.py app/api/v1/zalo_webhook.py app/services/scheduled_task_executor.py tests/unit/test_scheduled_task_executor.py tests/unit/test_sprint174_cross_platform.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed
- Production callsite scan: remaining `process_with_multi_agent(` references are runtime compatibility surfaces, comments, or internal method names; Messenger/Zalo/scheduled task direct calls are removed.

Closes #182
Refs #170, #179, #180