### PR TITLE
[codex] Finalize errored SSE streams

### DIFF
--- a/maritime-ai-service/app/api/v1/chat_stream.py
+++ b/maritime-ai-service/app/api/v1/chat_stream.py
@@ -12,6 +12,7 @@ see app/services/REQUEST_FLOW_CONTRACT.md
 """
 
 import logging
+import time
 from typing import AsyncGenerator
 
 from fastapi import APIRouter, BackgroundTasks, Request
@@ -68,6 +69,8 @@ def _canonicalize_stream_request_from_auth(
 async def _keepalive_generator(
     inner_gen: AsyncGenerator[str, None],
     request: Request,
+    *,
+    start_time: float | None = None,
 ) -> AsyncGenerator[str, None]:
     """
     Wrap an SSE generator with keepalive heartbeats and client disconnect detection.
@@ -80,7 +83,12 @@ async def _keepalive_generator(
     - Checks `request.is_disconnected()` to abort when client disconnects
     """
     def _inner_error_chunks() -> list[str]:
-        return _stream_presenter.emit_internal_error_sse_events()[0]
+        processing_time = None
+        if start_time is not None:
+            processing_time = max(time.time() - start_time, 0.0)
+        return _stream_presenter.emit_internal_error_sse_events(
+            processing_time=processing_time,
+        )[0]
 
     async for chunk in _stream_transport.wrap_sse_with_keepalive(
         inner_gen=inner_gen,
@@ -174,5 +182,9 @@ async def chat_stream_v3(
 
     # Sprint 26: Wrap with keepalive heartbeat + client disconnect detection
     return _stream_endpoint_support.build_chat_streaming_response(
-        event_generator=_keepalive_generator(generate_events_v3(), request),
+        event_generator=_keepalive_generator(
+            generate_events_v3(),
+            request,
+            start_time=start_time,
+        ),
     )

--- a/maritime-ai-service/tests/unit/test_sprint26_sse_keepalive.py
+++ b/maritime-ai-service/tests/unit/test_sprint26_sse_keepalive.py
@@ -139,6 +139,37 @@ class TestKeepaliveGenerator:
         assert len(error_chunks) >= 1
 
     @pytest.mark.asyncio
+    async def test_handles_inner_generator_error_with_done_when_start_time_supplied(
+        self,
+        monkeypatch,
+    ):
+        """Endpoint wrapper should finalize errored streams so FE can stop thinking."""
+        async def failing_inner():
+            yield "first"
+            raise ValueError("Test error")
+
+        mock_request = MagicMock()
+        mock_request.is_disconnected = AsyncMock(return_value=False)
+
+        import app.api.v1.chat_stream as module
+
+        monkeypatch.setattr(module.time, "time", lambda: 105.0)
+
+        chunks = []
+        async for chunk in _keepalive_generator(
+            failing_inner(),
+            mock_request,
+            start_time=100.0,
+        ):
+            chunks.append(chunk)
+
+        assert "first" in chunks
+        assert any("event: error" in chunk for chunk in chunks)
+        done_chunks = [chunk for chunk in chunks if "event: done" in chunk]
+        assert len(done_chunks) == 1
+        assert '"processing_time": 5.0' in done_chunks[0]
+
+    @pytest.mark.asyncio
     async def test_empty_inner_generator(self):
         """Should handle an inner generator that yields nothing."""
         async def empty_inner():


### PR DESCRIPTION
## Summary

- Passes the chat stream request start time into the endpoint keepalive wrapper.
- Makes transport-level inner stream failures emit the standard `error` plus final `done` SSE sequence when timing is available.
- Adds focused coverage so errored endpoint streams still finalize and the frontend can leave the live/thinking state.

## Why

The coordinator already emits `error` + `done` for handled runtime failures, but the endpoint-level keepalive guard used the internal-error presenter without `processing_time`, which produced only `error`. That could leave the frontend waiting for finalization when an inner generator failed or the transport guard aborted the stream.

Closes #186.

## Verification

- `cd maritime-ai-service && python -m pytest tests/unit/test_sprint26_sse_keepalive.py tests/unit/test_runtime_endpoint_smoke.py -q` -> 23 passed
- `cd maritime-ai-service && python -m ruff check app/api/v1/chat_stream.py tests/unit/test_sprint26_sse_keepalive.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk and rollback

- Risk: Low. This only changes the error/finalization path of the SSE endpoint wrapper and preserves backwards compatibility when `start_time` is omitted.
- Rollback: Revert this PR if downstream clients intentionally rely on transport-level errors omitting `done`, though that would conflict with the V3 stream finalization contract.