### PR TITLE
[codex] Runtime chat smoke contracts

### DIFF
--- a/maritime-ai-service/tests/unit/test_runtime_endpoint_smoke.py
+++ b/maritime-ai-service/tests/unit/test_runtime_endpoint_smoke.py
@@ -443,7 +443,9 @@ async def test_chat_stream_v3_smoke_success_transport(smoke_app):
             'event: metadata\n'
             'data: {"session_id":"session-stream","provider":"nvidia",'
             '"model":"deepseek-ai/deepseek-v4-flash",'
-            '"runtime_authoritative":true}\n\n'
+            '"runtime_authoritative":true,'
+            '"failover":{"switched":false,"initial_provider":"nvidia",'
+            '"final_provider":"nvidia"}}\n\n'
         )
         yield 'event: done\ndata: {"processing_time":0.1}\n\n'
 
@@ -478,6 +480,8 @@ async def test_chat_stream_v3_smoke_success_transport(smoke_app):
     assert '"provider":"nvidia"' in body
     assert '"model":"deepseek-ai/deepseek-v4-flash"' in body
     assert '"runtime_authoritative":true' in body
+    assert '"failover":{"switched":false' in body
+    assert '"final_provider":"nvidia"' in body
     assert "event: done" in body
 
 

--- a/maritime-ai-service/tests/unit/test_runtime_endpoint_smoke.py
+++ b/maritime-ai-service/tests/unit/test_runtime_endpoint_smoke.py
@@ -303,8 +303,12 @@ async def test_chat_sync_smoke_success_response(smoke_app):
     payload = response.json()
     assert payload["status"] == "success"
     assert payload["data"]["answer"] == "Chao ban, minh da xu ly xong."
+    assert payload["metadata"]["session_id"] == "session-1"
+    assert payload["metadata"]["provider"] == "google"
     assert payload["metadata"]["model"] == "gemini-3.1-flash-lite-preview"
+    assert payload["metadata"]["runtime_authoritative"] is True
     assert payload["metadata"]["failover"]["last_reason_code"] == "auth_error"
+    assert payload["metadata"]["failover"]["final_provider"] == "zhipu"
 
 
 @pytest.mark.asyncio
@@ -434,6 +438,13 @@ async def test_chat_stream_v3_smoke_success_transport(smoke_app):
 
     async def _fake_stream(*args, **kwargs):
         yield 'event: status\ndata: {"content":"Dang xu ly"}\n\n'
+        yield 'event: answer\ndata: {"content":"Chao ban qua SSE"}\n\n'
+        yield (
+            'event: metadata\n'
+            'data: {"session_id":"session-stream","provider":"nvidia",'
+            '"model":"deepseek-ai/deepseek-v4-flash",'
+            '"runtime_authoritative":true}\n\n'
+        )
         yield 'event: done\ndata: {"processing_time":0.1}\n\n'
 
     with patch(
@@ -460,6 +471,13 @@ async def test_chat_stream_v3_smoke_success_transport(smoke_app):
 
     assert response.status_code == 200
     assert "event: status" in body
+    assert "event: answer" in body
+    assert "Chao ban qua SSE" in body
+    assert "event: metadata" in body
+    assert '"session_id":"session-stream"' in body
+    assert '"provider":"nvidia"' in body
+    assert '"model":"deepseek-ai/deepseek-v4-flash"' in body
+    assert '"runtime_authoritative":true' in body
     assert "event: done" in body
 
 


### PR DESCRIPTION
## Summary

- Tightens `/api/v1/chat` endpoint smoke coverage for session, provider, model, runtime-authoritative metadata, and failover final provider.
- Tightens `/api/v1/chat/stream/v3` endpoint smoke coverage so the deterministic transport test proves `answer`, `metadata`, and `done` SSE events reach clients.

## Why

This is a small runtime checkpoint after #178, #180, and #183 moved primary and auxiliary entrypoints onto the native Wiii turn path. It gives us a deterministic guardrail before deeper provider reliability and LangGraph cleanup work.

Closes #184.

## Verification

- `cd maritime-ai-service && python -m pytest tests/unit/test_runtime_endpoint_smoke.py -q` -> 13 passed
- `cd maritime-ai-service && python -m ruff check tests/unit/test_runtime_endpoint_smoke.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk and rollback

- Risk: Low; test-only change, no runtime behavior change.
- Rollback: Revert this commit if the stricter smoke expectations conflict with an intentional API contract change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation in runtime endpoint smoke tests to verify proper propagation of metadata including session identifiers, provider information, and runtime authorization status across both synchronous chat and streaming transports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->