### PR TITLE
test(pointy): harden edge cases — 33 → 55 vitest cases

### DIFF
--- a/wiii-desktop/src/pointy-host/__tests__/bridge.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/bridge.test.ts
@@ -153,6 +153,56 @@ describe("handleNavigate", () => {
   });
 });
 
+describe("isSafeUrl edge cases", () => {
+  it("rejects malformed URLs", () => {
+    expect(_testing.isSafeUrl("https://")).toBe(false);
+    expect(_testing.isSafeUrl("not a url at all")).toBe(false);
+  });
+  it("accepts the canonical LMS domain", () => {
+    expect(_testing.isSafeUrl("https://holilihu.online")).toBe(true);
+    expect(_testing.isSafeUrl("https://wiii.holilihu.online/embed/")).toBe(true);
+  });
+  it("rejects 0.0.0.0 explicitly", () => {
+    expect(_testing.isSafeUrl("http://0.0.0.0:8000")).toBe(false);
+  });
+});
+
+describe("handleHighlight edge cases", () => {
+  it("returns missing-selector when params.selector is empty string", async () => {
+    const result = await handleHighlight({ selector: "" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("selector_not_found");
+  });
+  it("does not throw when target lacks scrollIntoView", async () => {
+    document.body.innerHTML = `<div id="x"></div>`;
+    const target = document.getElementById("x") as HTMLElement & { scrollIntoView?: unknown };
+    // Force-remove scrollIntoView to simulate exotic elements.
+    target.scrollIntoView = undefined as unknown as () => void;
+    const result = await handleHighlight({ selector: "#x", message: "ok", duration_ms: 800 });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("handleNavigate edge cases", () => {
+  it("succeeds for route fallback when no onNavigate callback is provided", async () => {
+    // jsdom forbids redefining window.location.assign — we only assert the
+    // return shape. Real browsers exercise window.location.assign in QA.
+    const result = await handleNavigate({ route: "/courses/42" }, { iframeOrigin: "https://x" });
+    expect(result.success).toBe(true);
+    expect(result.data?.summary).toContain("/courses/42");
+  });
+  it("passes through when onNavigate callback throws", async () => {
+    const onNavigate = vi.fn().mockRejectedValue(new Error("router_error"));
+    const result = await handleNavigate(
+      { route: "/courses/42" },
+      { iframeOrigin: "https://x", onNavigate },
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("navigate_failed");
+    expect(result.error).toContain("router_error");
+  });
+});
+
 describe("createBridge", () => {
   it("ignores messages from other origins", async () => {
     const onNavigate = vi.fn();
@@ -218,5 +268,36 @@ describe("createBridge", () => {
     const reply = replies[0] as { result: { success: boolean; error?: string } };
     expect(reply.result.success).toBe(false);
     expect(reply.result.error).toContain("unsupported_action");
+  });
+
+  it("ignores requests whose data is not a pointy request", async () => {
+    const onNavigate = vi.fn();
+    makeBridge({ iframeOrigin: "https://wiii.example", onNavigate });
+    const noise = new MessageEvent("message", {
+      data: { type: "some-other-event", payload: { foo: 1 } },
+      origin: "https://wiii.example",
+    });
+    window.dispatchEvent(noise);
+    await Promise.resolve();
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("logs and short-circuits when event.source is missing", async () => {
+    const logSpy = vi.fn();
+    document.body.innerHTML = `<button data-wiii-id="login"></button>`;
+    makeBridge({ iframeOrigin: "https://wiii.example", log: logSpy });
+    const event = new MessageEvent("message", {
+      data: {
+        type: "wiii:action-request",
+        id: "req-no-source",
+        action: "ui.highlight",
+        params: { selector: '[data-wiii-id="login"]' },
+      },
+      origin: "https://wiii.example",
+    });
+    // No source set on the event — bridge must not throw.
+    window.dispatchEvent(event);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(logSpy).toHaveBeenCalledWith("warn", "no_event_source");
   });
 });

--- a/wiii-desktop/src/pointy-host/__tests__/cursor.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/cursor.test.ts
@@ -71,4 +71,39 @@ describe("hideCursor / destroyCursor", () => {
     destroyCursor();
     expect(document.querySelector(`#${_testing.CURSOR_ID}`)).toBeNull();
   });
+  it("destroy is idempotent — calling twice does not throw", () => {
+    moveCursorToRect({ left: 0, top: 0, width: 10, height: 10 } as DOMRect);
+    destroyCursor();
+    expect(() => destroyCursor()).not.toThrow();
+  });
+  it("hideCursor before any move is a no-op", () => {
+    expect(() => hideCursor()).not.toThrow();
+  });
+});
+
+describe("moveCursorToRect — animation fallback", () => {
+  it("falls back to direct transform when Element.animate is unavailable", () => {
+    // Simulate browsers / shadow DOM where animate is not on the prototype.
+    const animateBackup = (SVGElement.prototype as unknown as { animate?: unknown }).animate;
+    (SVGElement.prototype as unknown as { animate?: unknown }).animate = undefined;
+    try {
+      const rect = { left: 50, top: 50, width: 30, height: 30 } as DOMRect;
+      const result = moveCursorToRect(rect);
+      expect(result).toBeNull();
+      const el = document.querySelector(`#${_testing.CURSOR_ID}`) as SVGSVGElement;
+      expect(el.style.transform).toContain("translate(");
+    } finally {
+      (SVGElement.prototype as unknown as { animate?: unknown }).animate = animateBackup;
+    }
+  });
+});
+
+describe("moveCursorToRect — duration clamping", () => {
+  it("clamps duration to [200, 2000]", () => {
+    const rect = { left: 10, top: 10, width: 10, height: 10 } as DOMRect;
+    // We only assert no throw + cursor created. Vitest jsdom does not expose
+    // Animation.effect timing reliably, so deeper assertion is not stable.
+    expect(() => moveCursorToRect(rect, { duration_ms: 0 })).not.toThrow();
+    expect(() => moveCursorToRect(rect, { duration_ms: 99999 })).not.toThrow();
+  });
 });

--- a/wiii-desktop/src/pointy-host/__tests__/spotlight.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/spotlight.test.ts
@@ -63,4 +63,49 @@ describe("showSpotlight", () => {
     const overlay = document.querySelector(`#${_testing.OVERLAY_ID}`) as HTMLDivElement;
     expect(overlay.style.background).toBe("transparent");
   });
+
+  it("does not show tooltip when message is omitted", () => {
+    document.body.innerHTML = `<button data-wiii-id="silent"></button>`;
+    showSpotlight(document.querySelector('[data-wiii-id="silent"]')!, { duration_ms: 999 });
+    const tooltip = document.querySelector(`#${_testing.TOOLTIP_ID}`) as HTMLDivElement;
+    expect(tooltip.style.opacity).toBe("0");
+  });
+
+  it("destroySpotlight after hideSpotlight is idempotent", () => {
+    document.body.innerHTML = `<button data-wiii-id="z"></button>`;
+    showSpotlight(document.querySelector('[data-wiii-id="z"]')!, { duration_ms: 999 });
+    hideSpotlight();
+    expect(() => destroySpotlight()).not.toThrow();
+    expect(document.querySelector(`#${_testing.OVERLAY_ID}`)).toBeNull();
+  });
+
+  it("rapidly calling show twice keeps only the latest tooltip text", () => {
+    document.body.innerHTML = `
+      <button id="a">A</button>
+      <button id="b">B</button>
+    `;
+    showSpotlight(document.getElementById("a")!, { message: "first", duration_ms: 1000 });
+    showSpotlight(document.getElementById("b")!, { message: "second", duration_ms: 1000 });
+    const tooltip = document.querySelector(`#${_testing.TOOLTIP_ID}`) as HTMLDivElement;
+    expect(tooltip.textContent).toBe("second");
+  });
+});
+
+describe("computeTooltipPosition — additional clamps", () => {
+  it("clamps to right viewport edge when target is far right", () => {
+    const target = { left: 1000, top: 100, right: 1080, bottom: 140, width: 80, height: 40 } as DOMRect;
+    const t = { width: 200, height: 60 };
+    const viewport = { width: 1024, height: 768 };
+    const pos = computeTooltipPosition(target, t, viewport);
+    expect(pos.left).toBe(viewport.width - t.width - 8);
+  });
+  it("places tooltip at viewport top boundary when target near top edge", () => {
+    const target = { left: 100, top: 5, right: 200, bottom: 45, width: 100, height: 40 } as DOMRect;
+    const t = { width: 200, height: 60 };
+    const viewport = { width: 1024, height: 100 };
+    const pos = computeTooltipPosition(target, t, viewport);
+    // Below would overflow vertical viewport (40+60+12 > 100), so flip above —
+    // but above also overflows. Expect clamped to >= 8.
+    expect(pos.top).toBeGreaterThanOrEqual(8);
+  });
 });

--- a/wiii-desktop/src/pointy-host/__tests__/tour.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/tour.test.ts
@@ -2,7 +2,7 @@
  * Tour tests — step progression, missing selectors, cancellation.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { _testing, runTour } from "../tour";
+import { _testing, cancelActiveTour, runTour } from "../tour";
 import type { TourStep } from "../types";
 
 beforeEach(() => {
@@ -62,5 +62,34 @@ describe("runTour", () => {
     const result = await runTour(steps, { resolveSelector: resolver });
     expect(resolver).toHaveBeenCalledWith("wiii://step-1");
     expect(result.completed_steps).toBe(1);
+  });
+
+  it("returns 0/0 immediately for an empty steps array", async () => {
+    const result = await runTour([]);
+    expect(result.completed_steps).toBe(0);
+    expect(result.total_steps).toBe(0);
+    expect(result.cancelled).toBe(false);
+    expect(result.missing_selectors).toEqual([]);
+  });
+
+  it("clamps start_at >= steps.length to no-op completion", async () => {
+    document.body.innerHTML = `<div id="a"></div><div id="b"></div>`;
+    const steps: TourStep[] = [
+      { selector: "#a", message: "A", duration_ms: 1 },
+      { selector: "#b", message: "B", duration_ms: 1 },
+    ];
+    const result = await runTour(steps, { startAt: 9 });
+    expect(result.completed_steps).toBe(0);
+    expect(result.total_steps).toBe(2);
+  });
+
+  it("negative start_at is normalised to 0", async () => {
+    document.body.innerHTML = `<div id="z"></div>`;
+    const result = await runTour([{ selector: "#z", message: "Z", duration_ms: 1 }], { startAt: -5 });
+    expect(result.completed_steps).toBe(1);
+  });
+
+  it("cancelActiveTour without an active tour does not throw", () => {
+    expect(() => cancelActiveTour()).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Add 22 edge-case tests for the Wiii Pointy V1 host module (PR [#188](https://github.com/meiiie/wiii/pull/188)) surfaced during V2 readiness review. **Tests-only — no production code changes.**

| Module | Before | After | New coverage |
|---|---:|---:|---|
| bridge.test.ts | 18 | 26 | isSafeUrl edges, scrollIntoView absent, navigate fallback + callback throw, noise filter, missing source |
| cursor.test.ts | 6 | 10 | idempotent destroy, no-op hide, animation fallback, duration clamps |
| spotlight.test.ts | 5 | 10 | no-message path, idempotent destroy, rapid-call last-wins, right-edge clamp, top-overflow clamp |
| tour.test.ts | 4 | 9 | empty steps, `start_at >= length`, negative `start_at`, standalone cancel |
| **Total** | **33** | **55** | **+22** |

## Risk & rollback

Risk: **none**. Tests-only. No imports added in src files, no behaviour changed.

Rollback: revert this commit.

## Verification

- `npx vitest run src/pointy-host/` → **55/55 pass**
- `npx vitest run` → **2117/2117 pass** (was 2095)
- `npx tsc --noEmit` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Significantly expanded test coverage across internal host modules. Added tests for protocol message edge cases, cursor animation fallbacks and boundary conditions, spotlight tooltip positioning and visibility, and tour progression with various starting conditions. Enhancements verify error resilience and proper boundary behavior throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->