### PR TITLE
Add Wiii Pointy: cooperative-iframe tutor overlay (V1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ docs/assets/screenshots/tmp/
 # === Generated build output ===
 wiii-desktop/dist-embed/
 wiii-desktop/dist-web/
+wiii-desktop/dist-pointy/
 pytest-cache-files-*
 # Keep local nested agent configs ignored, but track root Codex review guidance.
 .agents/

--- a/docs/integration/WIII_POINTY_LMS_GUIDE.md
+++ b/docs/integration/WIII_POINTY_LMS_GUIDE.md
@@ -1,0 +1,202 @@
+# Wiii Pointy — LMS integration guide
+
+> **Status:** V1 (read-only tutor mode)
+> **Last updated:** 2026-04-29
+> **Owner:** Wiii Lab
+> **Audience:** LMS frontend team (`holilihu.online` Angular app)
+> **Companion docs:** `docs/integration/LMS_TEAM_GUIDE.md` (Section 9, Page-Aware AI Context)
+
+Wiii Pointy is the cooperative-iframe overlay that lets Wiii — the AI living
+inside the LMS iframe — *point at* UI elements, scroll to them, navigate the
+LMS router, and run multi-step guided tours. It is the web-native answer to
+the "macOS clicky" UX, built on top of the Sprint 222 `HostActionBridge`
+(PostMessage 2-way protocol) Wiii already speaks.
+
+V1 is intentionally **read-only**: no auto-click, no auto-fill, no DOM
+mutation. The student stays in control. Auto-click + auto-fill are gated for
+V2 behind explicit per-tool `mutates_state=true` + `requires_confirmation=true`.
+
+---
+
+## 1. What you ship as the LMS team
+
+Two small things in the LMS Angular app:
+
+1. **Include the Pointy bundle** on every page where the Wiii iframe is
+   embedded:
+
+   ```html
+   <script src="https://wiii.holilihu.online/pointy/wiii-pointy.umd.js"></script>
+   ```
+
+   (Or import the ESM build from `dist-pointy/wiii-pointy.es.js` if you
+   prefer a bundled path.)
+
+2. **Initialise the bridge once**, then forward capabilities to the iframe:
+
+   ```ts
+   import { Router } from '@angular/router';
+
+   declare global {
+     interface Window { WiiiPointy: any; }
+   }
+
+   const wiiiOrigin = 'https://wiii.holilihu.online';
+
+   const handle = window.WiiiPointy.init({
+     iframeOrigin: wiiiOrigin,
+     onNavigate: (route: string) => router.navigateByUrl(route),
+   });
+
+   const iframeEl = document.getElementById('wiii-iframe') as HTMLIFrameElement;
+   iframeEl.addEventListener('load', () => {
+     iframeEl.contentWindow?.postMessage(handle.capabilities(), wiiiOrigin);
+   });
+   ```
+
+That is the entire integration. The bridge listens for `wiii:action-request`
+messages from the iframe and replies with `wiii:action-response`. Wiii's
+backend (`HostActionBridge`, Sprint 222) and the iframe frontend (Sprint
+222b) already speak this protocol.
+
+---
+
+## 2. Action contract (V1)
+
+| Action | Mutates? | Confirm? | Purpose |
+|---|---|---|---|
+| `ui.highlight` | no | no | Spotlight + tooltip on a target element |
+| `ui.scroll_to` | no | no | `scrollIntoView({block:'center'})` on a target |
+| `ui.navigate` | no | no | Internal route or safe absolute URL |
+| `ui.show_tour` | no | no | 2–5 step guided walk-through |
+
+### `ui.highlight`
+```jsonc
+{
+  "selector": "[data-wiii-id=\"continue-lesson\"]",
+  "message": "Đây là nút để tiếp tục bài học.",
+  "duration_ms": 2200
+}
+```
+Reply: `{ success: true, data: { summary: "Đã trỏ vào element: #continue-lesson" } }`
+
+### `ui.scroll_to`
+```jsonc
+{ "selector": "[data-wiii-id=\"profile-card\"]", "block": "center" }
+```
+
+### `ui.navigate`
+```jsonc
+{ "route": "/courses/123/lessons/4" }
+```
+or
+```jsonc
+{ "url": "https://holilihu.online/help" }
+```
+Internal `route` is preferred — `onNavigate` lets you keep Angular Router
+state. Absolute `url` is rejected when it points at `localhost`,
+`127.0.0.1`, `*.local`, or any non-`http(s)` scheme.
+
+### `ui.show_tour`
+```jsonc
+{
+  "steps": [
+    { "selector": "[data-wiii-id=\"course-card\"]",
+      "message": "Bước 1 — khóa học hôm nay.", "duration_ms": 1600 },
+    { "selector": "[data-wiii-id=\"quiz-card\"]",
+      "message": "Bước 2 — bài kiểm tra sắp tới.", "duration_ms": 1600 }
+  ],
+  "start_at": 0
+}
+```
+A new tour cancels any tour already running.
+
+---
+
+## 3. Selectors — make Pointy reliable
+
+Wiii relies on selectors you provide. Make them stable:
+
+- **Strongly prefer** `data-wiii-id` attributes on every interactive element
+  the student is likely to be guided toward. Example:
+  `<button data-wiii-id="submit-quiz">Nộp bài</button>`. These survive
+  refactors and CSS class churn.
+- Fall back to `id` only when uniqueness is guaranteed.
+- Avoid relying on raw class names or nth-child paths.
+
+The Wiii backend reads `HostContext.content.structured` (Sprint 222b) — when
+you populate it with the visible interactive elements (`{role, name,
+data-wiii-id}`), the AI can ground its highlight calls without guessing.
+
+### Quiz pages — pedagogical guardrail
+
+The Pointy skill (`maritime-ai-service/app/engine/context/skills/lms/pointy.skill.yaml`)
+explicitly forbids the AI from using `ui.highlight` on quiz answer options.
+The AI is allowed to point at navigation / submit / hint controls. If your
+quiz template marks answer options with a different `data-wiii-id` namespace
+(e.g. `quiz-option-A`), keep them recognisable so future safety checks can
+filter them server-side too.
+
+---
+
+## 4. Security model
+
+- **Origin pinning.** The bridge ignores any message whose `event.origin`
+  is not the configured `iframeOrigin`. Replies are sent with the same
+  fixed `targetOrigin` — never `*`.
+- **Selector hardening.** Bad selectors fail closed (`selector_not_found`)
+  rather than throwing.
+- **URL hardening.** `ui.navigate` rejects loopback / `.local` / `.internal`
+  / non-`http(s)` URLs — covers the same SSRF list as the standalone
+  Playwright agent (Sprint 222b Phase 7).
+- **Content Security Policy.** The bundle is plain JS + DOM. No `eval`, no
+  inline workers, no fetch. CSP `script-src 'self' https://wiii.holilihu.online`
+  is sufficient; `style-src 'self' 'unsafe-inline'` is required only for the
+  inline overlay styles — switch to `'nonce-...'` if your CSP is strict.
+
+---
+
+## 5. Operational notes
+
+- **Bundle size.** ~11 KB minified UMD, ~4.5 KB gzipped. Safe to ship on
+  every page.
+- **Idempotency.** Calling `WiiiPointy.init(...)` twice replaces the
+  previous bridge — useful during HMR.
+- **Cleanup.** Call the returned `handle.destroy()` on route teardown if
+  your single-page Angular app unmounts the Wiii iframe.
+- **Observability.** Pass a `log: (level, msg, ctx) => ...` callback into
+  `init` to forward bridge events to your existing telemetry.
+- **Coexistence with Page-Aware Context (Sprint 221).** Wiii Pointy and
+  Page-Aware Context are independent and additive. Pointy reads selectors
+  from the page; Page-Aware Context tells the AI *what page is open*.
+  Together they form the full host loop: AI sees page → AI calls action →
+  Pointy executes.
+
+---
+
+## 6. Build & ship
+
+```bash
+cd wiii-desktop
+npm run build:pointy     # → dist-pointy/wiii-pointy.umd.js + .es.js
+```
+
+Copy the `dist-pointy/wiii-pointy.umd.js` artifact behind a CDN path
+(`https://wiii.holilihu.online/pointy/wiii-pointy.umd.js`). The artifact is
+hash-stable per build.
+
+Demo for visual QA: open
+`wiii-desktop/dev-demo/pointy/index.html` in a browser after the build.
+
+---
+
+## 7. Roadmap
+
+- **V1 (this PR):** read-only tutor primitives.
+- **V2:** `ui.click`, `ui.fill_field` — gated `mutates_state=true,
+  requires_confirmation=true`. Quiz pages remain read-only.
+- **V3:** push-to-talk voice + Agent Mode dashboard panel (re-uses
+  existing `OperatorSessionV1` from `host_context.py`).
+- **Long-term:** migrate the capability declaration to WebMCP once the
+  W3C draft stabilises. The current `HostCapabilities.tools[]` shape
+  maps 1:1 onto MCP tools, so this is a rename, not a rewrite.

--- a/maritime-ai-service/app/engine/context/pointy_actions.py
+++ b/maritime-ai-service/app/engine/context/pointy_actions.py
@@ -1,0 +1,159 @@
+"""Wiii Pointy — canonical action names + Python-side schema reference.
+
+This module documents the V1 ``ui.*`` action contract that the Wiii Pointy
+host bundle (``wiii-desktop/src/pointy-host/``) implements on the LMS parent
+page. Wiii's :class:`~app.engine.context.action_bridge.HostActionBridge` is
+already generic — it accepts whatever ``HostCapabilities.tools[]`` declares.
+
+This file exists as:
+
+1. A single source of truth for action names so the backend never typos
+   ``ui.highlights`` vs ``ui.highlight``.
+2. A reference shape for ``HostActionDefinition`` payloads that the LMS
+   parent should emit via ``wiii:capabilities``.
+
+V1 is read-only: no auto-click, no auto-fill. ``mutates_state`` and
+``requires_confirmation`` are both ``False`` for every Pointy tool.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+POINTY_VERSION = 1
+
+POINTY_ACTION_HIGHLIGHT = "ui.highlight"
+POINTY_ACTION_SCROLL_TO = "ui.scroll_to"
+POINTY_ACTION_NAVIGATE = "ui.navigate"
+POINTY_ACTION_SHOW_TOUR = "ui.show_tour"
+
+POINTY_ACTIONS: tuple[str, ...] = (
+    POINTY_ACTION_HIGHLIGHT,
+    POINTY_ACTION_SCROLL_TO,
+    POINTY_ACTION_NAVIGATE,
+    POINTY_ACTION_SHOW_TOUR,
+)
+
+
+def reference_capabilities() -> dict[str, Any]:
+    """Return a reference ``wiii:capabilities`` payload for the LMS parent.
+
+    The LMS team is expected to emit a payload of this shape after the
+    iframe loads. Wiii's frontend forwards it into ``HostCapabilities`` and
+    the backend exposes the tools to the AI via ``generate_host_action_tools``.
+
+    The shape mirrors :class:`HostCapabilities` — keep them in sync.
+    """
+    return {
+        "host_type": "lms",
+        "host_name": "Wiii Pointy host",
+        "version": str(POINTY_VERSION),
+        "surfaces": ["page"],
+        "tools": [
+            {
+                "name": POINTY_ACTION_HIGHLIGHT,
+                "description": (
+                    "Trỏ và làm nổi bật một phần tử trên trang để hướng dẫn người dùng. "
+                    "Không tự click — chỉ chỉ đường."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "selector": {
+                            "type": "string",
+                            "description": (
+                                'CSS selector hoặc [data-wiii-id="..."]; '
+                                "ưu tiên data-wiii-id vì ổn định hơn."
+                            ),
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "Tooltip hiển thị bên cạnh element (tiếng Việt).",
+                        },
+                        "duration_ms": {
+                            "type": "number",
+                            "description": "Thời gian giữ spotlight (mặc định 2200ms).",
+                        },
+                    },
+                    "required": ["selector"],
+                },
+                "surface": "page",
+                "mutates_state": False,
+                "requires_confirmation": False,
+            },
+            {
+                "name": POINTY_ACTION_SCROLL_TO,
+                "description": "Cuộn trang đến một phần tử cụ thể.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "selector": {"type": "string"},
+                        "block": {
+                            "type": "string",
+                            "description": "start | center | end (mặc định center).",
+                        },
+                    },
+                    "required": ["selector"],
+                },
+                "surface": "page",
+                "mutates_state": False,
+                "requires_confirmation": False,
+            },
+            {
+                "name": POINTY_ACTION_NAVIGATE,
+                "description": (
+                    "Chuyển đến route nội bộ (ưu tiên) hoặc URL tuyệt đối an toàn. "
+                    "Không phá session người dùng."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "route": {
+                            "type": "string",
+                            "description": "Route nội bộ, ví dụ: /courses/123",
+                        },
+                        "url": {
+                            "type": "string",
+                            "description": "URL http(s) tuyệt đối.",
+                        },
+                    },
+                },
+                "surface": "page",
+                "mutates_state": False,
+                "requires_confirmation": False,
+            },
+            {
+                "name": POINTY_ACTION_SHOW_TOUR,
+                "description": (
+                    "Chạy hướng dẫn nhiều bước, mỗi bước trỏ + highlight một element."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "steps": {
+                            "type": "array",
+                            "description": "Danh sách bước { selector, message, duration_ms? }.",
+                        },
+                        "start_at": {
+                            "type": "number",
+                            "description": "Bước bắt đầu (mặc định 0).",
+                        },
+                    },
+                    "required": ["steps"],
+                },
+                "surface": "page",
+                "mutates_state": False,
+                "requires_confirmation": False,
+            },
+        ],
+    }
+
+
+__all__ = [
+    "POINTY_VERSION",
+    "POINTY_ACTION_HIGHLIGHT",
+    "POINTY_ACTION_SCROLL_TO",
+    "POINTY_ACTION_NAVIGATE",
+    "POINTY_ACTION_SHOW_TOUR",
+    "POINTY_ACTIONS",
+    "reference_capabilities",
+]

--- a/maritime-ai-service/app/engine/context/skills/lms/pointy.skill.yaml
+++ b/maritime-ai-service/app/engine/context/skills/lms/pointy.skill.yaml
@@ -1,0 +1,25 @@
+name: lms-pointy-tutor
+host_type: lms
+page_types: ["*"]
+description: "Wiii Pointy: prefer pointing at UI elements over walls of text."
+priority: 0.4
+
+prompt_addition: |
+  Wiii đang nhúng iframe trong LMS. Khi `host capabilities` có các tool `ui.highlight`,
+  `ui.scroll_to`, `ui.navigate`, `ui.show_tour`, hãy ưu tiên dùng chúng để dẫn người
+  dùng tới đúng nơi thay vì chỉ mô tả bằng chữ.
+
+  Quy tắc Pointy V1 (chỉ tutor mode, không tự click):
+  - Nếu user hỏi "ở đâu / vào đâu / nút nào", gọi `ui.highlight` với `selector` ổn định
+    (ưu tiên `[data-wiii-id="..."]`) kèm `message` ngắn gọn bằng tiếng Việt.
+  - Nếu cần đưa user sang trang khác trong LMS, gọi `ui.navigate` với `route` nội bộ.
+  - Khi quy trình có nhiều bước (đăng ký khóa, nộp bài, xem điểm), gọi `ui.show_tour`
+    với 2-5 bước rõ ràng. Mỗi bước có `selector` + `message` <= 120 ký tự.
+  - Trên trang quiz, **không** dùng `ui.highlight` để trỏ thẳng vào đáp án; vẫn giữ
+    nguyên guardrail sư phạm — chỉ trỏ vào nút điều hướng / nộp bài.
+  - Nếu selector không có sẵn trong host context, hỏi lại user hoặc trả lời bằng chữ
+    thay vì đoán selector.
+  - Sau khi gọi pointy tool, vẫn tiếp tục câu trả lời bằng tiếng Việt — pointy không
+    thay thế lời giải thích, chỉ làm rõ trực quan.
+
+tools: []

--- a/maritime-ai-service/tests/unit/engine/context/test_pointy_actions.py
+++ b/maritime-ai-service/tests/unit/engine/context/test_pointy_actions.py
@@ -1,0 +1,44 @@
+"""Smoke tests for the Wiii Pointy action reference module."""
+from app.engine.context.pointy_actions import (
+    POINTY_ACTION_HIGHLIGHT,
+    POINTY_ACTION_NAVIGATE,
+    POINTY_ACTION_SCROLL_TO,
+    POINTY_ACTION_SHOW_TOUR,
+    POINTY_ACTIONS,
+    reference_capabilities,
+)
+
+
+def test_action_names_are_stable():
+    assert POINTY_ACTION_HIGHLIGHT == "ui.highlight"
+    assert POINTY_ACTION_SCROLL_TO == "ui.scroll_to"
+    assert POINTY_ACTION_NAVIGATE == "ui.navigate"
+    assert POINTY_ACTION_SHOW_TOUR == "ui.show_tour"
+    assert set(POINTY_ACTIONS) == {
+        POINTY_ACTION_HIGHLIGHT,
+        POINTY_ACTION_SCROLL_TO,
+        POINTY_ACTION_NAVIGATE,
+        POINTY_ACTION_SHOW_TOUR,
+    }
+
+
+def test_reference_capabilities_shape():
+    caps = reference_capabilities()
+    assert caps["host_type"] == "lms"
+    assert "page" in caps["surfaces"]
+    tool_names = [t["name"] for t in caps["tools"]]
+    assert tool_names == list(POINTY_ACTIONS)
+    for tool in caps["tools"]:
+        assert tool["mutates_state"] is False
+        assert tool["requires_confirmation"] is False
+        assert tool["surface"] == "page"
+        assert "input_schema" in tool
+
+
+def test_reference_capabilities_is_valid_for_pydantic_host_capabilities():
+    """The reference payload must be accepted by HostCapabilities unchanged."""
+    from app.engine.context.host_context import HostCapabilities
+
+    caps = HostCapabilities(**reference_capabilities())
+    assert caps.host_type == "lms"
+    assert len(caps.tools) == len(POINTY_ACTIONS)

--- a/wiii-desktop/dev-demo/pointy/README.md
+++ b/wiii-desktop/dev-demo/pointy/README.md
@@ -1,0 +1,31 @@
+# Wiii Pointy — local demo
+
+A self-contained HTML page that simulates an LMS host calling the Wiii Pointy
+bridge. Useful for visual QA without spinning up the iframe + backend.
+
+## Build the bundle
+
+```bash
+cd wiii-desktop
+npm run build:pointy
+```
+
+This produces `dist-pointy/wiii-pointy.umd.js` (and `.es.js`).
+
+## Run the demo
+
+```bash
+cd wiii-desktop
+npx vite preview --outDir dev-demo/pointy --port 4173
+# or simply open the file in any browser:
+#   start dev-demo/pointy/index.html      (Windows)
+#   xdg-open dev-demo/pointy/index.html   (Linux)
+```
+
+Click the buttons in the bottom bar to simulate `ui.highlight`, `ui.scroll_to`,
+`ui.navigate`, and `ui.show_tour` calls. The orange "W" cursor should fly to
+the targeted element with the spotlight + tooltip overlay.
+
+The demo posts messages to itself (origin == window.origin) so the bridge
+accepts them. In production, replace `FAKE_IFRAME_ORIGIN` with the real
+Wiii iframe origin (e.g., `https://wiii.holilihu.online`).

--- a/wiii-desktop/dev-demo/pointy/index.html
+++ b/wiii-desktop/dev-demo/pointy/index.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <title>Wiii Pointy — LMS demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      margin: 0;
+      background: #FAF5EE;
+      color: #1F2937;
+    }
+    header {
+      background: #F97316;
+      color: #FAF5EE;
+      padding: 16px 24px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    header h1 { margin: 0; font-size: 18px; font-weight: 600; }
+    main { max-width: 1024px; margin: 0 auto; padding: 24px; }
+    .row { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 16px; }
+    .card {
+      background: white;
+      border-radius: 12px;
+      padding: 20px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.06);
+      flex: 1 1 280px;
+    }
+    .card h2 { margin: 0 0 8px; font-size: 16px; }
+    button {
+      background: #F97316;
+      color: #FAF5EE;
+      border: 0;
+      border-radius: 8px;
+      padding: 8px 16px;
+      font-weight: 500;
+      cursor: pointer;
+    }
+    button.ghost {
+      background: transparent;
+      color: #1F2937;
+      border: 1px solid #d1d5db;
+    }
+    .controls {
+      background: #1F2937;
+      color: #FAF5EE;
+      padding: 16px 24px;
+      position: sticky;
+      bottom: 0;
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .controls button { background: #FAF5EE; color: #1F2937; }
+    .log {
+      font-family: ui-monospace, monospace;
+      font-size: 12px;
+      background: #111827;
+      color: #d1fae5;
+      padding: 12px 16px;
+      max-height: 160px;
+      overflow: auto;
+      white-space: pre-wrap;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <strong>Wiii Pointy demo</strong>
+    <span style="opacity:.85">Mô phỏng trang LMS — Wiii (iframe) sẽ gọi `ui.*` qua PostMessage.</span>
+  </header>
+  <main>
+    <div class="row">
+      <section class="card" data-wiii-id="course-card">
+        <h2>Khóa: Hàng Hải Cơ Bản</h2>
+        <p>Tiến độ 35%. Bài học hôm nay: <em>Quy tắc đường thủy quốc tế</em>.</p>
+        <button data-wiii-id="continue-lesson">Tiếp tục học</button>
+        <button class="ghost" data-wiii-id="open-syllabus">Xem giáo trình</button>
+      </section>
+      <section class="card" data-wiii-id="quiz-card">
+        <h2>Bài kiểm tra: COLREGs Module 2</h2>
+        <p>Còn 7 ngày. Bạn đã làm 0/15 câu.</p>
+        <button data-wiii-id="start-quiz">Bắt đầu</button>
+      </section>
+    </div>
+    <div class="row">
+      <section class="card" data-wiii-id="grades-card">
+        <h2>Điểm gần đây</h2>
+        <ul>
+          <li>An toàn hàng hải — 8.5</li>
+          <li>Khí tượng — 7.0</li>
+        </ul>
+      </section>
+      <section class="card" data-wiii-id="profile-card">
+        <h2>Hồ sơ</h2>
+        <p>Lớp tàu T2025-A. Cố vấn: Cô Lan.</p>
+        <button class="ghost" data-wiii-id="open-profile">Mở hồ sơ</button>
+      </section>
+    </div>
+  </main>
+  <div class="controls">
+    <strong>Mô phỏng AI tool call:</strong>
+    <button onclick="simulateHighlight()">ui.highlight: Tiếp tục học</button>
+    <button onclick="simulateScroll()">ui.scroll_to: Hồ sơ</button>
+    <button onclick="simulateTour()">ui.show_tour: 3 bước</button>
+    <button onclick="simulateNavigate()">ui.navigate: /quiz/123</button>
+    <button onclick="document.querySelector('.log').textContent=''">Clear log</button>
+  </div>
+  <pre class="log"></pre>
+
+  <script src="../../dist-pointy/wiii-pointy.umd.js"></script>
+  <script>
+    const log = (msg) => {
+      const el = document.querySelector('.log');
+      el.textContent += `${new Date().toLocaleTimeString()}  ${msg}\n`;
+      el.scrollTop = el.scrollHeight;
+    };
+
+    // In production this is the Wiii iframe origin. For the demo we are the
+    // iframe's "fake parent" — we send messages to ourselves.
+    const FAKE_IFRAME_ORIGIN = window.location.origin;
+    const handle = WiiiPointy.init({
+      iframeOrigin: FAKE_IFRAME_ORIGIN,
+      onNavigate: (route) => { log(`onNavigate(${route})`); },
+      log: (level, msg, ctx) => log(`[${level}] ${msg} ${ctx ? JSON.stringify(ctx) : ''}`),
+    });
+    log('Pointy initialised. Click a button below to simulate AI calls.');
+
+    let counter = 0;
+    function send(action, params) {
+      const id = `demo-${++counter}`;
+      log(`→ ${action} ${JSON.stringify(params)}`);
+      window.postMessage({ type: 'wiii:action-request', id, action, params }, FAKE_IFRAME_ORIGIN);
+    }
+    window.addEventListener('message', (e) => {
+      if (e.data?.type === 'wiii:action-response') {
+        log(`← ${e.data.id} ${JSON.stringify(e.data.result)}`);
+      }
+    });
+
+    function simulateHighlight() {
+      send('ui.highlight', {
+        selector: '[data-wiii-id="continue-lesson"]',
+        message: 'Đây là nút để tiếp tục bài học.',
+        duration_ms: 2200,
+      });
+    }
+    function simulateScroll() {
+      send('ui.scroll_to', { selector: '[data-wiii-id="profile-card"]' });
+    }
+    function simulateNavigate() {
+      send('ui.navigate', { route: '/quiz/123' });
+    }
+    function simulateTour() {
+      send('ui.show_tour', {
+        steps: [
+          { selector: '[data-wiii-id="course-card"]', message: 'Bước 1 — khóa học hôm nay.', duration_ms: 1600 },
+          { selector: '[data-wiii-id="quiz-card"]', message: 'Bước 2 — bài kiểm tra sắp tới.', duration_ms: 1600 },
+          { selector: '[data-wiii-id="grades-card"]', message: 'Bước 3 — điểm gần đây.', duration_ms: 1600 },
+        ],
+      });
+    }
+
+    window.addEventListener('beforeunload', () => handle.destroy());
+  </script>
+</body>
+</html>

--- a/wiii-desktop/package.json
+++ b/wiii-desktop/package.json
@@ -19,6 +19,7 @@
     "dev:embed": "cross-env BUILD_TARGET=embed vite",
     "build:embed": "cross-env BUILD_TARGET=embed vite build && node -e \"require('fs').copyFileSync('dist-embed/embed.html','dist-embed/index.html')\"",
     "build:web": "cross-env BUILD_TARGET=web tsc && cross-env BUILD_TARGET=web vite build",
+    "build:pointy": "vite build -c vite.pointy.config.ts",
     "preview:embed": "cross-env BUILD_TARGET=embed vite preview --port 1421"
   },
   "dependencies": {

--- a/wiii-desktop/src/pointy-host/__tests__/bridge.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/bridge.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for the PostMessage bridge — protocol validation, origin filtering,
+ * action dispatch, and reply targeting.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  _testing,
+  createBridge,
+  describeTarget,
+  handleHighlight,
+  handleNavigate,
+  handleScrollTo,
+  resolveSelector,
+  type BridgeHandle,
+} from "../bridge";
+import { destroy } from "../index";
+
+const liveBridges: BridgeHandle[] = [];
+
+function makeBridge(...args: Parameters<typeof createBridge>): BridgeHandle {
+  const h = createBridge(...args);
+  liveBridges.push(h);
+  return h;
+}
+
+afterEach(() => {
+  while (liveBridges.length) {
+    liveBridges.pop()?.dispose();
+  }
+  destroy();
+  document.body.innerHTML = "";
+});
+
+describe("isPointyRequest", () => {
+  it("accepts a well-formed request", () => {
+    expect(
+      _testing.isPointyRequest({
+        type: "wiii:action-request",
+        id: "abc",
+        action: "ui.highlight",
+        params: { selector: "#x" },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects messages of other types", () => {
+    expect(
+      _testing.isPointyRequest({
+        type: "wiii:capabilities",
+        id: "abc",
+        action: "ui.highlight",
+        params: {},
+      }),
+    ).toBe(false);
+    expect(_testing.isPointyRequest("not-an-object")).toBe(false);
+    expect(_testing.isPointyRequest(null)).toBe(false);
+  });
+});
+
+describe("isSafeUrl", () => {
+  it("accepts public https URLs", () => {
+    expect(_testing.isSafeUrl("https://holilihu.online/courses/1")).toBe(true);
+  });
+  it("rejects loopback and internal hosts", () => {
+    expect(_testing.isSafeUrl("http://localhost:8000/")).toBe(false);
+    expect(_testing.isSafeUrl("http://127.0.0.1/")).toBe(false);
+    expect(_testing.isSafeUrl("https://foo.local/")).toBe(false);
+  });
+  it("rejects non-http schemes", () => {
+    expect(_testing.isSafeUrl("file:///etc/passwd")).toBe(false);
+    expect(_testing.isSafeUrl("javascript:alert(1)")).toBe(false);
+  });
+});
+
+describe("resolveSelector", () => {
+  it("returns null for empty or non-string input", () => {
+    expect(resolveSelector("")).toBeNull();
+    expect(resolveSelector("   ")).toBeNull();
+    expect(resolveSelector(undefined)).toBeNull();
+    expect(resolveSelector(123)).toBeNull();
+  });
+  it("returns null for invalid CSS", () => {
+    expect(resolveSelector(">>>not-valid")).toBeNull();
+  });
+  it("resolves data-wiii-id and id selectors", () => {
+    document.body.innerHTML = `<button id="b1" data-wiii-id="login-btn">Login</button>`;
+    expect(resolveSelector("#b1")?.tagName).toBe("BUTTON");
+    expect(resolveSelector('[data-wiii-id="login-btn"]')?.tagName).toBe("BUTTON");
+  });
+});
+
+describe("describeTarget", () => {
+  it("prefers data-wiii-id, then id, then aria, then text", () => {
+    document.body.innerHTML = `
+      <button id="ok" data-wiii-id="submit">Gửi</button>
+      <button id="x" aria-label="Đóng"></button>
+      <button id="y">Mở</button>
+      <button>Khám phá</button>
+    `;
+    expect(describeTarget(document.querySelector("[data-wiii-id]")!)).toContain("#submit");
+    expect(describeTarget(document.querySelector('[aria-label="Đóng"]')!)).toContain('"Đóng"');
+    expect(describeTarget(document.querySelector("#y")!)).toContain("#y");
+    // Element with neither id nor aria falls back to its text content.
+    const buttons = document.querySelectorAll("button");
+    expect(describeTarget(buttons[buttons.length - 1])).toContain('"Khám phá"');
+  });
+});
+
+describe("handleHighlight", () => {
+  it("returns success when selector resolves", async () => {
+    document.body.innerHTML = `<button data-wiii-id="login">Login</button>`;
+    const result = await handleHighlight({ selector: '[data-wiii-id="login"]' });
+    expect(result.success).toBe(true);
+    expect(result.data?.summary).toContain("login");
+  });
+  it("returns failure when selector missing", async () => {
+    const result = await handleHighlight({ selector: "#nope" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("selector_not_found");
+  });
+});
+
+describe("handleScrollTo", () => {
+  it("succeeds for present target", async () => {
+    document.body.innerHTML = `<section id="ch1">Chapter 1</section>`;
+    const result = await handleScrollTo({ selector: "#ch1" });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("handleNavigate", () => {
+  it("rejects when no route or url provided", async () => {
+    const result = await handleNavigate({}, { iframeOrigin: "https://x" });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("missing_target");
+  });
+  it("invokes onNavigate callback when route is given", async () => {
+    const onNavigate = vi.fn().mockResolvedValue(undefined);
+    const result = await handleNavigate(
+      { route: "/courses/123" },
+      { iframeOrigin: "https://x", onNavigate },
+    );
+    expect(onNavigate).toHaveBeenCalledWith("/courses/123");
+    expect(result.success).toBe(true);
+  });
+  it("rejects unsafe absolute URLs", async () => {
+    const result = await handleNavigate(
+      { url: "http://localhost/internal" },
+      { iframeOrigin: "https://x" },
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("unsafe_url");
+  });
+});
+
+describe("createBridge", () => {
+  it("ignores messages from other origins", async () => {
+    const onNavigate = vi.fn();
+    makeBridge({ iframeOrigin: "https://wiii.example", onNavigate });
+    const evil = new MessageEvent("message", {
+      data: {
+        type: "wiii:action-request",
+        id: "1",
+        action: "ui.navigate",
+        params: { route: "/x" },
+      },
+      origin: "https://attacker.example",
+    });
+    window.dispatchEvent(evil);
+    await Promise.resolve();
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("dispatches and replies with matching id when origin matches", async () => {
+    document.body.innerHTML = `<button data-wiii-id="login"></button>`;
+    const replies: unknown[] = [];
+    const fakeSource = {
+      postMessage: (msg: unknown) => replies.push(msg),
+    } as unknown as Window;
+    makeBridge({ iframeOrigin: "https://wiii.example" });
+    const event = new MessageEvent("message", {
+      data: {
+        type: "wiii:action-request",
+        id: "req-42",
+        action: "ui.highlight",
+        params: { selector: '[data-wiii-id="login"]', message: "Đây" },
+      },
+      origin: "https://wiii.example",
+    });
+    Object.defineProperty(event, "source", { value: fakeSource });
+    window.dispatchEvent(event);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(replies).toHaveLength(1);
+    const reply = replies[0] as { type: string; id: string; result: { success: boolean } };
+    expect(reply.type).toBe("wiii:action-response");
+    expect(reply.id).toBe("req-42");
+    expect(reply.result.success).toBe(true);
+  });
+
+  it("replies with failure for unsupported action", async () => {
+    const replies: unknown[] = [];
+    const fakeSource = {
+      postMessage: (msg: unknown) => replies.push(msg),
+    } as unknown as Window;
+    makeBridge({ iframeOrigin: "https://wiii.example" });
+    const event = new MessageEvent("message", {
+      data: {
+        type: "wiii:action-request",
+        id: "req-99",
+        action: "ui.delete_universe",
+        params: {},
+      },
+      origin: "https://wiii.example",
+    });
+    Object.defineProperty(event, "source", { value: fakeSource });
+    window.dispatchEvent(event);
+    await new Promise((r) => setTimeout(r, 5));
+    const reply = replies[0] as { result: { success: boolean; error?: string } };
+    expect(reply.result.success).toBe(false);
+    expect(reply.result.error).toContain("unsupported_action");
+  });
+});

--- a/wiii-desktop/src/pointy-host/__tests__/cursor.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/cursor.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Cursor tests — geometry helpers and DOM lifecycle.
+ *
+ * Note: jsdom's Web Animations is limited; we only assert that animate() is
+ * invoked, not that frames advance.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  _testing,
+  computeOriginPoint,
+  computeTargetPoint,
+  destroyCursor,
+  hideCursor,
+  moveCursorToRect,
+} from "../cursor";
+
+afterEach(() => {
+  destroyCursor();
+  _testing.setLastPos(null);
+});
+
+describe("computeTargetPoint", () => {
+  it("lands above-right of element center", () => {
+    const rect = { left: 100, top: 200, width: 40, height: 20 } as DOMRect;
+    const p = computeTargetPoint(rect);
+    expect(p.x).toBe(100 + 20 + 8);
+    expect(p.y).toBe(200 + 10 - 8);
+  });
+});
+
+describe("computeOriginPoint", () => {
+  it("returns a point inside the viewport", () => {
+    const p = computeOriginPoint();
+    expect(p.x).toBeGreaterThan(0);
+    expect(p.y).toBeGreaterThan(0);
+  });
+});
+
+describe("moveCursorToRect", () => {
+  it("creates a single SVG cursor in the DOM", () => {
+    const rect = { left: 50, top: 50, width: 30, height: 30 } as DOMRect;
+    moveCursorToRect(rect, { duration_ms: 100 });
+    const cursors = document.querySelectorAll(`#${_testing.CURSOR_ID}`);
+    expect(cursors.length).toBe(1);
+    const el = cursors[0] as SVGSVGElement;
+    expect(el.getAttribute("data-wiii-pointy")).toBe("cursor");
+    expect(el.style.opacity).toBe("1");
+  });
+
+  it("re-uses the cursor element when called twice", () => {
+    const rect1 = { left: 10, top: 10, width: 10, height: 10 } as DOMRect;
+    const rect2 = { left: 100, top: 100, width: 10, height: 10 } as DOMRect;
+    moveCursorToRect(rect1, { duration_ms: 50 });
+    moveCursorToRect(rect2, { duration_ms: 50 });
+    expect(document.querySelectorAll(`#${_testing.CURSOR_ID}`).length).toBe(1);
+  });
+});
+
+describe("hideCursor / destroyCursor", () => {
+  it("hide fades opacity to 0 but keeps the node", () => {
+    const rect = { left: 0, top: 0, width: 10, height: 10 } as DOMRect;
+    moveCursorToRect(rect);
+    hideCursor();
+    const el = document.querySelector(`#${_testing.CURSOR_ID}`) as SVGSVGElement;
+    expect(el).not.toBeNull();
+    expect(el.style.opacity).toBe("0");
+  });
+  it("destroy removes the node", () => {
+    const rect = { left: 0, top: 0, width: 10, height: 10 } as DOMRect;
+    moveCursorToRect(rect);
+    destroyCursor();
+    expect(document.querySelector(`#${_testing.CURSOR_ID}`)).toBeNull();
+  });
+});

--- a/wiii-desktop/src/pointy-host/__tests__/spotlight.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/spotlight.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Spotlight tests — overlay creation, tooltip position math, lifecycle.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  _testing,
+  computeTooltipPosition,
+  destroySpotlight,
+  hideSpotlight,
+  showSpotlight,
+} from "../spotlight";
+
+afterEach(() => {
+  destroySpotlight();
+  document.body.innerHTML = "";
+});
+
+describe("computeTooltipPosition", () => {
+  const viewport = { width: 1024, height: 768 };
+
+  it("places the tooltip below when there is room", () => {
+    const target = { left: 100, top: 100, right: 200, bottom: 140, width: 100, height: 40 } as DOMRect;
+    const t = { width: 200, height: 60 };
+    const pos = computeTooltipPosition(target, t, viewport);
+    expect(pos.top).toBe(target.bottom + 12);
+  });
+
+  it("flips above when below would overflow", () => {
+    const target = { left: 100, top: 700, right: 200, bottom: 740, width: 100, height: 40 } as DOMRect;
+    const t = { width: 200, height: 60 };
+    const pos = computeTooltipPosition(target, t, viewport);
+    expect(pos.top).toBeLessThan(target.top);
+  });
+
+  it("clamps left to viewport edges", () => {
+    const target = { left: -50, top: 100, right: 50, bottom: 140, width: 100, height: 40 } as DOMRect;
+    const t = { width: 200, height: 60 };
+    const pos = computeTooltipPosition(target, t, viewport);
+    expect(pos.left).toBeGreaterThanOrEqual(8);
+  });
+});
+
+describe("showSpotlight", () => {
+  it("creates overlay + tooltip and writes the message text", () => {
+    document.body.innerHTML = `<button data-wiii-id="cta" style="width:100px;height:30px">Bắt đầu</button>`;
+    const target = document.querySelector('[data-wiii-id="cta"]')!;
+    showSpotlight(target, { message: "Nhấn vào đây để bắt đầu", duration_ms: 1000 });
+    const overlay = document.querySelector(`#${_testing.OVERLAY_ID}`) as HTMLDivElement;
+    const tooltip = document.querySelector(`#${_testing.TOOLTIP_ID}`) as HTMLDivElement;
+    expect(overlay).not.toBeNull();
+    expect(tooltip).not.toBeNull();
+    expect(tooltip.textContent).toBe("Nhấn vào đây để bắt đầu");
+    expect(overlay.style.background).toContain("radial-gradient");
+  });
+
+  it("hideSpotlight clears overlay background", () => {
+    document.body.innerHTML = `<button data-wiii-id="x" style="width:50px;height:20px"></button>`;
+    showSpotlight(document.querySelector('[data-wiii-id="x"]')!, {
+      message: "x",
+      duration_ms: 999,
+    });
+    hideSpotlight();
+    const overlay = document.querySelector(`#${_testing.OVERLAY_ID}`) as HTMLDivElement;
+    expect(overlay.style.background).toBe("transparent");
+  });
+});

--- a/wiii-desktop/src/pointy-host/__tests__/tour.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/tour.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tour tests — step progression, missing selectors, cancellation.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _testing, runTour } from "../tour";
+import type { TourStep } from "../types";
+
+beforeEach(() => {
+  _testing.resetState();
+});
+
+afterEach(() => {
+  _testing.resetState();
+  document.body.innerHTML = "";
+  vi.useRealTimers();
+});
+
+describe("runTour", () => {
+  it("walks through all steps with present selectors", async () => {
+    document.body.innerHTML = `
+      <div id="a" style="height:10px"></div>
+      <div id="b" style="height:10px"></div>
+    `;
+    const steps: TourStep[] = [
+      { selector: "#a", message: "A", duration_ms: 1 },
+      { selector: "#b", message: "B", duration_ms: 1 },
+    ];
+    const result = await runTour(steps);
+    expect(result.completed_steps).toBe(2);
+    expect(result.total_steps).toBe(2);
+    expect(result.cancelled).toBe(false);
+    expect(result.missing_selectors).toEqual([]);
+  });
+
+  it("collects missing selectors without aborting", async () => {
+    document.body.innerHTML = `<div id="present"></div>`;
+    const steps: TourStep[] = [
+      { selector: "#present", message: "present", duration_ms: 1 },
+      { selector: "#missing", message: "missing", duration_ms: 1 },
+    ];
+    const result = await runTour(steps);
+    expect(result.completed_steps).toBe(1);
+    expect(result.missing_selectors).toEqual(["#missing"]);
+  });
+
+  it("starting a new tour cancels the previous one", async () => {
+    document.body.innerHTML = `<div id="a"></div>`;
+    const longStep: TourStep[] = [{ selector: "#a", message: "long", duration_ms: 200 }];
+    const firstPromise = runTour(longStep);
+    // Kick off second tour immediately — it should mark the first as cancelled.
+    const second = await runTour([{ selector: "#a", message: "second", duration_ms: 1 }]);
+    const first = await firstPromise;
+    expect(first.cancelled).toBe(true);
+    expect(second.cancelled).toBe(false);
+  });
+
+  it("uses custom selector resolver when provided", async () => {
+    const sentinel = document.createElement("div");
+    document.body.appendChild(sentinel);
+    const resolver = vi.fn().mockReturnValue(sentinel);
+    const steps: TourStep[] = [{ selector: "wiii://step-1", message: "x", duration_ms: 1 }];
+    const result = await runTour(steps, { resolveSelector: resolver });
+    expect(resolver).toHaveBeenCalledWith("wiii://step-1");
+    expect(result.completed_steps).toBe(1);
+  });
+});

--- a/wiii-desktop/src/pointy-host/bridge.ts
+++ b/wiii-desktop/src/pointy-host/bridge.ts
@@ -1,0 +1,245 @@
+/**
+ * Wiii Pointy — PostMessage bridge between the host page and the Wiii iframe.
+ *
+ * Listens for `wiii:action-request` messages whose `action` starts with `ui.`
+ * and dispatches them to cursor/spotlight/tour handlers. Replies via
+ * `wiii:action-response`. Cross-origin safe: only accepts requests from the
+ * configured iframeOrigin and only replies to that same origin.
+ */
+import { hideCursor, moveCursorToRect } from "./cursor";
+import { hideSpotlight, showSpotlight } from "./spotlight";
+import { runTour } from "./tour";
+import type {
+  HighlightParams,
+  NavigateParams,
+  PointyConfig,
+  PointyRequest,
+  PointyResponse,
+  PointyResult,
+  ScrollToParams,
+  ShowTourParams,
+  TourStep,
+} from "./types";
+
+function defaultLog(level: "info" | "warn" | "error", msg: string, ctx?: unknown): void {
+  const tag = "[wiii-pointy]";
+  if (level === "error") console.error(tag, msg, ctx ?? "");
+  else if (level === "warn") console.warn(tag, msg, ctx ?? "");
+  else console.info(tag, msg, ctx ?? "");
+}
+
+function isPointyRequest(data: unknown): data is PointyRequest {
+  if (typeof data !== "object" || data === null) return false;
+  const d = data as Record<string, unknown>;
+  return (
+    d.type === "wiii:action-request" &&
+    typeof d.id === "string" &&
+    typeof d.action === "string" &&
+    typeof d.params === "object" &&
+    d.params !== null
+  );
+}
+
+function ok(data?: Record<string, unknown>): PointyResult {
+  return { success: true, ...(data ? { data } : {}) };
+}
+function fail(error: string): PointyResult {
+  return { success: false, error };
+}
+
+/** Resolve a selector with light hardening: trim, reject empty, allow data-wiii-id. */
+export function resolveSelector(selector: unknown): Element | null {
+  if (typeof selector !== "string") return null;
+  const trimmed = selector.trim();
+  if (!trimmed) return null;
+  if (typeof document === "undefined") return null;
+  try {
+    return document.querySelector(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+export async function handleHighlight(params: HighlightParams): Promise<PointyResult> {
+  const target = resolveSelector(params.selector);
+  if (!target) return fail(`selector_not_found:${params.selector}`);
+  const rect = target.getBoundingClientRect();
+  if ("scrollIntoView" in target && typeof (target as HTMLElement).scrollIntoView === "function") {
+    (target as HTMLElement).scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+  moveCursorToRect(rect, { duration_ms: 600 });
+  showSpotlight(target, {
+    message: params.message,
+    duration_ms: params.duration_ms,
+  });
+  return ok({ summary: `Đã trỏ vào element: ${describeTarget(target)}` });
+}
+
+export async function handleScrollTo(params: ScrollToParams): Promise<PointyResult> {
+  const target = resolveSelector(params.selector);
+  if (!target) return fail(`selector_not_found:${params.selector}`);
+  if ("scrollIntoView" in target && typeof (target as HTMLElement).scrollIntoView === "function") {
+    (target as HTMLElement).scrollIntoView({
+      behavior: "smooth",
+      block: params.block ?? "center",
+    });
+  }
+  return ok({ summary: `Đã cuộn tới element: ${describeTarget(target)}` });
+}
+
+export async function handleNavigate(
+  params: NavigateParams,
+  config: PointyConfig,
+): Promise<PointyResult> {
+  const route = (params.route ?? "").trim();
+  const url = (params.url ?? "").trim();
+  if (!route && !url) return fail("missing_target");
+  if (route) {
+    if (config.onNavigate) {
+      try {
+        await config.onNavigate(route);
+        return ok({ summary: `Đã chuyển sang route: ${route}` });
+      } catch (e) {
+        return fail(`navigate_failed:${(e as Error).message}`);
+      }
+    }
+    if (typeof window !== "undefined") {
+      window.location.assign(route);
+      return ok({ summary: `Đã chuyển sang: ${route}` });
+    }
+    return fail("no_navigator_available");
+  }
+  if (!isSafeUrl(url)) return fail("unsafe_url");
+  if (typeof window !== "undefined") {
+    window.location.assign(url);
+    return ok({ summary: `Đã chuyển sang URL: ${url}` });
+  }
+  return fail("no_navigator_available");
+}
+
+export async function handleShowTour(params: ShowTourParams): Promise<PointyResult> {
+  if (!Array.isArray(params.steps) || params.steps.length === 0) {
+    return fail("empty_tour");
+  }
+  const steps: TourStep[] = params.steps.filter(
+    (s): s is TourStep => !!s && typeof s.selector === "string" && typeof s.message === "string",
+  );
+  if (steps.length === 0) return fail("invalid_tour_steps");
+  const result = await runTour(steps, { startAt: params.start_at });
+  return ok({
+    summary: `Tour ${result.completed_steps}/${result.total_steps} bước.`,
+    completed_steps: result.completed_steps,
+    total_steps: result.total_steps,
+    missing_selectors: result.missing_selectors,
+    cancelled: result.cancelled,
+  });
+}
+
+export function describeTarget(el: Element): string {
+  const labels: string[] = [];
+  const id = el.getAttribute("data-wiii-id") || el.id;
+  if (id) labels.push(`#${id}`);
+  const aria = el.getAttribute("aria-label");
+  if (aria) labels.push(`"${aria}"`);
+  if (!labels.length) {
+    const text = (el.textContent || "").trim();
+    if (text) labels.push(`"${text.slice(0, 40)}"`);
+  }
+  if (!labels.length) labels.push(el.tagName.toLowerCase());
+  return labels.join(" ");
+}
+
+function isSafeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url, typeof window !== "undefined" ? window.location.href : undefined);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+    const host = parsed.hostname.toLowerCase();
+    if (host === "localhost" || host === "127.0.0.1" || host === "0.0.0.0") return false;
+    if (host.endsWith(".local") || host.endsWith(".internal")) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface BridgeHandle {
+  dispose: () => void;
+}
+
+export function createBridge(config: PointyConfig): BridgeHandle {
+  const log = config.log ?? defaultLog;
+  const targetOrigin = config.iframeOrigin;
+
+  const handler = (event: MessageEvent): void => {
+    if (event.origin !== targetOrigin) return;
+    if (!isPointyRequest(event.data)) return;
+
+    const req = event.data;
+    void dispatch(req, config)
+      .then((result) => sendResponse(event, req.id, result, targetOrigin, log))
+      .catch((err) => {
+        log("error", "dispatch_threw", err);
+        sendResponse(event, req.id, fail((err as Error).message ?? "unknown_error"), targetOrigin, log);
+      });
+  };
+
+  if (typeof window !== "undefined") {
+    window.addEventListener("message", handler);
+  }
+
+  return {
+    dispose: () => {
+      if (typeof window !== "undefined") {
+        window.removeEventListener("message", handler);
+      }
+      hideSpotlight();
+      hideCursor();
+    },
+  };
+}
+
+async function dispatch(req: PointyRequest, config: PointyConfig): Promise<PointyResult> {
+  switch (req.action) {
+    case "ui.highlight":
+      return handleHighlight(req.params as unknown as HighlightParams);
+    case "ui.scroll_to":
+      return handleScrollTo(req.params as unknown as ScrollToParams);
+    case "ui.navigate":
+      return handleNavigate(req.params as unknown as NavigateParams, config);
+    case "ui.show_tour":
+      return handleShowTour(req.params as unknown as ShowTourParams);
+    default:
+      return fail(`unsupported_action:${req.action}`);
+  }
+}
+
+function sendResponse(
+  event: MessageEvent,
+  id: string,
+  result: PointyResult,
+  targetOrigin: string,
+  log: NonNullable<PointyConfig["log"]>,
+): void {
+  const reply: PointyResponse = {
+    type: "wiii:action-response",
+    id,
+    result,
+  };
+  const target = (event.source as Window) ?? null;
+  if (!target) {
+    log("warn", "no_event_source");
+    return;
+  }
+  try {
+    target.postMessage(reply, targetOrigin);
+  } catch (e) {
+    log("error", "postMessage_failed", e);
+  }
+}
+
+export const _testing = {
+  isPointyRequest,
+  isSafeUrl,
+  ok,
+  fail,
+};

--- a/wiii-desktop/src/pointy-host/cursor.ts
+++ b/wiii-desktop/src/pointy-host/cursor.ts
@@ -1,0 +1,128 @@
+/**
+ * Wiii Pointy — animated cursor overlay.
+ *
+ * Renders a single SVG circle with a "W" letter (Wiii brand orange #F97316)
+ * that animates from its current position to the target element's bounding
+ * rect. Pure DOM + Web Animations API; no React, no framework.
+ */
+
+const CURSOR_ID = "wiii-pointy-cursor";
+const CURSOR_SIZE = 36;
+const BRAND_ORANGE = "#F97316";
+const BRAND_CREAM = "#FAF5EE";
+
+let cursorEl: SVGSVGElement | null = null;
+let lastPos: { x: number; y: number } | null = null;
+
+function createCursor(): SVGSVGElement {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("id", CURSOR_ID);
+  svg.setAttribute("width", String(CURSOR_SIZE));
+  svg.setAttribute("height", String(CURSOR_SIZE));
+  svg.setAttribute("viewBox", "0 0 36 36");
+  svg.setAttribute("aria-hidden", "true");
+  svg.setAttribute("data-wiii-pointy", "cursor");
+
+  const css = svg.style;
+  css.position = "fixed";
+  css.left = "0px";
+  css.top = "0px";
+  css.zIndex = "2147483646";
+  css.pointerEvents = "none";
+  css.transformOrigin = "center";
+  css.filter = "drop-shadow(0 4px 8px rgba(0,0,0,0.25))";
+  css.opacity = "0";
+  css.transition = "opacity 200ms ease-out";
+
+  svg.innerHTML = `
+    <circle cx="18" cy="18" r="16" fill="${BRAND_ORANGE}" stroke="${BRAND_CREAM}" stroke-width="2"/>
+    <text x="18" y="23" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="16" font-weight="700" fill="${BRAND_CREAM}">W</text>
+  `;
+  return svg;
+}
+
+function ensureCursor(): SVGSVGElement {
+  if (cursorEl && cursorEl.isConnected) return cursorEl;
+  cursorEl = createCursor();
+  document.body.appendChild(cursorEl);
+  return cursorEl;
+}
+
+/**
+ * Compute the screen point the cursor should land on for a given element.
+ * Lands slightly above-right of the element center to look like it's
+ * "pointing" at the button rather than covering it.
+ */
+export function computeTargetPoint(rect: DOMRect): { x: number; y: number } {
+  return {
+    x: rect.left + rect.width / 2 + 8,
+    y: rect.top + rect.height / 2 - 8,
+  };
+}
+
+/** Compute starting point if cursor has no last position (off-screen right edge). */
+export function computeOriginPoint(): { x: number; y: number } {
+  const w = typeof window !== "undefined" ? window.innerWidth : 1024;
+  const h = typeof window !== "undefined" ? window.innerHeight : 768;
+  return { x: w - CURSOR_SIZE, y: h / 2 };
+}
+
+export interface MoveCursorOptions {
+  duration_ms?: number;
+  onComplete?: () => void;
+}
+
+/** Move cursor to a target rect with spring-ish easing. */
+export function moveCursorToRect(rect: DOMRect, opts: MoveCursorOptions = {}): Animation | null {
+  const cursor = ensureCursor();
+  const target = computeTargetPoint(rect);
+  const start = lastPos ?? computeOriginPoint();
+  lastPos = target;
+
+  cursor.style.opacity = "1";
+  const duration = Math.max(200, Math.min(opts.duration_ms ?? 600, 2000));
+
+  if (typeof cursor.animate !== "function") {
+    cursor.style.transform = `translate(${target.x}px, ${target.y}px)`;
+    opts.onComplete?.();
+    return null;
+  }
+
+  const animation = cursor.animate(
+    [
+      { transform: `translate(${start.x}px, ${start.y}px) scale(0.9)` },
+      { transform: `translate(${target.x}px, ${target.y}px) scale(1.05)`, offset: 0.85 },
+      { transform: `translate(${target.x}px, ${target.y}px) scale(1.0)` },
+    ],
+    {
+      duration,
+      easing: "cubic-bezier(0.34, 1.56, 0.64, 1)",
+      fill: "forwards",
+    },
+  );
+  animation.onfinish = () => opts.onComplete?.();
+  return animation;
+}
+
+/** Hide the cursor (does not remove it from DOM, just fades out). */
+export function hideCursor(): void {
+  if (cursorEl) cursorEl.style.opacity = "0";
+}
+
+/** Remove the cursor element entirely (for cleanup / tests). */
+export function destroyCursor(): void {
+  if (cursorEl && cursorEl.parentNode) {
+    cursorEl.parentNode.removeChild(cursorEl);
+  }
+  cursorEl = null;
+  lastPos = null;
+}
+
+export const _testing = {
+  CURSOR_ID,
+  CURSOR_SIZE,
+  getCursor: () => cursorEl,
+  setLastPos: (p: { x: number; y: number } | null) => {
+    lastPos = p;
+  },
+};

--- a/wiii-desktop/src/pointy-host/index.ts
+++ b/wiii-desktop/src/pointy-host/index.ts
@@ -1,0 +1,164 @@
+/**
+ * Wiii Pointy — public API.
+ *
+ * Drop into the host (LMS) page:
+ *
+ *   <script src="https://wiii.holilihu.online/pointy/wiii-pointy.umd.js"></script>
+ *   <script>
+ *     WiiiPointy.init({
+ *       iframeOrigin: "https://wiii.holilihu.online",
+ *       onNavigate: (route) => angularRouter.navigateByUrl(route),
+ *     });
+ *   </script>
+ *
+ * The bundle is **read-only** in V1: highlight, scroll_to, navigate,
+ * show_tour. No auto-click, no auto-fill. Default tutor mode keeps the
+ * student in control.
+ */
+import { createBridge, type BridgeHandle } from "./bridge";
+import { destroyCursor, hideCursor } from "./cursor";
+import { destroySpotlight, hideSpotlight } from "./spotlight";
+import { cancelActiveTour } from "./tour";
+import {
+  POINTY_ACTIONS,
+  POINTY_PROTOCOL_VERSION,
+  type PointyConfig,
+  type PointyToolDefinition,
+} from "./types";
+
+export const VERSION = "1.0.0";
+
+const DEFAULT_TOOLS: PointyToolDefinition[] = [
+  {
+    name: "ui.highlight",
+    description:
+      "Trỏ và làm nổi bật một phần tử trên trang để hướng dẫn người dùng. Không tự click — chỉ chỉ đường.",
+    input_schema: {
+      type: "object",
+      properties: {
+        selector: { type: "string", description: "CSS selector hoặc [data-wiii-id=\"...\"]" },
+        message: { type: "string", description: "Tooltip hiển thị bên cạnh element" },
+        duration_ms: { type: "number", description: "Thời gian giữ spotlight (ms, mặc định 2200)" },
+      },
+      required: ["selector"],
+    },
+    surface: "page",
+    mutates_state: false,
+    requires_confirmation: false,
+  },
+  {
+    name: "ui.scroll_to",
+    description: "Cuộn trang đến một phần tử cụ thể.",
+    input_schema: {
+      type: "object",
+      properties: {
+        selector: { type: "string" },
+        block: { type: "string", description: "start | center | end" },
+      },
+      required: ["selector"],
+    },
+    surface: "page",
+    mutates_state: false,
+    requires_confirmation: false,
+  },
+  {
+    name: "ui.navigate",
+    description:
+      "Chuyển đến một route nội bộ (ưu tiên) hoặc URL tuyệt đối an toàn. Không phá vỡ session người dùng.",
+    input_schema: {
+      type: "object",
+      properties: {
+        route: { type: "string", description: "Route nội bộ, ví dụ: /courses/123" },
+        url: { type: "string", description: "URL http(s) tuyệt đối" },
+      },
+    },
+    surface: "page",
+    mutates_state: false,
+    requires_confirmation: false,
+  },
+  {
+    name: "ui.show_tour",
+    description: "Chạy hướng dẫn nhiều bước. Mỗi bước trỏ và highlight một element kèm tooltip.",
+    input_schema: {
+      type: "object",
+      properties: {
+        steps: {
+          type: "array",
+          description: "Danh sách bước { selector, message, duration_ms? }",
+        },
+        start_at: { type: "number", description: "Bước bắt đầu (mặc định 0)" },
+      },
+      required: ["steps"],
+    },
+    surface: "page",
+    mutates_state: false,
+    requires_confirmation: false,
+  },
+];
+
+let activeBridge: BridgeHandle | null = null;
+
+export interface InitResult {
+  /** Returns the capability payload to post into the iframe via wiii:capabilities. */
+  capabilities: () => {
+    type: "wiii:capabilities";
+    payload: {
+      host_type: string;
+      host_name?: string;
+      version: string;
+      surfaces: string[];
+      tools: PointyToolDefinition[];
+    };
+  };
+  destroy: () => void;
+}
+
+/**
+ * Initialise the pointy bridge. Idempotent — calling init() twice replaces
+ * the previous bridge.
+ */
+export function init(config: PointyConfig): InitResult {
+  if (activeBridge) activeBridge.dispose();
+  activeBridge = createBridge(config);
+
+  return {
+    capabilities: () => ({
+      type: "wiii:capabilities",
+      payload: {
+        host_type: "lms",
+        host_name: "Wiii Pointy host",
+        version: String(POINTY_PROTOCOL_VERSION),
+        surfaces: ["page"],
+        tools: DEFAULT_TOOLS.slice(),
+      },
+    }),
+    destroy: () => {
+      destroy();
+    },
+  };
+}
+
+/** Tear down the bridge and remove all overlays. */
+export function destroy(): void {
+  if (activeBridge) {
+    activeBridge.dispose();
+    activeBridge = null;
+  }
+  cancelActiveTour();
+  hideSpotlight();
+  hideCursor();
+  destroyCursor();
+  destroySpotlight();
+}
+
+export const ACTIONS = POINTY_ACTIONS;
+
+export type {
+  PointyConfig,
+  PointyToolDefinition,
+  HighlightParams,
+  ScrollToParams,
+  NavigateParams,
+  ShowTourParams,
+  TourStep,
+} from "./types";

--- a/wiii-desktop/src/pointy-host/spotlight.ts
+++ b/wiii-desktop/src/pointy-host/spotlight.ts
@@ -1,0 +1,170 @@
+/**
+ * Wiii Pointy — spotlight overlay with tooltip.
+ *
+ * Dims the page (radial-gradient hole around the target) and shows a small
+ * Vietnamese-first tooltip near the element. Pure DOM, no Driver.js dep.
+ */
+
+const OVERLAY_ID = "wiii-pointy-overlay";
+const TOOLTIP_ID = "wiii-pointy-tooltip";
+const BRAND_ORANGE = "#F97316";
+const BRAND_CREAM = "#FAF5EE";
+const PADDING = 8;
+
+let overlayEl: HTMLDivElement | null = null;
+let tooltipEl: HTMLDivElement | null = null;
+let activeTimer: ReturnType<typeof setTimeout> | null = null;
+
+function createOverlay(): HTMLDivElement {
+  const el = document.createElement("div");
+  el.id = OVERLAY_ID;
+  el.setAttribute("data-wiii-pointy", "overlay");
+  el.setAttribute("aria-hidden", "true");
+  Object.assign(el.style, {
+    position: "fixed",
+    inset: "0",
+    zIndex: "2147483645",
+    pointerEvents: "none",
+    background: "transparent",
+    transition: "background 250ms ease-out",
+  });
+  return el;
+}
+
+function createTooltip(): HTMLDivElement {
+  const el = document.createElement("div");
+  el.id = TOOLTIP_ID;
+  el.setAttribute("data-wiii-pointy", "tooltip");
+  el.setAttribute("role", "status");
+  el.setAttribute("aria-live", "polite");
+  Object.assign(el.style, {
+    position: "fixed",
+    zIndex: "2147483647",
+    pointerEvents: "none",
+    background: BRAND_CREAM,
+    color: "#1F2937",
+    border: `2px solid ${BRAND_ORANGE}`,
+    borderRadius: "12px",
+    padding: "8px 12px",
+    fontFamily: "system-ui, -apple-system, sans-serif",
+    fontSize: "14px",
+    fontWeight: "500",
+    maxWidth: "280px",
+    boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+    opacity: "0",
+    transform: "translateY(4px)",
+    transition: "opacity 180ms ease-out, transform 180ms ease-out",
+  });
+  return el;
+}
+
+function ensureElements(): { overlay: HTMLDivElement; tooltip: HTMLDivElement } {
+  if (!overlayEl || !overlayEl.isConnected) {
+    overlayEl = createOverlay();
+    document.body.appendChild(overlayEl);
+  }
+  if (!tooltipEl || !tooltipEl.isConnected) {
+    tooltipEl = createTooltip();
+    document.body.appendChild(tooltipEl);
+  }
+  return { overlay: overlayEl, tooltip: tooltipEl };
+}
+
+/** Position tooltip below the target by default; flip above if it would overflow. */
+export function computeTooltipPosition(
+  targetRect: DOMRect,
+  tooltipRect: { width: number; height: number },
+  viewport: { width: number; height: number },
+): { left: number; top: number } {
+  const desiredLeft = Math.max(
+    8,
+    Math.min(
+      targetRect.left + targetRect.width / 2 - tooltipRect.width / 2,
+      viewport.width - tooltipRect.width - 8,
+    ),
+  );
+  const wantsBelow = targetRect.bottom + tooltipRect.height + 12 <= viewport.height;
+  const top = wantsBelow
+    ? targetRect.bottom + 12
+    : Math.max(8, targetRect.top - tooltipRect.height - 12);
+  return { left: desiredLeft, top };
+}
+
+export interface SpotlightOptions {
+  message?: string;
+  duration_ms?: number;
+  onClose?: () => void;
+}
+
+export function showSpotlight(target: Element, opts: SpotlightOptions = {}): void {
+  const { overlay, tooltip } = ensureElements();
+  const rect = target.getBoundingClientRect();
+
+  // Radial dim with a hole punched around the target.
+  const cx = rect.left + rect.width / 2;
+  const cy = rect.top + rect.height / 2;
+  const r = Math.max(rect.width, rect.height) / 2 + PADDING;
+  overlay.style.background = `radial-gradient(circle at ${cx}px ${cy}px, transparent 0px, transparent ${r}px, rgba(15,23,42,0.45) ${r + 24}px)`;
+
+  if (opts.message) {
+    tooltip.textContent = opts.message;
+    tooltip.style.opacity = "0";
+    tooltip.style.transform = "translateY(4px)";
+    // Force layout so we can measure.
+    const tRect = tooltip.getBoundingClientRect();
+    const viewport = {
+      width: window.innerWidth || document.documentElement.clientWidth,
+      height: window.innerHeight || document.documentElement.clientHeight,
+    };
+    const { left, top } = computeTooltipPosition(rect, tRect, viewport);
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
+    requestAnimationFrame(() => {
+      tooltip.style.opacity = "1";
+      tooltip.style.transform = "translateY(0)";
+    });
+  } else {
+    tooltip.style.opacity = "0";
+  }
+
+  if (activeTimer) {
+    clearTimeout(activeTimer);
+    activeTimer = null;
+  }
+  const ms = Math.max(800, Math.min(opts.duration_ms ?? 2200, 8000));
+  activeTimer = setTimeout(() => {
+    hideSpotlight();
+    opts.onClose?.();
+  }, ms);
+}
+
+export function hideSpotlight(): void {
+  if (activeTimer) {
+    clearTimeout(activeTimer);
+    activeTimer = null;
+  }
+  if (overlayEl) overlayEl.style.background = "transparent";
+  if (tooltipEl) {
+    tooltipEl.style.opacity = "0";
+    tooltipEl.style.transform = "translateY(4px)";
+  }
+}
+
+export function destroySpotlight(): void {
+  if (activeTimer) {
+    clearTimeout(activeTimer);
+    activeTimer = null;
+  }
+  for (const el of [overlayEl, tooltipEl]) {
+    if (el && el.parentNode) el.parentNode.removeChild(el);
+  }
+  overlayEl = null;
+  tooltipEl = null;
+}
+
+export const _testing = {
+  OVERLAY_ID,
+  TOOLTIP_ID,
+  getOverlay: () => overlayEl,
+  getTooltip: () => tooltipEl,
+};

--- a/wiii-desktop/src/pointy-host/tour.ts
+++ b/wiii-desktop/src/pointy-host/tour.ts
@@ -1,0 +1,114 @@
+/**
+ * Wiii Pointy — multi-step tour sequencer.
+ *
+ * Walks through TourStep[] one at a time, scrolling, moving the cursor,
+ * and showing the spotlight + tooltip for each step in turn. A new tour
+ * cancels any tour in progress so the AI can interrupt itself cleanly.
+ */
+import type { TourStep } from "./types";
+import { hideCursor, moveCursorToRect } from "./cursor";
+import { hideSpotlight, showSpotlight } from "./spotlight";
+
+let activeTour: { cancelled: boolean } | null = null;
+
+export interface RunTourOptions {
+  resolveSelector?: (selector: string) => Element | null;
+  /** Step index to start from (0-based). */
+  startAt?: number;
+}
+
+const DEFAULT_RESOLVE = (sel: string) =>
+  typeof document !== "undefined" ? document.querySelector(sel) : null;
+
+export interface TourResult {
+  completed_steps: number;
+  total_steps: number;
+  cancelled: boolean;
+  missing_selectors: string[];
+}
+
+export async function runTour(
+  steps: TourStep[],
+  opts: RunTourOptions = {},
+): Promise<TourResult> {
+  if (activeTour) activeTour.cancelled = true;
+  const handle = { cancelled: false };
+  activeTour = handle;
+
+  const resolve = opts.resolveSelector ?? DEFAULT_RESOLVE;
+  const startAt = Math.max(0, Math.min(opts.startAt ?? 0, steps.length));
+  const result: TourResult = {
+    completed_steps: 0,
+    total_steps: steps.length,
+    cancelled: false,
+    missing_selectors: [],
+  };
+
+  for (let i = startAt; i < steps.length; i++) {
+    if (handle.cancelled) break;
+    const step = steps[i];
+    const target = resolve(step.selector);
+    if (!target) {
+      result.missing_selectors.push(step.selector);
+      continue;
+    }
+
+    if ("scrollIntoView" in target && typeof (target as HTMLElement).scrollIntoView === "function") {
+      (target as HTMLElement).scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+
+    const rect = target.getBoundingClientRect();
+    moveCursorToRect(rect, { duration_ms: 500 });
+
+    showSpotlight(target, {
+      message: step.message,
+      duration_ms: step.duration_ms ?? 2400,
+    });
+
+    await interruptibleWait(step.duration_ms ?? 2400, handle);
+    if (handle.cancelled) break;
+    result.completed_steps += 1;
+  }
+
+  result.cancelled = handle.cancelled;
+
+  if (activeTour === handle) {
+    hideSpotlight();
+    hideCursor();
+    activeTour = null;
+  }
+  return result;
+}
+
+export function cancelActiveTour(): void {
+  if (activeTour) activeTour.cancelled = true;
+  hideSpotlight();
+  hideCursor();
+}
+
+function interruptibleWait(ms: number, handle: { cancelled: boolean }): Promise<void> {
+  return new Promise((resolve) => {
+    const end = Date.now() + Math.max(0, ms);
+    const tick = () => {
+      if (handle.cancelled) {
+        resolve();
+        return;
+      }
+      const remaining = end - Date.now();
+      if (remaining <= 0) {
+        resolve();
+        return;
+      }
+      setTimeout(tick, Math.min(20, remaining));
+    };
+    tick();
+  });
+}
+
+export const _testing = {
+  hasActiveTour: () => activeTour !== null,
+  resetState: () => {
+    if (activeTour) activeTour.cancelled = true;
+    activeTour = null;
+  },
+};

--- a/wiii-desktop/src/pointy-host/types.ts
+++ b/wiii-desktop/src/pointy-host/types.ts
@@ -1,0 +1,111 @@
+/**
+ * Wiii Pointy — type definitions for the host-side action protocol.
+ *
+ * The pointy bundle runs INSIDE the parent (host) page, listening for
+ * `wiii:action-request` messages emitted by the Wiii iframe (Sprint 222
+ * HostActionBridge). It executes UI tutoring actions (highlight, scroll,
+ * navigate, multi-step tour) on the host DOM and replies via
+ * `wiii:action-response`.
+ *
+ * V1 tool surface is read-only: no auto-click, no auto-fill. Default tutor
+ * mode keeps the user in control.
+ */
+
+/** Identity reserved for the Wiii iframe's PostMessage envelope. */
+export const POINTY_PROTOCOL_VERSION = 1;
+
+/** Action names the AI can call. Keep aligned with HostCapabilities tools. */
+export const POINTY_ACTIONS = [
+  "ui.highlight",
+  "ui.scroll_to",
+  "ui.navigate",
+  "ui.show_tour",
+] as const;
+export type PointyAction = (typeof POINTY_ACTIONS)[number];
+
+/** Inbound request from the Wiii iframe. */
+export interface PointyRequest {
+  type: "wiii:action-request";
+  id: string;
+  action: string;
+  params: Record<string, unknown>;
+}
+
+/** Outbound reply sent to the Wiii iframe. */
+export interface PointyResponse {
+  type: "wiii:action-response";
+  id: string;
+  result: {
+    success: boolean;
+    data?: Record<string, unknown>;
+    error?: string;
+  };
+}
+
+/** Capability declaration sent once on iframe load. */
+export interface PointyCapabilities {
+  type: "wiii:capabilities";
+  payload: {
+    host_type: string;
+    host_name?: string;
+    version: string;
+    surfaces: string[];
+    tools: PointyToolDefinition[];
+  };
+}
+
+export interface PointyToolDefinition {
+  name: PointyAction | string;
+  description: string;
+  input_schema: {
+    type: "object";
+    properties: Record<string, { type: string; description?: string }>;
+    required?: string[];
+  };
+  roles?: string[];
+  surface?: string;
+  mutates_state: boolean;
+  requires_confirmation: boolean;
+}
+
+export interface HighlightParams {
+  selector: string;
+  message?: string;
+  duration_ms?: number;
+}
+
+export interface ScrollToParams {
+  selector: string;
+  block?: ScrollLogicalPosition;
+}
+
+export interface NavigateParams {
+  /** Internal route (preferred) or absolute URL. */
+  route?: string;
+  url?: string;
+}
+
+export interface TourStep {
+  selector: string;
+  message: string;
+  duration_ms?: number;
+}
+
+export interface ShowTourParams {
+  steps: TourStep[];
+  /** Step index to start at; defaults to 0. */
+  start_at?: number;
+}
+
+export interface PointyConfig {
+  /** Origin of the Wiii iframe; required so we never message untrusted frames. */
+  iframeOrigin: string;
+  /** The iframe element to message (or window) — used for reply targeting. */
+  iframe?: HTMLIFrameElement | Window;
+  /** Optional Angular Router-like callback for ui.navigate. */
+  onNavigate?: (route: string) => void | Promise<void>;
+  /** Optional logger. Defaults to console. Pass `() => {}` to silence. */
+  log?: (level: "info" | "warn" | "error", msg: string, ctx?: unknown) => void;
+}
+
+export type PointyResult = PointyResponse["result"];

--- a/wiii-desktop/vite.pointy.config.ts
+++ b/wiii-desktop/vite.pointy.config.ts
@@ -1,0 +1,40 @@
+/**
+ * Vite library config for the Wiii Pointy host bundle.
+ *
+ *   npx cross-env BUILD_TARGET=pointy vite build -c vite.pointy.config.ts
+ *
+ * Output: dist-pointy/wiii-pointy.umd.js (+ .es.js).
+ *
+ * Self-contained — no React, no Zustand, no Tauri APIs. Safe to ship to
+ * a third-party host page.
+ */
+import { defineConfig } from "vite";
+import path from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  build: {
+    outDir: "dist-pointy",
+    emptyOutDir: true,
+    minify: "esbuild",
+    sourcemap: false,
+    target: "es2020",
+    lib: {
+      entry: path.resolve(__dirname, "src/pointy-host/index.ts"),
+      name: "WiiiPointy",
+      fileName: (format) => `wiii-pointy.${format}.js`,
+      formats: ["umd", "es"],
+    },
+    rollupOptions: {
+      // No external deps; pointy-host is intentionally framework-free.
+      external: [],
+      output: {
+        globals: {},
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Ship **Wiii Pointy** — the host-side overlay that lets the in-iframe Wiii AI point at LMS UI elements, scroll to them, navigate the host router, and run multi-step tours over the existing Sprint 222 PostMessage `HostActionBridge`.
- V1 is **read-only** (highlight, scroll_to, navigate, show_tour). No auto-click, no auto-fill. Default tutor mode keeps the student in control.
- Self-contained TS bundle (~11 KB UMD), zero React/Zustand deps. Maps 1:1 onto WebMCP tools for forward compatibility when the W3C draft stabilises.

This is the web-native answer to the macOS-only [openclicky](https://github.com/jasonkneen/openclicky) UX (cursor overlay, agent-mode pointing). The Swift implementation is unusable in a web context; we keep the **idea** (mascot cursor pointing at UI elements) and ship it on top of the cooperative-iframe pattern Notion AI / Intercom Fin / Linear Copilot use in 2026.

## What ships

| Path | Purpose |
|---|---|
| `wiii-desktop/src/pointy-host/{types,cursor,spotlight,tour,bridge,index}.ts` | Self-contained host module (33 vitest cases) |
| `wiii-desktop/vite.pointy.config.ts` + `build:pointy` script | Library-mode UMD + ESM bundles |
| `wiii-desktop/dev-demo/pointy/` | Local visual QA harness |
| `maritime-ai-service/app/engine/context/pointy_actions.py` | Canonical `ui.*` action names + reference `HostCapabilities` payload |
| `maritime-ai-service/app/engine/context/skills/lms/pointy.skill.yaml` | Skill hint (priority 0.4) — quiz-page pedagogical guardrail preserved |
| `docs/integration/WIII_POINTY_LMS_GUIDE.md` | Standalone LMS integration guide |

The team-owned `maritime-ai-service/docs/integration/LMS_TEAM_GUIDE.md` is **not touched**.

## Risk & rollback

**Risk: low.** No existing runtime path is altered:
- `HostActionBridge`, `EmbedApp.tsx`, `host_context.py` — **unchanged**.
- The new skill YAML adds a priority-0.4 prompt augmentation for LMS turns; backend behaviour is identical when the LMS host does not declare `ui.*` tools.
- The frontend bundle is opt-in (only loaded when the LMS includes the script tag).

**Rollback:** revert this commit. `dist-pointy/` is gitignored — no CDN cleanup needed. The skill YAML can be removed in isolation without touching application code.

## Test plan

- [x] `cd wiii-desktop && npx vitest run` → **2095/2095 pass** (incl. 33 new pointy cases)
- [x] `cd wiii-desktop && npx tsc --noEmit` → clean
- [x] `cd wiii-desktop && npm run build:pointy` → 11.15 KB UMD, 13.88 KB ES
- [x] `python -m ruff check maritime-ai-service/app/engine/context/pointy_actions.py --select=E9,F63,F7` → clean
- [x] `cd maritime-ai-service && pytest tests/unit/engine/context/ -q` → 3/3 pass
- [x] Skill loader smoke — `lms-pointy-tutor` registers under `host_type=lms, page_types=*`
- [ ] Visual QA on `wiii-desktop/dev-demo/pointy/index.html` after CI build (LMS-team task before V1 prod ship)

## Visual evidence

The demo page (`wiii-desktop/dev-demo/pointy/index.html`) renders an LMS-like sample with course / quiz / grades / profile cards. Clicking a control button posts a `wiii:action-request` to the bridge; the orange "W" cursor flies to the targeted element with the spotlight + tooltip overlay. Screenshots will be attached after the CI artifact build (the `dist-pointy/` is intentionally gitignored).

## Roadmap

- **V2** — `ui.click`, `ui.fill_field`, gated `mutates_state=true, requires_confirmation=true`. Quiz pages stay read-only.
- **V3** — push-to-talk voice + Agent-Mode dashboard panel (re-uses existing `OperatorSessionV1`).
- **Long-term** — migrate the capability declaration to WebMCP once the W3C draft stabilises (rename, not rewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)