### PR TITLE
feat: checkpoint native runtime hardening

### DIFF
--- a/docs/plans/2026-04-28-wiii-pipeline-simplification-plan.md
+++ b/docs/plans/2026-04-28-wiii-pipeline-simplification-plan.md
@@ -113,6 +113,98 @@ list; it is a safety map for future PRs.
 | Text cleanup filters | `public_thinking.py`, `reasoning/*` filter lists containing `langgraph` | Prevents visible framework jargon leaking to users. | Keep until replacement filter contract exists. |
 | Provider compatibility wording | `llm_providers/unified_client.py` | Mentions LangChain/LangGraph compatibility. | Update wording after provider route contract is finalized. |
 
+## 2026-04-29 LangChain Exit Status
+
+LangGraph is no longer the active orchestrator. LangChain/LangChain Core are
+still present as compatibility surfaces for provider objects, tool binding,
+RAG/CRAG helper calls, and older message builders. Treat this as a staged
+framework exit, not a one-shot dependency deletion.
+
+Completed first slice:
+
+- Added a Wiii-native chat runtime contract for OpenAI-compatible message
+  payloads and assistant response objects.
+- Added a native provider/model handle so direct no-tool turns can use NVIDIA
+  or other OpenAI-compatible providers without constructing a LangChain
+  `BaseChatModel`.
+- Switched the direct no-tool native stream path to return Wiii-native
+  assistant messages instead of LangChain `AIMessage`.
+- Added native dict message support for direct prompt building and direct
+  response extraction.
+- Kept tool/RAG lanes on the legacy adapter until their behavior has focused
+  smoke tests.
+
+Completed second slice:
+
+- Direct no-tool turns now try the Wiii-native provider handle first even when
+  the request did not explicitly pin a provider; provider resolution comes from
+  settings and grouped agent runtime profiles.
+- Native OpenAI-compatible streams now receive the same first-token timeout
+  guard used by the legacy stream path, so the UI can recover instead of
+  waiting silently on a stuck provider stream.
+- Native stream success/failure updates the existing model-health registry.
+  Timeout/rate-limit/server failures temporarily mark a concrete provider/model
+  degraded.
+- NVIDIA native model selection now skips a degraded Flash/Pro model and uses
+  the healthy sibling model when available.
+
+Completed third slice:
+
+- Added framework-free native system, user, and tool-result message objects
+  with the same duck-typed surface the existing runtime expects.
+- Direct tool rounds can now append native tool-result and synthesis messages
+  when the route is native, while legacy LangChain tool loops keep the old
+  `ToolMessage`/`HumanMessage` path.
+- Direct node execution passes the native message mode through to the tool
+  loop, giving future native tool-call adapters a stable switch point.
+- Added focused tests so native tool-result messages serialize to
+  OpenAI-compatible payloads and direct tool rounds can synthesize without
+  constructing LangChain message classes in native mode.
+
+Completed fourth slice:
+
+- Added Wiii-owned tool schema serialization from existing tool objects into
+  OpenAI-compatible `type=function` payloads.
+- Native provider handles now support `bind_tools(...)` and preserve normalized
+  tool-choice hints without constructing LangChain model wrappers.
+- Native provider handles now support `ainvoke(...)` through the existing
+  OpenAI-compatible client layer, returning Wiii-native assistant messages with
+  direct-loop-friendly `tool_calls`.
+- Direct forced-tool turns can now select the native provider handle when the
+  route is native, while optional-tool turns stay on the legacy path until
+  native streaming with tool schemas is covered.
+
+Completed fifth slice:
+
+- Native OpenAI-compatible streaming now sends bound tool schemas and
+  normalized tool-choice hints when a native handle has tools attached.
+- Native stream responses now accumulate streamed function-call chunks across
+  deltas and return direct-loop-compatible `tool_calls` without emitting
+  duplicate tool events.
+- Direct optional-tool turns can now select the native provider handle while
+  identity, emotional support, and house/social chatter stay on the protected
+  legacy path.
+- The stream first-chunk guard keeps a single iterator instance, preventing
+  duplicate first chunks from custom async iterators.
+
+Remaining LangChain work should be split into small PRs:
+
+- Provider pool: replace `LLMPool`/`BaseChatModel` as the default provider
+  route with a Wiii-owned provider adapter and health/fallback contract.
+- Tool runtime: replace `StructuredTool`, `@tool`, `ToolMessage`, and tool
+  call result objects with Wiii tool-call events plus provider-specific
+  serializers.
+- RAG/CRAG: migrate `ainvoke`/`astream` helper calls to native provider
+  adapters after golden RAG smoke cases exist.
+- Memory/context: move history and budget message builders to Wiii-native
+  message blocks while preserving identity, relationship, and fact memory
+  behavior.
+
+Do not remove LangChain dependencies from packaging until all four areas above
+have passing smoke gates. The current safe direction is to make new hot-path
+runtime code native first, then retire compatibility adapters only when their
+callers disappear.
+
 ## Target Runtime Shape
 
 Wiii should converge on a runtime that is explicit and boring in the best way:
@@ -226,6 +318,55 @@ Exit criteria:
 - No active `import langgraph`, `from langgraph`, `StateGraph`,
   `MemorySaver`, `CompiledStateGraph`, `get_multi_agent_graph`, or
   `build_multi_agent_graph` references remain outside explicit historical docs.
+
+### Completed fifth slice: Native optional tools
+
+Implemented in the Phase 5 runtime slice:
+
+- Native OpenAI-compatible streaming now forwards bound tool schemas and
+  normalized `tool_choice` instead of silently falling back to LangChain for
+  optional-tool turns.
+- Streaming tool-call deltas are accumulated into final assistant `tool_calls`
+  before the direct loop executes tools, matching the provider contract for
+  chunked function arguments.
+- Direct optional-tool turns can use the native provider path while
+  identity/emotional/social house turns remain on the protected natural voice
+  lane.
+- The native first-chunk guard keeps a single stream iterator instance so the
+  first answer/tool chunk is not duplicated or lost.
+
+### Completed sixth slice: Native RAG/CRAG socket
+
+Implemented in the first Phase 6 runtime slice:
+
+- Agentic RAG now builds framework-free native message objects through a single
+  `make_agentic_rag_messages()` helper rather than importing LangChain message
+  classes across RAG/CRAG callsites.
+- `resolve_agentic_rag_llm()` can prefer an `AgentConfigRegistry` native
+  provider handle when the OpenAI-compatible client is actually configured, and
+  falls back to the shared pool when native credentials are absent.
+- `ainvoke_agentic_rag_llm()` pins native handles to their provider name so the
+  failover socket does not accidentally replace a native NVIDIA/OpenAI-compatible
+  request with an unrelated LangChain primary.
+- CRAG fallback, translation, web-context generation, HyDE, query analysis,
+  query rewriting, retrieval grading, and answer verification now use the shared
+  RAG socket instead of constructing LangChain messages locally.
+- CRAG streaming has a native OpenAI-compatible branch for configured native
+  handles, then falls back to legacy `astream()` and finally buffered invoke.
+- CRAG streaming now has chunk/total timeout guards so a dead stream can fall
+  back instead of leaving the frontend stuck on "đang suy nghĩ".
+
+Why this order:
+
+- CRAG research emphasizes a lightweight retrieval evaluator plus corrective
+  actions when retrieved documents are weak; Self-RAG emphasizes adaptive
+  retrieval and critique rather than unconditional fixed retrieval. Wiii keeps
+  those retrieval/verification policies intact while replacing the model socket
+  underneath first.
+- Hosted retrieval systems such as OpenAI file search expose semantic/keyword
+  search, vector stores, result limits, citations, and metadata filters as
+  explicit contracts. Wiii's native RAG direction should mirror that clarity:
+  retrieval contract first, model socket second, UI stream evidence always.
 
 ## Migration Rules For Agents
 

--- a/docs/plans/2026-04-28-wiii-pipeline-simplification-plan.md
+++ b/docs/plans/2026-04-28-wiii-pipeline-simplification-plan.md
@@ -120,7 +120,10 @@ still present as compatibility surfaces for provider objects, tool binding,
 RAG/CRAG helper calls, and older message builders. Treat this as a staged
 framework exit, not a one-shot dependency deletion.
 
-Completed first slice:
+Checkpoint evidence (first slice):
+
+Evidence: PR #190 (`codex/native-runtime-hardening-checkpoint`), backend
+runtime subset tests, and PR CI gates.
 
 - Added a Wiii-native chat runtime contract for OpenAI-compatible message
   payloads and assistant response objects.
@@ -134,7 +137,10 @@ Completed first slice:
 - Kept tool/RAG lanes on the legacy adapter until their behavior has focused
   smoke tests.
 
-Completed second slice:
+Checkpoint evidence (second slice):
+
+Evidence: PR #190 (`codex/native-runtime-hardening-checkpoint`), provider
+runtime subset tests, and PR CI gates.
 
 - Direct no-tool turns now try the Wiii-native provider handle first even when
   the request did not explicitly pin a provider; provider resolution comes from
@@ -148,7 +154,10 @@ Completed second slice:
 - NVIDIA native model selection now skips a degraded Flash/Pro model and uses
   the healthy sibling model when available.
 
-Completed third slice:
+Checkpoint evidence (third slice):
+
+Evidence: PR #190 (`codex/native-runtime-hardening-checkpoint`), direct
+tool-round subset tests, and PR CI gates.
 
 - Added framework-free native system, user, and tool-result message objects
   with the same duck-typed surface the existing runtime expects.
@@ -161,7 +170,10 @@ Completed third slice:
   OpenAI-compatible payloads and direct tool rounds can synthesize without
   constructing LangChain message classes in native mode.
 
-Completed fourth slice:
+Checkpoint evidence (fourth slice):
+
+Evidence: PR #190 (`codex/native-runtime-hardening-checkpoint`), native
+provider/tool subset tests, and PR CI gates.
 
 - Added Wiii-owned tool schema serialization from existing tool objects into
   OpenAI-compatible `type=function` payloads.
@@ -174,7 +186,10 @@ Completed fourth slice:
   route is native, while optional-tool turns stay on the legacy path until
   native streaming with tool schemas is covered.
 
-Completed fifth slice:
+Checkpoint evidence (fifth slice):
+
+Evidence: PR #190 (`codex/native-runtime-hardening-checkpoint`), native
+stream/tool-call subset tests, and PR CI gates.
 
 - Native OpenAI-compatible streaming now sends bound tool schemas and
   normalized tool-choice hints when a native handle has tools attached.
@@ -196,9 +211,8 @@ Remaining LangChain work should be split into small PRs:
   serializers.
 - RAG/CRAG: migrate `ainvoke`/`astream` helper calls to native provider
   adapters after golden RAG smoke cases exist.
-- Memory/context: move history and budget message builders to Wiii-native
-  message blocks while preserving identity, relationship, and fact memory
-  behavior.
+- Memory/context: move history and budget message builders into Wiii-native
+  message blocks, preserving identity, relationship, and fact memory behavior.
 
 Do not remove LangChain dependencies from packaging until all four areas above
 have passing smoke gates. The current safe direction is to make new hot-path
@@ -319,9 +333,10 @@ Exit criteria:
   `MemorySaver`, `CompiledStateGraph`, `get_multi_agent_graph`, or
   `build_multi_agent_graph` references remain outside explicit historical docs.
 
-### Completed fifth slice: Native optional tools
+### Checkpoint Evidence: Native Optional Tools
 
-Implemented in the Phase 5 runtime slice:
+Evidence: PR #190 (`codex/native-runtime-hardening-checkpoint`), native
+stream/tool-call subset tests, and PR CI gates.
 
 - Native OpenAI-compatible streaming now forwards bound tool schemas and
   normalized `tool_choice` instead of silently falling back to LangChain for
@@ -335,9 +350,10 @@ Implemented in the Phase 5 runtime slice:
 - The native first-chunk guard keeps a single stream iterator instance so the
   first answer/tool chunk is not duplicated or lost.
 
-### Completed sixth slice: Native RAG/CRAG socket
+### Checkpoint Evidence: Native RAG/CRAG Socket
 
-Implemented in the first Phase 6 runtime slice:
+Evidence: PR #190 (`codex/native-runtime-hardening-checkpoint`), native
+RAG/CRAG socket subset tests, and PR CI gates.
 
 - Agentic RAG now builds framework-free native message objects through a single
   `make_agentic_rag_messages()` helper rather than importing LangChain message
@@ -390,13 +406,13 @@ git status --short
 Suggested inventory commands for future implementation PRs:
 
 ```powershell
-Get-ChildItem maritime-ai-service -Recurse -File |
+Get-ChildItem . -Recurse -File |
   Select-String -Pattern '^(import langgraph|from langgraph)'
 
-Get-ChildItem maritime-ai-service -Recurse -File |
+Get-ChildItem . -Recurse -File |
   Select-String -Pattern '\b(MemorySaver|CompiledStateGraph|StateGraph)\b'
 
-Get-ChildItem maritime-ai-service -Recurse -File |
+Get-ChildItem . -Recurse -File |
   Select-String -Pattern '\b(get_multi_agent_graph|build_multi_agent_graph)\b'
 ```
 

--- a/maritime-ai-service/app/api/v1/chat_stream_transport.py
+++ b/maritime-ai-service/app/api/v1/chat_stream_transport.py
@@ -26,7 +26,6 @@ async def wrap_sse_with_keepalive(
     queue: asyncio.Queue[str | None] = asyncio.Queue()
     loop = asyncio.get_running_loop()
     last_inner_chunk_at = loop.time()
-    sent_keepalive_since_inner = False
 
     async def _producer() -> None:
         try:
@@ -64,19 +63,11 @@ async def wrap_sse_with_keepalive(
                 if item is None:
                     return
                 last_inner_chunk_at = loop.time()
-                sent_keepalive_since_inner = False
                 yield item
             except asyncio.TimeoutError:
                 if idle_timeout_sec and idle_timeout_sec > 0:
                     idle_elapsed = loop.time() - last_inner_chunk_at
                     if idle_elapsed >= idle_timeout_sec:
-                        if (
-                            not sent_keepalive_since_inner
-                            and keepalive_interval_sec < idle_timeout_sec
-                        ):
-                            sent_keepalive_since_inner = True
-                            yield keepalive_chunk
-                            continue
                         logger.warning(
                             "[SSE] Inner generator idle timeout after %.2fs",
                             idle_timeout_sec,
@@ -86,7 +77,6 @@ async def wrap_sse_with_keepalive(
                             for chunk in on_inner_error():
                                 yield chunk
                         return
-                sent_keepalive_since_inner = True
                 yield keepalive_chunk
     finally:
         if not producer_task.done():

--- a/maritime-ai-service/app/core/config/_settings_base_fields.py
+++ b/maritime-ai-service/app/core/config/_settings_base_fields.py
@@ -39,17 +39,17 @@ class BaseSettingsFieldsMixin:
 
     # API Settings
     api_v1_prefix: str = Field(default="/api/v1", description="API version 1 prefix")
-    api_key: Optional[str] = Field(default=None, description="API Key for authentication")
-    jwt_secret_key: str = Field(default="change-me-in-production", description="JWT secret key")
+    api_key: Optional[str] = Field(default=None, description="API Key for authentication", repr=False)
+    jwt_secret_key: str = Field(default="change-me-in-production", description="JWT secret key", repr=False)
     jwt_algorithm: str = Field(default="HS256", description="JWT algorithm")
     jwt_expire_minutes: int = Field(default=15, description="JWT token expiration in minutes")
 
     # Google OAuth (Sprint 157: Đăng Nhập)
     enable_google_oauth: bool = Field(default=False, description="Enable Google OAuth login")
     google_oauth_client_id: Optional[str] = Field(default=None, description="Google OAuth 2.0 client ID")
-    google_oauth_client_secret: Optional[str] = Field(default=None, description="Google OAuth 2.0 client secret")
+    google_oauth_client_secret: Optional[str] = Field(default=None, description="Google OAuth 2.0 client secret", repr=False)
     oauth_redirect_base_url: Optional[str] = Field(default=None, description="Base URL for OAuth callbacks (e.g. https://api.wiii.app)")
-    session_secret_key: str = Field(default="change-session-secret-in-production", description="Session middleware secret for OAuth CSRF state")
+    session_secret_key: str = Field(default="change-session-secret-in-production", description="Session middleware secret for OAuth CSRF state", repr=False)
     # Sprint 193: Allowed redirect origins for web OAuth (comma-separated whitelist)
     oauth_allowed_redirect_origins: str = Field(
         default="http://localhost:1420,http://localhost:1421",
@@ -79,7 +79,7 @@ class BaseSettingsFieldsMixin:
 
     # Magic Link Email Auth (Sprint 224)
     enable_magic_link_auth: bool = Field(default=False, description="Enable Magic Link email authentication")
-    resend_api_key: str = Field(default="", description="Resend API key for sending magic link emails")
+    resend_api_key: str = Field(default="", description="Resend API key for sending magic link emails", repr=False)
     magic_link_base_url: str = Field(default="http://localhost:8000", description="Base URL for magic link verification endpoint")
     magic_link_expires_seconds: int = Field(default=600, ge=60, le=3600, description="Magic link token expiry (default 10 min)")
     magic_link_from_email: str = Field(default="Wiii <noreply@wiii.app>", description="Sender email for magic links")
@@ -104,7 +104,7 @@ class BaseSettingsFieldsMixin:
     postgres_host: str = Field(default="localhost", description="PostgreSQL host")
     postgres_port: int = Field(default=5433, description="PostgreSQL port (Docker maps to 5433)")
     postgres_user: str = Field(default="wiii", description="PostgreSQL user")
-    postgres_password: str = Field(default="wiii_secret", description="PostgreSQL password")
+    postgres_password: str = Field(default="wiii_secret", description="PostgreSQL password", repr=False)
     postgres_db: str = Field(default="wiii_ai", description="PostgreSQL database name")
 
     # Database - Cloud (Production) - CHỈ THỊ 19: Now using Neon
@@ -122,30 +122,30 @@ class BaseSettingsFieldsMixin:
     # Object Storage (MinIO / S3-compatible)
     minio_endpoint: Optional[str] = Field(default=None, description="MinIO endpoint (host:port, no scheme)")
     minio_external_endpoint: Optional[str] = Field(default=None, description="MinIO endpoint for browser-facing presigned URLs (defaults to minio_endpoint)")
-    minio_access_key: Optional[str] = Field(default=None, description="MinIO access key")
-    minio_secret_key: Optional[str] = Field(default=None, description="MinIO secret key")
+    minio_access_key: Optional[str] = Field(default=None, description="MinIO access key", repr=False)
+    minio_secret_key: Optional[str] = Field(default=None, description="MinIO secret key", repr=False)
     minio_bucket: str = Field(default="wiii-docs", description="Storage bucket for document images")
     minio_secure: bool = Field(default=False, description="Use HTTPS for MinIO connection")
 
     # LMS API Key (for authentication from LMS)
-    lms_api_key: Optional[str] = Field(default=None, description="API Key for LMS integration")
+    lms_api_key: Optional[str] = Field(default=None, description="API Key for LMS integration", repr=False)
 
     # LMS Callback Configuration (AI-LMS Integration v2.0)
     lms_callback_url: Optional[str] = Field(default=None, description="LMS callback URL for AI events")
-    lms_callback_secret: Optional[str] = Field(default=None, description="Shared secret for callback authentication")
+    lms_callback_secret: Optional[str] = Field(default=None, description="Shared secret for callback authentication", repr=False)
 
     # LMS Integration (Sprint 155: Cầu Nối — inbound from LMS)
     enable_lms_integration: bool = Field(default=False, description="Enable LMS webhook + API integration")
     lms_base_url: Optional[str] = Field(default=None, description="LMS REST API base URL (single-LMS compat)")
-    lms_service_token: Optional[str] = Field(default=None, description="Service account token for LMS API (single-LMS compat)")
-    lms_webhook_secret: Optional[str] = Field(default=None, description="HMAC-SHA256 secret for incoming webhooks (single-LMS compat)")
+    lms_service_token: Optional[str] = Field(default=None, description="Service account token for LMS API (single-LMS compat)", repr=False)
+    lms_webhook_secret: Optional[str] = Field(default=None, description="HMAC-SHA256 secret for incoming webhooks (single-LMS compat)", repr=False)
     lms_api_timeout: int = Field(default=10, ge=3, le=60, description="LMS API call timeout (seconds)")
 
     # Course Generation (design spec v2.0, 2026-03-22)
     use_docling_for_course_gen: bool = Field(default=False, description="Use Docling for document conversion (requires pip install docling)")
     docling_vlm_backend: str = Field(default="none", description="VLM backend for scanned pages: 'gemini', 'ollama', 'none'")
     docling_vlm_api_url: Optional[str] = Field(default=None, description="VLM API URL for Docling scanned page extraction")
-    docling_vlm_api_key: Optional[str] = Field(default=None, description="VLM API key for Docling")
+    docling_vlm_api_key: Optional[str] = Field(default=None, description="VLM API key for Docling", repr=False)
     docling_vlm_model: str = Field(default="gemini-3.1-flash-lite", description="VLM model for Docling scanned pages")
     course_gen_max_concurrent_chapters: int = Field(default=3, ge=1, le=10, description="Max parallel chapter expansions")
     course_gen_chapter_timeout_seconds: int = Field(default=120, ge=30, le=600, description="Timeout per chapter expansion")
@@ -194,14 +194,14 @@ class BaseSettingsFieldsMixin:
     neo4j_uri: str = Field(default="bolt://localhost:7687", description="Neo4j connection URI (local or Aura)")
     neo4j_user: str = Field(default="neo4j", description="Neo4j user")
     neo4j_username: Optional[str] = Field(default=None, description="Neo4j username (Aura format)")
-    neo4j_password: str = Field(default="neo4j_secret", description="Neo4j password")
+    neo4j_password: str = Field(default="neo4j_secret", description="Neo4j password", repr=False)
 
     neo4j_username_resolved = property(resolve_neo4j_username)
 
     # LLM Settings - OpenAI/OpenRouter (legacy)
-    openai_api_key: Optional[str] = Field(default=None, description="OpenAI API key")
+    openai_api_key: Optional[str] = Field(default=None, description="OpenAI API key", repr=False)
     openai_base_url: Optional[str] = Field(default=None, description="OpenAI API base URL")
-    openrouter_api_key: Optional[str] = Field(default=None, description="OpenRouter API key")
+    openrouter_api_key: Optional[str] = Field(default=None, description="OpenRouter API key", repr=False)
     openrouter_base_url: Optional[str] = Field(default=OPENROUTER_DEFAULT_BASE_URL, description="OpenRouter API base URL")
     openai_model: str = Field(default=OPENAI_DEFAULT_MODEL, description="OpenAI model for general tasks")
     openai_model_advanced: str = Field(default=OPENAI_DEFAULT_MODEL_ADVANCED, description="OpenAI model for complex tasks")
@@ -210,7 +210,7 @@ class BaseSettingsFieldsMixin:
 
     # NVIDIA NIM (Issue #110) — OpenAI-compatible endpoint at integrate.api.nvidia.com.
     # NGC API key from build.nvidia.com unlocks Llama 3.1 405B, Nemotron 70B, etc.
-    nvidia_api_key: Optional[str] = Field(default=None, description="NVIDIA NIM (NGC) API key")
+    nvidia_api_key: Optional[str] = Field(default=None, description="NVIDIA NIM (NGC) API key", repr=False)
     nvidia_base_url: Optional[str] = Field(default=NVIDIA_DEFAULT_BASE_URL, description="NVIDIA NIM API base URL")
     nvidia_model: str = Field(default=NVIDIA_DEFAULT_MODEL, description="NVIDIA model for general tasks")
     nvidia_model_advanced: str = Field(default=NVIDIA_DEFAULT_MODEL_ADVANCED, description="NVIDIA model for complex tasks")
@@ -252,7 +252,7 @@ class BaseSettingsFieldsMixin:
     )
 
     # LLM Settings - Google Gemini (cloud fallback)
-    google_api_key: Optional[str] = Field(default=None, description="Google Gemini API key")
+    google_api_key: Optional[str] = Field(default=None, description="Google Gemini API key", repr=False)
     google_model: str = Field(
         default=GOOGLE_DEFAULT_MODEL,
         description="Google Gemini model (default: gemini-3.1-flash-lite-preview, current March 2026 default)",
@@ -270,6 +270,7 @@ class BaseSettingsFieldsMixin:
     ollama_api_key: Optional[str] = Field(
         default=None,
         description="Ollama Cloud API key for direct access to https://ollama.com/api",
+        repr=False,
     )
     ollama_base_url: Optional[str] = Field(default="http://localhost:11434", description="Ollama API base URL")
     ollama_model: str = Field(
@@ -287,10 +288,10 @@ class BaseSettingsFieldsMixin:
 
     # LLM Settings - Zhipu AI / GLM (cloud fallback)
     # Vertex AI (separate from Google AI Studio — independent quota)
-    vertex_api_key: Optional[str] = Field(default=None, description="Vertex AI API key (format: AQ.xxx)")
+    vertex_api_key: Optional[str] = Field(default=None, description="Vertex AI API key (format: AQ.xxx)", repr=False)
     vertex_model: Optional[str] = Field(default=None, description="Vertex AI model (defaults to google_model if not set)")
 
-    zhipu_api_key: Optional[str] = Field(default=None, description="Zhipu AI (GLM) API key")
+    zhipu_api_key: Optional[str] = Field(default=None, description="Zhipu AI (GLM) API key", repr=False)
     zhipu_base_url: str = Field(
         default="https://open.bigmodel.cn/api/paas/v4",
         description="Zhipu AI API base URL (OpenAI-compatible)",
@@ -506,14 +507,14 @@ class BaseSettingsFieldsMixin:
     # Multi-Channel Gateway
     enable_websocket: bool = Field(default=True, description="Enable WebSocket chat endpoint")
     enable_telegram: bool = Field(default=False, description="Enable Telegram bot integration")
-    telegram_bot_token: Optional[str] = Field(default=None, description="Telegram Bot API token")
+    telegram_bot_token: Optional[str] = Field(default=None, description="Telegram Bot API token", repr=False)
     telegram_webhook_url: Optional[str] = Field(default=None, description="Telegram webhook callback URL")
     enable_messenger_webhook: bool = Field(default=False, description="Enable Facebook Messenger Platform webhook")
     facebook_app_id: Optional[str] = Field(default=None, description="Facebook App ID")
-    facebook_app_secret: Optional[str] = Field(default=None, description="Facebook App Secret for X-Hub-Signature verification")
+    facebook_app_secret: Optional[str] = Field(default=None, description="Facebook App Secret for X-Hub-Signature verification", repr=False)
     facebook_page_id: Optional[str] = Field(default=None, description="Facebook Page ID")
     enable_zalo: bool = Field(default=False, description="Enable Zalo OA notification channel")
-    zalo_oa_refresh_token: Optional[str] = Field(default=None, description="Zalo OA refresh token")
+    zalo_oa_refresh_token: Optional[str] = Field(default=None, description="Zalo OA refresh token", repr=False)
     zalo_oa_app_id: Optional[str] = Field(default=None, description="Zalo OA application ID")
 
     # Sprint 174b: OTP Identity Linking
@@ -522,7 +523,7 @@ class BaseSettingsFieldsMixin:
     # Sprint 174: Cross-Platform Identity + Dual Personality
     enable_cross_platform_identity: bool = Field(default=False, description="Enable canonical identity resolution across platforms")
     enable_zalo_webhook: bool = Field(default=False, description="Enable Zalo OA incoming message webhook")
-    zalo_webhook_token: Optional[str] = Field(default=None, description="Verify token for Zalo webhook handshake")
+    zalo_webhook_token: Optional[str] = Field(default=None, description="Verify token for Zalo webhook handshake", repr=False)
     default_personality_mode: str = Field(default="professional", description="Default personality mode: professional or soul")
     channel_personality_map: str = Field(
         default='{"web":"professional","desktop":"professional","messenger":"soul","zalo":"soul","telegram":"professional"}',
@@ -626,7 +627,7 @@ class BaseSettingsFieldsMixin:
     sandbox_default_timeout_seconds: int = Field(default=120, ge=5, le=3600, description="Default timeout for remote sandbox workloads in seconds")
     sandbox_allow_browser_workloads: bool = Field(default=False, description="Allow browser-class workloads to use the privileged sandbox executor")
     opensandbox_base_url: Optional[str] = Field(default=None, description="Base URL for OpenSandbox control plane")
-    opensandbox_api_key: Optional[str] = Field(default=None, description="API key for OpenSandbox control plane")
+    opensandbox_api_key: Optional[str] = Field(default=None, description="API key for OpenSandbox control plane", repr=False)
     opensandbox_healthcheck_path: str = Field(default="/health", description="Health check path for OpenSandbox control plane")
     opensandbox_code_template: str = Field(default="opensandbox/code-interpreter:v1.0.1", description="Default OpenSandbox runtime image for Python or command execution")
     opensandbox_browser_template: str = Field(default="opensandbox/playwright:latest", description="Default OpenSandbox runtime image for browser automation workloads")

--- a/maritime-ai-service/app/core/config/_settings_feature_fields.py
+++ b/maritime-ai-service/app/core/config/_settings_feature_fields.py
@@ -60,7 +60,7 @@ class FeatureSettingsMixin:
 
     # LangSmith Observability
     enable_langsmith: bool = Field(default=False, description="Enable LangSmith tracing")
-    langsmith_api_key: Optional[str] = Field(default=None, description="LangSmith API key")
+    langsmith_api_key: Optional[str] = Field(default=None, description="LangSmith API key", repr=False)
     langsmith_project: str = Field(default="wiii", description="LangSmith project name")
     langsmith_endpoint: str = Field(default="https://api.smith.langchain.com", description="LangSmith API endpoint")
 
@@ -85,12 +85,12 @@ class FeatureSettingsMixin:
     living_agent_max_skills_per_week: int = Field(default=5, ge=1, le=20, description="Max new skills to discover per week")
     living_agent_max_searches_per_heartbeat: int = Field(default=3, ge=1, le=10, description="Max web searches per heartbeat cycle")
     living_agent_max_daily_cycles: int = Field(default=48, ge=1, le=200, description="Max heartbeat cycles per 24h")
-    living_agent_callmebot_api_key: Optional[str] = Field(default=None, description="CallMeBot API key for Facebook Messenger notifications")
+    living_agent_callmebot_api_key: Optional[str] = Field(default=None, description="CallMeBot API key for Facebook Messenger notifications", repr=False)
     living_agent_notification_channel: str = Field(default="websocket", description="Notification channel for heartbeat discoveries (websocket, telegram, messenger)")
 
     # Soul AGI: Weather (Phase 1B)
     living_agent_enable_weather: bool = Field(default=False, description="Enable weather awareness via OpenWeatherMap")
-    living_agent_weather_api_key: Optional[str] = Field(default=None, description="OpenWeatherMap API key")
+    living_agent_weather_api_key: Optional[str] = Field(default=None, description="OpenWeatherMap API key", repr=False)
     living_agent_weather_city: str = Field(default="Ho Chi Minh City", description="Default city for weather queries")
 
     # Soul AGI: Briefing (Phase 2A)
@@ -134,13 +134,13 @@ class FeatureSettingsMixin:
     cross_platform_context_max_items: int = Field(default=3, ge=1, le=10, description="Max items in cross-platform activity summary")
 
     # Facebook Messenger (for webhooks)
-    facebook_verify_token: Optional[str] = Field(default=None, description="Facebook webhook verification token")
-    facebook_page_access_token: Optional[str] = Field(default=None, description="Facebook Page access token for Send API")
+    facebook_verify_token: Optional[str] = Field(default=None, description="Facebook webhook verification token", repr=False)
+    facebook_page_access_token: Optional[str] = Field(default=None, description="Facebook Page access token for Send API", repr=False)
     facebook_graph_api_version: str = Field(default="v22.0", description="Facebook Graph API version (Sprint 188)")
 
     # Zalo OA
-    zalo_oa_access_token: Optional[str] = Field(default=None, description="Zalo OA access token")
-    zalo_oa_secret_key: Optional[str] = Field(default=None, description="Zalo OA secret key for MAC verification")
+    zalo_oa_access_token: Optional[str] = Field(default=None, description="Zalo OA access token", repr=False)
+    zalo_oa_secret_key: Optional[str] = Field(default=None, description="Zalo OA secret key for MAC verification", repr=False)
 
     # Preview System (Sprint 166)
     enable_preview: bool = Field(default=True, description="Rich preview cards in streaming responses")
@@ -150,8 +150,8 @@ class FeatureSettingsMixin:
 
     # Product Search Agent
     enable_product_search: bool = Field(default=True, description="Enable product search agent")
-    serper_api_key: Optional[str] = Field(default=None, description="Serper.dev API key")
-    apify_api_token: Optional[str] = Field(default=None, description="Apify API token")
+    serper_api_key: Optional[str] = Field(default=None, description="Serper.dev API key", repr=False)
+    apify_api_token: Optional[str] = Field(default=None, description="Apify API token", repr=False)
 
     # Site Playbooks (Firecrawl pattern)
     enable_site_playbooks: bool = Field(default=True, description="Enable YAML-driven site playbooks for scraping config")
@@ -177,7 +177,7 @@ class FeatureSettingsMixin:
     )
     enable_tiktok_native_api: bool = Field(default=False, description="Enable TikTok Research API")
     tiktok_client_key: Optional[str] = Field(default=None, description="TikTok Developer Portal client key")
-    tiktok_client_secret: Optional[str] = Field(default=None, description="TikTok Developer Portal client secret")
+    tiktok_client_secret: Optional[str] = Field(default=None, description="TikTok Developer Portal client secret", repr=False)
 
     # Sprint 150: Deep Product Search
     product_search_max_iterations: int = Field(default=15, ge=5, le=30, description="Max ReAct iterations")
@@ -368,7 +368,7 @@ class FeatureSettingsMixin:
 
     # OAuth skeleton
     enable_oauth_token_store: bool = Field(default=False, description="Enable OAuth token store")
-    oauth_encryption_key: Optional[str] = Field(default=None, description="Fernet encryption key for OAuth tokens")
+    oauth_encryption_key: Optional[str] = Field(default=None, description="Fernet encryption key for OAuth tokens", repr=False)
 
     # Quality & Model Config
     quality_skip_threshold: float = Field(default=0.85, description="Skip grader when confidence >= this")

--- a/maritime-ai-service/app/core/config/llm.py
+++ b/maritime-ai-service/app/core/config/llm.py
@@ -1,7 +1,7 @@
 """LLMConfig — LLM provider settings (Gemini, OpenAI, Ollama)."""
 from typing import Any, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.engine.model_catalog import (
     GOOGLE_DEEP_MODEL,
@@ -32,14 +32,14 @@ class LLMConfig(BaseModel):
     stream_keepalive_interval_seconds: float = 15.0
     stream_idle_timeout_seconds: float = 0.0
     timeout_provider_overrides: dict[str, dict[str, Any]] = {}
-    google_api_key: Optional[str] = None
+    google_api_key: Optional[str] = Field(default=None, repr=False)
     google_model: str = GOOGLE_DEFAULT_MODEL
     google_model_advanced: str = GOOGLE_DEEP_MODEL
-    openai_api_key: Optional[str] = None
+    openai_api_key: Optional[str] = Field(default=None, repr=False)
     openai_base_url: Optional[str] = None
-    openrouter_api_key: Optional[str] = None
+    openrouter_api_key: Optional[str] = Field(default=None, repr=False)
     openrouter_base_url: Optional[str] = OPENROUTER_DEFAULT_BASE_URL
-    nvidia_api_key: Optional[str] = None
+    nvidia_api_key: Optional[str] = Field(default=None, repr=False)
     nvidia_base_url: Optional[str] = NVIDIA_DEFAULT_BASE_URL
     openai_model: str = OPENAI_DEFAULT_MODEL
     openai_model_advanced: str = OPENAI_DEFAULT_MODEL_ADVANCED
@@ -56,12 +56,12 @@ class LLMConfig(BaseModel):
     openrouter_data_collection: Optional[str] = None
     openrouter_zdr: Optional[bool] = None
     openrouter_provider_sort: Optional[str] = None
-    ollama_api_key: Optional[str] = None
+    ollama_api_key: Optional[str] = Field(default=None, repr=False)
     ollama_base_url: Optional[str] = "http://localhost:11434"
     ollama_model: str = "qwen3:4b-instruct-2507-q4_K_M"
     ollama_keep_alive: Optional[str] = "30m"
     ollama_thinking_models: list[str] = ["qwen3", "deepseek-r1", "qwq"]
-    zhipu_api_key: Optional[str] = None
+    zhipu_api_key: Optional[str] = Field(default=None, repr=False)
     zhipu_base_url: str = "https://open.bigmodel.cn/api/paas/v4"
     zhipu_model: str = ZHIPU_DEFAULT_MODEL
     zhipu_model_advanced: str = ZHIPU_DEFAULT_MODEL_ADVANCED

--- a/maritime-ai-service/app/core/logging_config.py
+++ b/maritime-ai-service/app/core/logging_config.py
@@ -63,8 +63,16 @@ def setup_logging(*, json_output: bool = False, log_level: str = "INFO") -> None
     root.addHandler(handler)
     root.setLevel(getattr(logging, log_level.upper(), logging.INFO))
 
-    # Silence noisy third-party loggers
-    for noisy in ("httpcore", "httpx", "urllib3", "asyncio"):
+    # Silence noisy third-party loggers. OpenAI-compatible SDKs can log full
+    # request payloads/URLs at INFO, which is too risky for production logs.
+    for noisy in (
+        "httpcore",
+        "httpx",
+        "openai",
+        "openai._base_client",
+        "urllib3",
+        "asyncio",
+    ):
         logging.getLogger(noisy).setLevel(logging.WARNING)
 
     # Local dev: keep MCP dependency chatter out of startup logs.

--- a/maritime-ai-service/app/core/middleware.py
+++ b/maritime-ai-service/app/core/middleware.py
@@ -13,17 +13,20 @@ SOTA 2026: Every production service must propagate correlation IDs.
 """
 
 import logging
+import re
 import uuid
+from pathlib import Path
 
 import structlog
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
+from starlette.responses import FileResponse, JSONResponse, Response
 
 logger = logging.getLogger(__name__)
 
 # Subdomains that should NOT be treated as org slugs
 _RESERVED_SUBDOMAINS = frozenset({"www", "api", "admin", "app", "mail", "static", "cdn"})
+_EMBED_HASHED_ASSET_RE = re.compile(r"^(?P<prefix>.+)-(?P<hash>[A-Za-z0-9_-]+)\.(?P<ext>js|css)$")
 
 
 def extract_org_from_subdomain(host: str, base_domain: str) -> str | None:
@@ -57,11 +60,41 @@ def extract_org_from_subdomain(host: str, base_domain: str) -> str | None:
     return subdomain
 
 
+def _embed_asset_roots() -> list[Path]:
+    return [
+        Path("/app-embed"),
+        Path(__file__).resolve().parents[3] / "wiii-desktop" / "dist-embed",
+    ]
+
+
+def _find_embed_asset_replacement(path: str, roots: list[Path] | None = None) -> Path | None:
+    """Find the current dev asset for a stale hashed embed chunk request."""
+    filename = path.rsplit("/", 1)[-1]
+    match = _EMBED_HASHED_ASSET_RE.match(filename)
+    if not match:
+        return None
+
+    prefix = match.group("prefix")
+    extension = match.group("ext")
+    for root in roots or _embed_asset_roots():
+        assets_dir = root / "assets"
+        if not assets_dir.exists():
+            continue
+        matches = sorted(assets_dir.glob(f"{prefix}-*.{extension}"))
+        existing = [candidate for candidate in matches if candidate.is_file()]
+        if len(existing) == 1:
+            return existing[0]
+    return None
+
+
 class EmbedCSPMiddleware(BaseHTTPMiddleware):
     """
     Sprint 220b: Set CSP frame-ancestors on /embed routes to allow iframe embedding.
 
     Without this, browsers block iframing due to X-Frame-Options: DENY (default).
+    Local development also disables browser caching for embed assets. Rebuilding
+    dist-embed changes hashed chunk filenames, and stale cached entry chunks can
+    otherwise request deleted dynamic chunks and break answer rendering.
     Only applies to /embed paths — other routes remain unaffected.
     """
 
@@ -71,6 +104,14 @@ class EmbedCSPMiddleware(BaseHTTPMiddleware):
         if request.url.path.startswith("/embed"):
             from app.core.config import settings
 
+            if (
+                settings.environment != "production"
+                and response.status_code == 404
+                and request.url.path.startswith("/embed/assets/")
+                and (replacement := _find_embed_asset_replacement(request.url.path))
+            ):
+                response = FileResponse(replacement)
+
             origins = settings.embed_allowed_origins.strip()
             if origins:
                 # Space-separated origins → CSP frame-ancestors directive
@@ -79,6 +120,10 @@ class EmbedCSPMiddleware(BaseHTTPMiddleware):
                 frame_ancestors = "frame-ancestors 'self'"
 
             response.headers["Content-Security-Policy"] = frame_ancestors
+            if settings.environment != "production":
+                response.headers["Cache-Control"] = "no-store"
+                response.headers["Pragma"] = "no-cache"
+                response.headers["Expires"] = "0"
             # Remove X-Frame-Options — it conflicts with CSP frame-ancestors
             # and older browsers use it to block iframes
             if "X-Frame-Options" in response.headers:

--- a/maritime-ai-service/app/core/middleware.py
+++ b/maritime-ai-service/app/core/middleware.py
@@ -76,15 +76,15 @@ def _find_embed_asset_replacement(path: str, roots: list[Path] | None = None) ->
 
     prefix = match.group("prefix")
     extension = match.group("ext")
+    candidates: list[Path] = []
     for root in roots or _embed_asset_roots():
         assets_dir = root / "assets"
         if not assets_dir.exists():
             continue
         matches = sorted(assets_dir.glob(f"{prefix}-*.{extension}"))
         existing = [candidate for candidate in matches if candidate.is_file()]
-        if len(existing) == 1:
-            return existing[0]
-    return None
+        candidates.extend(existing)
+    return candidates[0] if len(candidates) == 1 else None
 
 
 class EmbedCSPMiddleware(BaseHTTPMiddleware):

--- a/maritime-ai-service/app/engine/agentic_rag/answer_generator.py
+++ b/maritime-ai-service/app/engine/agentic_rag/answer_generator.py
@@ -23,9 +23,11 @@ import time
 from typing import Any, List, Optional, Tuple
 from unittest.mock import Mock
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
-
-from app.engine.agentic_rag.runtime_llm_socket import ainvoke_agentic_rag_llm
+from app.engine.agentic_rag.runtime_llm_socket import (
+    ainvoke_agentic_rag_llm,
+    make_agentic_rag_messages,
+)
+from app.engine.native_chat_runtime import make_assistant_message
 from app.engine.llm_factory import ThinkingTier
 from app.engine.llm_failover_runtime import is_failover_eligible_error_impl
 from app.models.knowledge_graph import KnowledgeNode
@@ -310,10 +312,10 @@ class AnswerGenerator:
         )
 
         try:
-            messages = [
-                SystemMessage(content=system_prompt),
-                HumanMessage(content=user_prompt)
-            ]
+            messages = make_agentic_rag_messages(
+                system=system_prompt,
+                user=user_prompt,
+            )
 
             # Sprint audit: Timeout-protected invoke. Live runtime now routes this
             # through the shared failover socket so sync RAG answers do not stay
@@ -505,10 +507,10 @@ class AnswerGenerator:
         TOTAL_TIMEOUT = 600  # Max total streaming time (10 min)
 
         try:
-            messages = [
-                SystemMessage(content=system_prompt),
-                HumanMessage(content=user_prompt)
-            ]
+            messages = make_agentic_rag_messages(
+                system=system_prompt,
+                user=user_prompt,
+            )
 
             # P3: Assistant pre-fill to force System 2 activation for Z.ai/GLM
             try:
@@ -520,7 +522,7 @@ class AnswerGenerator:
                     )
                     _msg_dicts = [{"role": getattr(m, "type", "system"), "content": getattr(m, "content", "")} for m in messages]
                     if should_prefill_thinking(_msg_dicts, provider=_llm_provider):
-                        messages.append(AIMessage(content="<thinking>\nPhan tich: "))
+                        messages.append(make_assistant_message("<thinking>\nPhan tich: "))
             except Exception:
                 pass
 

--- a/maritime-ai-service/app/engine/agentic_rag/answer_verifier.py
+++ b/maritime-ai-service/app/engine/agentic_rag/answer_verifier.py
@@ -14,11 +14,10 @@ import logging
 from dataclasses import dataclass
 from typing import List, Optional, Dict, Any
 
-from langchain_core.messages import HumanMessage, SystemMessage
-
 from app.core.singleton import singleton_factory
 from app.engine.agentic_rag.runtime_llm_socket import (
     ainvoke_agentic_rag_llm,
+    make_agentic_rag_messages,
     resolve_agentic_rag_llm,
 )
 from app.engine.llm_factory import ThinkingTier
@@ -157,13 +156,13 @@ class AnswerVerifier:
                 for s in sources[:3]  # Limit to 3 sources
             ])
             
-            messages = [
-                SystemMessage(content="You are a fact-checker. Return only valid JSON."),
-                HumanMessage(content=VERIFY_PROMPT.format(
+            messages = make_agentic_rag_messages(
+                system="You are a fact-checker. Return only valid JSON.",
+                user=VERIFY_PROMPT.format(
                     answer=answer[:1500],  # Limit answer length
-                    sources=source_text
-                ))
-            ]
+                    sources=source_text,
+                ),
+            )
             
             response = await ainvoke_agentic_rag_llm(
                 llm=llm,

--- a/maritime-ai-service/app/engine/agentic_rag/answer_verifier.py
+++ b/maritime-ai-service/app/engine/agentic_rag/answer_verifier.py
@@ -157,7 +157,7 @@ class AnswerVerifier:
             ])
             
             messages = make_agentic_rag_messages(
-                system="You are a fact-checker. Return only valid JSON.",
+                system="Bạn là bộ kiểm chứng thông tin. Chỉ trả về JSON hợp lệ.",
                 user=VERIFY_PROMPT.format(
                     answer=answer[:1500],  # Limit answer length
                     sources=source_text,

--- a/maritime-ai-service/app/engine/agentic_rag/corrective_rag_generation.py
+++ b/maritime-ai-service/app/engine/agentic_rag/corrective_rag_generation.py
@@ -65,18 +65,26 @@ async def generate_fallback_impl(
     query: str,
     context: dict[str, Any],
     settings_obj: Any,
-) -> str:
+) -> tuple[str, Optional[str]]:
     """Generate an answer from model general knowledge when RAG has no docs."""
     try:
+        from app.engine.agentic_rag.runtime_llm_socket import (
+            ainvoke_agentic_rag_llm,
+            make_agentic_rag_messages,
+            resolve_agentic_rag_llm,
+        )
+        from app.engine.llm_factory import ThinkingTier
         from app.engine.llm_pool import get_llm_light
         from app.prompts.prompt_loader import get_prompt_loader
         from app.services.output_processor import extract_thinking_from_response
-        from langchain_core.messages import HumanMessage, SystemMessage
 
-        # Prefer pool directly — the runtime socket may have stale failover chains
-        llm = get_llm_light()
+        llm = resolve_agentic_rag_llm(
+            tier=ThinkingTier.LIGHT,
+            fallback_factory=get_llm_light,
+            component="CorrectiveRAGFallback",
+        )
         if not llm:
-            return ""
+            return "", None
 
         domain_name = resolve_fallback_domain_name(context, settings_obj)
 
@@ -107,11 +115,16 @@ async def generate_fallback_impl(
             web_context=web_context,
         )
 
-        messages = [
-            SystemMessage(content=sys_content),
-            HumanMessage(content=query),
-        ]
-        response = await llm.ainvoke(messages)
+        messages = make_agentic_rag_messages(
+            system=sys_content,
+            user=query,
+        )
+        response = await ainvoke_agentic_rag_llm(
+            llm=llm,
+            messages=messages,
+            tier=ThinkingTier.LIGHT,
+            component="CorrectiveRAGFallback",
+        )
         text, native_thinking = extract_thinking_from_response(response.content)
         text = text.strip()
 
@@ -125,7 +138,7 @@ async def generate_fallback_impl(
         return (text or build_house_fallback_reply(), native_thinking)
     except Exception as exc:
         logger.warning("[CRAG] Fallback generation failed: %s", exc)
-        return build_house_fallback_reply()
+        return build_house_fallback_reply(), None
 
 
 async def generate_answer_impl(

--- a/maritime-ai-service/app/engine/agentic_rag/corrective_rag_stream_runtime.py
+++ b/maritime-ai-service/app/engine/agentic_rag/corrective_rag_stream_runtime.py
@@ -5,12 +5,29 @@ Keeps the main CorrectiveRAG class focused on orchestration and ownership while
 the large streaming implementation lives in a dedicated module.
 """
 
+import asyncio
 import logging
 import time
 from typing import Any, AsyncGenerator, Dict, Optional
 
+from app.engine.agentic_rag.runtime_llm_socket import (
+    ainvoke_agentic_rag_llm,
+    make_agentic_rag_messages,
+    resolve_agentic_rag_llm,
+)
+from app.engine.llm_factory import ThinkingTier
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_crag_light_llm(component: str):
+    from app.engine.llm_pool import get_llm_light
+
+    return resolve_agentic_rag_llm(
+        tier=ThinkingTier.LIGHT,
+        fallback_factory=get_llm_light,
+        component=component,
+    )
 
 
 def _build_soul_system_prompt(
@@ -68,6 +85,9 @@ async def _stream_llm_with_thinking(
     """
     full_answer = ""
     _tag_state = {"inside_thinking": False, "pending": ""}
+    stream_start = time.time()
+    chunk_timeout = 60
+    total_timeout = 240
 
     def _extract_tagged_thinking(text: str) -> tuple[str, str]:
         """Split <thinking> tags from streamed text. Returns (reasoning, visible)."""
@@ -111,8 +131,88 @@ async def _stream_llm_with_thinking(
         _tag_state["inside_thinking"] = inside
         return "".join(reasoning_parts), "".join(visible_parts)
 
+    if getattr(llm, "_wiii_native_route", False):
+        try:
+            from app.engine.multi_agent.openai_stream_runtime import (
+                _create_openai_compatible_stream_client_impl,
+                _extract_openai_delta_text_impl,
+                _resolve_openai_stream_model_name_impl,
+            )
+            from app.engine.native_chat_runtime import message_to_openai_payload
+
+            provider_name = str(getattr(llm, "_wiii_provider_name", "") or "").strip().lower()
+            tier_key = str(getattr(llm, "_wiii_tier_key", "") or "light").strip().lower()
+            client = _create_openai_compatible_stream_client_impl(provider_name)
+            model_name = _resolve_openai_stream_model_name_impl(llm, provider_name, tier_key)
+            if client is not None and model_name:
+                request_kwargs: dict[str, Any] = {
+                    "model": model_name,
+                    "messages": [message_to_openai_payload(message) for message in messages],
+                    "stream": True,
+                }
+                temperature = getattr(llm, "temperature", None)
+                if temperature is not None:
+                    request_kwargs["temperature"] = temperature
+
+                stream = await client.chat.completions.create(**request_kwargs)
+                stream_iter = stream.__aiter__()
+                while True:
+                    if time.time() - stream_start > total_timeout:
+                        logger.warning("[CRAG-V3] Native LLM stream total timeout")
+                        break
+                    try:
+                        chunk = await asyncio.wait_for(
+                            stream_iter.__anext__(),
+                            timeout=chunk_timeout,
+                        )
+                    except StopAsyncIteration:
+                        break
+                    except asyncio.TimeoutError:
+                        logger.warning("[CRAG-V3] Native LLM stream chunk timeout")
+                        break
+                    for choice in getattr(chunk, "choices", []) or []:
+                        delta = getattr(choice, "delta", None)
+                        if delta is None:
+                            continue
+                        reasoning, content = _extract_openai_delta_text_impl(delta)
+                        if content:
+                            tagged_reasoning, visible = _extract_tagged_thinking(content)
+                            if tagged_reasoning:
+                                reasoning = f"{reasoning}{tagged_reasoning}"
+                            content = visible
+                        if reasoning:
+                            yield {"type": "thinking_delta", "content": reasoning}
+                        if content:
+                            full_answer += content
+                            yield {"type": "answer", "content": content}
+                if full_answer:
+                    return
+        except Exception as native_stream_exc:
+            logger.warning(
+                "[CRAG-V3] Native LLM stream failed, falling back to invoke: %s",
+                native_stream_exc,
+            )
+
     try:
-        async for chunk in llm.astream(messages):
+        aiter = llm.astream(messages).__aiter__()
+        while True:
+            if time.time() - stream_start > total_timeout:
+                logger.warning("[CRAG-V3] LLM astream total timeout")
+                if not full_answer:
+                    raise TimeoutError("CRAG LLM stream timed out before first answer chunk")
+                break
+            try:
+                chunk = await asyncio.wait_for(
+                    aiter.__anext__(),
+                    timeout=chunk_timeout,
+                )
+            except StopAsyncIteration:
+                break
+            except asyncio.TimeoutError:
+                logger.warning("[CRAG-V3] LLM astream chunk timeout")
+                if not full_answer:
+                    raise TimeoutError("CRAG LLM stream chunk timed out before first answer chunk")
+                break
             content = chunk.content if hasattr(chunk, "content") else str(chunk)
 
             # Handle list content (Gemini native format)
@@ -147,7 +247,12 @@ async def _stream_llm_with_thinking(
         logger.warning("[CRAG-V3] LLM astream failed, falling back to ainvoke: %s", stream_exc)
         try:
             from app.services.output_processor import extract_thinking_from_response
-            response = await llm.ainvoke(messages)
+            response = await ainvoke_agentic_rag_llm(
+                llm=llm,
+                messages=messages,
+                tier=ThinkingTier.LIGHT,
+                component="CorrectiveRAGStreamInvokeFallback",
+            )
             text, thinking = extract_thinking_from_response(response.content)
             if thinking:
                 yield {"type": "thinking_delta", "content": thinking}
@@ -181,12 +286,10 @@ async def _generate_from_web_context(
     Kept for backward compatibility with callers that need a single string.
     """
     try:
-        from app.engine.llm_pool import get_llm_light
         from app.services.output_processor import extract_thinking_from_response
-        from langchain_core.messages import HumanMessage, SystemMessage
         from app.prompts.prompt_loader import get_prompt_loader
 
-        llm = get_llm_light()
+        llm = _resolve_crag_light_llm("CorrectiveRAGWebContext")
         if not llm:
             fallback_text, _ = await owner._generate_fallback(query, context)
             return fallback_text
@@ -200,11 +303,16 @@ async def _generate_from_web_context(
         system_prompt = _build_soul_system_prompt(
             personality, name_hint, context_type="web"
         )
-        messages = [
-            SystemMessage(content=system_prompt),
-            HumanMessage(content=f"{web_context}\n\nCâu hỏi: {query}"),
-        ]
-        response = await llm.ainvoke(messages)
+        messages = make_agentic_rag_messages(
+            system=system_prompt,
+            user=f"{web_context}\n\nCâu hỏi: {query}",
+        )
+        response = await ainvoke_agentic_rag_llm(
+            llm=llm,
+            messages=messages,
+            tier=ThinkingTier.LIGHT,
+            component="CorrectiveRAGWebContext",
+        )
         text, _ = extract_thinking_from_response(response.content)
         return text.strip() if text else ""
 
@@ -431,11 +539,9 @@ async def process_streaming_impl(
                 yield {"type": "status", "content": "Đang tạo câu trả lời từ kết quả web"}
 
                 try:
-                    from app.engine.llm_pool import get_llm_light
-                    from langchain_core.messages import HumanMessage, SystemMessage
                     from app.prompts.prompt_loader import get_prompt_loader
 
-                    _llm = get_llm_light()
+                    _llm = _resolve_crag_light_llm("CorrectiveRAGWebStream")
                     _loader = get_prompt_loader()
                     _identity = _loader.get_identity().get("identity", {})
                     _personality = _identity.get("personality", {}).get("summary", "")
@@ -443,10 +549,10 @@ async def process_streaming_impl(
                     _nhint = f"User tên {_uname}. " if _uname else ""
 
                     _sys = _build_soul_system_prompt(_personality, _nhint, context_type="web")
-                    _msgs = [
-                        SystemMessage(content=_sys),
-                        HumanMessage(content=f"{_web_context}\n\nCâu hỏi: {query}"),
-                    ]
+                    _msgs = make_agentic_rag_messages(
+                        system=_sys,
+                        user=f"{_web_context}\n\nCâu hỏi: {query}",
+                    )
 
                     web_answer = ""
                     if _llm:
@@ -485,11 +591,9 @@ async def process_streaming_impl(
 
                 fallback_answer = ""
                 try:
-                    from app.engine.llm_pool import get_llm_light
-                    from langchain_core.messages import HumanMessage, SystemMessage
                     from app.prompts.prompt_loader import get_prompt_loader
 
-                    _llm = get_llm_light()
+                    _llm = _resolve_crag_light_llm("CorrectiveRAGIntrinsicFallback")
                     _loader = get_prompt_loader()
                     _identity = _loader.get_identity().get("identity", {})
                     _personality = _identity.get("personality", {}).get("summary", "")
@@ -497,10 +601,10 @@ async def process_streaming_impl(
                     _nhint = f"User tên {_uname}. " if _uname else ""
 
                     _sys = _build_soul_system_prompt(_personality, _nhint, context_type="fallback")
-                    _msgs = [
-                        SystemMessage(content=_sys),
-                        HumanMessage(content=query),
-                    ]
+                    _msgs = make_agentic_rag_messages(
+                        system=_sys,
+                        user=query,
+                    )
 
                     if _llm:
                         async for evt in _stream_llm_with_thinking(_llm, _msgs, owner, query, context or {}):
@@ -592,11 +696,9 @@ async def process_streaming_impl(
 
             fallback_answer = ""
             try:
-                from app.engine.llm_pool import get_llm_light
-                from langchain_core.messages import HumanMessage, SystemMessage
                 from app.prompts.prompt_loader import get_prompt_loader
 
-                _llm = get_llm_light()
+                _llm = _resolve_crag_light_llm("CorrectiveRAGNoDocsFallback")
                 _loader = get_prompt_loader()
                 _identity = _loader.get_identity().get("identity", {})
                 _personality = _identity.get("personality", {}).get("summary", "")
@@ -604,10 +706,10 @@ async def process_streaming_impl(
                 _nhint = f"User tên {_uname}. " if _uname else ""
 
                 _sys = _build_soul_system_prompt(_personality, _nhint, context_type="fallback")
-                _msgs = [
-                    SystemMessage(content=_sys),
-                    HumanMessage(content=query),
-                ]
+                _msgs = make_agentic_rag_messages(
+                    system=_sys,
+                    user=query,
+                )
 
                 if _llm:
                     async for evt in _stream_llm_with_thinking(_llm, _msgs, owner, query, context or {}):

--- a/maritime-ai-service/app/engine/agentic_rag/corrective_rag_surface.py
+++ b/maritime-ai-service/app/engine/agentic_rag/corrective_rag_surface.py
@@ -56,11 +56,11 @@ async def translate_to_vietnamese(text: str) -> str:
     try:
         from app.engine.agentic_rag.runtime_llm_socket import (
             ainvoke_agentic_rag_llm,
+            make_agentic_rag_messages,
             resolve_agentic_rag_llm,
         )
         from app.engine.llm_factory import ThinkingTier
         from app.engine.llm_pool import get_llm_light
-        from langchain_core.messages import HumanMessage, SystemMessage
 
         llm = resolve_agentic_rag_llm(
             tier=ThinkingTier.LIGHT,
@@ -70,16 +70,16 @@ async def translate_to_vietnamese(text: str) -> str:
         if not llm:
             return text
 
-        messages = [
-            SystemMessage(content=(
+        messages = make_agentic_rag_messages(
+            system=(
                 "Dịch đoạn văn sau sang tiếng Việt tự nhiên, chính xác. "
                 "Giữ nguyên thuật ngữ chuyên ngành hàng hải/giao thông bằng tiếng Anh "
                 "nếu cần (ví dụ: COLREGs, SOLAS, starboard). "
                 "CHỈ trả lời bản dịch tiếng Việt, KHÔNG thêm giải thích hay ghi chú. "
                 "KHÔNG bao gồm quá trình suy nghĩ."
-            )),
-            HumanMessage(content=text),
-        ]
+            ),
+            user=text,
+        )
         response = await ainvoke_agentic_rag_llm(
             llm=llm,
             messages=messages,

--- a/maritime-ai-service/app/engine/agentic_rag/hyde_generator.py
+++ b/maritime-ai-service/app/engine/agentic_rag/hyde_generator.py
@@ -127,12 +127,19 @@ async def _generate_hypothetical_doc(query: str) -> str:
         Hypothetical document text, or empty string on failure.
     """
     try:
-        from app.engine.agentic_rag.runtime_llm_socket import ainvoke_agentic_rag_llm
+        from app.engine.agentic_rag.runtime_llm_socket import (
+            ainvoke_agentic_rag_llm,
+            make_agentic_rag_messages,
+            resolve_agentic_rag_llm,
+        )
         from app.engine.llm_factory import ThinkingTier
         from app.engine.llm_pool import get_llm_light
-        from langchain_core.messages import HumanMessage
 
-        llm = get_llm_light()
+        llm = resolve_agentic_rag_llm(
+            tier=ThinkingTier.LIGHT,
+            fallback_factory=get_llm_light,
+            component="HyDEGenerator",
+        )
         if not llm:
             logger.debug("[HyDE] LLM light tier unavailable")
             return ""
@@ -140,7 +147,7 @@ async def _generate_hypothetical_doc(query: str) -> str:
         prompt = _HYDE_PROMPT_VI.format(query=query)
         response = await ainvoke_agentic_rag_llm(
             llm=llm,
-            messages=[HumanMessage(content=prompt)],
+            messages=make_agentic_rag_messages(user=prompt),
             tier=ThinkingTier.LIGHT,
             component="HyDEGenerator",
         )

--- a/maritime-ai-service/app/engine/agentic_rag/query_analyzer.py
+++ b/maritime-ai-service/app/engine/agentic_rag/query_analyzer.py
@@ -131,7 +131,7 @@ class QueryAnalyzer:
         try:
             # Use LLM for analysis
             messages = make_agentic_rag_messages(
-                system="You are a query analyzer. Return only valid JSON.",
+                system="Bạn là bộ phân tích truy vấn. Chỉ trả về JSON hợp lệ.",
                 user=ANALYSIS_PROMPT.format(query=query),
             )
             

--- a/maritime-ai-service/app/engine/agentic_rag/query_analyzer.py
+++ b/maritime-ai-service/app/engine/agentic_rag/query_analyzer.py
@@ -15,11 +15,10 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 from enum import Enum
 
-from langchain_core.messages import HumanMessage, SystemMessage
-
 from app.core.singleton import singleton_factory
 from app.engine.agentic_rag.runtime_llm_socket import (
     ainvoke_agentic_rag_llm,
+    make_agentic_rag_messages,
     resolve_agentic_rag_llm,
 )
 from app.engine.llm_factory import ThinkingTier
@@ -131,10 +130,10 @@ class QueryAnalyzer:
         
         try:
             # Use LLM for analysis
-            messages = [
-                SystemMessage(content="You are a query analyzer. Return only valid JSON."),
-                HumanMessage(content=ANALYSIS_PROMPT.format(query=query))
-            ]
+            messages = make_agentic_rag_messages(
+                system="You are a query analyzer. Return only valid JSON.",
+                user=ANALYSIS_PROMPT.format(query=query),
+            )
             
             response = await ainvoke_agentic_rag_llm(
                 llm=llm,

--- a/maritime-ai-service/app/engine/agentic_rag/query_rewriter.py
+++ b/maritime-ai-service/app/engine/agentic_rag/query_rewriter.py
@@ -12,11 +12,10 @@ Features:
 import logging
 from typing import List, Optional
 
-from langchain_core.messages import HumanMessage, SystemMessage
-
 from app.core.singleton import singleton_factory
 from app.engine.agentic_rag.runtime_llm_socket import (
     ainvoke_agentic_rag_llm,
+    make_agentic_rag_messages,
     resolve_agentic_rag_llm,
 )
 from app.engine.llm_factory import ThinkingTier
@@ -108,13 +107,13 @@ class QueryRewriter:
             return self._rule_based_rewrite(query)
         
         try:
-            messages = [
-                SystemMessage(content="You are a query optimizer. Return only the improved query."),
-                HumanMessage(content=REWRITE_PROMPT.format(
+            messages = make_agentic_rag_messages(
+                system="You are a query optimizer. Return only the improved query.",
+                user=REWRITE_PROMPT.format(
                     query=query,
                     feedback=feedback or "Documents retrieved were not relevant"
-                ))
-            ]
+                ),
+            )
             
             response = await ainvoke_agentic_rag_llm(
                 llm=llm,
@@ -153,9 +152,9 @@ class QueryRewriter:
             return self._add_domain_keywords(query)
         
         try:
-            messages = [
-                HumanMessage(content=EXPAND_PROMPT.format(query=query))
-            ]
+            messages = make_agentic_rag_messages(
+                user=EXPAND_PROMPT.format(query=query),
+            )
             
             response = await ainvoke_agentic_rag_llm(
                 llm=llm,
@@ -188,9 +187,9 @@ class QueryRewriter:
             return [query]  # Can't decompose without LLM
         
         try:
-            messages = [
-                HumanMessage(content=DECOMPOSE_PROMPT.format(query=query))
-            ]
+            messages = make_agentic_rag_messages(
+                user=DECOMPOSE_PROMPT.format(query=query),
+            )
             
             response = await ainvoke_agentic_rag_llm(
                 llm=llm,

--- a/maritime-ai-service/app/engine/agentic_rag/query_rewriter.py
+++ b/maritime-ai-service/app/engine/agentic_rag/query_rewriter.py
@@ -108,7 +108,7 @@ class QueryRewriter:
         
         try:
             messages = make_agentic_rag_messages(
-                system="You are a query optimizer. Return only the improved query.",
+                system="Bạn là bộ tối ưu truy vấn. Chỉ trả về truy vấn đã cải thiện, không giải thích.",
                 user=REWRITE_PROMPT.format(
                     query=query,
                     feedback=feedback or "Documents retrieved were not relevant"

--- a/maritime-ai-service/app/engine/agentic_rag/retrieval_grader.py
+++ b/maritime-ai-service/app/engine/agentic_rag/retrieval_grader.py
@@ -240,7 +240,7 @@ class RetrievalGrader:
         from app.engine.structured_schemas import SingleDocGrade
 
         messages = make_agentic_rag_messages(
-            system="You are a document relevance grader.",
+            system="Bạn là bộ chấm mức độ liên quan của tài liệu.",
             user=GRADING_PROMPT.format(query=query, document=content),
         )
 
@@ -264,7 +264,7 @@ class RetrievalGrader:
     async def _grade_document_legacy(self, query: str, doc_id: str, content: str) -> DocumentGrade:
         """Grade single document using legacy JSON parsing."""
         messages = make_agentic_rag_messages(
-            system="You are a document relevance grader. Return only valid JSON.",
+            system="Bạn là bộ chấm mức độ liên quan của tài liệu. Chỉ trả về JSON hợp lệ.",
             user=GRADING_PROMPT.format(query=query, document=content),
         )
 

--- a/maritime-ai-service/app/engine/agentic_rag/retrieval_grader.py
+++ b/maritime-ai-service/app/engine/agentic_rag/retrieval_grader.py
@@ -14,12 +14,11 @@ import logging
 from dataclasses import dataclass, field
 from typing import List, Optional, Dict, Any
 
-from langchain_core.messages import HumanMessage, SystemMessage
-
 from app.core.constants import DEFAULT_RELEVANCE_THRESHOLD, MAX_CONTENT_SNIPPET_LENGTH, MAX_DOCUMENT_PREVIEW_LENGTH
 from app.core.resilience import retry_on_transient
 from app.engine.agentic_rag.runtime_llm_socket import (
     ainvoke_agentic_rag_llm,
+    make_agentic_rag_messages,
     resolve_agentic_rag_llm,
 )
 from app.engine.llm_factory import ThinkingTier
@@ -240,10 +239,10 @@ class RetrievalGrader:
         """Grade single document using structured output."""
         from app.engine.structured_schemas import SingleDocGrade
 
-        messages = [
-            SystemMessage(content="You are a document relevance grader."),
-            HumanMessage(content=GRADING_PROMPT.format(query=query, document=content))
-        ]
+        messages = make_agentic_rag_messages(
+            system="You are a document relevance grader.",
+            user=GRADING_PROMPT.format(query=query, document=content),
+        )
 
         from app.services.structured_invoke_service import StructuredInvokeService
 
@@ -264,10 +263,10 @@ class RetrievalGrader:
     @retry_on_transient()
     async def _grade_document_legacy(self, query: str, doc_id: str, content: str) -> DocumentGrade:
         """Grade single document using legacy JSON parsing."""
-        messages = [
-            SystemMessage(content="You are a document relevance grader. Return only valid JSON."),
-            HumanMessage(content=GRADING_PROMPT.format(query=query, document=content))
-        ]
+        messages = make_agentic_rag_messages(
+            system="You are a document relevance grader. Return only valid JSON.",
+            user=GRADING_PROMPT.format(query=query, document=content),
+        )
 
         response = await ainvoke_agentic_rag_llm(
             llm=self._llm,

--- a/maritime-ai-service/app/engine/agentic_rag/retrieval_grader_support.py
+++ b/maritime-ai-service/app/engine/agentic_rag/retrieval_grader_support.py
@@ -6,13 +6,14 @@ import json
 import logging
 from typing import Any, Dict, List
 
-from langchain_core.messages import HumanMessage, SystemMessage
-
 from app.core.constants import (
     MAX_CONTENT_SNIPPET_LENGTH,
     MAX_DOCUMENT_PREVIEW_LENGTH,
 )
-from app.engine.agentic_rag.runtime_llm_socket import ainvoke_agentic_rag_llm
+from app.engine.agentic_rag.runtime_llm_socket import (
+    ainvoke_agentic_rag_llm,
+    make_agentic_rag_messages,
+)
 from app.engine.llm_factory import ThinkingTier
 logger = logging.getLogger(__name__)
 
@@ -30,10 +31,10 @@ async def batch_grade_structured_impl(
     """Batch grade using structured output."""
     from app.engine.structured_schemas import BatchDocGrades
 
-    messages = [
-        SystemMessage(content="Grade document relevance for each document."),
-        HumanMessage(content=prompt.format(query=query, documents=docs_text)),
-    ]
+    messages = make_agentic_rag_messages(
+        system="Grade document relevance for each document.",
+        user=prompt.format(query=query, documents=docs_text),
+    )
 
     from app.services.structured_invoke_service import StructuredInvokeService
 
@@ -75,12 +76,10 @@ async def batch_grade_legacy_impl(
     parse_batch_response,
 ):
     """Batch grade using legacy JSON parsing."""
-    messages = [
-        SystemMessage(
-            content="Grade document relevance. Return only valid JSON array."
-        ),
-        HumanMessage(content=prompt.format(query=query, documents=docs_text)),
-    ]
+    messages = make_agentic_rag_messages(
+        system="Grade document relevance. Return only valid JSON array.",
+        user=prompt.format(query=query, documents=docs_text),
+    )
 
     response = await ainvoke_agentic_rag_llm(
         llm=llm,
@@ -211,9 +210,8 @@ async def generate_feedback_impl(
         return f"Low relevance ({avg_score:.1f}/10). Try more specific keywords."
 
     try:
-        messages = [
-            HumanMessage(
-                content=prompt.format(
+        messages = make_agentic_rag_messages(
+            user=prompt.format(
                     query=query,
                     avg_score=f"{avg_score:.1f}",
                     relevant_count=relevant_count,
@@ -221,9 +219,8 @@ async def generate_feedback_impl(
                     issues="; ".join(issues[:3])
                     if issues
                     else "Documents không trực tiếp trả lời query",
-                )
-            )
-        ]
+            ),
+        )
 
         response = await ainvoke_agentic_rag_llm(
             llm=llm,

--- a/maritime-ai-service/app/engine/agentic_rag/runtime_llm_socket.py
+++ b/maritime-ai-service/app/engine/agentic_rag/runtime_llm_socket.py
@@ -8,6 +8,11 @@ from unittest.mock import Mock
 
 from app.engine.llm_factory import ThinkingTier
 from app.engine.llm_pool import ainvoke_with_failover, get_llm_for_provider
+from app.engine.native_chat_runtime import (
+    make_assistant_message,
+    make_system_message,
+    make_user_message,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +23,8 @@ def resolve_agentic_rag_llm(
     cached_llm: Any = None,
     fallback_factory: Optional[Callable[[], Any]] = None,
     component: str = "agentic_rag",
+    node_id: str = "rag_agent",
+    prefer_native: bool = True,
 ) -> Any:
     """Resolve the request-time LLM for an agentic RAG component.
 
@@ -41,6 +48,23 @@ def resolve_agentic_rag_llm(
                 exc,
             )
             return cached_llm
+
+    if prefer_native:
+        try:
+            native_llm = _resolve_native_agentic_rag_llm(
+                node_id=node_id,
+                tier=tier,
+                component=component,
+            )
+            if native_llm is not None:
+                return native_llm
+        except Exception as exc:
+            logger.debug(
+                "[%s] Native %s-tier RAG LLM unavailable: %s",
+                component,
+                getattr(tier, "value", str(tier)),
+                exc,
+            )
 
     try:
         llm = get_llm_for_provider(None, default_tier=tier)
@@ -71,8 +95,60 @@ def resolve_agentic_rag_llm(
     return None
 
 
+def make_agentic_rag_messages(
+    *,
+    user: Any,
+    system: Any | None = None,
+    assistant_prefill: Any | None = None,
+) -> list[Any]:
+    """Build framework-free chat messages for RAG/CRAG model calls."""
+    messages: list[Any] = []
+    if system is not None:
+        messages.append(make_system_message(system))
+    messages.append(make_user_message(user))
+    if assistant_prefill is not None:
+        messages.append(make_assistant_message(assistant_prefill))
+    return messages
+
+
 def _normalize_tier_name(tier: ThinkingTier | str) -> str:
     return str(getattr(tier, "value", tier) or "moderate").strip().lower() or "moderate"
+
+
+def _resolve_native_agentic_rag_llm(
+    *,
+    node_id: str,
+    tier: ThinkingTier | str,
+    component: str,
+) -> Any:
+    """Resolve a native provider handle only when its OpenAI-compatible client exists."""
+    from app.engine.multi_agent.agent_config import AgentConfigRegistry
+    from app.engine.multi_agent.openai_stream_runtime import (
+        _create_openai_compatible_stream_client_impl,
+    )
+
+    tier_name = _normalize_tier_name(tier)
+    native_llm = AgentConfigRegistry.get_native_llm(
+        node_id,
+        effort_override=tier_name,
+    )
+    provider_name = str(getattr(native_llm, "_wiii_provider_name", "") or "").strip().lower()
+    if not native_llm or not provider_name:
+        return None
+
+    # AgentConfigRegistry can create a metadata-only native handle. Keep runtime
+    # fail-closed unless credentials/client config are actually present.
+    if _create_openai_compatible_stream_client_impl(provider_name) is None:
+        return None
+
+    logger.info(
+        "[%s] Using native RAG LLM: provider=%s model=%s tier=%s",
+        component,
+        provider_name,
+        getattr(native_llm, "_wiii_model_name", "unknown"),
+        tier_name,
+    )
+    return native_llm
 
 
 async def ainvoke_agentic_rag_llm(
@@ -98,14 +174,17 @@ async def ainvoke_agentic_rag_llm(
         return await llm.ainvoke(messages)
 
     tier_name = _normalize_tier_name(tier)
+    effective_provider = provider
+    if not effective_provider and getattr(llm, "_wiii_native_route", False):
+        effective_provider = getattr(llm, "_wiii_provider_name", None)
     try:
         return await ainvoke_with_failover(
             llm,
             messages,
             tier=tier_name,
-            provider=provider,
+            provider=effective_provider,
             failover_mode="auto",
-            prefer_selectable_fallback=provider in {None, "", "auto"},
+            prefer_selectable_fallback=effective_provider in {None, "", "auto"},
             primary_timeout=primary_timeout,
             timeout_profile=timeout_profile,
         )

--- a/maritime-ai-service/app/engine/context/adapters/lms.py
+++ b/maritime-ai-service/app/engine/context/adapters/lms.py
@@ -119,6 +119,31 @@ class LMSHostAdapter(HostAdapter):
             if labels:
                 parts.append(f"  <entity_refs>{' | '.join(labels)}</entity_refs>")
 
+        available_targets = metadata.get("available_targets")
+        if isinstance(available_targets, list):
+            target_labels: list[str] = []
+            for target in available_targets[:24]:
+                if not isinstance(target, dict):
+                    continue
+                target_id = str(target.get("id", "")).strip()
+                if not target_id:
+                    continue
+                label = str(target.get("label", "")).strip()
+                selector = str(target.get("selector", "")).strip()
+                text = target_id
+                if label:
+                    text = f'{text}="{label[:80]}"'
+                if selector and selector != target_id:
+                    text = f"{text} selector={selector}"
+                if target.get("click_safe") is True:
+                    click_kind = str(target.get("click_kind", "")).strip()
+                    text = f"{text} click_safe=true"
+                    if click_kind:
+                        text = f"{text} click_kind={click_kind}"
+                target_labels.append(text)
+            if target_labels:
+                parts.append(f"  <available_targets>{' | '.join(target_labels)}</available_targets>")
+
         if ctx.available_actions:
             labels = [
                 (

--- a/maritime-ai-service/app/engine/context/adapters/lms.py
+++ b/maritime-ai-service/app/engine/context/adapters/lms.py
@@ -1,5 +1,7 @@
 """LMS Host Adapter - Vietnamese prompt formatting with role/stage awareness."""
 
+import html
+
 from app.engine.context.adapters.base import HostAdapter
 from app.engine.context.host_context import HostContext
 
@@ -38,6 +40,13 @@ _PAGE_SKILL_MAP: dict[str, list[str]] = {
     "admin_page": ["lms-org-admin-governance", "lms-system-admin-ops"],
     "teacher_page": ["lms-teacher-course-editor"],
 }
+
+
+def _escape_target_field(value: object, *, max_length: int | None = None) -> str:
+    text = str(value or "").strip().replace("|", "/")
+    if max_length is not None:
+        text = text[:max_length]
+    return html.escape(text, quote=True)
 
 
 class LMSHostAdapter(HostAdapter):
@@ -125,18 +134,18 @@ class LMSHostAdapter(HostAdapter):
             for target in available_targets[:24]:
                 if not isinstance(target, dict):
                     continue
-                target_id = str(target.get("id", "")).strip()
+                target_id = _escape_target_field(target.get("id"), max_length=80)
                 if not target_id:
                     continue
-                label = str(target.get("label", "")).strip()
-                selector = str(target.get("selector", "")).strip()
+                label = _escape_target_field(target.get("label"), max_length=80)
+                selector = _escape_target_field(target.get("selector"), max_length=200)
                 text = target_id
                 if label:
-                    text = f'{text}="{label[:80]}"'
+                    text = f'{text}="{label}"'
                 if selector and selector != target_id:
                     text = f"{text} selector={selector}"
                 if target.get("click_safe") is True:
-                    click_kind = str(target.get("click_kind", "")).strip()
+                    click_kind = _escape_target_field(target.get("click_kind"), max_length=40)
                     text = f"{text} click_safe=true"
                     if click_kind:
                         text = f"{text} click_kind={click_kind}"

--- a/maritime-ai-service/app/engine/context/pointy_actions.py
+++ b/maritime-ai-service/app/engine/context/pointy_actions.py
@@ -12,8 +12,9 @@ This file exists as:
 2. A reference shape for ``HostActionDefinition`` payloads that the LMS
    parent should emit via ``wiii:capabilities``.
 
-V1 is read-only: no auto-click, no auto-fill. ``mutates_state`` and
-``requires_confirmation`` are both ``False`` for every Pointy tool.
+V1 is tutor-safe: highlight/scroll/tour plus fail-closed safe-click. ``ui.click``
+only works for host elements explicitly marked ``data-wiii-click-safe="true"``.
+No auto-fill.
 """
 from __future__ import annotations
 
@@ -25,12 +26,14 @@ POINTY_ACTION_HIGHLIGHT = "ui.highlight"
 POINTY_ACTION_SCROLL_TO = "ui.scroll_to"
 POINTY_ACTION_NAVIGATE = "ui.navigate"
 POINTY_ACTION_SHOW_TOUR = "ui.show_tour"
+POINTY_ACTION_CLICK = "ui.click"
 
 POINTY_ACTIONS: tuple[str, ...] = (
     POINTY_ACTION_HIGHLIGHT,
     POINTY_ACTION_SCROLL_TO,
     POINTY_ACTION_NAVIGATE,
     POINTY_ACTION_SHOW_TOUR,
+    POINTY_ACTION_CLICK,
 )
 
 
@@ -144,6 +147,34 @@ def reference_capabilities() -> dict[str, Any]:
                 "mutates_state": False,
                 "requires_confirmation": False,
             },
+            {
+                "name": POINTY_ACTION_CLICK,
+                "description": (
+                    "Click an LMS element only when host context marks it "
+                    'data-wiii-click-safe="true". Fail closed for unsafe, disabled, '
+                    "payment, enrollment, submit, destructive, or unlisted targets."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "selector": {
+                            "type": "string",
+                            "description": (
+                                "Stable data-wiii-id or CSS selector from available_targets. "
+                                "Use only when the target has click_safe=true."
+                            ),
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "Short tooltip shown just before the click.",
+                        },
+                    },
+                    "required": ["selector"],
+                },
+                "surface": "page",
+                "mutates_state": False,
+                "requires_confirmation": False,
+            },
         ],
     }
 
@@ -154,6 +185,7 @@ __all__ = [
     "POINTY_ACTION_SCROLL_TO",
     "POINTY_ACTION_NAVIGATE",
     "POINTY_ACTION_SHOW_TOUR",
+    "POINTY_ACTION_CLICK",
     "POINTY_ACTIONS",
     "reference_capabilities",
 ]

--- a/maritime-ai-service/app/engine/context/pointy_fast_path.py
+++ b/maritime-ai-service/app/engine/context/pointy_fast_path.py
@@ -118,7 +118,9 @@ def get_pointy_targets_from_context(context: dict[str, Any] | None) -> list[dict
     host_page = host_context.get("page") if isinstance(host_context.get("page"), dict) else {}
     host_metadata = host_page.get("metadata") if isinstance(host_page.get("metadata"), dict) else {}
     page_context = ctx.get("page_context") if isinstance(ctx.get("page_context"), dict) else {}
-    raw_targets = host_metadata.get("available_targets") or page_context.get("available_targets")
+    raw_targets = host_metadata.get("available_targets")
+    if raw_targets is None:
+        raw_targets = page_context.get("available_targets")
     if not isinstance(raw_targets, list):
         return []
     return [target for item in raw_targets if (target := _coerce_target(item))]
@@ -199,7 +201,7 @@ def build_pointy_fast_path_action(
             "action": POINTY_ACTION_CLICK,
             "params": {
                 "selector": target["id"],
-                "message": f"Wiii dang mo {label} cho ban.",
+                "message": f"Wiii đang mở {label} cho bạn.",
                 "source": POINTY_FAST_PATH_SOURCE,
             },
             "target": target,
@@ -211,7 +213,7 @@ def build_pointy_fast_path_action(
         "action": POINTY_ACTION_HIGHLIGHT,
         "params": {
             "selector": target["id"],
-            "message": f"Day la {label}. Wiii tro vao de ban thay ngay.",
+            "message": f"Đây là {label}. Wiii trỏ vào để bạn thấy ngay.",
             "duration_ms": 5600 if wants_click else 5200,
             "source": POINTY_FAST_PATH_SOURCE,
         },

--- a/maritime-ai-service/app/engine/context/pointy_fast_path.py
+++ b/maritime-ai-service/app/engine/context/pointy_fast_path.py
@@ -1,0 +1,228 @@
+"""Fast local Pointy intent matching for host UI guidance.
+
+This is intentionally conservative. It exists to emit safe UI guidance before
+the slower model/router path decides whether to call a host action tool.
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+import uuid
+from typing import Any
+
+from app.engine.context.pointy_actions import POINTY_ACTION_CLICK, POINTY_ACTION_HIGHLIGHT
+
+POINTY_FAST_PATH_SOURCE = "pointy_fast_path"
+
+_LOCATE_TERMS = (
+    "o dau",
+    "where",
+    "chi",
+    "chi cho",
+    "tim",
+    "tro",
+    "highlight",
+    "nut",
+    "button",
+)
+_CLICK_TERMS = (
+    "mo",
+    "bam",
+    "click",
+    "nhan vao",
+    "vao",
+    "di toi",
+    "chuyen toi",
+    "open",
+)
+_UNSAFE_CLICK_TERMS = (
+    "submit",
+    "nop bai",
+    "quiz",
+    "checkout",
+    "payment",
+    "thanh toan",
+    "enroll",
+    "dang ky",
+    "logout",
+    "dang xuat",
+    "delete",
+    "xoa",
+    "mark complete",
+    "hoan thanh",
+)
+
+_TARGET_ALIASES: tuple[tuple[tuple[str, ...], tuple[str, ...]], ...] = (
+    (
+        ("browse-courses", "browse-courses-link", "browse-courses-button"),
+        ("kham pha khoa hoc", "kham pha", "browse courses", "browse"),
+    ),
+    (
+        ("continue-learn", "continue-lesson", "continue-course"),
+        ("tiep tuc hoc", "tiep tuc", "continue learning", "continue"),
+    ),
+    (
+        ("my-courses", "my-courses-link"),
+        ("khoa hoc cua toi", "khoa hoc dang hoc", "my courses"),
+    ),
+    (
+        ("profile-link", "profile-card"),
+        ("ho so", "profile"),
+    ),
+)
+
+
+def normalize_pointy_text(value: str) -> str:
+    normalized = (value or "").replace("đ", "d").replace("Đ", "d")
+    normalized = unicodedata.normalize("NFD", normalized)
+    normalized = "".join(ch for ch in normalized if unicodedata.category(ch) != "Mn")
+    normalized = normalized.replace("đ", "d").replace("Đ", "d").lower()
+    normalized = re.sub(r"[^a-z0-9]+", " ", normalized)
+    return re.sub(r"\s+", " ", normalized).strip()
+
+
+def _has_any_term(prompt: str, terms: tuple[str, ...]) -> bool:
+    return any(term in prompt for term in terms)
+
+
+def _pointy_fast_path_already_ran(context: dict[str, Any] | None) -> bool:
+    feedback = (context or {}).get("host_action_feedback")
+    if not isinstance(feedback, dict):
+        return False
+    last = feedback.get("last_action_result")
+    if not isinstance(last, dict):
+        return False
+    params = last.get("params")
+    return isinstance(params, dict) and params.get("source") == POINTY_FAST_PATH_SOURCE
+
+
+def _coerce_target(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    target_id = str(value.get("id") or "").strip()
+    selector = str(value.get("selector") or "").strip()
+    if not target_id or not selector:
+        return None
+    return {
+        "id": target_id,
+        "selector": selector,
+        "label": str(value.get("label") or "").strip() or None,
+        "click_safe": value.get("click_safe") is True,
+        "click_kind": str(value.get("click_kind") or "").strip() or None,
+    }
+
+
+def get_pointy_targets_from_context(context: dict[str, Any] | None) -> list[dict[str, Any]]:
+    ctx = context or {}
+    host_context = ctx.get("host_context") if isinstance(ctx.get("host_context"), dict) else {}
+    host_page = host_context.get("page") if isinstance(host_context.get("page"), dict) else {}
+    host_metadata = host_page.get("metadata") if isinstance(host_page.get("metadata"), dict) else {}
+    page_context = ctx.get("page_context") if isinstance(ctx.get("page_context"), dict) else {}
+    raw_targets = host_metadata.get("available_targets") or page_context.get("available_targets")
+    if not isinstance(raw_targets, list):
+        return []
+    return [target for item in raw_targets if (target := _coerce_target(item))]
+
+
+def _alias_score(prompt: str, target: dict[str, Any]) -> int:
+    target_id = normalize_pointy_text(str(target.get("id") or ""))
+    for alias_ids, alias_terms in _TARGET_ALIASES:
+        if not any(term in prompt for term in alias_terms):
+            continue
+        if any(normalize_pointy_text(alias_id) in target_id for alias_id in alias_ids):
+            return 40
+    return 0
+
+
+def _target_score(prompt: str, target: dict[str, Any]) -> int:
+    target_id = normalize_pointy_text(str(target.get("id") or ""))
+    selector = normalize_pointy_text(str(target.get("selector") or ""))
+    label = normalize_pointy_text(str(target.get("label") or ""))
+    label_words = [word for word in label.split(" ") if len(word) >= 3]
+
+    score = _alias_score(prompt, target)
+    if label and label in prompt:
+        score += 35
+    if target_id and target_id in prompt:
+        score += 24
+    if selector and selector in prompt:
+        score += 12
+    if label_words:
+        matched = sum(1 for word in label_words if word in prompt)
+        score += matched * 6
+        if matched == len(label_words):
+            score += 12
+    if target.get("click_safe"):
+        score += 2
+    return score
+
+
+def _select_target(prompt: str, targets: list[dict[str, Any]]) -> dict[str, Any] | None:
+    best_target: dict[str, Any] | None = None
+    best_score = 0
+    for target in targets:
+        score = _target_score(prompt, target)
+        if score > best_score:
+            best_target = target
+            best_score = score
+    return best_target if best_score >= 12 else None
+
+
+def _is_unsafe_click_target(prompt: str, target: dict[str, Any]) -> bool:
+    combined = normalize_pointy_text(
+        f"{prompt} {target.get('id') or ''} {target.get('label') or ''} {target.get('click_kind') or ''}"
+    )
+    return _has_any_term(combined, _UNSAFE_CLICK_TERMS)
+
+
+def build_pointy_fast_path_action(
+    prompt: str,
+    context: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if _pointy_fast_path_already_ran(context):
+        return None
+
+    normalized_prompt = normalize_pointy_text(prompt)
+    wants_locate = _has_any_term(normalized_prompt, _LOCATE_TERMS)
+    wants_click = _has_any_term(normalized_prompt, _CLICK_TERMS)
+    if not normalized_prompt or (not wants_locate and not wants_click):
+        return None
+
+    target = _select_target(normalized_prompt, get_pointy_targets_from_context(context))
+    if not target:
+        return None
+
+    label = str(target.get("label") or target["id"])
+    if wants_click and target.get("click_safe") and not _is_unsafe_click_target(normalized_prompt, target):
+        return {
+            "request_id": f"pointy-fast-{uuid.uuid4()}",
+            "action": POINTY_ACTION_CLICK,
+            "params": {
+                "selector": target["id"],
+                "message": f"Wiii dang mo {label} cho ban.",
+                "source": POINTY_FAST_PATH_SOURCE,
+            },
+            "target": target,
+            "reason": "click",
+        }
+
+    return {
+        "request_id": f"pointy-fast-{uuid.uuid4()}",
+        "action": POINTY_ACTION_HIGHLIGHT,
+        "params": {
+            "selector": target["id"],
+            "message": f"Day la {label}. Wiii tro vao de ban thay ngay.",
+            "duration_ms": 5600 if wants_click else 5200,
+            "source": POINTY_FAST_PATH_SOURCE,
+        },
+        "target": target,
+        "reason": "unsafe_click_demoted" if wants_click else "locate",
+    }
+
+
+__all__ = [
+    "POINTY_FAST_PATH_SOURCE",
+    "build_pointy_fast_path_action",
+    "get_pointy_targets_from_context",
+    "normalize_pointy_text",
+]

--- a/maritime-ai-service/app/engine/context/skills/lms/pointy.skill.yaml
+++ b/maritime-ai-service/app/engine/context/skills/lms/pointy.skill.yaml
@@ -6,13 +6,13 @@ priority: 0.4
 
 prompt_addition: |
   Wiii đang nhúng iframe trong LMS. Khi `host capabilities` có các tool `ui.highlight`,
-  `ui.scroll_to`, `navigation.go_to`, `ui.show_tour`, hãy ưu tiên dùng chúng để dẫn người
+  `ui.scroll_to`, `ui.navigate`, `ui.show_tour`, hãy ưu tiên dùng chúng để dẫn người
   dùng tới đúng nơi thay vì chỉ mô tả bằng chữ.
 
   Quy tắc Pointy V1 (chỉ tutor mode, không tự click):
   - Nếu user hỏi "ở đâu / vào đâu / nút nào", gọi `ui.highlight` với `selector` ổn định
     (ưu tiên `[data-wiii-id="..."]`) kèm `message` ngắn gọn bằng tiếng Việt.
-  - Nếu cần đưa user sang trang khác trong LMS, gọi `navigation.go_to` với `route` nội bộ.
+  - Nếu cần đưa user sang trang khác trong LMS, gọi `ui.navigate` với `route` nội bộ.
   - Nếu host context có `<available_targets>`, dùng id trong danh sách đó làm selector trước;
     ví dụ `browse-courses` hoặc `[data-wiii-id="browse-courses"]`.
   - Khi quy trình có nhiều bước (đăng ký khóa, nộp bài, xem điểm), gọi `ui.show_tour`
@@ -24,13 +24,14 @@ prompt_addition: |
   - Sau khi gọi pointy tool, vẫn tiếp tục câu trả lời bằng tiếng Việt — pointy không
     thay thế lời giải thích, chỉ làm rõ trực quan.
 
-  Pointy safe-click update:
-  - `ui.click` is allowed only when the selected target is listed in `<available_targets>` with `click_safe=true`
-    or the host context explicitly says it is safe for `ui.click`.
-  - Use a bare stable target id when possible, for example `browse-courses` or `continue-learn`.
-  - Never call `ui.click` for checkout, payment, enroll, submit quiz, delete, logout, quiz answer options,
-    mark-complete, or any target that is not explicitly click-safe. Highlight or scroll instead.
-  - Prefer flow: `ui.highlight` first when explaining where something is; `ui.click` only when the user
-    asks Wiii to open/go there or when a safe navigation action clearly continues the user's intent.
+  Cập nhật Pointy safe-click:
+  - Chỉ dùng `ui.click` khi target đã có trong `<available_targets>` với `click_safe=true`
+    hoặc host context nói rõ target đó an toàn cho `ui.click`.
+  - Ưu tiên dùng id ổn định dạng trần khi có thể, ví dụ `browse-courses` hoặc `continue-learn`.
+  - Không bao giờ gọi `ui.click` cho checkout, payment, enroll, submit quiz, delete, logout,
+    quiz answer options, mark-complete, hoặc bất kỳ target nào chưa được đánh dấu an toàn rõ ràng.
+    Hãy dùng `ui.highlight` hoặc `ui.scroll_to` thay thế.
+  - Luồng ưu tiên: dùng `ui.highlight` trước khi giải thích vị trí; chỉ dùng `ui.click` khi user
+    yêu cầu Wiii mở/đi tới đó hoặc khi hành động điều hướng an toàn tiếp nối rõ ý định của user.
 
 tools: []

--- a/maritime-ai-service/app/engine/context/skills/lms/pointy.skill.yaml
+++ b/maritime-ai-service/app/engine/context/skills/lms/pointy.skill.yaml
@@ -6,13 +6,15 @@ priority: 0.4
 
 prompt_addition: |
   Wiii đang nhúng iframe trong LMS. Khi `host capabilities` có các tool `ui.highlight`,
-  `ui.scroll_to`, `ui.navigate`, `ui.show_tour`, hãy ưu tiên dùng chúng để dẫn người
+  `ui.scroll_to`, `navigation.go_to`, `ui.show_tour`, hãy ưu tiên dùng chúng để dẫn người
   dùng tới đúng nơi thay vì chỉ mô tả bằng chữ.
 
   Quy tắc Pointy V1 (chỉ tutor mode, không tự click):
   - Nếu user hỏi "ở đâu / vào đâu / nút nào", gọi `ui.highlight` với `selector` ổn định
     (ưu tiên `[data-wiii-id="..."]`) kèm `message` ngắn gọn bằng tiếng Việt.
-  - Nếu cần đưa user sang trang khác trong LMS, gọi `ui.navigate` với `route` nội bộ.
+  - Nếu cần đưa user sang trang khác trong LMS, gọi `navigation.go_to` với `route` nội bộ.
+  - Nếu host context có `<available_targets>`, dùng id trong danh sách đó làm selector trước;
+    ví dụ `browse-courses` hoặc `[data-wiii-id="browse-courses"]`.
   - Khi quy trình có nhiều bước (đăng ký khóa, nộp bài, xem điểm), gọi `ui.show_tour`
     với 2-5 bước rõ ràng. Mỗi bước có `selector` + `message` <= 120 ký tự.
   - Trên trang quiz, **không** dùng `ui.highlight` để trỏ thẳng vào đáp án; vẫn giữ
@@ -21,5 +23,14 @@ prompt_addition: |
     thay vì đoán selector.
   - Sau khi gọi pointy tool, vẫn tiếp tục câu trả lời bằng tiếng Việt — pointy không
     thay thế lời giải thích, chỉ làm rõ trực quan.
+
+  Pointy safe-click update:
+  - `ui.click` is allowed only when the selected target is listed in `<available_targets>` with `click_safe=true`
+    or the host context explicitly says it is safe for `ui.click`.
+  - Use a bare stable target id when possible, for example `browse-courses` or `continue-learn`.
+  - Never call `ui.click` for checkout, payment, enroll, submit quiz, delete, logout, quiz answer options,
+    mark-complete, or any target that is not explicitly click-safe. Highlight or scroll instead.
+  - Prefer flow: `ui.highlight` first when explaining where something is; `ui.click` only when the user
+    asks Wiii to open/go there or when a safe navigation action clearly continues the user's intent.
 
 tools: []

--- a/maritime-ai-service/app/engine/model_catalog_runtime_support.py
+++ b/maritime-ai-service/app/engine/model_catalog_runtime_support.py
@@ -3,10 +3,18 @@
 from __future__ import annotations
 
 import hashlib
+import re
 import time
 from typing import Any, Awaitable, Callable
 
 _CATALOG_CACHE_FINGERPRINT_SALT = b"wiii-model-catalog-cache-fingerprint-v1"
+_SECRET_QUERY_RE = re.compile(
+    r"([?&](?:key|api[_-]?key|access[_-]?token|token|secret|authorization)=)"
+    r"[^&\s'\"<>]+",
+    re.IGNORECASE,
+)
+_BEARER_RE = re.compile(r"(Bearer\s+)[A-Za-z0-9._-]+", re.IGNORECASE)
+_COMMON_SECRET_RE = re.compile(r"\b(?:nvapi|sk)-[A-Za-z0-9_-]+")
 
 
 def hash_secret(secret: str | None) -> str:
@@ -20,6 +28,14 @@ def hash_secret(secret: str | None) -> str:
         dklen=16,
     )
     return digest.hex()[:12]
+
+
+def sanitize_exception_for_log(exc: Exception) -> str:
+    """Return an exception summary safe for provider/runtime logs."""
+    message = str(exc)
+    message = _SECRET_QUERY_RE.sub(r"\1REDACTED", message)
+    message = _BEARER_RE.sub(r"\1REDACTED", message)
+    return _COMMON_SECRET_RE.sub("SECRET-REDACTED", message)
 
 
 async def run_cached_discovery(
@@ -38,7 +54,11 @@ async def run_cached_discovery(
     try:
         models = await fetcher()
     except Exception as exc:
-        logger.debug("Runtime model discovery failed for %s: %s", cache_key, exc)
+        logger.debug(
+            "Runtime model discovery failed for %s: %s",
+            cache_key,
+            sanitize_exception_for_log(exc),
+        )
         if cached:
             return list(cached[1]), False
         return [], False

--- a/maritime-ai-service/app/engine/multi_agent/agent_config.py
+++ b/maritime-ai-service/app/engine/multi_agent/agent_config.py
@@ -339,6 +339,104 @@ class AgentConfigRegistry:
         }.get(effective_tier, get_llm_moderate)()
 
     @classmethod
+    def get_native_llm(
+        cls,
+        node_id: str,
+        effort_override: Optional[str] = None,
+        provider_override: Optional[str] = None,
+        requested_model: Optional[str] = None,
+    ):
+        """Resolve a framework-free provider/model handle for native chat calls."""
+        from app.engine.multi_agent.openai_stream_runtime import (
+            _supports_native_answer_streaming_impl,
+        )
+        from app.engine.native_chat_runtime import NativeChatModelHandle
+
+        config, _group_profile, effective_provider, effective_tier, model_override = (
+            cls._resolve_effective_runtime(
+                node_id,
+                provider_override=provider_override,
+            )
+        )
+        if not _supports_native_answer_streaming_impl(effective_provider):
+            return None
+
+        tier_key = str(effort_override or effective_tier or "moderate").strip().lower()
+        if tier_key not in {"deep", "moderate", "light"}:
+            tier_key = effective_tier if effective_tier in {"deep", "moderate", "light"} else "moderate"
+
+        normalized_requested_model = (
+            str(requested_model).strip()
+            if requested_model is not None and str(requested_model).strip()
+            else None
+        )
+        model_name = (
+            normalized_requested_model
+            or model_override
+            or cls._resolve_native_model_name(effective_provider, tier_key)
+        )
+        if not model_name:
+            return None
+
+        return NativeChatModelHandle(
+            _wiii_provider_name=effective_provider,
+            _wiii_requested_provider=provider_override,
+            _wiii_model_name=str(model_name),
+            _wiii_tier_key=tier_key,
+            temperature=config.temperature,
+        )
+
+    @staticmethod
+    def _resolve_native_model_name(provider_name: str, tier_key: str) -> str | None:
+        """Resolve native model names without constructing LangChain provider objects."""
+        normalized = str(provider_name or "").strip().lower()
+        if normalized == "nvidia":
+            from app.engine.openai_compatible_credentials import (
+                resolve_nvidia_model,
+                resolve_nvidia_model_advanced,
+            )
+            from app.engine.llm_model_health import is_model_degraded
+
+            base = str(resolve_nvidia_model(settings) or "").strip()
+            advanced = str(resolve_nvidia_model_advanced(settings) or "").strip()
+            if tier_key == "deep":
+                selected = advanced
+                fallback = base
+            else:
+                selected = base
+                fallback = advanced
+            if (
+                selected
+                and fallback
+                and selected != fallback
+                and is_model_degraded("nvidia", selected)
+                and not is_model_degraded("nvidia", fallback)
+            ):
+                logger.warning(
+                    "[AGENT_CONFIG] NVIDIA native model %s is degraded; selecting %s for %s tier",
+                    selected,
+                    fallback,
+                    tier_key,
+                )
+                return fallback
+            return selected or fallback or None
+        if normalized == "google":
+            if tier_key == "deep":
+                return getattr(settings, "google_model_advanced", settings.google_model)
+            return settings.google_model
+        if normalized == "zhipu":
+            if tier_key == "deep":
+                return settings.zhipu_model_advanced
+            return settings.zhipu_model
+        if normalized == "openrouter":
+            return getattr(settings, "openrouter_model", None) or settings.openai_model
+        if normalized == "openai":
+            if tier_key == "deep":
+                return settings.openai_model_advanced
+            return settings.openai_model
+        return None
+
+    @classmethod
     def _get_or_create_model_llm_for_provider(
         cls,
         provider_name: str,

--- a/maritime-ai-service/app/engine/multi_agent/direct_execution.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_execution.py
@@ -83,6 +83,7 @@ from app.engine.multi_agent.code_studio_patterns import (
 )
 from app.engine.multi_agent.direct_runtime_bindings import (
     _extract_runtime_target,
+    _is_native_runtime_handle,
     _remember_runtime_target,
     _stream_openai_compatible_answer_with_route,
     _truncate_before_code_dump,
@@ -747,8 +748,10 @@ async def _stream_answer_with_fallback(
     FAILOVER_MODE_AUTO = "auto"
     FAILOVER_MODE_PINNED = "pinned"
     tier_key = str(getattr(llm, "_wiii_tier_key", "") or "moderate").strip().lower()
-    if getattr(llm, "_wiii_native_route", False) and not str(resolved_provider or "").strip():
-        resolved_provider = str(getattr(llm, "_wiii_provider_name", "") or "").strip().lower()
+    native_route_enabled = _is_native_runtime_handle(llm)
+    if native_route_enabled and not str(resolved_provider or "").strip():
+        native_provider, _native_model = _extract_runtime_target(llm)
+        resolved_provider = native_provider or ""
     normalized_provider = str(provider or "").strip().lower()
     effective_failover_mode = failover_mode or (
         FAILOVER_MODE_PINNED if normalized_provider and normalized_provider != "auto" else FAILOVER_MODE_AUTO
@@ -758,11 +761,12 @@ async def _stream_answer_with_fallback(
         and normalized_provider in {"", "auto"}
         and bool(str(resolved_provider or "").strip())
     )
-    if getattr(llm, "_wiii_native_route", False):
+    if native_route_enabled:
         from types import SimpleNamespace
 
+        native_provider, _native_model = _extract_runtime_target(llm)
         route = SimpleNamespace(
-            provider=str(getattr(llm, "_wiii_provider_name", "") or resolved_provider or provider).strip().lower(),
+            provider=str(native_provider or resolved_provider or provider or "").strip().lower(),
             llm=llm,
         )
         _remember_runtime_target(state, route.llm)

--- a/maritime-ai-service/app/engine/multi_agent/direct_execution.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_execution.py
@@ -475,11 +475,11 @@ async def _preserve_ai_message_metadata(
     """Keep native message metadata when stream rendering trims visible content.
 
     Some providers stream plain answer deltas but only attach thought metadata on the
-    final merged AIMessage. If we replace that object with a bare AIMessage(content=...),
+    final merged message. If we replace that object with a bare response object,
     sync/stream parity breaks and visible-thought review loses the model-authored
     reasoning that is still present in the final object.
     """
-    from langchain_core.messages import AIMessage
+    from app.engine.native_chat_runtime import make_assistant_message
 
     preserved: dict[str, Any] = {}
     additional_kwargs = dict(getattr(merged_chunk, "additional_kwargs", None) or {})
@@ -533,7 +533,7 @@ async def _preserve_ai_message_metadata(
         if value in (None, "", [], {}):
             continue
         preserved[field_name] = value
-    return AIMessage(content=visible_text, **preserved)
+    return make_assistant_message(visible_text, **preserved)
 
 async def _ainvoke_with_fallback(
     llm, messages, tools=None, tool_choice=None, tier="moderate",
@@ -658,7 +658,7 @@ async def _stream_direct_wait_heartbeats(
     interval_sec: float = 6.0,
     stop_signal: Optional[asyncio.Event] = None,
 ) -> None:
-    """Emit hidden wait heartbeats so direct turns keep progress without public duplicate thinking."""
+    """Emit compact visible wait beats so slow provider paths do not feel frozen."""
     beat_index = 0
     while True:
         if stop_signal is not None:
@@ -674,11 +674,19 @@ async def _stream_direct_wait_heartbeats(
         beat_index += 1
         if beat_index > 2:
             return
+        wait_text = _build_direct_wait_heartbeat_text(
+            query=query,
+            phase=phase,
+            cue=cue,
+            beat_index=beat_index,
+            elapsed_sec=beat_index * interval_sec,
+            tool_names=tool_names,
+        )
         _hb_event: dict = {
             "type": "status",
-            "content": "Đang giữ nhịp xử lý...",
+            "content": wait_text,
             "node": "direct",
-            "details": {"visibility": "status_only"},
+            "details": {"subtype": "visible_wait", "visibility": "progress"},
         }
         await push_event(_hb_event)
 
@@ -735,10 +743,12 @@ async def _stream_answer_with_fallback(
     timeout_profile: str | None = None,
 ) -> tuple[object, bool]:
     """Stream answer text deltas for provider-backed lanes when no tools are needed."""
-    from app.engine.llm_pool import FAILOVER_MODE_AUTO, FAILOVER_MODE_PINNED, LLMPool
-    from langchain_core.messages import AIMessage
     from app.services.output_processor import extract_thinking_from_response
+    FAILOVER_MODE_AUTO = "auto"
+    FAILOVER_MODE_PINNED = "pinned"
     tier_key = str(getattr(llm, "_wiii_tier_key", "") or "moderate").strip().lower()
+    if getattr(llm, "_wiii_native_route", False) and not str(resolved_provider or "").strip():
+        resolved_provider = str(getattr(llm, "_wiii_provider_name", "") or "").strip().lower()
     normalized_provider = str(provider or "").strip().lower()
     effective_failover_mode = failover_mode or (
         FAILOVER_MODE_PINNED if normalized_provider and normalized_provider != "auto" else FAILOVER_MODE_AUTO
@@ -748,6 +758,31 @@ async def _stream_answer_with_fallback(
         and normalized_provider in {"", "auto"}
         and bool(str(resolved_provider or "").strip())
     )
+    if getattr(llm, "_wiii_native_route", False):
+        from types import SimpleNamespace
+
+        route = SimpleNamespace(
+            provider=str(getattr(llm, "_wiii_provider_name", "") or resolved_provider or provider).strip().lower(),
+            llm=llm,
+        )
+        _remember_runtime_target(state, route.llm)
+        logger.info("[%s] Path: Native SDK handle (provider=%s)", node.upper(), route.provider)
+        native_response, native_streamed = await _stream_openai_compatible_answer_with_route(
+            route,
+            messages,
+            push_event,
+            node=node,
+            thinking_stop_signal=thinking_stop_signal,
+            primary_timeout=primary_timeout,
+        )
+        if native_response is not None:
+            return native_response, native_streamed
+        logger.warning(
+            "[%s] Native handle produced no response; falling back to legacy pool route",
+            node.upper(),
+        )
+
+    from app.engine.llm_pool import LLMPool
     if not str(resolved_provider or provider or "").strip():
         fallback_response = await llm.ainvoke(messages)
         _remember_runtime_target(state, llm)
@@ -886,6 +921,7 @@ async def _stream_answer_with_fallback(
             push_event,
             node=node,
             thinking_stop_signal=thinking_stop_signal,
+            primary_timeout=primary_timeout,
         )
         if native_response is not None:
             return native_response, native_streamed
@@ -1141,6 +1177,7 @@ async def _execute_direct_tool_rounds(
     direct_answer_timeout_profile: str | None = None,
     direct_answer_primary_timeout: float | None = None,
     allowed_fallback_providers: tuple[str, ...] | list[str] | set[str] | None = None,
+    native_tool_messages: bool = False,
 ):
     """Execute multi-round tool calling loop for direct response.
 
@@ -1148,7 +1185,7 @@ async def _execute_direct_tool_rounds(
     Gemini often calls tools sequentially (datetime → web_search → answer).
 
     Returns:
-        tuple: (AIMessage, messages, tool_call_events) — final response, messages, and
+        tuple: (assistant response, messages, tool_call_events) — final response, messages, and
                structured tool events for downstream preview emission (Sprint 166).
     """
     return await execute_direct_tool_rounds_impl(
@@ -1167,6 +1204,7 @@ async def _execute_direct_tool_rounds(
         direct_answer_timeout_profile=direct_answer_timeout_profile,
         direct_answer_primary_timeout=direct_answer_primary_timeout,
         allowed_fallback_providers=allowed_fallback_providers,
+        native_tool_messages=native_tool_messages,
         ainvoke_with_fallback=_ainvoke_with_fallback,
         stream_direct_answer_with_fallback=_stream_direct_answer_with_fallback,
         stream_direct_wait_heartbeats=_stream_direct_wait_heartbeats,
@@ -1187,4 +1225,3 @@ _STRUCTURED_VISUAL_PLACEHOLDER_MD_RE = re.compile(
     r"!\[[^\]]*\]\((?:https?://example\.com/[^)\s]+|https?://[^)\s]*chart-placeholder[^)\s]*|sandbox:[^)]+)\)",
     re.IGNORECASE,
 )
-

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -708,16 +708,75 @@ async def direct_response_node_impl(
             )
             direct_provider_override = explicit_user_provider or preferred_provider
 
+            if is_short_house_chatter or is_identity_turn or is_emotional_support_turn:
+                tools, force_tools = [], False
+            else:
+                tools, force_tools = collect_direct_tools(
+                    query,
+                    ctx.get("user_role", "student"),
+                    state=state,
+                )
+                try:
+                    from app.engine.skills.skill_recommender import select_runtime_tools
+
+                    selected_tools = select_runtime_tools(
+                        tools,
+                        query=query,
+                        intent=(state.get("routing_metadata") or {}).get("intent"),
+                        user_role=ctx.get("user_role", "student"),
+                        max_tools=min(len(tools), 7),
+                        must_include=direct_required_tool_names(
+                            query,
+                            ctx.get("user_role", "student"),
+                        ),
+                    )
+                    if selected_tools:
+                        tools = selected_tools
+                        logger.info(
+                            "[DIRECT] Runtime-selected tools: %s",
+                            [getattr(tool, "name", getattr(tool, "__name__", "unknown")) for tool in tools],
+                        )
+                except Exception as selection_error:
+                    logger.debug("[DIRECT] Runtime tool selection skipped: %s", selection_error)
+
             direct_node_id = "direct_identity" if is_identity_turn else "direct"
 
-            llm = AgentConfigRegistry.get_llm(
-                direct_node_id,
-                effort_override=thinking_effort,
-                provider_override=direct_provider_override,
-                requested_model=state.get("model"),
+            from app.engine.multi_agent.openai_stream_runtime import (
+                _supports_native_answer_streaming_impl,
             )
 
-            if llm and getattr(settings, "enable_natural_conversation", False) is True:
+            native_direct_possible = (
+                not bool(ctx.get("images") or [])
+                and not is_short_house_chatter
+                and not is_identity_turn
+                and not is_emotional_support_turn
+                and not use_house_voice_direct
+            )
+            llm = None
+            if native_direct_possible:
+                llm = AgentConfigRegistry.get_native_llm(
+                    direct_node_id,
+                    effort_override=thinking_effort,
+                    provider_override=direct_provider_override,
+                    requested_model=state.get("model"),
+                )
+                if llm and not _supports_native_answer_streaming_impl(
+                    getattr(llm, "_wiii_provider_name", None)
+                ):
+                    llm = None
+            if llm is None:
+                llm = AgentConfigRegistry.get_llm(
+                    direct_node_id,
+                    effort_override=thinking_effort,
+                    provider_override=direct_provider_override,
+                    requested_model=state.get("model"),
+                )
+
+            if (
+                llm
+                and getattr(settings, "enable_natural_conversation", False) is True
+                and not getattr(llm, "_wiii_native_route", False)
+            ):
                 presence_penalty = getattr(settings, "llm_presence_penalty", 0.0)
                 frequency_penalty = getattr(settings, "llm_frequency_penalty", 0.0)
                 if presence_penalty or frequency_penalty:
@@ -733,36 +792,6 @@ async def direct_response_node_impl(
                         pass
 
             if llm:
-                if is_short_house_chatter or is_identity_turn or is_emotional_support_turn:
-                    tools, force_tools = [], False
-                else:
-                    tools, force_tools = collect_direct_tools(
-                        query,
-                        ctx.get("user_role", "student"),
-                        state=state,
-                    )
-                    try:
-                        from app.engine.skills.skill_recommender import select_runtime_tools
-
-                        selected_tools = select_runtime_tools(
-                            tools,
-                            query=query,
-                            intent=(state.get("routing_metadata") or {}).get("intent"),
-                            user_role=ctx.get("user_role", "student"),
-                            max_tools=min(len(tools), 7),
-                            must_include=direct_required_tool_names(
-                                query,
-                                ctx.get("user_role", "student"),
-                            ),
-                        )
-                        if selected_tools:
-                            tools = selected_tools
-                            logger.info(
-                                "[DIRECT] Runtime-selected tools: %s",
-                                [getattr(tool, "name", getattr(tool, "__name__", "unknown")) for tool in tools],
-                            )
-                    except Exception as selection_error:
-                        logger.debug("[DIRECT] Runtime tool selection skipped: %s", selection_error)
                 logger.warning(
                     "[DIRECT] tools=%d, force=%s, web=%s, dt=%s, query='%s'",
                     len(tools),
@@ -842,6 +871,7 @@ async def direct_response_node_impl(
                         visual_decision.force_tool,
                     )
 
+                native_direct_messages = bool(getattr(llm, "_wiii_native_route", False))
                 messages = build_direct_system_messages(
                     state,
                     query,
@@ -850,6 +880,7 @@ async def direct_response_node_impl(
                     tools_context_override=tools_context_override,
                     visual_decision=visual_decision,
                     history_limit=history_limit,
+                    native_messages=native_direct_messages,
                 )
                 runtime_context_base = build_tool_runtime_context(
                     event_bus_id=bus_id,
@@ -878,6 +909,7 @@ async def direct_response_node_impl(
                     direct_answer_timeout_profile=direct_answer_timeout_profile,
                     direct_answer_primary_timeout=direct_answer_primary_timeout,
                     allowed_fallback_providers=direct_allowed_fallback_providers,
+                    native_tool_messages=native_direct_messages,
                 )
 
                 if tool_call_events:

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -33,7 +33,11 @@ from app.engine.reasoning import (
     should_align_visible_thinking_language,
 )
 from app.engine.tools.runtime_context import build_tool_runtime_context
-from app.engine.multi_agent.graph_runtime_helpers import _copy_runtime_metadata
+from app.engine.multi_agent.graph_runtime_helpers import (
+    _copy_runtime_metadata,
+    _extract_runtime_target,
+    _is_native_runtime_handle,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -775,7 +779,7 @@ async def direct_response_node_impl(
             if (
                 llm
                 and getattr(settings, "enable_natural_conversation", False) is True
-                and not getattr(llm, "_wiii_native_route", False)
+                and not _is_native_runtime_handle(llm)
             ):
                 presence_penalty = getattr(settings, "llm_presence_penalty", 0.0)
                 frequency_penalty = getattr(settings, "llm_frequency_penalty", 0.0)
@@ -814,12 +818,8 @@ async def direct_response_node_impl(
                             "[DIRECT] Visual intent detected but tool_generate_visual not in tools list",
                         )
 
-                bound_provider = getattr(llm, "_wiii_provider_name", None) or state.get("provider")
-                bound_model = (
-                    getattr(llm, "_wiii_model_name", None)
-                    or getattr(llm, "model_name", None)
-                    or getattr(llm, "model", None)
-                )
+                bound_provider, bound_model = _extract_runtime_target(llm)
+                bound_provider = bound_provider or state.get("provider")
                 if bound_provider and str(bound_provider).strip().lower() != "auto":
                     state["_execution_provider"] = str(bound_provider)
                 if bound_model:
@@ -871,7 +871,7 @@ async def direct_response_node_impl(
                         visual_decision.force_tool,
                     )
 
-                native_direct_messages = bool(getattr(llm, "_wiii_native_route", False))
+                native_direct_messages = _is_native_runtime_handle(llm)
                 messages = build_direct_system_messages(
                     state,
                     query,

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
@@ -1043,16 +1043,20 @@ def _build_direct_system_messages(
     tools_context_override: Optional[str] = None,
     visual_decision=None,
     history_limit: int = 10,
+    native_messages: bool = False,
 ):
     """Build system prompt and message list for direct-style nodes.
 
     Sprint 154: Extracted from direct_response_node.
 
     Returns:
-        list: LangChain messages [SystemMessage, ...history, HumanMessage]
+        list: message objects [system, ...history, user]
     """
-    from langchain_core.messages import HumanMessage, SystemMessage
     from app.prompts.prompt_loader import get_prompt_loader
+    if native_messages:
+        from app.engine.native_chat_runtime import message_to_openai_payload
+    else:
+        from langchain_core.messages import HumanMessage, SystemMessage
 
     ctx = state.get("context", {})
     loader = get_prompt_loader()
@@ -1226,10 +1230,16 @@ def _build_direct_system_messages(
         from app.engine.reasoning.thinking_enforcement import get_thinking_enforcement
         system_prompt = get_thinking_enforcement() + "\n\n" + system_prompt + "\n\n" + thinking_instruction
 
-    messages = [SystemMessage(content=system_prompt)]
+    if native_messages:
+        messages = [{"role": "system", "content": system_prompt}]
+    else:
+        messages = [SystemMessage(content=system_prompt)]
     lc_messages = ctx.get("langchain_messages", [])
     if lc_messages and history_limit > 0:
-        messages.extend(lc_messages[-history_limit:])
+        if native_messages:
+            messages.extend(message_to_openai_payload(message) for message in lc_messages[-history_limit:])
+        else:
+            messages.extend(lc_messages[-history_limit:])
 
     # Sprint 179: Multimodal content blocks when images are present
     images = ctx.get("images") or []
@@ -1252,7 +1262,13 @@ def _build_direct_system_messages(
                         "detail": img.get("detail", "auto"),
                     }
                 })
-        messages.append(HumanMessage(content=content_blocks))
+        if native_messages:
+            messages.append({"role": "user", "content": content_blocks})
+        else:
+            messages.append(HumanMessage(content=content_blocks))
     else:
-        messages.append(HumanMessage(content=query))
+        if native_messages:
+            messages.append({"role": "user", "content": query})
+        else:
+            messages.append(HumanMessage(content=query))
     return messages

--- a/maritime-ai-service/app/engine/multi_agent/direct_response_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_response_runtime.py
@@ -37,7 +37,10 @@ def _flatten_message_content(value) -> str:
 
 def _extract_last_query(messages: list) -> str:
     for message in reversed(messages or []):
-        content = _flatten_message_content(getattr(message, "content", ""))
+        if isinstance(message, dict):
+            content = _flatten_message_content(message.get("content", ""))
+        else:
+            content = _flatten_message_content(getattr(message, "content", ""))
         if content:
             return content
     return ""
@@ -285,8 +288,13 @@ def extract_direct_response_impl(llm_response, messages: list):
     response = text_content.strip()
     tools_used_names = set()
     for message in messages:
-        if hasattr(message, "tool_calls") and message.tool_calls:
-            for tool_call in message.tool_calls:
+        tool_calls = (
+            message.get("tool_calls")
+            if isinstance(message, dict)
+            else getattr(message, "tool_calls", None)
+        )
+        if tool_calls:
+            for tool_call in tool_calls:
                 tools_used_names.add(tool_call.get("name", "unknown"))
 
     if not thinking_content:

--- a/maritime-ai-service/app/engine/multi_agent/direct_runtime_bindings.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_runtime_bindings.py
@@ -8,6 +8,7 @@ from typing import Any, Optional
 from app.engine.multi_agent.code_studio_response import _truncate_before_code_dump
 from app.engine.multi_agent.graph_runtime_helpers import (
     _extract_runtime_target,
+    _is_native_runtime_handle,
     _remember_runtime_target,
 )
 from app.engine.multi_agent.graph_surface_runtime import render_reasoning_fast_impl

--- a/maritime-ai-service/app/engine/multi_agent/direct_runtime_bindings.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_runtime_bindings.py
@@ -14,14 +14,13 @@ from app.engine.multi_agent.graph_surface_runtime import render_reasoning_fast_i
 from app.engine.multi_agent.openai_stream_runtime import (
     _create_openai_compatible_stream_client_impl,
     _extract_openai_delta_text_impl,
-    _flatten_langchain_content_impl,
-    _langchain_message_to_openai_payload_impl,
     _resolve_openai_stream_model_name_impl,
     _should_enable_real_code_streaming_impl,
     _stream_openai_compatible_answer_with_route_impl,
     _supports_native_answer_streaming_impl,
 )
 from app.engine.multi_agent.state import AgentState
+from app.engine.native_chat_runtime import message_to_openai_payload
 from app.engine.multi_agent.widget_surface import _inject_widget_blocks_from_tool_results
 
 
@@ -35,6 +34,10 @@ def _graph_override(name: str, current):
     return candidate
 
 
+def _langchain_message_to_openai_payload(message: Any) -> dict[str, Any]:
+    return message_to_openai_payload(message)
+
+
 async def _stream_openai_compatible_answer_with_route(
     route,
     messages: list,
@@ -42,6 +45,7 @@ async def _stream_openai_compatible_answer_with_route(
     *,
     node: str = "direct",
     thinking_stop_signal=None,
+    primary_timeout: float | None = None,
 ) -> tuple[object | None, bool]:
     override = _graph_override("_stream_openai_compatible_answer_with_route", _stream_openai_compatible_answer_with_route)
     if override is not None:
@@ -51,6 +55,7 @@ async def _stream_openai_compatible_answer_with_route(
             push_event,
             node=node,
             thinking_stop_signal=thinking_stop_signal,
+            primary_timeout=primary_timeout,
         )
     return await _stream_openai_compatible_answer_with_route_impl(
         route,
@@ -58,10 +63,11 @@ async def _stream_openai_compatible_answer_with_route(
         push_event,
         node=node,
         thinking_stop_signal=thinking_stop_signal,
+        primary_timeout=primary_timeout,
         supports_native_answer_streaming=_supports_native_answer_streaming_impl,
         create_openai_compatible_stream_client=_create_openai_compatible_stream_client_impl,
         resolve_openai_stream_model_name=_resolve_openai_stream_model_name_impl,
-        langchain_message_to_openai_payload=_langchain_message_to_openai_payload_impl,
+        langchain_message_to_openai_payload=_langchain_message_to_openai_payload,
         extract_openai_delta_text=_extract_openai_delta_text_impl,
     )
 

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -97,6 +97,39 @@ def _build_direct_final_synthesis_instruction(
     return base
 
 
+def _build_tool_result_message(
+    content: str,
+    *,
+    tool_call_id: str,
+    native_tool_messages: bool,
+) -> Any:
+    """Create the post-tool message without hard-wiring LangChain in native lanes."""
+    if native_tool_messages:
+        from app.engine.native_chat_runtime import make_tool_message
+
+        return make_tool_message(content, tool_call_id=tool_call_id)
+
+    from langchain_core.messages import ToolMessage as _TM
+
+    return _TM(content=content, tool_call_id=tool_call_id)
+
+
+def _build_user_instruction_message(
+    content: str,
+    *,
+    native_tool_messages: bool,
+) -> Any:
+    """Create a user instruction message for final synthesis."""
+    if native_tool_messages:
+        from app.engine.native_chat_runtime import make_user_message
+
+        return make_user_message(content)
+
+    from langchain_core.messages import HumanMessage as _HM
+
+    return _HM(content=content)
+
+
 async def execute_direct_tool_rounds_impl(
     llm_with_tools,
     llm_auto,
@@ -118,10 +151,9 @@ async def execute_direct_tool_rounds_impl(
     stream_direct_answer_with_fallback,
     stream_direct_wait_heartbeats,
     push_status_only_progress,
+    native_tool_messages: bool = False,
 ):
     """Execute multi-round tool calling loop for direct response."""
-    from langchain_core.messages import ToolMessage as _TM
-
     from app.engine.tools.invocation import (
         get_tool_by_name as _get_tool_by_name_impl,
         invoke_tool_with_runtime as _invoke_tool_with_runtime_impl,
@@ -400,7 +432,13 @@ async def execute_direct_tool_rounds_impl(
                     "id": tc_id,
                 }
             )
-            messages.append(_TM(content=str(result), tool_call_id=tc_id))
+            messages.append(
+                _build_tool_result_message(
+                    str(result),
+                    tool_call_id=tc_id,
+                    native_tool_messages=native_tool_messages,
+                )
+            )
 
             # Phase 3: Detect handoff tool call and set state signal
             if state is not None and tc_name == "handoff_to_agent" and settings.enable_agent_handoffs:
@@ -504,8 +542,6 @@ async def execute_direct_tool_rounds_impl(
         getattr(llm_response, "content", "")
     )
     if tool_call_events and (remaining_tool_calls or not visible_response_text):
-        from langchain_core.messages import HumanMessage as _HM
-
         logger.warning(
             "[DIRECT] Tool loop ended without final prose "
             "(remaining_tool_calls=%s, visible_len=%d) -> forcing no-tool synthesis",
@@ -519,12 +555,13 @@ async def execute_direct_tool_rounds_impl(
         ]
         synthesis_messages = list(messages)
         synthesis_messages.append(
-            _HM(
-                content=_build_direct_final_synthesis_instruction(
+            _build_user_instruction_message(
+                _build_direct_final_synthesis_instruction(
                     query,
                     state,
                     synthesis_tool_names,
-                )
+                ),
+                native_tool_messages=native_tool_messages,
             )
         )
         synthesis_llm = llm_base or llm_auto or llm_with_tools

--- a/maritime-ai-service/app/engine/multi_agent/graph.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph.py
@@ -229,6 +229,7 @@ async def _stream_openai_compatible_answer_with_route(
     *,
     node: str = "direct",
     thinking_stop_signal: Optional[asyncio.Event] = None,
+    primary_timeout: float | None = None,
 ) -> tuple[object | None, bool]:
     """Use graph-local names so tests can patch the streaming dependencies here."""
     impl = importlib.import_module(
@@ -240,6 +241,7 @@ async def _stream_openai_compatible_answer_with_route(
         push_event,
         node=node,
         thinking_stop_signal=thinking_stop_signal,
+        primary_timeout=primary_timeout,
         supports_native_answer_streaming=_supports_native_answer_streaming,
         create_openai_compatible_stream_client=_create_openai_compatible_stream_client,
         resolve_openai_stream_model_name=_resolve_openai_stream_model_name,

--- a/maritime-ai-service/app/engine/multi_agent/graph_runtime_helpers.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph_runtime_helpers.py
@@ -40,6 +40,11 @@ def _extract_runtime_target(source_obj: Any | None) -> tuple[str | None, str | N
     return normalized_provider, model_name
 
 
+def _is_native_runtime_handle(source_obj: Any | None) -> bool:
+    """Return true only for handles explicitly marked as Wiii-native."""
+    return getattr(source_obj, "_wiii_native_route", False) is True
+
+
 def _remember_runtime_target(
     state: Optional[AgentState],
     source_obj: Any | None,
@@ -85,6 +90,9 @@ def _copy_runtime_metadata(source_obj: Any | None, target_obj: Any | None):
     requested_provider = getattr(source_obj, "_wiii_requested_provider", None)
     if isinstance(requested_provider, str) and requested_provider.strip():
         setattr(target_obj, "_wiii_requested_provider", requested_provider.strip().lower())
+
+    if _is_native_runtime_handle(source_obj):
+        setattr(target_obj, "_wiii_native_route", True)
 
     return target_obj
 

--- a/maritime-ai-service/app/engine/multi_agent/graph_stream_agent_handlers.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph_stream_agent_handlers.py
@@ -90,19 +90,14 @@ async def handle_direct_node_impl(
 
     final_response = node_output.get("final_response", "")
     if final_response and not answer_emitted:
-        answer_via_bus = "direct" in bus_answer_nodes
-        answer_as_thinking = node_output.get("_answer_streamed_via_bus", False)
-        if not answer_via_bus and not answer_as_thinking:
-            async for event in extract_and_stream_emotion_then_answer(
-                final_response,
-                soul_emotion_emitted,
-            ):
-                if event.type == "emotion":
-                    soul_emotion_emitted = True
-                events.append(event)
-            answer_emitted = True
-        elif answer_via_bus or answer_as_thinking:
-            answer_emitted = True
+        async for event in extract_and_stream_emotion_then_answer(
+            final_response,
+            soul_emotion_emitted,
+        ):
+            if event.type == "emotion":
+                soul_emotion_emitted = True
+            events.append(event)
+        answer_emitted = True
 
     domain_notice = node_output.get("domain_notice")
     if domain_notice:
@@ -202,19 +197,14 @@ async def handle_product_search_node_impl(
 
     final_response = node_output.get("final_response", "")
     if final_response and not answer_emitted:
-        answer_via_bus = "product_search_agent" in bus_answer_nodes
-        answer_as_thinking = node_output.get("_answer_streamed_via_bus", False)
-        if not answer_via_bus and not answer_as_thinking:
-            async for event in extract_and_stream_emotion_then_answer(
-                final_response,
-                soul_emotion_emitted,
-            ):
-                if event.type == "emotion":
-                    soul_emotion_emitted = True
-                events.append(event)
-            answer_emitted = True
-        elif answer_via_bus:
-            answer_emitted = True
+        async for event in extract_and_stream_emotion_then_answer(
+            final_response,
+            soul_emotion_emitted,
+        ):
+            if event.type == "emotion":
+                soul_emotion_emitted = True
+            events.append(event)
+        answer_emitted = True
 
     return {
         "events": events,

--- a/maritime-ai-service/app/engine/multi_agent/graph_streaming.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph_streaming.py
@@ -41,6 +41,7 @@ from app.core.config import settings
 from app.core.exceptions import ProviderUnavailableError
 from app.engine.llm_runtime_metadata import resolve_runtime_llm_metadata
 from app.core.constants import PREVIEW_SNIPPET_MAX_LENGTH
+from app.engine.context.pointy_fast_path import build_pointy_fast_path_action
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.graph_support import (
     _build_domain_config,
@@ -131,6 +132,7 @@ from app.engine.multi_agent.stream_utils import (
     create_code_open_event,
     create_code_delta_event,
     create_code_complete_event,
+    create_host_action_event,
 )
 
 logger = logging.getLogger(__name__)
@@ -241,6 +243,21 @@ async def process_with_multi_agent_streaming(
     try:
         # Yield initial status (pipeline — hidden from thinking rail)
         yield await create_status_event("Đang bắt đầu lượt xử lý...", None, details=_PIPELINE_STATUS_DETAILS)
+
+        pointy_fast_path = build_pointy_fast_path_action(query, context)
+        if pointy_fast_path:
+            logger.info(
+                "[POINTY_FAST_PATH] Emitting %s for target=%s reason=%s before router",
+                pointy_fast_path["action"],
+                pointy_fast_path.get("target", {}).get("id"),
+                pointy_fast_path.get("reason"),
+            )
+            yield await create_host_action_event(
+                request_id=pointy_fast_path["request_id"],
+                action=pointy_fast_path["action"],
+                params=pointy_fast_path["params"],
+                node="pointy_fast_path",
+            )
 
         bootstrap = await build_stream_bootstrap_impl(
             query=query,
@@ -362,6 +379,8 @@ async def process_with_multi_agent_streaming(
                     create_answer_event=create_answer_event,
                 )
                 for event in bus_events:
+                    if getattr(event, "type", None) == "answer":
+                        answer_emitted = True
                     yield event
                 continue
             elif msg_type == "provider_unavailable":

--- a/maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py
@@ -530,16 +530,9 @@ async def _stream_openai_compatible_answer_with_route_impl(
             from app.engine.llm_model_health import record_model_success
 
             record_model_success(provider_name, model_name)
-            if not thinking_closed:
-                if thinking_stop_signal is not None:
-                    thinking_stop_signal.set()
-                if reasoning_started:
-                    await push_event({
-                        "type": "thinking_end",
-                        "content": "",
-                        "node": node,
-                    })
+            await _close_thinking_for_non_answer()
             return make_assistant_message(emitted_answer), True
+        await _close_thinking_for_non_answer()
     except Exception as exc:
         from app.engine.llm_failover_runtime import classify_failover_reason_impl
         from app.engine.llm_model_health import record_model_failure
@@ -565,10 +558,9 @@ async def _stream_openai_compatible_answer_with_route_impl(
             exc_info=True,
         )
         if emitted_answer:
-            from app.engine.llm_model_health import record_model_success
-
-            record_model_success(provider_name, model_name)
+            await _close_thinking_for_non_answer()
             return make_assistant_message(emitted_answer), True
+        await _close_thinking_for_non_answer()
     logger.info(
         "[%s] Native stream result: provider=%s model=%s answer=%d chars",
         node.upper(),

--- a/maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py
@@ -11,10 +11,20 @@ from typing import Any, Optional
 from app.core import config as app_config
 from app.core.config import settings
 from app.engine.openai_compatible_credentials import (
+    resolve_nvidia_api_key,
+    resolve_nvidia_base_url,
+    resolve_nvidia_model,
+    resolve_nvidia_model_advanced,
     resolve_openai_api_key,
     resolve_openai_base_url,
     resolve_openrouter_api_key,
     resolve_openrouter_base_url,
+)
+from app.engine.native_chat_runtime import (
+    make_assistant_message,
+    message_to_openai_payload,
+    normalize_tool_choice,
+    openai_response_to_assistant_message,
 )
 from app.engine.reasoning import sanitize_visible_reasoning_text
 
@@ -59,7 +69,7 @@ def _should_enable_real_code_streaming_impl(
 
 def _supports_native_answer_streaming_impl(provider: str | None) -> bool:
     normalized = str(provider or "").strip().lower()
-    return normalized in {"google", "zhipu", "openai", "openrouter"}
+    return normalized in {"google", "zhipu", "openai", "openrouter", "nvidia"}
 
 
 def _flatten_langchain_content_impl(content: Any) -> str:
@@ -86,51 +96,9 @@ def _langchain_message_to_openai_payload_impl(
     *,
     flatten_langchain_content,
 ) -> dict[str, Any]:
-    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
-
-    content = flatten_langchain_content(getattr(message, "content", ""))
-    if isinstance(message, SystemMessage):
-        return {"role": "system", "content": content}
-    if isinstance(message, HumanMessage):
-        return {"role": "user", "content": content}
-    if isinstance(message, ToolMessage):
-        payload = {"role": "tool", "content": content}
-        tool_call_id = getattr(message, "tool_call_id", None)
-        if tool_call_id:
-            payload["tool_call_id"] = tool_call_id
-        return payload
-    if isinstance(message, AIMessage):
-        payload: dict[str, Any] = {"role": "assistant", "content": content}
-        tool_calls = getattr(message, "tool_calls", None) or []
-        if tool_calls:
-            payload["tool_calls"] = [
-                {
-                    "id": str(tool_call.get("id") or f"tc_{idx}"),
-                    "type": "function",
-                    "function": {
-                        "name": str(tool_call.get("name") or ""),
-                        "arguments": json.dumps(
-                            tool_call.get("args") or {},
-                            ensure_ascii=False,
-                        ),
-                    },
-                }
-                for idx, tool_call in enumerate(tool_calls)
-                if tool_call.get("name")
-            ]
-        return payload
-    role = getattr(message, "type", None) or getattr(message, "role", None) or "user"
-    if role in {"human", "user"}:
-        return {"role": "user", "content": content}
-    if role == "system":
-        return {"role": "system", "content": content}
-    if role == "tool":
-        payload = {"role": "tool", "content": content}
-        tool_call_id = getattr(message, "tool_call_id", None)
-        if tool_call_id:
-            payload["tool_call_id"] = tool_call_id
-        return payload
-    return {"role": "assistant", "content": content}
+    # Compatibility shim: callers still use the legacy function name, but the
+    # conversion is now framework-free and accepts LangChain-like duck objects.
+    return message_to_openai_payload(message)
 
 
 def _create_openai_compatible_stream_client_impl(provider_name: str):
@@ -157,6 +125,13 @@ def _create_openai_compatible_stream_client_impl(provider_name: str):
         return AsyncOpenAI(
             api_key=resolve_openrouter_api_key(settings),
             base_url=resolve_openrouter_base_url(settings),
+        )
+    if normalized == "nvidia":
+        if not resolve_nvidia_api_key(settings):
+            return None
+        return AsyncOpenAI(
+            api_key=resolve_nvidia_api_key(settings),
+            base_url=resolve_nvidia_base_url(settings),
         )
     if normalized == "openai":
         if not resolve_openai_api_key(settings):
@@ -193,11 +168,59 @@ def _resolve_openai_stream_model_name_impl(
         return settings.zhipu_model
     if normalized == "openrouter":
         return settings.openai_model or "openai/gpt-oss-20b:free"
+    if normalized == "nvidia":
+        if tier_key == "deep":
+            return resolve_nvidia_model_advanced(settings)
+        return resolve_nvidia_model(settings)
     if normalized == "openai":
         if tier_key == "deep":
             return settings.openai_model_advanced
         return settings.openai_model
     return None
+
+
+async def _ainvoke_openai_compatible_chat_impl(
+    llm: Any,
+    messages: list,
+) -> Any:
+    """Invoke one native OpenAI-compatible chat completion, including tools."""
+    provider_name = str(getattr(llm, "_wiii_provider_name", "") or "").strip().lower()
+    if not _supports_native_answer_streaming_impl(provider_name):
+        raise RuntimeError(f"Native provider is not supported: {provider_name or 'unknown'}")
+
+    client = _create_openai_compatible_stream_client_impl(provider_name)
+    if client is None:
+        raise RuntimeError(f"Native provider client is unavailable: {provider_name}")
+
+    tier_key = str(getattr(llm, "_wiii_tier_key", "") or "moderate").strip().lower()
+    model_name = _resolve_openai_stream_model_name_impl(llm, provider_name, tier_key)
+    if not model_name:
+        raise RuntimeError(f"Native model is not configured for provider: {provider_name}")
+
+    request_kwargs: dict[str, Any] = {
+        "model": model_name,
+        "messages": [message_to_openai_payload(message) for message in messages],
+    }
+    temperature = getattr(llm, "temperature", None)
+    if temperature is not None:
+        request_kwargs["temperature"] = temperature
+
+    bound_tools = list(getattr(llm, "_wiii_bound_tools", []) or [])
+    if bound_tools:
+        request_kwargs["tools"] = bound_tools
+    tool_choice = normalize_tool_choice(getattr(llm, "_wiii_tool_choice", None))
+    if tool_choice is not None:
+        request_kwargs["tool_choice"] = tool_choice
+
+    if provider_name == "openrouter":
+        from app.engine.openrouter_routing import build_openrouter_extra_body
+
+        extra_body = build_openrouter_extra_body(settings, primary_model=model_name)
+        if extra_body:
+            request_kwargs["extra_body"] = extra_body
+
+    response = await client.chat.completions.create(**request_kwargs)
+    return openai_response_to_assistant_message(response)
 
 
 def _extract_openai_delta_text_impl(delta: Any) -> tuple[str, str]:
@@ -274,6 +297,64 @@ def _extract_google_tagged_thinking_impl(
     return "".join(reasoning_parts), "".join(visible_parts)
 
 
+def _get_chunk_value(value: Any, key: str) -> Any:
+    if isinstance(value, dict):
+        return value.get(key)
+    return getattr(value, key, None)
+
+
+def _accumulate_tool_call_chunk(
+    accumulator: dict[int, dict[str, str]],
+    tool_call_chunk: Any,
+) -> None:
+    """Merge OpenAI-compatible streamed function-call chunks by index."""
+    try:
+        index = int(_get_chunk_value(tool_call_chunk, "index") or 0)
+    except Exception:
+        index = 0
+    slot = accumulator.setdefault(index, {"id": "", "name": "", "arguments": ""})
+
+    tool_call_id = _get_chunk_value(tool_call_chunk, "id")
+    if tool_call_id:
+        slot["id"] = str(tool_call_id)
+
+    function = _get_chunk_value(tool_call_chunk, "function") or {}
+    name = _get_chunk_value(function, "name")
+    if name:
+        if slot["name"] and str(name) not in slot["name"]:
+            slot["name"] = f"{slot['name']}{name}"
+        else:
+            slot["name"] = str(name)
+
+    arguments = _get_chunk_value(function, "arguments")
+    if arguments:
+        slot["arguments"] = f"{slot['arguments']}{arguments}"
+
+
+def _finalize_tool_call_chunks(
+    accumulator: dict[int, dict[str, str]],
+) -> list[dict[str, Any]]:
+    tool_calls: list[dict[str, Any]] = []
+    for index in sorted(accumulator):
+        chunk = accumulator[index]
+        name = str(chunk.get("name") or "").strip()
+        if not name:
+            continue
+        raw_arguments = str(chunk.get("arguments") or "").strip()
+        args: Any = {}
+        if raw_arguments:
+            try:
+                args = json.loads(raw_arguments)
+            except Exception:
+                args = {"_raw": raw_arguments}
+        tool_calls.append({
+            "id": str(chunk.get("id") or f"call_{index}"),
+            "name": name,
+            "args": args if isinstance(args, dict) else {"_raw": str(args)},
+        })
+    return tool_calls
+
+
 async def _stream_openai_compatible_answer_with_route_impl(
     route,
     messages: list,
@@ -281,14 +362,13 @@ async def _stream_openai_compatible_answer_with_route_impl(
     *,
     node: str = "direct",
     thinking_stop_signal: Optional[asyncio.Event] = None,
+    primary_timeout: float | None = None,
     supports_native_answer_streaming,
     create_openai_compatible_stream_client,
     resolve_openai_stream_model_name,
     langchain_message_to_openai_payload,
     extract_openai_delta_text,
 ) -> tuple[object | None, bool]:
-    from langchain_core.messages import AIMessage
-
     provider_name = str(route.provider or "").strip().lower()
     if not supports_native_answer_streaming(provider_name):
         return None, False
@@ -326,6 +406,13 @@ async def _stream_openai_compatible_answer_with_route_impl(
     if temperature is not None:
         request_kwargs["temperature"] = temperature
 
+    bound_tools = list(getattr(route.llm, "_wiii_bound_tools", []) or [])
+    if bound_tools:
+        request_kwargs["tools"] = bound_tools
+    tool_choice = normalize_tool_choice(getattr(route.llm, "_wiii_tool_choice", None))
+    if tool_choice is not None:
+        request_kwargs["tool_choice"] = tool_choice
+
     if provider_name == "openrouter":
         from app.engine.openrouter_routing import build_openrouter_extra_body
 
@@ -338,14 +425,55 @@ async def _stream_openai_compatible_answer_with_route_impl(
     emit_provider_reasoning = str(node or "").strip().lower() != "code_studio_agent"
     google_tag_state = {"inside_thinking": False, "pending": ""}
     reasoning_started = False
+    tool_call_chunks: dict[int, dict[str, str]] = {}
+
+    async def _close_thinking_for_non_answer() -> None:
+        nonlocal thinking_closed
+        if thinking_closed:
+            return
+        if thinking_stop_signal is not None:
+            thinking_stop_signal.set()
+        if reasoning_started:
+            await push_event({
+                "type": "thinking_end",
+                "content": "",
+                "node": node,
+            })
+        thinking_closed = True
 
     try:
         stream = await client.chat.completions.create(**request_kwargs)
-        async for chunk in stream:
+        stream_iter = stream.__aiter__()
+        first_stream_chunk = None
+        try:
+            if primary_timeout is not None and primary_timeout > 0:
+                first_stream_chunk = await asyncio.wait_for(
+                    anext(stream_iter),
+                    timeout=primary_timeout,
+                )
+            else:
+                first_stream_chunk = await anext(stream_iter)
+        except StopAsyncIteration:
+            first_stream_chunk = None
+
+        async def _iter_stream_chunks():
+            if first_stream_chunk is not None:
+                yield first_stream_chunk
+            while True:
+                try:
+                    yield await anext(stream_iter)
+                except StopAsyncIteration:
+                    break
+
+        async for chunk in _iter_stream_chunks():
             for choice in getattr(chunk, "choices", []) or []:
                 delta = getattr(choice, "delta", None)
                 if delta is None:
                     continue
+                for tool_call_chunk in getattr(delta, "tool_calls", []) or []:
+                    _accumulate_tool_call_chunk(tool_call_chunks, tool_call_chunk)
+                if tool_call_chunks:
+                    await _close_thinking_for_non_answer()
                 reasoning_delta, answer_delta = extract_openai_delta_text(delta)
                 if answer_delta and str(node or "").strip().lower() != "code_studio_agent":
                     tagged_reasoning, cleaned_answer = _extract_google_tagged_thinking_impl(
@@ -385,10 +513,23 @@ async def _stream_openai_compatible_answer_with_route_impl(
                 await push_event({
                     "type": "answer_delta",
                     "content": answer_delta,
-                    "node": node,
-                })
+                        "node": node,
+                    })
                 emitted_answer += answer_delta
+        tool_calls = _finalize_tool_call_chunks(tool_call_chunks)
+        if tool_calls:
+            from app.engine.llm_model_health import record_model_success
+
+            record_model_success(provider_name, model_name)
+            await _close_thinking_for_non_answer()
+            return make_assistant_message(
+                emitted_answer,
+                tool_calls=tool_calls,
+            ), bool(emitted_answer)
         if emitted_answer:
+            from app.engine.llm_model_health import record_model_success
+
+            record_model_success(provider_name, model_name)
             if not thinking_closed:
                 if thinking_stop_signal is not None:
                     thinking_stop_signal.set()
@@ -398,8 +539,23 @@ async def _stream_openai_compatible_answer_with_route_impl(
                         "content": "",
                         "node": node,
                     })
-            return AIMessage(content=emitted_answer), True
+            return make_assistant_message(emitted_answer), True
     except Exception as exc:
+        from app.engine.llm_failover_runtime import classify_failover_reason_impl
+        from app.engine.llm_model_health import record_model_failure
+
+        timeout_seconds = primary_timeout if isinstance(exc, asyncio.TimeoutError) else None
+        classified = classify_failover_reason_impl(
+            error=exc,
+            timeout_seconds=timeout_seconds,
+        )
+        record_model_failure(
+            provider_name,
+            model_name,
+            reason_code=classified.get("reason_code"),
+            error=exc,
+            timeout_seconds=timeout_seconds,
+        )
         logger.warning(
             "[%s] Native OpenAI-compatible stream failed (%s/%s): %s",
             node.upper(),
@@ -409,7 +565,10 @@ async def _stream_openai_compatible_answer_with_route_impl(
             exc_info=True,
         )
         if emitted_answer:
-            return AIMessage(content=emitted_answer), True
+            from app.engine.llm_model_health import record_model_success
+
+            record_model_success(provider_name, model_name)
+            return make_assistant_message(emitted_answer), True
     logger.info(
         "[%s] Native stream result: provider=%s model=%s answer=%d chars",
         node.upper(),

--- a/maritime-ai-service/app/engine/native_chat_runtime.py
+++ b/maritime-ai-service/app/engine/native_chat_runtime.py
@@ -1,0 +1,355 @@
+"""Native chat message helpers for Wiii runtime.
+
+This module is intentionally independent from LangChain.  It accepts plain
+OpenAI-compatible dictionaries and LangChain-like duck-typed objects so the
+hot direct stream path can move off framework message classes first, while
+legacy RAG/tool lanes migrate in smaller follow-up slices.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+
+OPENAI_ROLES = {"system", "user", "assistant", "tool", "function"}
+_VALID_TOOL_CHOICE_STRINGS = frozenset({"auto", "none", "required", "validated"})
+_TOOL_CHOICE_ALIASES = {
+    "any": "required",
+    "tool": "required",
+}
+
+
+@dataclass(slots=True)
+class NativeAssistantMessage:
+    """Minimal assistant response object used by Wiii native runtime."""
+
+    content: Any = ""
+    additional_kwargs: dict[str, Any] = field(default_factory=dict)
+    response_metadata: dict[str, Any] = field(default_factory=dict)
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    invalid_tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    usage_metadata: dict[str, Any] | None = None
+    id: str | None = None
+    name: str | None = None
+    type: str = "ai"
+
+
+@dataclass(slots=True)
+class NativeSystemMessage:
+    """Framework-free system message with a LangChain-like surface."""
+
+    content: Any = ""
+    role: str = "system"
+    type: str = "system"
+
+
+@dataclass(slots=True)
+class NativeUserMessage:
+    """Framework-free user message with a LangChain-like surface."""
+
+    content: Any = ""
+    role: str = "user"
+    type: str = "human"
+
+
+@dataclass(slots=True)
+class NativeToolMessage:
+    """Framework-free tool-result message for native tool loops."""
+
+    content: Any = ""
+    tool_call_id: str = ""
+    role: str = "tool"
+    type: str = "tool"
+
+
+@dataclass(slots=True)
+class NativeChatModelHandle:
+    """Provider/model metadata for native OpenAI-compatible calls."""
+
+    _wiii_provider_name: str
+    _wiii_model_name: str
+    _wiii_tier_key: str = "moderate"
+    temperature: float | None = None
+    _wiii_requested_provider: str | None = None
+    _wiii_native_route: bool = True
+    _wiii_bound_tools: list[dict[str, Any]] = field(default_factory=list)
+    _wiii_tool_choice: Any = None
+
+    @property
+    def model_name(self) -> str:
+        return self._wiii_model_name
+
+    def bind_tools(self, tools: list, **kwargs: Any) -> "NativeChatModelHandle":
+        """Return a copy with OpenAI-compatible tools attached."""
+        return replace(
+            self,
+            _wiii_bound_tools=tools_to_openai_schemas(tools),
+            _wiii_tool_choice=normalize_tool_choice(kwargs.get("tool_choice")),
+        )
+
+    async def ainvoke(self, messages: list, **_kwargs: Any) -> NativeAssistantMessage:
+        """Invoke the provider through Wiii's native OpenAI-compatible adapter."""
+        from app.engine.multi_agent.openai_stream_runtime import (
+            _ainvoke_openai_compatible_chat_impl,
+        )
+
+        return await _ainvoke_openai_compatible_chat_impl(self, messages)
+
+
+def flatten_message_content(content: Any) -> str:
+    """Flatten common text block shapes into OpenAI chat text content."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                if item.strip():
+                    parts.append(item)
+                continue
+            if not isinstance(item, dict):
+                continue
+            text = item.get("text") or item.get("content") or item.get("value")
+            if text:
+                parts.append(str(text))
+        return "\n".join(part for part in parts if part)
+    return str(content or "")
+
+
+def message_to_openai_payload(message: Any) -> dict[str, Any]:
+    """Convert a native or LangChain-like message to an OpenAI chat payload."""
+    raw = dict(message) if isinstance(message, dict) else None
+    content = flatten_message_content(
+        raw.get("content", "") if raw is not None else getattr(message, "content", "")
+    )
+    role = _normalize_role(
+        raw.get("role") or raw.get("type") if raw is not None
+        else getattr(message, "role", None) or getattr(message, "type", None)
+    )
+
+    payload: dict[str, Any] = {"role": role, "content": content}
+    if role == "tool":
+        tool_call_id = _get_value(message, raw, "tool_call_id")
+        if tool_call_id:
+            payload["tool_call_id"] = str(tool_call_id)
+    if role == "function":
+        name = _get_value(message, raw, "name")
+        if name:
+            payload["name"] = str(name)
+    if role == "assistant":
+        tool_calls = _normalize_tool_calls(_get_value(message, raw, "tool_calls") or [])
+        if tool_calls:
+            payload["tool_calls"] = tool_calls
+    return payload
+
+
+def make_assistant_message(
+    content: Any,
+    *,
+    additional_kwargs: dict[str, Any] | None = None,
+    response_metadata: dict[str, Any] | None = None,
+    tool_calls: list[dict[str, Any]] | None = None,
+    invalid_tool_calls: list[dict[str, Any]] | None = None,
+    usage_metadata: dict[str, Any] | None = None,
+    id: str | None = None,
+    name: str | None = None,
+) -> NativeAssistantMessage:
+    """Create a framework-free assistant message with LangChain-like fields."""
+    return NativeAssistantMessage(
+        content=content,
+        additional_kwargs=dict(additional_kwargs or {}),
+        response_metadata=dict(response_metadata or {}),
+        tool_calls=list(tool_calls or []),
+        invalid_tool_calls=list(invalid_tool_calls or []),
+        usage_metadata=usage_metadata,
+        id=id,
+        name=name,
+    )
+
+
+def make_system_message(content: Any) -> NativeSystemMessage:
+    """Create a framework-free system message."""
+    return NativeSystemMessage(content=content)
+
+
+def make_user_message(content: Any) -> NativeUserMessage:
+    """Create a framework-free user message."""
+    return NativeUserMessage(content=content)
+
+
+def make_tool_message(content: Any, *, tool_call_id: str) -> NativeToolMessage:
+    """Create a framework-free tool result message."""
+    return NativeToolMessage(
+        content=content,
+        tool_call_id=str(tool_call_id or ""),
+    )
+
+
+def tool_to_openai_schema(tool: Any) -> dict[str, Any] | None:
+    """Serialize a Wiii/LangChain-like tool to OpenAI function-tool schema."""
+    if isinstance(tool, dict) and tool.get("type") == "function":
+        return dict(tool)
+
+    name = str(getattr(tool, "name", "") or getattr(tool, "__name__", "") or "").strip()
+    if not name:
+        return None
+
+    description = str(getattr(tool, "description", "") or "").strip()
+    parameters: dict[str, Any] = {}
+    args_schema = getattr(tool, "args_schema", None)
+    if args_schema is not None:
+        if hasattr(args_schema, "model_json_schema"):
+            parameters = dict(args_schema.model_json_schema())
+        elif hasattr(args_schema, "schema"):
+            parameters = dict(args_schema.schema())
+    elif isinstance(getattr(tool, "parameters", None), dict):
+        parameters = dict(getattr(tool, "parameters"))
+    elif isinstance(getattr(tool, "args", None), dict):
+        parameters = {
+            "type": "object",
+            "properties": dict(getattr(tool, "args")),
+        }
+
+    if not parameters:
+        parameters = {"type": "object", "properties": {}}
+
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": parameters,
+        },
+    }
+
+
+def tools_to_openai_schemas(tools: list | tuple | None) -> list[dict[str, Any]]:
+    """Serialize a sequence of tools, dropping only unnameable entries."""
+    schemas: list[dict[str, Any]] = []
+    for tool in tools or []:
+        schema = tool_to_openai_schema(tool)
+        if schema is not None:
+            schemas.append(schema)
+    return schemas
+
+
+def normalize_tool_choice(value: Any) -> Any:
+    """Normalize Wiii tool-choice hints for OpenAI-compatible endpoints."""
+    if not isinstance(value, str):
+        return value
+    normalized = value.strip()
+    if not normalized:
+        return None
+    aliased = _TOOL_CHOICE_ALIASES.get(normalized, normalized)
+    if aliased in _VALID_TOOL_CHOICE_STRINGS:
+        return aliased
+    return {"type": "function", "function": {"name": normalized}}
+
+
+def openai_response_to_assistant_message(response: Any) -> NativeAssistantMessage:
+    """Convert an OpenAI Chat Completions response into a native message."""
+    choices = list(getattr(response, "choices", []) or [])
+    choice = choices[0] if choices else None
+    raw_message = getattr(choice, "message", None) if choice is not None else None
+    content = getattr(raw_message, "content", "") or ""
+
+    tool_calls: list[dict[str, Any]] = []
+    for idx, tool_call in enumerate(getattr(raw_message, "tool_calls", []) or []):
+        function = getattr(tool_call, "function", None)
+        name = str(getattr(function, "name", "") or "").strip()
+        if not name:
+            continue
+        raw_args = getattr(function, "arguments", None)
+        args: Any = {}
+        if isinstance(raw_args, str) and raw_args.strip():
+            try:
+                args = json.loads(raw_args)
+            except Exception:
+                args = raw_args
+        elif raw_args is not None:
+            args = raw_args
+        tool_calls.append({
+            "id": str(getattr(tool_call, "id", "") or f"call_{idx}"),
+            "name": name,
+            "args": args if isinstance(args, dict) else {"_raw": str(args)},
+        })
+
+    usage = getattr(response, "usage", None)
+    if hasattr(usage, "model_dump"):
+        usage_metadata = usage.model_dump()
+    elif isinstance(usage, dict):
+        usage_metadata = dict(usage)
+    else:
+        usage_metadata = None
+
+    response_metadata = {
+        "model": getattr(response, "model", None),
+        "finish_reason": getattr(choice, "finish_reason", None) if choice is not None else None,
+    }
+    return make_assistant_message(
+        content,
+        tool_calls=tool_calls,
+        response_metadata={
+            key: value for key, value in response_metadata.items() if value is not None
+        },
+        usage_metadata=usage_metadata,
+    )
+
+
+def _get_value(message: Any, raw: dict[str, Any] | None, key: str) -> Any:
+    if raw is not None:
+        return raw.get(key)
+    return getattr(message, key, None)
+
+
+def _normalize_role(raw_role: Any) -> str:
+    role = str(raw_role or "").strip().lower()
+    if role in OPENAI_ROLES:
+        return role
+    if role in {"human", "chatmessage", "user_message"}:
+        return "user"
+    if role in {"ai", "ai_message", "assistant_message"}:
+        return "assistant"
+    if role in {"system_message"}:
+        return "system"
+    if role in {"tool_message"}:
+        return "tool"
+    return "user"
+
+
+def _normalize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
+    if not isinstance(tool_calls, list):
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    for idx, tool_call in enumerate(tool_calls):
+        raw = dict(tool_call) if isinstance(tool_call, dict) else None
+        name = _get_value(tool_call, raw, "name")
+        if not name and raw:
+            function = raw.get("function") or {}
+            if isinstance(function, dict):
+                name = function.get("name")
+        if not name:
+            continue
+
+        arguments = _get_value(tool_call, raw, "args")
+        if arguments is None and raw:
+            function = raw.get("function") or {}
+            if isinstance(function, dict):
+                arguments = function.get("arguments")
+        if isinstance(arguments, str):
+            arguments_json = arguments
+        else:
+            arguments_json = json.dumps(arguments or {}, ensure_ascii=False)
+
+        normalized.append({
+            "id": str(_get_value(tool_call, raw, "id") or f"tc_{idx}"),
+            "type": "function",
+            "function": {
+                "name": str(name),
+                "arguments": arguments_json,
+            },
+        })
+    return normalized

--- a/maritime-ai-service/app/engine/semantic_memory/core.py
+++ b/maritime-ai-service/app/engine/semantic_memory/core.py
@@ -255,6 +255,31 @@ class SemanticMemoryEngine:
             logger.error("Failed to get user facts for %s: %s", user_id, e)
             return {}
 
+    def search_relevant_facts(
+        self,
+        user_id: str,
+        query_embedding: List[float],
+        limit: int = DEFAULT_SEARCH_LIMIT,
+        min_similarity: float = 0.3,
+    ) -> List[SemanticMemorySearchResult]:
+        """
+        Search user facts by query embedding.
+
+        This keeps the facade aligned with the repository API used by the
+        prompt-context builder, so semantic fact retrieval does not silently
+        fall back to broad fact injection.
+        """
+        try:
+            return self._repository.search_relevant_facts(
+                user_id=user_id,
+                query_embedding=query_embedding,
+                limit=limit,
+                min_similarity=min_similarity,
+            )
+        except Exception as exc:
+            logger.warning("Failed to search relevant facts for %s: %s", user_id, exc)
+            return []
+
     # ==================== FACT EXTRACTION (Delegated) ====================
 
     async def _extract_and_store_facts(

--- a/maritime-ai-service/scripts/README.md
+++ b/maritime-ai-service/scripts/README.md
@@ -3,16 +3,34 @@
 ## Local Demo Smoke
 
 Use this before a localhost demo. It verifies the dev-login JWT path, admin/org
-permissions, sync chat, SSE V3 completion, and the local frontend.
+permissions, runtime provider surface, sync chat, SSE V3 answer/metadata/done,
+SSE first-event latency, SSE first-answer latency, and the local frontend.
 
 ```bash
 python scripts/local_demo_smoke.py
+```
+
+Pinned NVIDIA demo gate:
+
+```bash
+python scripts/local_demo_smoke.py ^
+  --provider nvidia ^
+  --model deepseek-ai/deepseek-v4-flash ^
+  --expect-provider nvidia ^
+  --expect-model deepseek-ai/deepseek-v4-flash
 ```
 
 For infrastructure-only checks while isolating provider failures:
 
 ```bash
 python scripts/local_demo_smoke.py --skip-chat --skip-stream
+```
+
+If a model is intentionally slow during investigation, relax the SSE budget
+explicitly instead of hiding the problem:
+
+```bash
+python scripts/local_demo_smoke.py --max-first-answer-seconds 75
 ```
 
 Scripts cho development, testing và data ingestion.

--- a/maritime-ai-service/scripts/local_demo_smoke.py
+++ b/maritime-ai-service/scripts/local_demo_smoke.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import socket
 import sys
 import time
 import urllib.error
@@ -50,6 +51,14 @@ class HttpResponse:
         if not isinstance(payload, dict):
             raise SmokeFailure(f"Expected JSON object from {self.url}")
         return payload
+
+
+@dataclass(frozen=True)
+class SseReadResult:
+    events: list[tuple[str, str]]
+    first_event_seconds: float | None
+    first_answer_seconds: float | None
+    total_seconds: float
 
 
 def join_url(base_url: str, path: str) -> str:
@@ -104,6 +113,103 @@ def request_bytes(
         raise SmokeFailure(f"{method} {url} failed: {exc.reason}") from exc
     except TimeoutError as exc:
         raise SmokeFailure(f"{method} {url} timed out after {timeout}s") from exc
+
+
+def request_sse_events(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+    idle_timeout: float = 10.0,
+    max_total_seconds: float = 90.0,
+) -> SseReadResult:
+    request_headers = {
+        "User-Agent": "wiii-local-demo-smoke/1.0",
+        **(headers or {}),
+    }
+    body: bytes | None = None
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        request_headers.setdefault("Content-Type", "application/json")
+
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers=request_headers,
+        method=method.upper(),
+    )
+    started_at = time.monotonic()
+    events: list[tuple[str, str]] = []
+    event_name = "message"
+    data_lines: list[str] = []
+    first_event_seconds: float | None = None
+    first_answer_seconds: float | None = None
+
+    def elapsed() -> float:
+        return time.monotonic() - started_at
+
+    def flush() -> None:
+        nonlocal event_name, data_lines, first_event_seconds, first_answer_seconds
+        if event_name != "message" or data_lines:
+            data = "\n".join(data_lines)
+            events.append((event_name, data))
+            current_elapsed = elapsed()
+            if first_event_seconds is None:
+                first_event_seconds = current_elapsed
+            if event_name == "answer" and data.strip() and first_answer_seconds is None:
+                first_answer_seconds = current_elapsed
+        event_name = "message"
+        data_lines = []
+
+    try:
+        with urllib.request.urlopen(req, timeout=idle_timeout) as response:
+            if response.status != 200:
+                raise SmokeFailure(f"{method} {url} -> HTTP {response.status}")
+            while True:
+                if max_total_seconds and elapsed() > max_total_seconds:
+                    raise SmokeFailure(
+                        f"{method} {url} exceeded SSE total budget "
+                        f"{max_total_seconds:.1f}s"
+                    )
+                raw_line = response.readline()
+                if raw_line == b"":
+                    break
+                line = raw_line.decode("utf-8", errors="replace").rstrip("\n").rstrip("\r")
+                if not line:
+                    flush()
+                    continue
+                if line.startswith(":"):
+                    continue
+                if line.startswith("event:"):
+                    event_name = line.split(":", 1)[1].strip() or "message"
+                    continue
+                if line.startswith("data:"):
+                    data_lines.append(line.split(":", 1)[1].lstrip())
+                    continue
+            flush()
+    except urllib.error.HTTPError as exc:
+        body_text = exc.read().decode("utf-8", errors="replace")
+        raise SmokeFailure(f"{method} {url} -> HTTP {exc.code}: {body_text}") from exc
+    except urllib.error.URLError as exc:
+        raise SmokeFailure(f"{method} {url} failed: {exc.reason}") from exc
+    except (TimeoutError, socket.timeout) as exc:
+        if events:
+            event_names = ",".join(dict.fromkeys(name for name, _data in events))
+            raise SmokeFailure(
+                f"{method} {url} SSE idle timeout after {idle_timeout:.1f}s "
+                f"(events so far: {event_names})"
+            ) from exc
+        raise SmokeFailure(
+            f"{method} {url} had no SSE data for {idle_timeout:.1f}s"
+        ) from exc
+
+    return SseReadResult(
+        events=events,
+        first_event_seconds=first_event_seconds,
+        first_answer_seconds=first_answer_seconds,
+        total_seconds=elapsed(),
+    )
 
 
 def parse_sse_events(text: str) -> list[tuple[str, str]]:
@@ -164,6 +270,24 @@ def build_chat_payload(
     return payload
 
 
+def decode_json_object(data: str) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def extract_event_content(data: str) -> str:
+    payload = decode_json_object(data)
+    if payload is None:
+        return data.strip()
+    content = payload.get("content")
+    if isinstance(content, str):
+        return content.strip()
+    return data.strip()
+
+
 class DemoSmoke:
     def __init__(self, args: argparse.Namespace) -> None:
         self.args = args
@@ -200,6 +324,40 @@ class DemoSmoke:
         if self.args.org_id:
             headers["X-Organization-ID"] = self.args.org_id
         return headers
+
+    def expected_provider(self) -> str | None:
+        if self.args.expect_provider:
+            return self.args.expect_provider
+        if (
+            self.args.provider
+            and self.args.provider != "auto"
+            and not self.args.allow_provider_failover
+        ):
+            return self.args.provider
+        return None
+
+    def expected_model(self) -> str | None:
+        return self.args.expect_model or self.args.model
+
+    def validate_runtime_metadata(self, metadata: dict[str, Any], *, source: str) -> str:
+        provider = str(metadata.get("provider") or metadata.get("active_provider") or "").strip()
+        model = str(metadata.get("model") or metadata.get("model_name") or "").strip()
+        if not provider or provider == "unknown":
+            raise SmokeFailure(f"{source} metadata did not include provider")
+        if not model or model == "unknown":
+            raise SmokeFailure(f"{source} metadata did not include model")
+
+        expected_provider = self.expected_provider()
+        if expected_provider and provider != expected_provider:
+            raise SmokeFailure(
+                f"{source} used provider={provider!r}; expected {expected_provider!r}"
+            )
+        expected_model = self.expected_model()
+        if expected_model and model != expected_model:
+            raise SmokeFailure(
+                f"{source} used model={model!r}; expected {expected_model!r}"
+            )
+        return f"provider={provider} model={model}"
 
     def check_backend_health(self) -> str:
         statuses: list[str] = []
@@ -300,6 +458,44 @@ class DemoSmoke:
             raise SmokeFailure("current user is not org admin")
         return f"admin_org_ids={payload.get('admin_org_ids')}"
 
+    def check_runtime_config(self) -> str:
+        payload = request_bytes(
+            "GET",
+            self.api_url("/api/v1/admin/llm-runtime"),
+            headers=self.auth_headers(),
+            timeout=self.args.timeout,
+        ).json()
+        active_provider = str(payload.get("active_provider") or payload.get("provider") or "").strip()
+        expected_provider = self.expected_provider()
+        if expected_provider == "nvidia":
+            if not payload.get("nvidia_base_url"):
+                raise SmokeFailure("NVIDIA base URL is missing from runtime config")
+            if not payload.get("nvidia_model"):
+                raise SmokeFailure("NVIDIA flash model is missing from runtime config")
+            if not payload.get("nvidia_model_advanced"):
+                raise SmokeFailure("NVIDIA pro model is missing from runtime config")
+            if payload.get("nvidia_api_key_configured") is not True:
+                raise SmokeFailure("NVIDIA API key is not configured")
+
+            nvidia_status = None
+            for status in payload.get("provider_status") or []:
+                if isinstance(status, dict) and status.get("provider") == "nvidia":
+                    nvidia_status = status
+                    break
+            if not nvidia_status:
+                raise SmokeFailure("NVIDIA provider is missing from provider_status")
+            if nvidia_status.get("configured") is not True:
+                raise SmokeFailure("NVIDIA provider is not configured")
+            if nvidia_status.get("request_selectable") is not True:
+                raise SmokeFailure("NVIDIA provider is not request-selectable")
+
+        nvidia_key = payload.get("nvidia_api_key_configured")
+        nvidia_model = payload.get("nvidia_model")
+        return (
+            f"active={active_provider or 'unknown'} "
+            f"nvidia_key={nvidia_key} nvidia_model={nvidia_model}"
+        )
+
     def check_org_permissions(self) -> str:
         response = request_bytes(
             "GET",
@@ -357,12 +553,13 @@ class DemoSmoke:
         if not answer:
             raise SmokeFailure("chat response did not include a non-empty answer")
         metadata = payload.get("metadata") or {}
-        provider = metadata.get("provider", "unknown")
-        model = metadata.get("model", "unknown")
-        return f"provider={provider} model={model} answer_chars={len(answer)}"
+        if not isinstance(metadata, dict):
+            raise SmokeFailure("chat response metadata is not an object")
+        runtime_detail = self.validate_runtime_metadata(metadata, source="sync chat")
+        return f"{runtime_detail} answer_chars={len(answer)}"
 
     def check_stream_chat(self) -> str:
-        response = request_bytes(
+        result = request_sse_events(
             "POST",
             self.api_url("/api/v1/chat/stream/v3"),
             headers={
@@ -370,16 +567,68 @@ class DemoSmoke:
                 "Accept": "text/event-stream",
             },
             payload=self.chat_payload(session_suffix="stream"),
-            timeout=self.args.stream_timeout,
+            idle_timeout=self.args.stream_idle_timeout,
+            max_total_seconds=min(
+                self.args.stream_timeout,
+                self.args.max_stream_total_seconds,
+            ),
         )
-        events = parse_sse_events(response.text())
+        events = result.events
         event_names = [name for name, _data in events]
         if "error" in event_names:
             error_data = next(data for name, data in events if name == "error")
             raise SmokeFailure(f"stream emitted error event: {error_data}")
+        if "answer" not in event_names:
+            raise SmokeFailure(f"stream did not emit answer event; saw {event_names}")
+        if "metadata" not in event_names:
+            raise SmokeFailure(f"stream did not emit metadata event; saw {event_names}")
         if "done" not in event_names:
             raise SmokeFailure(f"stream did not emit done event; saw {event_names}")
-        return f"events={','.join(dict.fromkeys(event_names))}"
+
+        if (
+            result.first_event_seconds is None
+            or result.first_event_seconds > self.args.max_first_event_seconds
+        ):
+            raise SmokeFailure(
+                "stream first event exceeded budget: "
+                f"{result.first_event_seconds}s > {self.args.max_first_event_seconds}s"
+            )
+        if (
+            result.first_answer_seconds is None
+            or result.first_answer_seconds > self.args.max_first_answer_seconds
+        ):
+            raise SmokeFailure(
+                "stream first answer exceeded budget: "
+                f"{result.first_answer_seconds}s > {self.args.max_first_answer_seconds}s"
+            )
+
+        answer_chars = sum(
+            len(extract_event_content(data))
+            for name, data in events
+            if name == "answer"
+        )
+        if answer_chars <= 0:
+            raise SmokeFailure("stream answer events were empty")
+
+        metadata_payload = None
+        for name, data in reversed(events):
+            if name == "metadata":
+                metadata_payload = decode_json_object(data)
+                if metadata_payload is not None:
+                    break
+        if metadata_payload is None:
+            raise SmokeFailure("stream metadata event was not a JSON object")
+        runtime_detail = self.validate_runtime_metadata(
+            metadata_payload,
+            source="stream chat",
+        )
+        unique_events = ",".join(dict.fromkeys(event_names))
+        return (
+            f"{runtime_detail} events={unique_events} "
+            f"first_event={result.first_event_seconds:.1f}s "
+            f"first_answer={result.first_answer_seconds:.1f}s "
+            f"total={result.total_seconds:.1f}s"
+        )
 
     def run(self) -> int:
         print("=== Wiii Local Demo Smoke Gate ===")
@@ -397,6 +646,8 @@ class DemoSmoke:
         if login_ready and self.run_check("dev-login JWT", self.check_dev_login):
             self.run_check("authenticated profile", self.check_profile)
             self.run_check("admin context", self.check_admin_context)
+            if not self.args.skip_runtime_config:
+                self.run_check("runtime config", self.check_runtime_config)
             self.run_check("organization permissions", self.check_org_permissions)
 
             if not self.args.skip_chat:
@@ -427,12 +678,20 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--domain-id", default="maritime")
     parser.add_argument("--provider", default="auto")
     parser.add_argument("--model", default=None)
+    parser.add_argument("--expect-provider", default=None)
+    parser.add_argument("--expect-model", default=None)
+    parser.add_argument("--allow-provider-failover", action="store_true")
     parser.add_argument("--session-id", default=f"local-demo-{int(time.time())}")
     parser.add_argument("--message", default=DEFAULT_MESSAGE)
     parser.add_argument("--timeout", type=float, default=8.0)
     parser.add_argument("--chat-timeout", type=float, default=45.0)
     parser.add_argument("--stream-timeout", type=float, default=90.0)
+    parser.add_argument("--stream-idle-timeout", type=float, default=20.0)
+    parser.add_argument("--max-first-event-seconds", type=float, default=5.0)
+    parser.add_argument("--max-first-answer-seconds", type=float, default=45.0)
+    parser.add_argument("--max-stream-total-seconds", type=float, default=90.0)
     parser.add_argument("--skip-frontend", action="store_true")
+    parser.add_argument("--skip-runtime-config", action="store_true")
     parser.add_argument("--skip-chat", action="store_true")
     parser.add_argument("--skip-stream", action="store_true")
     return parser

--- a/maritime-ai-service/scripts/local_demo_smoke.py
+++ b/maritime-ai-service/scripts/local_demo_smoke.py
@@ -299,7 +299,7 @@ class DemoSmoke:
     def run_check(self, name: str, func) -> bool:  # type: ignore[no-untyped-def]
         start = time.monotonic()
         try:
-            detail = func()
+            func()
         except SmokeFailure as exc:
             self.failed += 1
             print(f"[FAIL] {name} - {exc}")
@@ -309,8 +309,7 @@ class DemoSmoke:
             print(f"[FAIL] {name} - unexpected error: {exc}")
             return False
         elapsed = time.monotonic() - start
-        suffix = f" - {detail}" if detail else ""
-        print(f"[PASS] {name}{suffix} ({elapsed:.1f}s)")
+        print(f"[PASS] {name} ({elapsed:.1f}s)")
         self.passed += 1
         return True
 

--- a/maritime-ai-service/tests/unit/_direct_node_test_utils.py
+++ b/maritime-ai-service/tests/unit/_direct_node_test_utils.py
@@ -42,6 +42,12 @@ def patched_direct_node_runtime(
                 return_value=llm,
             )
         )
+        stack.enter_context(
+            patch(
+                "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_native_llm",
+                return_value=None,
+            )
+        )
         stack.enter_context(patch("app.engine.multi_agent.graph._get_effective_provider", return_value=None))
         stack.enter_context(patch("app.engine.multi_agent.graph._get_explicit_user_provider", return_value=None))
         stack.enter_context(

--- a/maritime-ai-service/tests/unit/engine/context/test_pointy_actions.py
+++ b/maritime-ai-service/tests/unit/engine/context/test_pointy_actions.py
@@ -1,5 +1,6 @@
 """Smoke tests for the Wiii Pointy action reference module."""
 from app.engine.context.pointy_actions import (
+    POINTY_ACTION_CLICK,
     POINTY_ACTION_HIGHLIGHT,
     POINTY_ACTION_NAVIGATE,
     POINTY_ACTION_SCROLL_TO,
@@ -14,11 +15,13 @@ def test_action_names_are_stable():
     assert POINTY_ACTION_SCROLL_TO == "ui.scroll_to"
     assert POINTY_ACTION_NAVIGATE == "ui.navigate"
     assert POINTY_ACTION_SHOW_TOUR == "ui.show_tour"
+    assert POINTY_ACTION_CLICK == "ui.click"
     assert set(POINTY_ACTIONS) == {
         POINTY_ACTION_HIGHLIGHT,
         POINTY_ACTION_SCROLL_TO,
         POINTY_ACTION_NAVIGATE,
         POINTY_ACTION_SHOW_TOUR,
+        POINTY_ACTION_CLICK,
     }
 
 
@@ -33,6 +36,8 @@ def test_reference_capabilities_shape():
         assert tool["requires_confirmation"] is False
         assert tool["surface"] == "page"
         assert "input_schema" in tool
+    click_tool = next(t for t in caps["tools"] if t["name"] == POINTY_ACTION_CLICK)
+    assert "click_safe=true" in click_tool["input_schema"]["properties"]["selector"]["description"]
 
 
 def test_reference_capabilities_is_valid_for_pydantic_host_capabilities():

--- a/maritime-ai-service/tests/unit/engine/context/test_pointy_fast_path.py
+++ b/maritime-ai-service/tests/unit/engine/context/test_pointy_fast_path.py
@@ -50,6 +50,28 @@ def test_extracts_valid_pointy_targets_from_host_context():
     ]
 
 
+def test_empty_host_targets_do_not_fall_back_to_stale_page_context():
+    ctx = {
+        "host_context": {
+            "page": {
+                "type": "course_list",
+                "metadata": {"available_targets": []},
+            },
+        },
+        "page_context": {
+            "available_targets": [
+                {
+                    "id": "stale-target",
+                    "selector": '[data-wiii-id="stale-target"]',
+                    "label": "Stale target",
+                }
+            ]
+        },
+    }
+
+    assert get_pointy_targets_from_context(ctx) == []
+
+
 def test_where_is_prompt_emits_highlight_action():
     action = build_pointy_fast_path_action(
         "Wiii oi, nut Kham pha khoa hoc o dau?",
@@ -106,6 +128,7 @@ def test_open_prompt_clicks_only_safe_navigation_target():
     assert action is not None
     assert action["action"] == POINTY_ACTION_CLICK
     assert action["params"]["selector"] == "browse-courses-link"
+    assert action["params"]["message"] == "Wiii đang mở Kham pha khoa hoc cho bạn."
     assert action["reason"] == "click"
 
 
@@ -124,6 +147,7 @@ def test_unsafe_click_intent_is_demoted_to_highlight():
 
     assert action is not None
     assert action["action"] == POINTY_ACTION_HIGHLIGHT
+    assert action["params"]["message"] == "Đây là Nop bai. Wiii trỏ vào để bạn thấy ngay."
     assert action["reason"] == "unsafe_click_demoted"
 
 

--- a/maritime-ai-service/tests/unit/engine/context/test_pointy_fast_path.py
+++ b/maritime-ai-service/tests/unit/engine/context/test_pointy_fast_path.py
@@ -1,0 +1,149 @@
+"""Tests for Pointy fast-path UI intent matching."""
+
+from app.engine.context.pointy_actions import POINTY_ACTION_CLICK, POINTY_ACTION_HIGHLIGHT
+from app.engine.context.pointy_fast_path import (
+    POINTY_FAST_PATH_SOURCE,
+    build_pointy_fast_path_action,
+    get_pointy_targets_from_context,
+    normalize_pointy_text,
+)
+
+
+def _context(targets, feedback=None):
+    return {
+        "host_context": {
+            "page": {
+                "type": "course_list",
+                "metadata": {
+                    "available_targets": targets,
+                },
+            },
+        },
+        **({"host_action_feedback": feedback} if feedback else {}),
+    }
+
+
+def test_normalize_pointy_text_handles_vietnamese():
+    assert normalize_pointy_text("Wiii oi, nut Kham pha khoa hoc o dau?") == (
+        "wiii oi nut kham pha khoa hoc o dau"
+    )
+    assert normalize_pointy_text("Wiii ơi, Khám phá khóa học ở đâu?") == (
+        "wiii oi kham pha khoa hoc o dau"
+    )
+
+
+def test_extracts_valid_pointy_targets_from_host_context():
+    ctx = _context([
+        {"id": "browse-courses", "selector": '[data-wiii-id="browse-courses"]', "label": "Kham pha"},
+        {"id": "", "selector": "#bad"},
+        "noise",
+    ])
+
+    assert get_pointy_targets_from_context(ctx) == [
+        {
+            "id": "browse-courses",
+            "selector": '[data-wiii-id="browse-courses"]',
+            "label": "Kham pha",
+            "click_safe": False,
+            "click_kind": None,
+        }
+    ]
+
+
+def test_where_is_prompt_emits_highlight_action():
+    action = build_pointy_fast_path_action(
+        "Wiii oi, nut Kham pha khoa hoc o dau?",
+        _context([
+            {
+                "id": "browse-courses",
+                "selector": '[data-wiii-id="browse-courses"]',
+                "label": "Kham pha khoa hoc",
+                "click_safe": True,
+            }
+        ]),
+    )
+
+    assert action is not None
+    assert action["action"] == POINTY_ACTION_HIGHLIGHT
+    assert action["params"]["selector"] == "browse-courses"
+    assert action["params"]["source"] == POINTY_FAST_PATH_SOURCE
+    assert action["reason"] == "locate"
+
+
+def test_accented_where_is_prompt_without_button_word_still_emits_highlight():
+    action = build_pointy_fast_path_action(
+        "Wiii ơi, Khám phá khóa học ở đâu?",
+        _context([
+            {
+                "id": "browse-courses-link",
+                "selector": '[data-wiii-id="browse-courses-link"]',
+                "label": "Khám phá khóa học",
+                "click_safe": True,
+            }
+        ]),
+    )
+
+    assert action is not None
+    assert action["action"] == POINTY_ACTION_HIGHLIGHT
+    assert action["params"]["selector"] == "browse-courses-link"
+    assert action["reason"] == "locate"
+
+
+def test_open_prompt_clicks_only_safe_navigation_target():
+    action = build_pointy_fast_path_action(
+        "Wiii mo Kham pha khoa hoc giup toi",
+        _context([
+            {
+                "id": "browse-courses-link",
+                "selector": '[data-wiii-id="browse-courses-link"]',
+                "label": "Kham pha khoa hoc",
+                "click_safe": True,
+                "click_kind": "navigation",
+            }
+        ]),
+    )
+
+    assert action is not None
+    assert action["action"] == POINTY_ACTION_CLICK
+    assert action["params"]["selector"] == "browse-courses-link"
+    assert action["reason"] == "click"
+
+
+def test_unsafe_click_intent_is_demoted_to_highlight():
+    action = build_pointy_fast_path_action(
+        "Wiii bam nut Nop bai giup toi",
+        _context([
+            {
+                "id": "submit-quiz",
+                "selector": '[data-wiii-id="submit-quiz"]',
+                "label": "Nop bai",
+                "click_safe": False,
+            }
+        ]),
+    )
+
+    assert action is not None
+    assert action["action"] == POINTY_ACTION_HIGHLIGHT
+    assert action["reason"] == "unsafe_click_demoted"
+
+
+def test_skips_when_frontend_fast_path_already_reported_feedback():
+    action = build_pointy_fast_path_action(
+        "Wiii oi, nut Kham pha khoa hoc o dau?",
+        _context(
+            [
+                {
+                    "id": "browse-courses",
+                    "selector": '[data-wiii-id="browse-courses"]',
+                    "label": "Kham pha khoa hoc",
+                }
+            ],
+            feedback={
+                "last_action_result": {
+                    "params": {"source": POINTY_FAST_PATH_SOURCE},
+                },
+            },
+        ),
+    )
+
+    assert action is None

--- a/maritime-ai-service/tests/unit/test_agentic_rag_runtime_llm_socket.py
+++ b/maritime-ai-service/tests/unit/test_agentic_rag_runtime_llm_socket.py
@@ -1,0 +1,109 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.engine.agentic_rag.runtime_llm_socket import (
+    ainvoke_agentic_rag_llm,
+    make_agentic_rag_messages,
+    resolve_agentic_rag_llm,
+)
+from app.engine.llm_factory import ThinkingTier
+from app.engine.native_chat_runtime import NativeChatModelHandle
+
+
+def test_make_agentic_rag_messages_uses_native_message_surface():
+    messages = make_agentic_rag_messages(
+        system="system prompt",
+        user="user prompt",
+        assistant_prefill="<thinking>",
+    )
+
+    assert [message.type for message in messages] == ["system", "human", "ai"]
+    assert [message.content for message in messages] == [
+        "system prompt",
+        "user prompt",
+        "<thinking>",
+    ]
+
+
+def test_resolve_agentic_rag_llm_prefers_native_handle_when_client_exists():
+    native_handle = NativeChatModelHandle(
+        _wiii_provider_name="nvidia",
+        _wiii_model_name="deepseek-ai/deepseek-v4-flash",
+        _wiii_tier_key="light",
+    )
+
+    with (
+        patch(
+            "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_native_llm",
+            return_value=native_handle,
+        ),
+        patch(
+            "app.engine.multi_agent.openai_stream_runtime."
+            "_create_openai_compatible_stream_client_impl",
+            return_value=object(),
+        ),
+        patch("app.engine.agentic_rag.runtime_llm_socket.get_llm_for_provider") as fallback,
+    ):
+        llm = resolve_agentic_rag_llm(
+            tier=ThinkingTier.LIGHT,
+            component="RuntimeSocketTest",
+        )
+
+    assert llm is native_handle
+    fallback.assert_not_called()
+
+
+def test_resolve_agentic_rag_llm_falls_back_when_native_client_missing():
+    native_handle = NativeChatModelHandle(
+        _wiii_provider_name="nvidia",
+        _wiii_model_name="deepseek-ai/deepseek-v4-flash",
+        _wiii_tier_key="light",
+    )
+    fallback_llm = object()
+
+    with (
+        patch(
+            "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_native_llm",
+            return_value=native_handle,
+        ),
+        patch(
+            "app.engine.multi_agent.openai_stream_runtime."
+            "_create_openai_compatible_stream_client_impl",
+            return_value=None,
+        ),
+        patch(
+            "app.engine.agentic_rag.runtime_llm_socket.get_llm_for_provider",
+            return_value=fallback_llm,
+        ),
+    ):
+        llm = resolve_agentic_rag_llm(
+            tier=ThinkingTier.LIGHT,
+            component="RuntimeSocketTest",
+        )
+
+    assert llm is fallback_llm
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_agentic_rag_llm_pins_native_provider_to_failover_socket():
+    native_handle = NativeChatModelHandle(
+        _wiii_provider_name="nvidia",
+        _wiii_model_name="deepseek-ai/deepseek-v4-flash",
+        _wiii_tier_key="light",
+    )
+
+    with patch(
+        "app.engine.agentic_rag.runtime_llm_socket.ainvoke_with_failover",
+        new=AsyncMock(return_value="ok"),
+    ) as invoke:
+        result = await ainvoke_agentic_rag_llm(
+            llm=native_handle,
+            messages=make_agentic_rag_messages(user="hello"),
+            tier=ThinkingTier.LIGHT,
+            component="RuntimeSocketTest",
+        )
+
+    assert result == "ok"
+    assert invoke.await_args.kwargs["provider"] == "nvidia"
+    assert invoke.await_args.kwargs["prefer_selectable_fallback"] is False

--- a/maritime-ai-service/tests/unit/test_chat_stream_transport.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_transport.py
@@ -58,6 +58,28 @@ async def test_wrap_sse_with_keepalive_sends_heartbeat_on_idle():
 
 
 @pytest.mark.asyncio
+async def test_wrap_sse_with_keepalive_repeats_heartbeats_until_data():
+    async def slow_inner():
+        await asyncio.sleep(0.035)
+        yield "data"
+
+    mock_request = MagicMock()
+    mock_request.is_disconnected = AsyncMock(return_value=False)
+
+    chunks = []
+    async for chunk in wrap_sse_with_keepalive(
+        inner_gen=slow_inner(),
+        request=mock_request,
+        keepalive_interval_sec=0.01,
+        idle_timeout_sec=0.1,
+    ):
+        chunks.append(chunk)
+
+    assert chunks.count(SSE_KEEPALIVE) >= 2
+    assert chunks[-1] == "data"
+
+
+@pytest.mark.asyncio
 async def test_wrap_sse_with_keepalive_allows_long_streams_when_idle_timeout_disabled():
     async def slow_inner():
         await asyncio.sleep(0.03)

--- a/maritime-ai-service/tests/unit/test_direct_execution_streaming.py
+++ b/maritime-ai-service/tests/unit/test_direct_execution_streaming.py
@@ -5,6 +5,7 @@ import pytest
 from app.engine.multi_agent.direct_execution import (
     _normalize_direct_visible_thinking,
     _stream_answer_with_fallback,
+    _stream_direct_wait_heartbeats,
 )
 
 
@@ -47,6 +48,28 @@ class _FakeLLM:
                 {"type": "text", "text": "Minh la Wiii."},
             ]
         )
+
+
+@pytest.mark.asyncio
+async def test_direct_wait_heartbeat_is_visible_progress():
+    events = []
+
+    async def _push_event(event):
+        events.append(event)
+
+    await _stream_direct_wait_heartbeats(
+        _push_event,
+        query="Wiii oi, nut Tin nhan nam o dau?",
+        phase="attune",
+        cue="lms",
+        interval_sec=0.001,
+    )
+
+    assert len(events) == 2
+    assert all(event["type"] == "status" for event in events)
+    assert all(event["details"]["subtype"] == "visible_wait" for event in events)
+    assert all(event["details"]["visibility"] == "progress" for event in events)
+    assert all(event["content"] for event in events)
 
 
 @pytest.mark.asyncio
@@ -137,6 +160,53 @@ async def test_stream_answer_with_fallback_prefers_openai_compat_stream_for_goog
     assert streamed is True
     assert response.content == "Native SDK answer."
     assert compat_calls == ["google"]
+    assert [event["type"] for event in events] == ["answer_delta"]
+
+
+@pytest.mark.asyncio
+async def test_stream_answer_with_fallback_uses_native_handle_without_langchain_pool(monkeypatch):
+    from app.engine.native_chat_runtime import NativeChatModelHandle, make_assistant_message
+
+    events = []
+    compat_calls = []
+
+    async def _push_event(event):
+        events.append(event)
+
+    async def _compat_stream(route, _messages, push_event, *, node, **_kwargs):
+        compat_calls.append((route.provider, route.llm.model_name))
+        await push_event({
+            "type": "answer_delta",
+            "content": "Native handle answer.",
+            "node": node,
+        })
+        return make_assistant_message("Native handle answer."), True
+
+    monkeypatch.setattr(
+        "app.engine.multi_agent.direct_execution._stream_openai_compatible_answer_with_route",
+        _compat_stream,
+    )
+
+    llm = NativeChatModelHandle(
+        _wiii_provider_name="nvidia",
+        _wiii_model_name="deepseek-ai/deepseek-v4-flash",
+        _wiii_tier_key="light",
+    )
+
+    response, streamed = await _stream_answer_with_fallback(
+        llm,
+        messages=[{"role": "user", "content": "Hi Wiii"}],
+        push_event=_push_event,
+        provider="nvidia",
+        resolved_provider="nvidia",
+        node="direct",
+        thinking_block_opened=False,
+        state={},
+    )
+
+    assert streamed is True
+    assert response.content == "Native handle answer."
+    assert compat_calls == [("nvidia", "deepseek-ai/deepseek-v4-flash")]
     assert [event["type"] for event in events] == ["answer_delta"]
 
 

--- a/maritime-ai-service/tests/unit/test_direct_node_provider_errors.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_provider_errors.py
@@ -127,6 +127,202 @@ async def test_direct_response_node_wraps_runtime_provider_failure_for_explicit_
 
 
 @pytest.mark.asyncio
+async def test_direct_response_node_uses_native_handle_without_explicit_provider():
+    from app.engine.native_chat_runtime import NativeChatModelHandle, make_assistant_message
+
+    state = _base_state()
+    state["query"] = "Hay noi ngan gon ve Wiii"
+    state["routing_metadata"] = {"intent": "general"}
+    state.pop("provider", None)
+
+    kwargs = _base_direct_kwargs()
+    captured: dict = {}
+    native_handle = NativeChatModelHandle(
+        _wiii_provider_name="nvidia",
+        _wiii_model_name="deepseek-ai/deepseek-v4-flash",
+        _wiii_tier_key="light",
+    )
+    kwargs["looks_identity_selfhood_turn"] = lambda *_args, **_kwargs: False
+    kwargs["get_effective_provider"] = lambda *_args, **_kwargs: None
+    kwargs["get_explicit_user_provider"] = lambda *_args, **_kwargs: None
+    kwargs["bind_direct_tools"] = lambda llm, *_args, **_kwargs: (llm, llm, None)
+
+    def _build_messages(*_args, **build_kwargs):
+        captured["native_messages"] = build_kwargs.get("native_messages")
+        return [{"role": "user", "content": state["query"]}]
+
+    kwargs["build_direct_system_messages"] = _build_messages
+    kwargs["extract_direct_response"] = lambda *_args, **_kwargs: (
+        "Native route ok",
+        "",
+        [],
+    )
+
+    async def _execute(llm_with_tools, _llm_auto, messages, *_args, **_kwargs):
+        captured["llm"] = llm_with_tools
+        captured["messages"] = messages
+        captured["native_tool_messages"] = _kwargs.get("native_tool_messages")
+        return make_assistant_message("Native route ok"), messages, []
+
+    kwargs["execute_direct_tool_rounds"] = _execute
+
+    with patch(
+        "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_native_llm",
+        return_value=native_handle,
+    ) as mock_get_native, patch(
+        "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_llm",
+        side_effect=AssertionError("legacy LangChain LLM should not be constructed"),
+    ):
+        result = await direct_response_node_impl(
+            state,
+            **kwargs,
+        )
+
+    assert result["final_response"] == "Native route ok"
+    assert captured["llm"] is native_handle
+    assert captured["native_messages"] is True
+    assert captured["native_tool_messages"] is True
+    assert captured["messages"] == [{"role": "user", "content": state["query"]}]
+    mock_get_native.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_direct_response_node_uses_native_handle_for_forced_tool_turn():
+    from app.engine.native_chat_runtime import NativeChatModelHandle, make_assistant_message
+
+    state = _base_state()
+    state["query"] = "May gio roi?"
+    state["routing_metadata"] = {"intent": "lookup"}
+    state.pop("provider", None)
+
+    tool = SimpleNamespace(
+        name="tool_current_datetime",
+        description="Get current date and time",
+        parameters={"type": "object", "properties": {}},
+    )
+    native_handle = NativeChatModelHandle(
+        _wiii_provider_name="nvidia",
+        _wiii_model_name="deepseek-ai/deepseek-v4-flash",
+        _wiii_tier_key="light",
+    )
+    kwargs = _base_direct_kwargs()
+    captured: dict = {}
+    kwargs["looks_identity_selfhood_turn"] = lambda *_args, **_kwargs: False
+    kwargs["get_effective_provider"] = lambda *_args, **_kwargs: None
+    kwargs["get_explicit_user_provider"] = lambda *_args, **_kwargs: None
+    kwargs["collect_direct_tools"] = lambda *_args, **_kwargs: ([tool], True)
+    kwargs["direct_required_tool_names"] = lambda *_args, **_kwargs: ["tool_current_datetime"]
+    kwargs["bind_direct_tools"] = lambda llm, *_args, **_kwargs: (
+        llm.bind_tools([tool], tool_choice="tool_current_datetime"),
+        llm.bind_tools([tool]),
+        "tool_current_datetime",
+    )
+    kwargs["build_direct_system_messages"] = lambda *_args, **_kwargs: [
+        {"role": "user", "content": state["query"]}
+    ]
+    kwargs["extract_direct_response"] = lambda *_args, **_kwargs: (
+        "Bay gio la 10:00.",
+        "",
+        ["tool_current_datetime"],
+    )
+
+    async def _execute(llm_with_tools, _llm_auto, messages, *_args, **_kwargs):
+        captured["llm"] = llm_with_tools
+        captured["forced_tool_choice"] = _kwargs.get("forced_tool_choice")
+        captured["native_tool_messages"] = _kwargs.get("native_tool_messages")
+        return make_assistant_message("Bay gio la 10:00."), messages, [
+            {"type": "call", "name": "tool_current_datetime", "id": "call_1"},
+        ]
+
+    kwargs["execute_direct_tool_rounds"] = _execute
+
+    with patch(
+        "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_native_llm",
+        return_value=native_handle,
+    ), patch(
+        "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_llm",
+        side_effect=AssertionError("legacy LangChain LLM should not be constructed"),
+    ):
+        result = await direct_response_node_impl(
+            state,
+            **kwargs,
+        )
+
+    assert result["final_response"] == "Bay gio la 10:00."
+    assert captured["llm"]._wiii_native_route is True
+    assert captured["llm"]._wiii_bound_tools[0]["function"]["name"] == "tool_current_datetime"
+    assert captured["forced_tool_choice"] == "tool_current_datetime"
+    assert captured["native_tool_messages"] is True
+
+
+@pytest.mark.asyncio
+async def test_direct_response_node_uses_native_handle_for_optional_tool_turn():
+    from app.engine.native_chat_runtime import NativeChatModelHandle, make_assistant_message
+
+    state = _base_state()
+    state["query"] = "Co gi moi trong khoa hoc cua toi?"
+    state["routing_metadata"] = {"intent": "general"}
+    state.pop("provider", None)
+
+    tool = SimpleNamespace(
+        name="tool_lms_courses",
+        description="Inspect LMS courses",
+        parameters={"type": "object", "properties": {}},
+    )
+    native_handle = NativeChatModelHandle(
+        _wiii_provider_name="nvidia",
+        _wiii_model_name="deepseek-ai/deepseek-v4-flash",
+        _wiii_tier_key="light",
+    )
+    kwargs = _base_direct_kwargs()
+    captured: dict = {}
+    kwargs["looks_identity_selfhood_turn"] = lambda *_args, **_kwargs: False
+    kwargs["get_effective_provider"] = lambda *_args, **_kwargs: None
+    kwargs["get_explicit_user_provider"] = lambda *_args, **_kwargs: None
+    kwargs["collect_direct_tools"] = lambda *_args, **_kwargs: ([tool], False)
+    kwargs["direct_required_tool_names"] = lambda *_args, **_kwargs: []
+    kwargs["bind_direct_tools"] = lambda llm, *_args, **_kwargs: (
+        llm.bind_tools([tool]),
+        llm.bind_tools([tool]),
+        None,
+    )
+    kwargs["build_direct_system_messages"] = lambda *_args, **_kwargs: [
+        {"role": "user", "content": state["query"]}
+    ]
+    kwargs["extract_direct_response"] = lambda *_args, **_kwargs: (
+        "Khoa hoc cua ban dang on.",
+        "",
+        [],
+    )
+
+    async def _execute(llm_with_tools, _llm_auto, messages, *_args, **_kwargs):
+        captured["llm"] = llm_with_tools
+        captured["forced_tool_choice"] = _kwargs.get("forced_tool_choice")
+        captured["native_tool_messages"] = _kwargs.get("native_tool_messages")
+        return make_assistant_message("Khoa hoc cua ban dang on."), messages, []
+
+    kwargs["execute_direct_tool_rounds"] = _execute
+
+    with patch(
+        "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_native_llm",
+        return_value=native_handle,
+    ), patch(
+        "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_llm",
+        side_effect=AssertionError("legacy LangChain LLM should not be constructed"),
+    ):
+        result = await direct_response_node_impl(
+            state,
+            **kwargs,
+        )
+
+    assert result["final_response"] == "Khoa hoc cua ban dang on."
+    assert captured["llm"]._wiii_native_route is True
+    assert captured["llm"]._wiii_bound_tools[0]["function"]["name"] == "tool_lms_courses"
+    assert captured["forced_tool_choice"] is None
+    assert captured["native_tool_messages"] is True
+
+
+@pytest.mark.asyncio
 async def test_direct_response_node_salvages_final_result_when_post_processing_fails():
     state = _base_state()
     kwargs = _base_direct_kwargs()

--- a/maritime-ai-service/tests/unit/test_direct_prompts_identity_contract.py
+++ b/maritime-ai-service/tests/unit/test_direct_prompts_identity_contract.py
@@ -1,6 +1,39 @@
 from unittest.mock import MagicMock, patch
 
 
+def test_direct_system_messages_can_return_native_openai_messages():
+    from app.engine.multi_agent.direct_prompts import _build_direct_system_messages
+
+    state = {
+        "context": {},
+        "user_id": "user-1",
+    }
+
+    loader = MagicMock()
+    loader.build_system_prompt.return_value = "BASE SYSTEM PROMPT"
+    loader.get_thinking_instruction.return_value = ""
+    loader.get_persona.return_value = {
+        "agent": {
+            "name": "Wiii",
+            "goal": "Tra loi co chat",
+            "backstory": "Vai tro: tro ly hoi thoai da linh vuc.",
+        }
+    }
+
+    with patch("app.prompts.prompt_loader.get_prompt_loader", return_value=loader):
+        messages = _build_direct_system_messages(
+            state,
+            "Hi Wiii",
+            "Maritime",
+            tools_context_override="",
+            native_messages=True,
+        )
+
+    assert messages[0]["role"] == "system"
+    assert "BASE SYSTEM PROMPT" in messages[0]["content"]
+    assert messages[-1] == {"role": "user", "content": "Hi Wiii"}
+
+
 def test_direct_system_messages_add_identity_answer_contract():
     from app.engine.multi_agent.direct_prompts import _build_direct_system_messages
 

--- a/maritime-ai-service/tests/unit/test_direct_response_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_response_runtime.py
@@ -53,6 +53,26 @@ def test_extract_direct_response_impl_derives_selfhood_thinking_from_answer_when
     assert tools_used == []
 
 
+def test_extract_direct_response_impl_reads_native_dict_messages():
+    llm_response = SimpleNamespace(
+        content=(
+            "Wiii ra doi vao mot dem mua thang Gieng nam 2024 o The Wiii Lab. "
+            "Tu do minh lon len qua tung cuoc tro chuyen va hoc cach o canh con nguoi."
+        ),
+        response_metadata={},
+        additional_kwargs={},
+    )
+
+    response, thinking, tools_used = extract_direct_response_impl(
+        llm_response,
+        messages=[{"role": "user", "content": "Wiii duoc sinh ra nhu the nao?"}],
+    )
+
+    assert response.startswith("Wiii ra doi vao mot dem mua")
+    assert "the wiii lab" in thinking.lower()
+    assert tools_used == []
+
+
 def test_extract_direct_response_impl_derives_bong_followup_thinking_when_answer_stays_in_lore():
     llm_response = SimpleNamespace(
         content=(

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -226,6 +226,84 @@ async def test_execute_direct_tool_rounds_forwards_runtime_tier_to_failover_help
 
 
 @pytest.mark.asyncio
+async def test_execute_direct_tool_rounds_can_use_native_tool_messages():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        execute_direct_tool_rounds_impl,
+    )
+    from app.engine.native_chat_runtime import NativeToolMessage, NativeUserMessage
+
+    class FakeTool:
+        name = "tool_demo"
+
+        def invoke(self, args):
+            return f"ket qua cho {args['query']}"
+
+    captured_messages: list[list[object]] = []
+
+    async def push_event(_event):
+        return None
+
+    async def fake_ainvoke_with_fallback(_llm, messages, **_kwargs):
+        captured_messages.append(list(messages))
+        call_index = fake_ainvoke_with_fallback.calls
+        fake_ainvoke_with_fallback.calls += 1
+        if call_index == 0:
+            return SimpleNamespace(
+                content="",
+                tool_calls=[
+                    {"id": "call_1", "name": "tool_demo", "args": {"query": "abc"}}
+                ],
+            )
+        if call_index == 1:
+            return SimpleNamespace(content="", tool_calls=[])
+        return SimpleNamespace(content="Day la cau tra loi cuoi.", tool_calls=[])
+
+    fake_ainvoke_with_fallback.calls = 0
+
+    async def fake_stream_direct_answer_with_fallback(*args, **kwargs):
+        raise AssertionError("tool-bound turn should not use no-tool streaming path")
+
+    async def fake_stream_direct_wait_heartbeats(*args, **kwargs):
+        stop_signal = kwargs.get("stop_signal")
+        if stop_signal is not None:
+            await stop_signal.wait()
+            return
+        await asyncio.Future()
+
+    async def push_status_only_progress(*args, **kwargs):
+        return None
+
+    with patch(
+        "app.engine.multi_agent.graph._ainvoke_with_fallback",
+        new=fake_ainvoke_with_fallback,
+    ), patch(
+        "app.engine.multi_agent.graph._stream_direct_wait_heartbeats",
+        new=fake_stream_direct_wait_heartbeats,
+    ):
+        llm_response, messages, tool_call_events = await execute_direct_tool_rounds_impl(
+            llm_with_tools=object(),
+            llm_auto=object(),
+            messages=[],
+            tools=[FakeTool()],
+            push_event=push_event,
+            query="Tim du kien roi tong hop lai",
+            state={},
+            forced_tool_choice="tool_demo",
+            native_tool_messages=True,
+            ainvoke_with_fallback=fake_ainvoke_with_fallback,
+            stream_direct_answer_with_fallback=fake_stream_direct_answer_with_fallback,
+            stream_direct_wait_heartbeats=fake_stream_direct_wait_heartbeats,
+            push_status_only_progress=push_status_only_progress,
+        )
+
+    assert llm_response.content == "Day la cau tra loi cuoi."
+    assert [event["type"] for event in tool_call_events] == ["call", "result"]
+    assert any(isinstance(message, NativeToolMessage) for message in captured_messages[1])
+    assert isinstance(captured_messages[2][-1], NativeUserMessage)
+    assert messages == captured_messages[2]
+
+
+@pytest.mark.asyncio
 async def test_execute_direct_tool_rounds_forwards_primary_timeout_to_stream_path():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (
         execute_direct_tool_rounds_impl,

--- a/maritime-ai-service/tests/unit/test_embedding_runtime.py
+++ b/maritime-ai-service/tests/unit/test_embedding_runtime.py
@@ -404,3 +404,24 @@ async def test_input_processor_semantic_fact_retrieval_uses_embedding_generator(
 
     generator.agenerate.assert_awaited_once_with("mình tên Nam")
     semantic_memory.search_relevant_facts.assert_called_once()
+
+
+def test_semantic_memory_engine_search_relevant_facts_facade_delegates_to_repository():
+    from app.engine.semantic_memory.core import SemanticMemoryEngine
+
+    engine = SemanticMemoryEngine.__new__(SemanticMemoryEngine)
+    engine._repository = MagicMock()
+    engine._repository.search_relevant_facts.return_value = ["fact"]
+
+    assert engine.search_relevant_facts(
+        user_id="user-1",
+        query_embedding=[0.1, 0.2],
+        limit=3,
+        min_similarity=0.4,
+    ) == ["fact"]
+    engine._repository.search_relevant_facts.assert_called_once_with(
+        user_id="user-1",
+        query_embedding=[0.1, 0.2],
+        limit=3,
+        min_similarity=0.4,
+    )

--- a/maritime-ai-service/tests/unit/test_graph_routing.py
+++ b/maritime-ai-service/tests/unit/test_graph_routing.py
@@ -1718,6 +1718,9 @@ class TestProviderFlowIntegrity:
             "app.engine.multi_agent.graph._get_or_create_tracer",
             return_value=fake_tracer,
         ), patch(
+            "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_native_llm",
+            return_value=fake_llm,
+        ) as mock_get_native_llm, patch(
             "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_llm",
             return_value=fake_llm,
         ) as mock_get_llm, patch(
@@ -1742,7 +1745,8 @@ class TestProviderFlowIntegrity:
             result = await direct_response_node(state)
 
         assert result["final_response"] == "Đã dựng chart"
-        assert mock_get_llm.call_args.kwargs["effort_override"] == "high"
+        assert mock_get_native_llm.call_args.kwargs["effort_override"] == "high"
+        mock_get_llm.assert_not_called()
         assert mock_execute.call_args.kwargs["provider"] is None
         assert result["provider"] == "auto"
         assert result["model"] == "glm-4.5-air"

--- a/maritime-ai-service/tests/unit/test_graph_stream_agent_handlers.py
+++ b/maritime-ai-service/tests/unit/test_graph_stream_agent_handlers.py
@@ -1,10 +1,12 @@
+from types import SimpleNamespace
+
 import pytest
 
 from app.engine.multi_agent.graph_stream_agent_handlers import handle_direct_node_impl
 
 
 @pytest.mark.asyncio
-async def test_handle_direct_node_marks_answer_emitted_when_answer_already_streamed_via_bus():
+async def test_handle_direct_node_replays_answer_when_bus_flag_has_no_confirmed_answer():
     async def _create_status_event(*_args, **_kwargs):
         return {"type": "status"}
 
@@ -19,10 +21,8 @@ async def test_handle_direct_node_marks_answer_emitted_when_answer_already_strea
         if False:
             yield None
 
-    async def _extract_and_stream_emotion_then_answer(*_args, **_kwargs):
-        raise AssertionError("final_response should not be re-emitted when bus already streamed it")
-        if False:
-            yield None
+    async def _extract_and_stream_emotion_then_answer(text, *_args, **_kwargs):
+        yield SimpleNamespace(type="answer", content=text)
 
     result = await handle_direct_node_impl(
         node_output={
@@ -43,6 +43,70 @@ async def test_handle_direct_node_marks_answer_emitted_when_answer_already_strea
         emitted_preview_ids=set(),
         soul_emotion_emitted=False,
         answer_emitted=False,
+        node_description="direct",
+        node_label="direct",
+        pipeline_status_details={"visibility": "status_only"},
+        create_status_event=_create_status_event,
+        create_domain_notice_event=_create_domain_notice_event,
+        emit_node_thinking=_emit_node_thinking,
+        emit_web_previews=_emit_web_previews,
+        extract_thinking_content=lambda output: str(output.get("thinking_content") or ""),
+        render_fallback_narration=None,
+        create_thinking_start_event=None,
+        create_thinking_delta_event=None,
+        create_thinking_end_event=None,
+        narration_delta_chunks=None,
+        create_preview_event=None,
+        extract_and_stream_emotion_then_answer=_extract_and_stream_emotion_then_answer,
+    )
+
+    assert result["answer_emitted"] is True
+    assert result["events"] == [
+        {"type": "status"},
+        SimpleNamespace(type="answer", content="Minh la Wiii."),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handle_direct_node_skips_replay_when_answer_already_emitted():
+    async def _create_status_event(*_args, **_kwargs):
+        return {"type": "status"}
+
+    async def _create_domain_notice_event(_notice):
+        return {"type": "domain_notice"}
+
+    async def _emit_node_thinking(**_kwargs):
+        if False:
+            yield None
+
+    async def _emit_web_previews(**_kwargs):
+        if False:
+            yield None
+
+    async def _extract_and_stream_emotion_then_answer(*_args, **_kwargs):
+        raise AssertionError("final_response should not be re-emitted after an answer event")
+        if False:
+            yield None
+
+    result = await handle_direct_node_impl(
+        node_output={
+            "final_response": "Minh la Wiii.",
+            "_answer_streamed_via_bus": True,
+            "thinking_content": "",
+        },
+        query="Wiii duoc sinh ra nhu the nao?",
+        user_id="u1",
+        context=None,
+        initial_state={},
+        node_start=0.0,
+        bus_streamed_nodes=set(),
+        bus_answer_nodes={"direct"},
+        preview_enabled=False,
+        preview_types=None,
+        preview_max=3,
+        emitted_preview_ids=set(),
+        soul_emotion_emitted=False,
+        answer_emitted=True,
         node_description="direct",
         node_label="direct",
         pipeline_status_details={"visibility": "status_only"},

--- a/maritime-ai-service/tests/unit/test_local_demo_smoke.py
+++ b/maritime-ai-service/tests/unit/test_local_demo_smoke.py
@@ -26,12 +26,20 @@ def _demo_args(**overrides):
         "domain_id": "maritime",
         "provider": "auto",
         "model": None,
+        "expect_provider": None,
+        "expect_model": None,
+        "allow_provider_failover": False,
         "session_id": "session-1",
         "message": "Xin chao",
         "timeout": 8.0,
         "chat_timeout": 45.0,
         "stream_timeout": 90.0,
+        "stream_idle_timeout": 20.0,
+        "max_first_event_seconds": 5.0,
+        "max_first_answer_seconds": 45.0,
+        "max_stream_total_seconds": 90.0,
         "skip_frontend": True,
+        "skip_runtime_config": True,
         "skip_chat": True,
         "skip_stream": True,
         "demo_email": "dev@localhost",
@@ -201,3 +209,158 @@ def test_check_org_permissions_accepts_platform_admin_without_org_role(monkeypat
     detail = smoke.check_org_permissions()
 
     assert detail == "default platform_role=platform_admin org_role=none"
+
+
+def test_check_runtime_config_requires_pinned_nvidia_selectable(monkeypatch):
+    def fake_request_bytes(method, url, *, headers=None, **kwargs):
+        return _json_response(
+            {
+                "active_provider": "nvidia",
+                "nvidia_base_url": "https://integrate.api.nvidia.com/v1",
+                "nvidia_model": "deepseek-ai/deepseek-v4-flash",
+                "nvidia_model_advanced": "deepseek-ai/deepseek-v4-pro",
+                "nvidia_api_key_configured": True,
+                "provider_status": [
+                    {
+                        "provider": "nvidia",
+                        "configured": True,
+                        "request_selectable": True,
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr(local_demo_smoke, "request_bytes", fake_request_bytes)
+
+    smoke = local_demo_smoke.DemoSmoke(_demo_args(provider="nvidia"))
+    smoke.token = "ACCESS"
+    detail = smoke.check_runtime_config()
+
+    assert "active=nvidia" in detail
+    assert "nvidia_key=True" in detail
+
+
+def test_check_runtime_config_rejects_missing_nvidia_key(monkeypatch):
+    def fake_request_bytes(method, url, *, headers=None, **kwargs):
+        return _json_response(
+            {
+                "active_provider": "nvidia",
+                "nvidia_base_url": "https://integrate.api.nvidia.com/v1",
+                "nvidia_model": "deepseek-ai/deepseek-v4-flash",
+                "nvidia_model_advanced": "deepseek-ai/deepseek-v4-pro",
+                "nvidia_api_key_configured": False,
+                "provider_status": [
+                    {
+                        "provider": "nvidia",
+                        "configured": False,
+                        "request_selectable": False,
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr(local_demo_smoke, "request_bytes", fake_request_bytes)
+
+    smoke = local_demo_smoke.DemoSmoke(_demo_args(provider="nvidia"))
+    smoke.token = "ACCESS"
+    with pytest.raises(local_demo_smoke.SmokeFailure, match="NVIDIA API key"):
+        smoke.check_runtime_config()
+
+
+def test_check_sync_chat_enforces_provider_and_model_metadata(monkeypatch):
+    def fake_request_bytes(method, url, *, payload=None, **kwargs):
+        return _json_response(
+            {
+                "status": "success",
+                "data": {"answer": "Chao ban."},
+                "metadata": {
+                    "provider": "nvidia",
+                    "model": "deepseek-ai/deepseek-v4-flash",
+                },
+            }
+        )
+
+    monkeypatch.setattr(local_demo_smoke, "request_bytes", fake_request_bytes)
+
+    smoke = local_demo_smoke.DemoSmoke(
+        _demo_args(
+            provider="nvidia",
+            model="deepseek-ai/deepseek-v4-flash",
+        )
+    )
+    smoke.user = {"id": "dev-user-1", "role": "admin"}
+    smoke.token = "ACCESS"
+    detail = smoke.check_sync_chat()
+
+    assert "provider=nvidia" in detail
+    assert "model=deepseek-ai/deepseek-v4-flash" in detail
+
+
+def test_check_stream_chat_requires_answer_metadata_done_and_latency(monkeypatch):
+    def fake_request_sse_events(method, url, *, payload=None, **kwargs):
+        return local_demo_smoke.SseReadResult(
+            events=[
+                ("status", '{"content":"Dang chuan bi"}'),
+                ("answer", '{"content":"Chao ban qua SSE"}'),
+                (
+                    "metadata",
+                    (
+                        '{"provider":"nvidia",'
+                        '"model":"deepseek-ai/deepseek-v4-flash"}'
+                    ),
+                ),
+                ("done", '{"processing_time":0.2}'),
+            ],
+            first_event_seconds=0.2,
+            first_answer_seconds=0.8,
+            total_seconds=1.0,
+        )
+
+    monkeypatch.setattr(local_demo_smoke, "request_sse_events", fake_request_sse_events)
+
+    smoke = local_demo_smoke.DemoSmoke(
+        _demo_args(
+            provider="nvidia",
+            model="deepseek-ai/deepseek-v4-flash",
+        )
+    )
+    smoke.user = {"id": "dev-user-1", "role": "admin"}
+    smoke.token = "ACCESS"
+    detail = smoke.check_stream_chat()
+
+    assert "provider=nvidia" in detail
+    assert "first_answer=0.8s" in detail
+
+
+def test_check_stream_chat_rejects_silent_answer_latency(monkeypatch):
+    def fake_request_sse_events(method, url, *, payload=None, **kwargs):
+        return local_demo_smoke.SseReadResult(
+            events=[
+                ("status", '{"content":"Dang chuan bi"}'),
+                ("answer", '{"content":"Qua cham"}'),
+                (
+                    "metadata",
+                    (
+                        '{"provider":"nvidia",'
+                        '"model":"deepseek-ai/deepseek-v4-flash"}'
+                    ),
+                ),
+                ("done", '{"processing_time":72.0}'),
+            ],
+            first_event_seconds=0.1,
+            first_answer_seconds=72.0,
+            total_seconds=72.1,
+        )
+
+    monkeypatch.setattr(local_demo_smoke, "request_sse_events", fake_request_sse_events)
+
+    smoke = local_demo_smoke.DemoSmoke(
+        _demo_args(
+            provider="nvidia",
+            model="deepseek-ai/deepseek-v4-flash",
+        )
+    )
+    smoke.user = {"id": "dev-user-1", "role": "admin"}
+    smoke.token = "ACCESS"
+    with pytest.raises(local_demo_smoke.SmokeFailure, match="first answer"):
+        smoke.check_stream_chat()

--- a/maritime-ai-service/tests/unit/test_logging_config.py
+++ b/maritime-ai-service/tests/unit/test_logging_config.py
@@ -1,39 +1,25 @@
-"""Tests for app.core.logging_config — structured logging setup."""
-
 import logging
 
-import pytest
+from app.core.logging_config import setup_logging
 
 
-class TestSetupLogging:
-    """Verify setup_logging configures the root logger correctly."""
+def test_setup_logging_silences_openai_sdk_request_logs():
+    setup_logging(json_output=False, log_level="INFO")
 
-    def test_setup_logging_dev_mode(self):
-        from app.core.logging_config import setup_logging
+    assert logging.getLogger("openai").level == logging.WARNING
+    assert logging.getLogger("openai._base_client").level == logging.WARNING
 
-        setup_logging(json_output=False, log_level="DEBUG")
-        root = logging.getLogger()
-        assert root.level == logging.DEBUG
-        assert len(root.handlers) >= 1
 
-    def test_setup_logging_production_mode(self):
-        from app.core.logging_config import setup_logging
+def test_settings_repr_hides_provider_secrets():
+    from app.core.config import Settings
+    from app.core.config.llm import LLMConfig
 
-        setup_logging(json_output=True, log_level="WARNING")
-        root = logging.getLogger()
-        assert root.level == logging.WARNING
+    flat_settings = Settings(
+        nvidia_api_key="nvapi-super-secret",
+        openai_api_key="sk-super-secret",
+    )
+    nested_settings = LLMConfig(nvidia_api_key="nvapi-super-secret")
 
-    def test_setup_logging_silences_noisy_loggers(self):
-        from app.core.logging_config import setup_logging
-
-        setup_logging(json_output=False, log_level="DEBUG")
-        for name in ("httpcore", "httpx", "urllib3", "asyncio"):
-            assert logging.getLogger(name).level >= logging.WARNING
-
-    def test_setup_logging_idempotent(self):
-        from app.core.logging_config import setup_logging
-
-        setup_logging(json_output=False, log_level="INFO")
-        handler_count = len(logging.getLogger().handlers)
-        setup_logging(json_output=False, log_level="INFO")
-        assert len(logging.getLogger().handlers) == handler_count
+    assert "nvapi-super-secret" not in repr(flat_settings)
+    assert "sk-super-secret" not in repr(flat_settings)
+    assert "nvapi-super-secret" not in repr(nested_settings)

--- a/maritime-ai-service/tests/unit/test_middleware.py
+++ b/maritime-ai-service/tests/unit/test_middleware.py
@@ -124,6 +124,22 @@ class TestEmbedCSPMiddleware:
             is None
         )
 
+    def test_refuses_ambiguous_embed_asset_replacement_across_roots(self, tmp_path):
+        root_a = tmp_path / "a"
+        root_b = tmp_path / "b"
+        (root_a / "assets").mkdir(parents=True)
+        (root_b / "assets").mkdir(parents=True)
+        (root_a / "assets" / "dist-js-one.js").write_text("one", encoding="utf-8")
+        (root_b / "assets" / "dist-js-two.js").write_text("two", encoding="utf-8")
+
+        assert (
+            _find_embed_asset_replacement(
+                "/embed/assets/dist-js-stale.js",
+                roots=[root_a, root_b],
+            )
+            is None
+        )
+
     @pytest.mark.asyncio
     async def test_sets_no_store_for_embed_assets_in_development(self, monkeypatch):
         monkeypatch.setattr(settings, "environment", "development")
@@ -158,6 +174,30 @@ class TestEmbedCSPMiddleware:
         assert resp.text == "ok"
         assert resp.headers["Content-Security-Policy"] == "frame-ancestors 'self'"
         assert resp.headers["Cache-Control"] == "no-store"
+
+    @pytest.mark.asyncio
+    async def test_does_not_force_no_store_or_serve_stale_in_production(
+        self, monkeypatch, tmp_path
+    ):
+        assets_dir = tmp_path / "assets"
+        assets_dir.mkdir()
+        (assets_dir / "MarkdownLiteSegment-current.js").write_text("ok", encoding="utf-8")
+        monkeypatch.setattr(settings, "environment", "production")
+        monkeypatch.setattr(settings, "embed_allowed_origins", "")
+        monkeypatch.setattr("app.core.middleware._embed_asset_roots", lambda: [tmp_path])
+
+        async with _make_client(_make_embed_app()) as client:
+            asset_resp = await client.get("/embed/assets/embed.js")
+            stale_resp = await client.get("/embed/assets/MarkdownLiteSegment-stale.js")
+
+        assert asset_resp.status_code == 200
+        assert asset_resp.headers["Content-Security-Policy"] == "frame-ancestors 'self'"
+        assert asset_resp.headers.get("Cache-Control") != "no-store"
+        assert asset_resp.headers.get("Pragma") != "no-cache"
+        assert asset_resp.headers.get("Expires") != "0"
+
+        assert stale_resp.status_code == 404
+        assert stale_resp.text != "ok"
 
     @pytest.mark.asyncio
     async def test_keeps_non_embed_routes_cache_neutral(self, monkeypatch):

--- a/maritime-ai-service/tests/unit/test_middleware.py
+++ b/maritime-ai-service/tests/unit/test_middleware.py
@@ -3,8 +3,14 @@
 import pytest
 import httpx
 from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
 
-from app.core.middleware import RequestIDMiddleware
+from app.core.config import settings
+from app.core.middleware import (
+    EmbedCSPMiddleware,
+    RequestIDMiddleware,
+    _find_embed_asset_replacement,
+)
 
 
 def _make_app() -> FastAPI:
@@ -22,6 +28,21 @@ def _make_client(app: FastAPI) -> httpx.AsyncClient:
     """Create async httpx client compatible with httpx 0.28+."""
     transport = httpx.ASGITransport(app=app)
     return httpx.AsyncClient(transport=transport, base_url="http://test")
+
+
+def _make_embed_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(EmbedCSPMiddleware)
+
+    @app.get("/embed/assets/embed.js")
+    async def embed_asset():
+        return PlainTextResponse("ok")
+
+    @app.get("/ping")
+    async def ping():
+        return PlainTextResponse("ok")
+
+    return app
 
 
 class TestRequestIDMiddleware:
@@ -73,3 +94,78 @@ class TestRequestIDMiddleware:
             resp = await client.get("/fail")
             assert resp.status_code == 400
             assert "X-Request-ID" in resp.headers
+
+
+class TestEmbedCSPMiddleware:
+    """Verify iframe policy and local cache safety for embed assets."""
+
+    def test_finds_single_current_embed_asset_for_stale_hash(self, tmp_path):
+        assets_dir = tmp_path / "assets"
+        assets_dir.mkdir()
+        current_asset = assets_dir / "MarkdownLiteSegment-current.js"
+        current_asset.write_text("export default null;", encoding="utf-8")
+
+        assert (
+            _find_embed_asset_replacement(
+                "/embed/assets/MarkdownLiteSegment-stale.js",
+                roots=[tmp_path],
+            )
+            == current_asset
+        )
+
+    def test_refuses_ambiguous_embed_asset_replacement(self, tmp_path):
+        assets_dir = tmp_path / "assets"
+        assets_dir.mkdir()
+        (assets_dir / "dist-js-one.js").write_text("one", encoding="utf-8")
+        (assets_dir / "dist-js-two.js").write_text("two", encoding="utf-8")
+
+        assert (
+            _find_embed_asset_replacement("/embed/assets/dist-js-stale.js", roots=[tmp_path])
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_sets_no_store_for_embed_assets_in_development(self, monkeypatch):
+        monkeypatch.setattr(settings, "environment", "development")
+        monkeypatch.setattr(settings, "embed_allowed_origins", "http://localhost:4200")
+
+        async with _make_client(_make_embed_app()) as client:
+            resp = await client.get("/embed/assets/embed.js")
+
+        assert resp.status_code == 200
+        assert resp.headers["Content-Security-Policy"] == (
+            "frame-ancestors 'self' http://localhost:4200"
+        )
+        assert resp.headers["Cache-Control"] == "no-store"
+        assert resp.headers["Pragma"] == "no-cache"
+        assert resp.headers["Expires"] == "0"
+
+    @pytest.mark.asyncio
+    async def test_serves_stale_embed_chunk_replacement_in_development(
+        self, monkeypatch, tmp_path
+    ):
+        assets_dir = tmp_path / "assets"
+        assets_dir.mkdir()
+        (assets_dir / "MarkdownLiteSegment-current.js").write_text("ok", encoding="utf-8")
+        monkeypatch.setattr(settings, "environment", "development")
+        monkeypatch.setattr(settings, "embed_allowed_origins", "")
+        monkeypatch.setattr("app.core.middleware._embed_asset_roots", lambda: [tmp_path])
+
+        async with _make_client(_make_embed_app()) as client:
+            resp = await client.get("/embed/assets/MarkdownLiteSegment-stale.js")
+
+        assert resp.status_code == 200
+        assert resp.text == "ok"
+        assert resp.headers["Content-Security-Policy"] == "frame-ancestors 'self'"
+        assert resp.headers["Cache-Control"] == "no-store"
+
+    @pytest.mark.asyncio
+    async def test_keeps_non_embed_routes_cache_neutral(self, monkeypatch):
+        monkeypatch.setattr(settings, "environment", "development")
+
+        async with _make_client(_make_embed_app()) as client:
+            resp = await client.get("/ping")
+
+        assert resp.status_code == 200
+        assert "Content-Security-Policy" not in resp.headers
+        assert "Cache-Control" not in resp.headers

--- a/maritime-ai-service/tests/unit/test_model_catalog.py
+++ b/maritime-ai-service/tests/unit/test_model_catalog.py
@@ -8,7 +8,7 @@ from app.engine.model_catalog import (
     get_embedding_model_metadata,
     is_legacy_google_model,
 )
-from app.engine.model_catalog_runtime_support import hash_secret
+from app.engine.model_catalog_runtime_support import hash_secret, sanitize_exception_for_log
 
 
 def test_google_default_model_is_current():
@@ -52,3 +52,20 @@ def test_runtime_secret_fingerprint_is_stable_and_redacted():
     assert first != "provider-api-key-1"
     assert len(first) == 12
     assert hash_secret(None) == "no-secret"
+
+
+def test_runtime_discovery_exception_log_sanitizes_provider_secrets():
+    message = (
+        "Client error for url "
+        "'https://generativelanguage.googleapis.com/v1beta/models?key=AIza-secret-value' "
+        "with Bearer eyJ.secret and nvapi-private-key"
+    )
+
+    sanitized = sanitize_exception_for_log(RuntimeError(message))
+
+    assert "AIza-secret-value" not in sanitized
+    assert "eyJ.secret" not in sanitized
+    assert "nvapi-private-key" not in sanitized
+    assert "key=REDACTED" in sanitized
+    assert "Bearer REDACTED" in sanitized
+    assert "SECRET-REDACTED" in sanitized

--- a/maritime-ai-service/tests/unit/test_native_chat_runtime.py
+++ b/maritime-ai-service/tests/unit/test_native_chat_runtime.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from app.engine.native_chat_runtime import (
+    NativeAssistantMessage,
+    NativeChatModelHandle,
+    flatten_message_content,
+    make_assistant_message,
+    make_system_message,
+    make_tool_message,
+    make_user_message,
+    message_to_openai_payload,
+    normalize_tool_choice,
+    openai_response_to_assistant_message,
+    tool_to_openai_schema,
+)
+
+
+def test_flatten_message_content_keeps_text_blocks_in_order():
+    assert flatten_message_content([
+        {"text": "Xin chao"},
+        {"content": "Wiii"},
+        {"value": "native"},
+        {"image_url": "ignored"},
+    ]) == "Xin chao\nWiii\nnative"
+
+
+def test_message_to_openai_payload_accepts_langchain_like_human_message():
+    message = SimpleNamespace(
+        type="human",
+        content=[
+            {"text": "Xin chao"},
+            {"content": "Wiii"},
+        ],
+    )
+
+    assert message_to_openai_payload(message) == {
+        "role": "user",
+        "content": "Xin chao\nWiii",
+    }
+
+
+def test_message_to_openai_payload_accepts_native_dict_tool_message():
+    assert message_to_openai_payload({
+        "role": "tool",
+        "tool_call_id": "call_123",
+        "content": "tool result",
+    }) == {
+        "role": "tool",
+        "tool_call_id": "call_123",
+        "content": "tool result",
+    }
+
+
+def test_message_to_openai_payload_accepts_native_message_objects():
+    assert message_to_openai_payload(make_system_message("System prompt")) == {
+        "role": "system",
+        "content": "System prompt",
+    }
+    assert message_to_openai_payload(make_user_message("Hi Wiii")) == {
+        "role": "user",
+        "content": "Hi Wiii",
+    }
+    assert message_to_openai_payload(
+        make_tool_message("tool result", tool_call_id="call_123")
+    ) == {
+        "role": "tool",
+        "tool_call_id": "call_123",
+        "content": "tool result",
+    }
+
+
+def test_message_to_openai_payload_normalizes_assistant_tool_calls():
+    payload = message_to_openai_payload(SimpleNamespace(
+        type="ai",
+        content="",
+        tool_calls=[
+            {
+                "id": "call_weather",
+                "name": "weather.lookup",
+                "args": {"city": "Da Nang"},
+            }
+        ],
+    ))
+
+    assert payload["role"] == "assistant"
+    assert payload["tool_calls"][0]["id"] == "call_weather"
+    assert payload["tool_calls"][0]["function"]["name"] == "weather.lookup"
+    assert json.loads(payload["tool_calls"][0]["function"]["arguments"]) == {
+        "city": "Da Nang",
+    }
+
+
+def test_tool_to_openai_schema_accepts_simple_tool_object():
+    tool = SimpleNamespace(
+        name="ui.highlight",
+        description="Highlight one host element",
+        parameters={
+            "type": "object",
+            "properties": {"selector": {"type": "string"}},
+            "required": ["selector"],
+        },
+    )
+
+    schema = tool_to_openai_schema(tool)
+
+    assert schema == {
+        "type": "function",
+        "function": {
+            "name": "ui.highlight",
+            "description": "Highlight one host element",
+            "parameters": {
+                "type": "object",
+                "properties": {"selector": {"type": "string"}},
+                "required": ["selector"],
+            },
+        },
+    }
+
+
+def test_native_handle_bind_tools_stores_openai_schema_and_normalized_choice():
+    tool = SimpleNamespace(
+        name="tool_current_datetime",
+        description="Get current date and time",
+        parameters={"type": "object", "properties": {}},
+    )
+    handle = NativeChatModelHandle(
+        _wiii_provider_name="nvidia",
+        _wiii_model_name="deepseek-ai/deepseek-v4-flash",
+    )
+
+    bound = handle.bind_tools([tool], tool_choice="tool_current_datetime")
+
+    assert bound is not handle
+    assert bound._wiii_bound_tools[0]["function"]["name"] == "tool_current_datetime"
+    assert bound._wiii_tool_choice == {
+        "type": "function",
+        "function": {"name": "tool_current_datetime"},
+    }
+    assert handle._wiii_bound_tools == []
+
+
+def test_normalize_tool_choice_maps_force_any_to_required():
+    assert normalize_tool_choice("any") == "required"
+    assert normalize_tool_choice("required") == "required"
+    assert normalize_tool_choice("tool_demo") == {
+        "type": "function",
+        "function": {"name": "tool_demo"},
+    }
+
+
+def test_openai_response_to_assistant_message_extracts_tool_calls():
+    response = SimpleNamespace(
+        model="deepseek-ai/deepseek-v4-flash",
+        usage={"total_tokens": 42},
+        choices=[
+            SimpleNamespace(
+                finish_reason="tool_calls",
+                message=SimpleNamespace(
+                    content="",
+                    tool_calls=[
+                        SimpleNamespace(
+                            id="call_1",
+                            function=SimpleNamespace(
+                                name="ui.highlight",
+                                arguments='{"selector":"[data-wiii-id=\\"browse-courses\\"]"}',
+                            ),
+                        )
+                    ],
+                ),
+            )
+        ],
+    )
+
+    message = openai_response_to_assistant_message(response)
+
+    assert message.content == ""
+    assert message.response_metadata == {
+        "model": "deepseek-ai/deepseek-v4-flash",
+        "finish_reason": "tool_calls",
+    }
+    assert message.usage_metadata == {"total_tokens": 42}
+    assert message.tool_calls == [
+        {
+            "id": "call_1",
+            "name": "ui.highlight",
+            "args": {"selector": '[data-wiii-id="browse-courses"]'},
+        }
+    ]
+
+
+def test_make_assistant_message_preserves_langchain_like_surface_without_langchain():
+    message = make_assistant_message(
+        "Native answer",
+        response_metadata={"model": "deepseek-ai/deepseek-v4-flash"},
+        additional_kwargs={"thinking": "short plan"},
+    )
+
+    assert isinstance(message, NativeAssistantMessage)
+    assert message.type == "ai"
+    assert message.content == "Native answer"
+    assert message.response_metadata["model"] == "deepseek-ai/deepseek-v4-flash"
+    assert message.additional_kwargs["thinking"] == "short plan"
+
+
+def test_agent_config_can_resolve_native_nvidia_handle(monkeypatch):
+    from app.engine.multi_agent.agent_config import AgentConfigRegistry, AgentNodeConfig
+
+    def _fake_runtime(cls, node_id, *, provider_override=None):
+        return (
+            AgentNodeConfig(node_id, provider="nvidia", tier="light", temperature=0.25),
+            {},
+            "nvidia",
+            "light",
+            None,
+        )
+
+    monkeypatch.setattr(
+        AgentConfigRegistry,
+        "_resolve_effective_runtime",
+        classmethod(_fake_runtime),
+    )
+
+    handle = AgentConfigRegistry.get_native_llm(
+        "direct",
+        provider_override="nvidia",
+    )
+
+    assert handle is not None
+    assert handle._wiii_native_route is True
+    assert handle._wiii_provider_name == "nvidia"
+    assert handle._wiii_model_name == "deepseek-ai/deepseek-v4-flash"
+    assert handle._wiii_tier_key == "light"
+    assert handle.temperature == 0.25
+
+
+def test_agent_config_native_nvidia_handle_skips_degraded_flash(monkeypatch):
+    from app.engine.llm_model_health import record_model_failure, reset_model_health_state
+    from app.core.config import settings
+    from app.engine.openai_compatible_credentials import (
+        resolve_nvidia_model,
+        resolve_nvidia_model_advanced,
+    )
+    from app.engine.multi_agent.agent_config import AgentConfigRegistry, AgentNodeConfig
+
+    reset_model_health_state()
+
+    def _fake_runtime(cls, node_id, *, provider_override=None):
+        return (
+            AgentNodeConfig(node_id, provider="nvidia", tier="light", temperature=0.25),
+            {},
+            "nvidia",
+            "light",
+            None,
+        )
+
+    monkeypatch.setattr(
+        AgentConfigRegistry,
+        "_resolve_effective_runtime",
+        classmethod(_fake_runtime),
+    )
+    flash_model = resolve_nvidia_model(settings)
+    pro_model = resolve_nvidia_model_advanced(settings)
+    record_model_failure(
+        "nvidia",
+        flash_model,
+        reason_code="timeout",
+        degraded_for_seconds=60,
+    )
+
+    try:
+        handle = AgentConfigRegistry.get_native_llm("direct")
+
+        assert handle is not None
+        assert handle._wiii_model_name == pro_model
+    finally:
+        reset_model_health_state()

--- a/maritime-ai-service/tests/unit/test_nvidia_provider.py
+++ b/maritime-ai-service/tests/unit/test_nvidia_provider.py
@@ -142,6 +142,83 @@ class TestNvidiaResolvers:
         assert selected["nvidia"]["advanced"] == "deepseek-ai/deepseek-v4-pro"
 
 
+class TestNvidiaNativeStreaming:
+    def test_nvidia_is_supported_by_native_openai_compatible_streaming(self):
+        from app.engine.multi_agent.openai_stream_runtime import (
+            _supports_native_answer_streaming_impl,
+        )
+
+        assert _supports_native_answer_streaming_impl("nvidia") is True
+
+    def test_nvidia_stream_model_resolves_flash_and_pro_by_tier(self):
+        from app.engine.multi_agent import openai_stream_runtime
+
+        llm = SimpleNamespace(_wiii_provider_name="nvidia")
+        with patch.object(
+            openai_stream_runtime,
+            "settings",
+            SimpleNamespace(
+                nvidia_model="deepseek-ai/deepseek-v4-flash",
+                nvidia_model_advanced="deepseek-ai/deepseek-v4-pro",
+            ),
+        ):
+            assert (
+                openai_stream_runtime._resolve_openai_stream_model_name_impl(
+                    llm, "nvidia", "moderate"
+                )
+                == "deepseek-ai/deepseek-v4-flash"
+            )
+            assert (
+                openai_stream_runtime._resolve_openai_stream_model_name_impl(
+                    llm, "nvidia", "deep"
+                )
+                == "deepseek-ai/deepseek-v4-pro"
+            )
+
+    def test_nvidia_stream_client_uses_nvidia_credentials(self):
+        from app.engine.multi_agent import openai_stream_runtime
+
+        captured: dict = {}
+
+        def _fake_async_openai(**kwargs):
+            captured.update(kwargs)
+            return object()
+
+        with patch.object(
+            openai_stream_runtime,
+            "settings",
+            SimpleNamespace(
+                nvidia_api_key="nvapi-test-key",
+                nvidia_base_url="https://nvidia.example.test/v1",
+            ),
+        ), patch("openai.AsyncOpenAI", new=_fake_async_openai):
+            client = openai_stream_runtime._create_openai_compatible_stream_client_impl(
+                "nvidia"
+            )
+
+        assert client is not None
+        assert captured == {
+            "api_key": "nvapi-test-key",
+            "base_url": "https://nvidia.example.test/v1",
+        }
+
+    def test_direct_runtime_payload_wrapper_flattens_langchain_content(self):
+        from app.engine.multi_agent import direct_runtime_bindings
+
+        message = SimpleNamespace(
+            type="human",
+            content=[
+                {"text": "Xin chao"},
+                {"content": "Wiii"},
+            ],
+        )
+
+        assert direct_runtime_bindings._langchain_message_to_openai_payload(message) == {
+            "role": "user",
+            "content": "Xin chao\nWiii",
+        }
+
+
 # ---------------------------------------------------------------------------
 # OpenAIProvider — nvidia alias behavior
 # ---------------------------------------------------------------------------

--- a/maritime-ai-service/tests/unit/test_openai_stream_runtime.py
+++ b/maritime-ai-service/tests/unit/test_openai_stream_runtime.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -321,5 +322,119 @@ async def test_native_direct_stream_timeout_marks_model_degraded():
         assert streamed is False
         assert is_model_degraded("nvidia", "deepseek-ai/deepseek-v4-flash") is True
         assert events == []
+    finally:
+        reset_model_health_state()
+
+
+@pytest.mark.asyncio
+async def test_native_direct_stream_closes_reasoning_when_no_answer_emitted():
+    events = []
+    thinking_stop_signal = asyncio.Event()
+
+    async def _push_event(event):
+        events.append(event)
+
+    class _ReasoningOnlyStream:
+        def __aiter__(self):
+            async def _gen():
+                yield SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            delta=SimpleNamespace(reasoning_content="Still thinking"),
+                        )
+                    ]
+                )
+
+            return _gen()
+
+    class _FakeChatCompletions:
+        async def create(self, **_kwargs):
+            return _ReasoningOnlyStream()
+
+    class _FakeChat:
+        completions = _FakeChatCompletions()
+
+    class _FakeClient:
+        chat = _FakeChat()
+
+    response, streamed = await _stream_openai_compatible_answer_with_route_impl(
+        SimpleNamespace(
+            provider="nvidia",
+            llm=SimpleNamespace(_wiii_tier_key="light", _wiii_model_name="deepseek-ai/deepseek-v4-flash"),
+        ),
+        messages=[{"role": "user", "content": "Hi Wiii"}],
+        push_event=_push_event,
+        node="direct",
+        thinking_stop_signal=thinking_stop_signal,
+        supports_native_answer_streaming=lambda provider: provider == "nvidia",
+        create_openai_compatible_stream_client=lambda _provider: _FakeClient(),
+        resolve_openai_stream_model_name=lambda *_args: "deepseek-ai/deepseek-v4-flash",
+        langchain_message_to_openai_payload=lambda message: message,
+        extract_openai_delta_text=lambda delta: (str(getattr(delta, "reasoning_content", "") or ""), ""),
+    )
+
+    assert response is None
+    assert streamed is False
+    assert thinking_stop_signal.is_set() is True
+    assert [event["type"] for event in events] == [
+        "thinking_start",
+        "thinking_delta",
+        "thinking_end",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_native_direct_stream_partial_exception_does_not_mark_model_healthy():
+    from app.engine.llm_model_health import is_model_degraded, reset_model_health_state
+
+    reset_model_health_state()
+    events = []
+
+    async def _push_event(event):
+        events.append(event)
+
+    class _PartialThenFailStream:
+        def __aiter__(self):
+            async def _gen():
+                yield SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(delta=SimpleNamespace(content="Xin chao"))
+                    ]
+                )
+                raise RuntimeError("503 service unavailable")
+
+            return _gen()
+
+    class _FakeChatCompletions:
+        async def create(self, **_kwargs):
+            return _PartialThenFailStream()
+
+    class _FakeChat:
+        completions = _FakeChatCompletions()
+
+    class _FakeClient:
+        chat = _FakeChat()
+
+    try:
+        response, streamed = await _stream_openai_compatible_answer_with_route_impl(
+            SimpleNamespace(
+                provider="nvidia",
+                llm=SimpleNamespace(_wiii_tier_key="light", _wiii_model_name="deepseek-ai/deepseek-v4-flash"),
+            ),
+            messages=[{"role": "user", "content": "Hi Wiii"}],
+            push_event=_push_event,
+            node="direct",
+            thinking_stop_signal=None,
+            supports_native_answer_streaming=lambda provider: provider == "nvidia",
+            create_openai_compatible_stream_client=lambda _provider: _FakeClient(),
+            resolve_openai_stream_model_name=lambda *_args: "deepseek-ai/deepseek-v4-flash",
+            langchain_message_to_openai_payload=lambda message: message,
+            extract_openai_delta_text=lambda delta: ("", str(getattr(delta, "content", "") or "")),
+        )
+
+        assert streamed is True
+        assert response.content == "Xin chao"
+        assert events == [{"type": "answer_delta", "content": "Xin chao", "node": "direct"}]
+        assert is_model_degraded("nvidia", "deepseek-ai/deepseek-v4-flash") is True
     finally:
         reset_model_health_state()

--- a/maritime-ai-service/tests/unit/test_openai_stream_runtime.py
+++ b/maritime-ai-service/tests/unit/test_openai_stream_runtime.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from app.engine.multi_agent.openai_stream_runtime import (
+    _ainvoke_openai_compatible_chat_impl,
     _stream_openai_compatible_answer_with_route_impl,
     _supports_native_answer_streaming_impl,
 )
@@ -10,6 +11,83 @@ from app.engine.multi_agent.openai_stream_runtime import (
 
 def test_supports_native_answer_streaming_now_includes_google():
     assert _supports_native_answer_streaming_impl("google") is True
+
+
+@pytest.mark.asyncio
+async def test_native_openai_compatible_ainvoke_sends_tools_and_choice(monkeypatch):
+    from app.engine.native_chat_runtime import NativeChatModelHandle
+
+    captured: dict = {}
+
+    class _FakeChatCompletions:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                model=kwargs["model"],
+                usage={"total_tokens": 12},
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="tool_calls",
+                        message=SimpleNamespace(
+                            content="",
+                            tool_calls=[
+                                SimpleNamespace(
+                                    id="call_1",
+                                    function=SimpleNamespace(
+                                        name="tool_current_datetime",
+                                        arguments="{}",
+                                    ),
+                                )
+                            ],
+                        ),
+                    )
+                ],
+            )
+
+    class _FakeChat:
+        completions = _FakeChatCompletions()
+
+    class _FakeClient:
+        chat = _FakeChat()
+
+    monkeypatch.setattr(
+        "app.engine.multi_agent.openai_stream_runtime._create_openai_compatible_stream_client_impl",
+        lambda _provider: _FakeClient(),
+    )
+    monkeypatch.setattr(
+        "app.engine.multi_agent.openai_stream_runtime._resolve_openai_stream_model_name_impl",
+        lambda *_args: "deepseek-ai/deepseek-v4-flash",
+    )
+
+    handle = NativeChatModelHandle(
+        _wiii_provider_name="nvidia",
+        _wiii_model_name="deepseek-ai/deepseek-v4-flash",
+    ).bind_tools(
+        [
+            SimpleNamespace(
+                name="tool_current_datetime",
+                description="Get current date and time",
+                parameters={"type": "object", "properties": {}},
+            )
+        ],
+        tool_choice="tool_current_datetime",
+    )
+
+    response = await _ainvoke_openai_compatible_chat_impl(
+        handle,
+        [{"role": "user", "content": "May gio roi?"}],
+    )
+
+    assert captured["model"] == "deepseek-ai/deepseek-v4-flash"
+    assert captured["messages"] == [{"role": "user", "content": "May gio roi?"}]
+    assert captured["tools"][0]["function"]["name"] == "tool_current_datetime"
+    assert captured["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "tool_current_datetime"},
+    }
+    assert response.tool_calls == [
+        {"id": "call_1", "name": "tool_current_datetime", "args": {}}
+    ]
 
 
 @pytest.mark.asyncio
@@ -74,3 +152,174 @@ async def test_google_direct_stream_emits_visible_reasoning_before_answer():
     ]
     assert events[1]["content"] == "Cham vao phan tu than cua minh."
     assert events[3]["content"] == "Minh la Wiii."
+
+
+@pytest.mark.asyncio
+async def test_native_direct_stream_returns_tool_call_chunks_with_bound_tools():
+    from app.engine.native_chat_runtime import NativeChatModelHandle
+
+    captured: dict = {}
+    events = []
+
+    async def _push_event(event):
+        events.append(event)
+
+    class _FakeStream:
+        def __aiter__(self):
+            async def _gen():
+                yield SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            delta=SimpleNamespace(
+                                tool_calls=[
+                                    SimpleNamespace(
+                                        index=0,
+                                        id="call_1",
+                                        function=SimpleNamespace(
+                                            name="tool_current_datetime",
+                                            arguments="",
+                                        ),
+                                    )
+                                ]
+                            )
+                        )
+                    ]
+                )
+                yield SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            delta=SimpleNamespace(
+                                tool_calls=[
+                                    SimpleNamespace(
+                                        index=0,
+                                        function=SimpleNamespace(
+                                            name="",
+                                            arguments='{"timezone":"Asia/Saigon"}',
+                                        ),
+                                    )
+                                ]
+                            )
+                        )
+                    ]
+                )
+
+            return _gen()
+
+    class _FakeChatCompletions:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+            return _FakeStream()
+
+    class _FakeChat:
+        completions = _FakeChatCompletions()
+
+    class _FakeClient:
+        chat = _FakeChat()
+
+    llm = NativeChatModelHandle(
+        _wiii_provider_name="nvidia",
+        _wiii_model_name="deepseek-ai/deepseek-v4-flash",
+    ).bind_tools(
+        [
+            SimpleNamespace(
+                name="tool_current_datetime",
+                description="Get current date and time",
+                parameters={
+                    "type": "object",
+                    "properties": {"timezone": {"type": "string"}},
+                },
+            )
+        ]
+    )
+
+    response, streamed = await _stream_openai_compatible_answer_with_route_impl(
+        SimpleNamespace(provider="nvidia", llm=llm),
+        messages=[{"role": "user", "content": "May gio roi?"}],
+        push_event=_push_event,
+        node="direct",
+        thinking_stop_signal=None,
+        supports_native_answer_streaming=lambda provider: provider == "nvidia",
+        create_openai_compatible_stream_client=lambda _provider: _FakeClient(),
+        resolve_openai_stream_model_name=lambda *_args: "deepseek-ai/deepseek-v4-flash",
+        langchain_message_to_openai_payload=lambda message: message,
+        extract_openai_delta_text=lambda delta: ("", str(getattr(delta, "content", "") or "")),
+    )
+
+    assert streamed is False
+    assert captured["tools"][0]["function"]["name"] == "tool_current_datetime"
+    assert response.content == ""
+    assert response.tool_calls == [
+        {
+            "id": "call_1",
+            "name": "tool_current_datetime",
+            "args": {"timezone": "Asia/Saigon"},
+        }
+    ]
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_native_direct_stream_timeout_marks_model_degraded():
+    from app.engine.llm_model_health import is_model_degraded, reset_model_health_state
+
+    reset_model_health_state()
+    events = []
+
+    async def _push_event(event):
+        events.append(event)
+
+    class _SlowStream:
+        def __aiter__(self):
+            async def _gen():
+                import asyncio
+
+                await asyncio.sleep(0.05)
+                yield SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            delta=SimpleNamespace(content="Too late"),
+                        )
+                    ]
+                )
+
+            return _gen()
+
+    class _FakeChatCompletions:
+        async def create(self, **_kwargs):
+            return _SlowStream()
+
+    class _FakeChat:
+        completions = _FakeChatCompletions()
+
+    class _FakeClient:
+        chat = _FakeChat()
+
+    route = SimpleNamespace(
+        provider="nvidia",
+        llm=SimpleNamespace(
+            _wiii_tier_key="light",
+            _wiii_model_name="deepseek-ai/deepseek-v4-flash",
+        ),
+    )
+
+    try:
+        response, streamed = await _stream_openai_compatible_answer_with_route_impl(
+            route,
+            messages=[{"role": "user", "content": "Hi Wiii"}],
+            push_event=_push_event,
+            node="direct",
+            thinking_stop_signal=None,
+            primary_timeout=0.001,
+            supports_native_answer_streaming=lambda provider: provider == "nvidia",
+            create_openai_compatible_stream_client=lambda _provider: _FakeClient(),
+            resolve_openai_stream_model_name=lambda *_args: "deepseek-ai/deepseek-v4-flash",
+            langchain_message_to_openai_payload=lambda message: message,
+            extract_openai_delta_text=lambda delta: ("", str(getattr(delta, "content", "") or "")),
+        )
+
+        assert response is None
+        assert streamed is False
+        assert is_model_degraded("nvidia", "deepseek-ai/deepseek-v4-flash") is True
+        assert events == []
+    finally:
+        reset_model_health_state()

--- a/maritime-ai-service/tests/unit/test_query_rewriter.py
+++ b/maritime-ai-service/tests/unit/test_query_rewriter.py
@@ -159,7 +159,12 @@ class TestRuntimeSocket:
         mock_runtime_llm = AsyncMock()
         mock_runtime_llm.ainvoke.return_value = MagicMock(content="rewritten query")
 
-        with patch("app.engine.agentic_rag.runtime_llm_socket.get_llm_for_provider", return_value=mock_runtime_llm), \
+        with patch(
+            "app.engine.multi_agent.openai_stream_runtime."
+            "_create_openai_compatible_stream_client_impl",
+            return_value=None,
+        ), \
+             patch("app.engine.agentic_rag.runtime_llm_socket.get_llm_for_provider", return_value=mock_runtime_llm), \
              patch("app.services.output_processor.extract_thinking_from_response", return_value=("rewritten query", None)):
             rewriter = QueryRewriter()
             rewriter._llm = None

--- a/maritime-ai-service/tests/unit/test_sprint100_unified_prompt.py
+++ b/maritime-ai-service/tests/unit/test_sprint100_unified_prompt.py
@@ -41,6 +41,23 @@ def _mock_character_state_manager():
         yield
 
 
+def _message_content(message) -> str:
+    """Return text from either LangChain messages or native OpenAI payloads."""
+    if isinstance(message, dict):
+        content = message.get("content", "")
+    else:
+        content = getattr(message, "content", message)
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                parts.append(str(block.get("text") or block.get("content") or ""))
+            else:
+                parts.append(str(block or ""))
+        return "\n".join(part for part in parts if part)
+    return str(content or "")
+
+
 # =============================================================================
 # Phase 1: direct.yaml Loading
 # =============================================================================
@@ -439,8 +456,7 @@ class TestDirectNodeUsesPromptLoader:
                     return_value=("Response here", None)):
             await direct_response_node(state)
 
-        # Find the SystemMessage
-        system_content = captured_messages[0].content
+        system_content = _message_content(captured_messages[0])
         assert "đa lĩnh vực" in system_content
         assert "Wiii" in system_content
         assert "2024" in system_content
@@ -496,7 +512,7 @@ class TestDirectNodeUsesPromptLoader:
                     return_value=("Response", None)):
             await direct_response_node(state)
 
-        system_content = captured_messages[0].content
+        system_content = _message_content(captured_messages[0])
         # The direct node must not append memory by hand; PromptLoader owns the
         # single authoritative memory injection path.
         assert "WIII MEMORY CONTRACT" in system_content

--- a/maritime-ai-service/tests/unit/test_sprint154_tech_debt.py
+++ b/maritime-ai-service/tests/unit/test_sprint154_tech_debt.py
@@ -867,8 +867,14 @@ class TestExecuteDirectToolRounds:
         llm_response.tool_calls = []
         # llm_with_tools is an object with .ainvoke() method
         llm_with_tools = MagicMock()
+        llm_with_tools._wiii_native_route = False
+        llm_with_tools._wiii_provider_name = ""
+        llm_with_tools._wiii_model_name = "test-direct"
         llm_with_tools.ainvoke = AsyncMock(return_value=llm_response)
         llm_auto = MagicMock()
+        llm_auto._wiii_native_route = False
+        llm_auto._wiii_provider_name = ""
+        llm_auto._wiii_model_name = "test-direct-auto"
         llm_auto.ainvoke = AsyncMock()
 
         async def noop_push(e):

--- a/maritime-ai-service/tests/unit/test_sprint222_host_adapters.py
+++ b/maritime-ai-service/tests/unit/test_sprint222_host_adapters.py
@@ -72,6 +72,36 @@ class TestLMSHostAdapter:
         result = adapter.format_context_for_prompt(ctx)
         assert "Đi tới bài tiếp" in result
 
+    def test_format_with_pointy_targets(self):
+        from app.engine.context.adapters.lms import LMSHostAdapter
+        from app.engine.context.host_context import HostContext
+
+        adapter = LMSHostAdapter()
+        ctx = HostContext(
+            host_type="lms",
+            page={
+                "type": "course_list",
+                "title": "Courses",
+                "metadata": {
+                    "available_targets": [
+                        {
+                            "id": "browse-courses",
+                            "selector": '[data-wiii-id="browse-courses"]',
+                            "label": "Browse courses",
+                            "click_safe": True,
+                            "click_kind": "navigation",
+                        }
+                    ]
+                },
+            },
+        )
+        result = adapter.format_context_for_prompt(ctx)
+        assert "<available_targets>" in result
+        assert "browse-courses" in result
+        assert '[data-wiii-id="browse-courses"]' in result
+        assert "click_safe=true" in result
+        assert "click_kind=navigation" in result
+
     def test_format_exam_page_has_socratic_warning(self):
         """Exam pages should also trigger Socratic warning like quiz."""
         from app.engine.context.adapters.lms import LMSHostAdapter

--- a/maritime-ai-service/tests/unit/test_sprint222_host_adapters.py
+++ b/maritime-ai-service/tests/unit/test_sprint222_host_adapters.py
@@ -98,9 +98,41 @@ class TestLMSHostAdapter:
         result = adapter.format_context_for_prompt(ctx)
         assert "<available_targets>" in result
         assert "browse-courses" in result
-        assert '[data-wiii-id="browse-courses"]' in result
+        assert "[data-wiii-id=&quot;browse-courses&quot;]" in result
         assert "click_safe=true" in result
         assert "click_kind=navigation" in result
+
+    def test_format_with_pointy_targets_escapes_dynamic_fields(self):
+        from app.engine.context.adapters.lms import LMSHostAdapter
+        from app.engine.context.host_context import HostContext
+
+        adapter = LMSHostAdapter()
+        ctx = HostContext(
+            host_type="lms",
+            page={
+                "type": "course_list",
+                "title": "Courses",
+                "metadata": {
+                    "available_targets": [
+                        {
+                            "id": "bad|id",
+                            "selector": '[data-wiii-id="bad|id"]',
+                            "label": 'Bad <script> "target" | ok',
+                            "click_safe": True,
+                            "click_kind": "nav|primary",
+                        }
+                    ]
+                },
+            },
+        )
+
+        result = adapter.format_context_for_prompt(ctx)
+
+        assert "bad/id" in result
+        assert "Bad &lt;script&gt; &quot;target&quot; / ok" in result
+        assert "[data-wiii-id=&quot;bad/id&quot;]" in result
+        assert "click_kind=nav/primary" in result
+        assert "<script>" not in result
 
     def test_format_exam_page_has_socratic_warning(self):
         """Exam pages should also trigger Socratic warning like quiz."""

--- a/maritime-ai-service/tests/unit/test_sprint97_living_character.py
+++ b/maritime-ai-service/tests/unit/test_sprint97_living_character.py
@@ -230,6 +230,7 @@ class TestDirectNodeLivingState:
              patch("app.prompts.prompt_loader.get_prompt_loader") as mock_pl, \
              patch("app.engine.multi_agent.graph.settings") as mock_settings:
             mock_acr.get_llm.return_value = mock_llm
+            mock_acr.get_native_llm.return_value = None
             mock_settings.app_name = "Wiii"
             mock_settings.default_domain = "maritime"
             mock_settings.enable_character_tools = True
@@ -283,6 +284,7 @@ class TestDirectNodeCharacterTools:
              patch("app.prompts.prompt_loader.get_prompt_loader") as mock_pl, \
              patch("app.engine.multi_agent.graph.settings") as mock_settings:
             mock_acr.get_llm.return_value = mock_llm
+            mock_acr.get_native_llm.return_value = None
             mock_settings.app_name = "Wiii"
             mock_settings.default_domain = "maritime"
             mock_settings.enable_character_tools = True
@@ -346,6 +348,7 @@ class TestDirectNodeCharacterTools:
              patch("app.prompts.prompt_loader.get_prompt_loader") as mock_pl, \
              patch("app.engine.multi_agent.graph.settings") as mock_settings:
             mock_acr.get_llm.return_value = mock_llm
+            mock_acr.get_native_llm.return_value = None
             mock_settings.app_name = "Wiii"
             mock_settings.default_domain = "maritime"
             mock_settings.enable_character_tools = False
@@ -411,6 +414,8 @@ class TestDirectNodeCharacterTools:
 
         with patch("app.engine.multi_agent.agent_config.AgentConfigRegistry.get_llm",
                    return_value=mock_llm), \
+             patch("app.engine.multi_agent.agent_config.AgentConfigRegistry.get_native_llm",
+                   return_value=None), \
              patch("app.engine.character.character_state.get_character_state_manager") as mock_csm, \
              patch("app.prompts.prompt_loader.get_prompt_loader") as mock_pl, \
              patch("app.engine.multi_agent.graph.settings") as mock_settings, \

--- a/maritime-ai-service/tests/unit/test_sprint99_forced_tool_calling.py
+++ b/maritime-ai-service/tests/unit/test_sprint99_forced_tool_calling.py
@@ -419,6 +419,8 @@ class TestForcedToolChoice:
 
         with patch("app.engine.multi_agent.agent_config.AgentConfigRegistry.get_llm",
                    return_value=mock_llm), \
+             patch("app.engine.multi_agent.agent_config.AgentConfigRegistry.get_native_llm",
+                   return_value=None), \
              patch("app.prompts.prompt_loader.get_prompt_loader") as mock_pl, \
              patch("app.engine.multi_agent.graph.settings") as mock_settings, \
              patch("app.engine.multi_agent.graph._get_or_create_tracer") as mock_tracer_fn, \
@@ -510,6 +512,7 @@ class TestPromptContent:
             mock_settings.enable_character_tools = False
             mock_settings.enable_code_execution = False
             mock_acr.get_llm.return_value = mock_llm
+            mock_acr.get_native_llm.return_value = None
 
             mock_tracer = MagicMock()
             mock_tracer_fn.return_value = mock_tracer
@@ -565,6 +568,7 @@ class TestPromptContent:
             mock_settings.enable_character_tools = False
             mock_settings.enable_code_execution = False
             mock_acr.get_llm.return_value = mock_llm
+            mock_acr.get_native_llm.return_value = None
 
             mock_tracer = MagicMock()
             mock_tracer_fn.return_value = mock_tracer

--- a/wiii-desktop/src/__tests__/context-bridge.test.ts
+++ b/wiii-desktop/src/__tests__/context-bridge.test.ts
@@ -3,14 +3,22 @@ import { useHostContextStore } from '../stores/host-context-store';
 import { usePageContextStore } from '../stores/page-context-store';
 import { initContextBridge, cleanupContextBridge } from '../lib/context-bridge';
 
-function dispatch(data: unknown) {
-  window.dispatchEvent(new MessageEvent('message', { data }));
+function setDocumentReferrer(value: string) {
+  Object.defineProperty(document, 'referrer', {
+    value,
+    configurable: true,
+  });
+}
+
+function dispatch(data: unknown, origin = '') {
+  window.dispatchEvent(new MessageEvent('message', { data, origin }));
 }
 
 describe('context-bridge', () => {
   beforeEach(() => {
     useHostContextStore.getState().clear();
     usePageContextStore.getState().clear();
+    setDocumentReferrer('');
     // Ensure bridge is active
     cleanupContextBridge();
     initContextBridge();
@@ -235,6 +243,28 @@ describe('context-bridge', () => {
   it('ignores wiii:clear-chat (handled by EmbedApp)', () => {
     dispatch({ type: 'wiii:clear-chat' });
     expect(useHostContextStore.getState().currentContext).toBeNull();
+  });
+
+  it('rejects context messages from origins that do not match the parent referrer', () => {
+    setDocumentReferrer('https://trusted.example/lms');
+
+    dispatch({
+      type: 'wiii:page-context',
+      payload: { page_type: 'lesson', page_title: 'Injected' },
+    }, 'https://evil.example');
+
+    expect(useHostContextStore.getState().currentContext).toBeNull();
+  });
+
+  it('accepts context messages from the parent referrer origin', () => {
+    setDocumentReferrer('https://trusted.example/lms');
+
+    dispatch({
+      type: 'wiii:page-context',
+      payload: { page_type: 'lesson', page_title: 'Trusted' },
+    }, 'https://trusted.example');
+
+    expect(useHostContextStore.getState().currentContext?.page.title).toBe('Trusted');
   });
 
   // ── Lifecycle ──

--- a/wiii-desktop/src/__tests__/host-context-store.test.ts
+++ b/wiii-desktop/src/__tests__/host-context-store.test.ts
@@ -90,6 +90,29 @@ describe('host-context-store', () => {
     expect(ctx?.page.metadata?.quiz_question).toBe('Which vessel gives way?');
   });
 
+  it('should preserve future host metadata such as Pointy targets', () => {
+    const store = useHostContextStore.getState();
+    store.setLegacyPageContext({
+      page_type: 'course_list',
+      page_title: 'Courses',
+      available_targets: [
+        {
+          id: 'browse-courses',
+          selector: '[data-wiii-id="browse-courses"]',
+          label: 'Browse courses',
+        },
+      ],
+    });
+
+    const ctx = useHostContextStore.getState().currentContext;
+    expect(ctx?.page.metadata?.available_targets).toEqual([
+      expect.objectContaining({
+        id: 'browse-courses',
+        selector: '[data-wiii-id="browse-courses"]',
+      }),
+    ]);
+  });
+
   it('should preserve connector and workspace overlays from legacy page context', () => {
     const store = useHostContextStore.getState();
     store.setLegacyPageContext({

--- a/wiii-desktop/src/__tests__/host-context-store.test.ts
+++ b/wiii-desktop/src/__tests__/host-context-store.test.ts
@@ -113,6 +113,29 @@ describe('host-context-store', () => {
     ]);
   });
 
+  it('should block dangerous legacy metadata keys', () => {
+    const store = useHostContextStore.getState();
+    const legacy = {
+      page_type: 'lesson',
+      page_title: 'Safe page',
+      constructor: 'bad',
+      prototype: 'bad',
+    } as Record<string, unknown>;
+    Object.defineProperty(legacy, '__proto__', {
+      value: { polluted: true },
+      enumerable: true,
+    });
+
+    store.setLegacyPageContext(legacy);
+
+    const metadata = useHostContextStore.getState().currentContext?.page.metadata;
+    expect(Object.getPrototypeOf(metadata)).toBeNull();
+    expect(metadata?.constructor).toBeUndefined();
+    expect(metadata?.prototype).toBeUndefined();
+    expect((metadata as Record<string, unknown>)?.__proto__).toBeUndefined();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
   it('should preserve connector and workspace overlays from legacy page context', () => {
     const store = useHostContextStore.getState();
     store.setLegacyPageContext({

--- a/wiii-desktop/src/__tests__/pointy-fast-path.test.ts
+++ b/wiii-desktop/src/__tests__/pointy-fast-path.test.ts
@@ -4,6 +4,7 @@ import {
   buildPointyFastPathAction,
   getPointyTargetsFromContext,
   normalizePointyText,
+  POINTY_FAST_PATH_SOURCE,
 } from "@/lib/pointy-fast-path";
 
 function makeHostContext(targets: unknown[]): HostContext {
@@ -96,7 +97,10 @@ describe("pointy fast path", () => {
 
     expect(action).toMatchObject({
       action: "ui.click",
-      params: expect.objectContaining({ selector: "browse-courses-link" }),
+      params: expect.objectContaining({
+        selector: "browse-courses-link",
+        message: "Wiii đang mở Kham pha khoa hoc cho bạn.",
+      }),
       reason: "click",
     });
   });
@@ -115,8 +119,30 @@ describe("pointy fast path", () => {
 
     expect(action).toMatchObject({
       action: "ui.highlight",
+      params: expect.objectContaining({
+        message: "Đây là Nop bai. Wiii trỏ vào để bạn thấy ngay.",
+      }),
       reason: "unsafe_click_demoted",
     });
+  });
+
+  it("does not reissue an action after pointy fast-path feedback", () => {
+    const ctx: HostContext = {
+      ...makeHostContext([
+        {
+          id: "browse-courses",
+          selector: "[data-wiii-id=\"browse-courses\"]",
+          label: "Kham pha khoa hoc",
+        },
+      ]),
+      host_action_feedback: {
+        last_action_result: {
+          params: { source: POINTY_FAST_PATH_SOURCE },
+        },
+      },
+    };
+
+    expect(buildPointyFastPathAction("Wiii oi, nut Kham pha khoa hoc o dau?", ctx)).toBeNull();
   });
 
   it("does nothing when no visible target matches", () => {

--- a/wiii-desktop/src/__tests__/pointy-fast-path.test.ts
+++ b/wiii-desktop/src/__tests__/pointy-fast-path.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import type { HostContext } from "@/stores/host-context-store";
+import {
+  buildPointyFastPathAction,
+  getPointyTargetsFromContext,
+  normalizePointyText,
+} from "@/lib/pointy-fast-path";
+
+function makeHostContext(targets: unknown[]): HostContext {
+  return {
+    host_type: "lms",
+    page: {
+      type: "course_list",
+      title: "Khoa hoc cua toi",
+      metadata: {
+        available_targets: targets,
+      },
+    },
+  };
+}
+
+describe("pointy fast path", () => {
+  it("normalizes Vietnamese UI prompts for local matching", () => {
+    expect(normalizePointyText("Wiii oi, nut Kham pha khoa hoc o dau?")).toContain(
+      "kham pha khoa hoc o dau",
+    );
+    expect(normalizePointyText("Wiii ơi, Khám phá khóa học ở đâu?")).toContain(
+      "kham pha khoa hoc o dau",
+    );
+  });
+
+  it("extracts valid Pointy targets from host context metadata", () => {
+    const ctx = makeHostContext([
+      { id: "browse-courses", selector: "[data-wiii-id=\"browse-courses\"]", label: "Kham pha" },
+      { id: "", selector: "#bad" },
+      "noise",
+    ]);
+
+    expect(getPointyTargetsFromContext(ctx)).toEqual([
+      expect.objectContaining({ id: "browse-courses", label: "Kham pha" }),
+    ]);
+  });
+
+  it("highlights the matching target immediately for where-is prompts", () => {
+    const ctx = makeHostContext([
+      {
+        id: "browse-courses",
+        selector: "[data-wiii-id=\"browse-courses\"]",
+        label: "Kham pha khoa hoc",
+        click_safe: true,
+      },
+    ]);
+
+    const action = buildPointyFastPathAction("Wiii oi, nut Kham pha khoa hoc o dau?", ctx);
+
+    expect(action).toMatchObject({
+      action: "ui.highlight",
+      target: expect.objectContaining({ id: "browse-courses" }),
+      params: expect.objectContaining({ selector: "browse-courses" }),
+      reason: "locate",
+    });
+  });
+
+  it("highlights accented where-is prompts even when the user does not say button", () => {
+    const ctx = makeHostContext([
+      {
+        id: "browse-courses-link",
+        selector: "[data-wiii-id=\"browse-courses-link\"]",
+        label: "Khám phá khóa học",
+        click_safe: true,
+      },
+    ]);
+
+    const action = buildPointyFastPathAction("Wiii ơi, Khám phá khóa học ở đâu?", ctx);
+
+    expect(action).toMatchObject({
+      action: "ui.highlight",
+      target: expect.objectContaining({ id: "browse-courses-link" }),
+      params: expect.objectContaining({ selector: "browse-courses-link" }),
+      reason: "locate",
+    });
+  });
+
+  it("clicks only explicitly safe navigation targets for open prompts", () => {
+    const ctx = makeHostContext([
+      {
+        id: "browse-courses-link",
+        selector: "[data-wiii-id=\"browse-courses-link\"]",
+        label: "Kham pha khoa hoc",
+        click_safe: true,
+        click_kind: "navigation",
+      },
+    ]);
+
+    const action = buildPointyFastPathAction("Wiii mo Kham pha khoa hoc giup toi", ctx);
+
+    expect(action).toMatchObject({
+      action: "ui.click",
+      params: expect.objectContaining({ selector: "browse-courses-link" }),
+      reason: "click",
+    });
+  });
+
+  it("demotes unsafe click intents to highlight instead of clicking", () => {
+    const ctx = makeHostContext([
+      {
+        id: "submit-quiz",
+        selector: "[data-wiii-id=\"submit-quiz\"]",
+        label: "Nop bai",
+        click_safe: false,
+      },
+    ]);
+
+    const action = buildPointyFastPathAction("Wiii bam nut Nop bai giup toi", ctx);
+
+    expect(action).toMatchObject({
+      action: "ui.highlight",
+      reason: "unsafe_click_demoted",
+    });
+  });
+
+  it("does nothing when no visible target matches", () => {
+    const ctx = makeHostContext([
+      { id: "profile-link", selector: "[data-wiii-id=\"profile-link\"]", label: "Ho so" },
+    ]);
+
+    expect(buildPointyFastPathAction("Wiii oi hom nay sao roi?", ctx)).toBeNull();
+  });
+});

--- a/wiii-desktop/src/__tests__/sprint110-hardening.test.ts
+++ b/wiii-desktop/src/__tests__/sprint110-hardening.test.ts
@@ -99,6 +99,12 @@ describe("useSSEStream — type-safe metadata", () => {
     const code = (src as any).default || src;
     expect(code).toContain("ChatResponseMetadata");
   });
+
+  it("should keep the idle guard above provider cold-start latency", async () => {
+    const src = await import("@/hooks/useSSEStream?raw");
+    const code = (src as any).default || src;
+    expect(code).toContain("const SSE_IDLE_TIMEOUT_MS = 120_000");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/wiii-desktop/src/__tests__/sprint110-hardening.test.ts
+++ b/wiii-desktop/src/__tests__/sprint110-hardening.test.ts
@@ -105,6 +105,16 @@ describe("useSSEStream — type-safe metadata", () => {
     const code = (src as any).default || src;
     expect(code).toContain("const SSE_IDLE_TIMEOUT_MS = 120_000");
   });
+
+  it("records Pointy fast-path progress only after host action success", async () => {
+    const src = await import("@/hooks/useSSEStream?raw");
+    const code = (src as any).default || src;
+    const successGuard = code.indexOf("if (result.success)");
+    const pointyStep = code.indexOf('eventOrderRef.current.push("pointy_fast_path")');
+    expect(successGuard).toBeGreaterThan(-1);
+    expect(pointyStep).toBeGreaterThan(successGuard);
+    expect(code).not.toContain("Wiii dang tro tren trang");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/wiii-desktop/src/hooks/useSSEStream.ts
+++ b/wiii-desktop/src/hooks/useSSEStream.ts
@@ -546,6 +546,11 @@ export function useSSEStream() {
                 success: result.success,
               });
             }
+            if (result.success) {
+              eventOrderRef.current.push("pointy_fast_path");
+              chatStore.setStreamingStep("Wiii đang trỏ trên trang...");
+              chatStore.addStreamingStep("Wiii đang trỏ trên trang...", "pointy_fast_path");
+            }
             return result;
           })
           .catch((err) => {
@@ -556,11 +561,6 @@ export function useSSEStream() {
             return null;
           })
       : null;
-    if (pointyFastPathAction) {
-      eventOrderRef.current.push("pointy_fast_path");
-      chatStore.setStreamingStep("Wiii dang tro tren trang...");
-      chatStore.addStreamingStep("Wiii dang tro tren trang...", "pointy_fast_path");
-    }
 
     // Keep a per-send controller so an aborted previous request cannot
     // accidentally clear/finalize the newly-started stream.

--- a/wiii-desktop/src/hooks/useSSEStream.ts
+++ b/wiii-desktop/src/hooks/useSSEStream.ts
@@ -24,6 +24,7 @@ import { useToastStore } from "@/stores/toast-store";
 import { useModelStore } from "@/stores/model-store";
 import { useAuthStore } from "@/stores/auth-store";
 import { StreamBuffer } from "@/lib/stream-buffer";
+import { buildPointyFastPathAction } from "@/lib/pointy-fast-path";
 import { trackVisualTelemetry } from "@/lib/visual-telemetry";
 import type { SSEEventHandler } from "@/api/sse";
 import type {
@@ -39,7 +40,8 @@ import type {
 
 const MAX_SSE_RETRIES = 3;
 const SSE_BACKOFF_MS = 1000; // 1s, 2s, 4s
-const SSE_IDLE_TIMEOUT_MS = 30_000;
+// Provider/router cold paths can exceed 30s before the first answer token.
+const SSE_IDLE_TIMEOUT_MS = 120_000;
 const IDLE_TIMEOUT_ABORT_REASON = "stream_idle_timeout";
 const STREAM_RESTART_ABORT_REASON = "stream_restart";
 const USER_CANCEL_ABORT_REASON = "user_cancel";
@@ -521,6 +523,45 @@ export function useSSEStream() {
     thinkingMetaRef.current = undefined;
     codeOpenActiveRef.current = false;
 
+    const canUseHostActionBridge =
+      typeof window !== "undefined" && window.parent !== window;
+    const pointyFastPathAction = canUseHostActionBridge
+      ? buildPointyFastPathAction(
+          content,
+          useHostContextStore.getState().currentContext,
+        )
+      : null;
+    const pointyFastPathPromise = pointyFastPathAction
+      ? useHostContextStore.getState()
+          .requestAction(
+            pointyFastPathAction.action,
+            pointyFastPathAction.params,
+            pointyFastPathAction.requestId,
+          )
+          .then((result) => {
+            if (TRACE_SSE) {
+              console.debug("[SSE] pointy-fast-path resolved", {
+                action: pointyFastPathAction.action,
+                target: pointyFastPathAction.target.id,
+                success: result.success,
+              });
+            }
+            return result;
+          })
+          .catch((err) => {
+            console.warn(
+              "[SSE] pointy-fast-path failed:",
+              err instanceof Error ? err.message : String(err),
+            );
+            return null;
+          })
+      : null;
+    if (pointyFastPathAction) {
+      eventOrderRef.current.push("pointy_fast_path");
+      chatStore.setStreamingStep("Wiii dang tro tren trang...");
+      chatStore.addStreamingStep("Wiii dang tro tren trang...", "pointy_fast_path");
+    }
+
     // Keep a per-send controller so an aborted previous request cannot
     // accidentally clear/finalize the newly-started stream.
     const streamController = new AbortController();
@@ -531,6 +572,10 @@ export function useSSEStream() {
       }
     };
     scheduleIdleGuard();
+
+    if (pointyFastPathPromise) {
+      await Promise.race([pointyFastPathPromise, sleep(350)]);
+    }
 
     // Sprint 150: Create fresh StreamBuffer instances for this stream
     answerBufferRef.current = new StreamBuffer({

--- a/wiii-desktop/src/lib/context-bridge.ts
+++ b/wiii-desktop/src/lib/context-bridge.ts
@@ -27,11 +27,41 @@ const CONTEXT_TYPES = new Set([
 
 let _registered = false;
 
+function extractOrigin(url: string): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+function expectedParentOrigin(): string | null {
+  if (typeof document === "undefined") return null;
+  return extractOrigin(document.referrer);
+}
+
+function isAllowedContextOrigin(event: MessageEvent): boolean {
+  if (typeof window === "undefined") return false;
+
+  const expectedOrigin = expectedParentOrigin();
+  if (expectedOrigin) {
+    return event.origin === expectedOrigin;
+  }
+
+  if (window.parent === window) {
+    return !event.origin || event.origin === window.location.origin;
+  }
+
+  return false;
+}
+
 // ── Handler ──
 
 function handleContextMessage(event: MessageEvent): void {
   const msgType = event.data?.type;
   if (!msgType || typeof msgType !== "string" || !CONTEXT_TYPES.has(msgType)) return;
+  if (!isAllowedContextOrigin(event)) return;
 
   if (msgType === "wiii:page-context") {
     const payload = event.data.payload || event.data;

--- a/wiii-desktop/src/lib/pointy-fast-path.ts
+++ b/wiii-desktop/src/lib/pointy-fast-path.ts
@@ -1,0 +1,220 @@
+import type { HostContext } from "@/stores/host-context-store";
+
+export const POINTY_FAST_PATH_SOURCE = "pointy_fast_path";
+
+const LOCATE_TERMS = [
+  "o dau",
+  "where",
+  "chi",
+  "chi cho",
+  "tim",
+  "tro",
+  "highlight",
+  "nut",
+  "button",
+];
+
+const CLICK_TERMS = [
+  "mo",
+  "bam",
+  "click",
+  "nhan vao",
+  "vao",
+  "di toi",
+  "chuyen toi",
+  "open",
+];
+
+const UNSAFE_CLICK_TERMS = [
+  "submit",
+  "nop bai",
+  "quiz",
+  "checkout",
+  "payment",
+  "thanh toan",
+  "enroll",
+  "dang ky",
+  "logout",
+  "dang xuat",
+  "delete",
+  "xoa",
+  "mark complete",
+  "hoan thanh",
+];
+
+const TARGET_ALIASES: Array<{ ids: string[]; terms: string[] }> = [
+  {
+    ids: ["browse-courses", "browse-courses-link", "browse-courses-button"],
+    terms: ["kham pha khoa hoc", "kham pha", "browse courses", "browse"],
+  },
+  {
+    ids: ["continue-learn", "continue-lesson", "continue-course"],
+    terms: ["tiep tuc hoc", "tiep tuc", "continue learning", "continue"],
+  },
+  {
+    ids: ["my-courses", "my-courses-link"],
+    terms: ["khoa hoc cua toi", "khoa hoc dang hoc", "my courses"],
+  },
+  {
+    ids: ["profile-link", "profile-card"],
+    terms: ["ho so", "profile"],
+  },
+];
+
+export interface PointyFastPathTarget {
+  id: string;
+  selector: string;
+  label?: string;
+  click_safe?: boolean;
+  click_kind?: string;
+}
+
+export interface PointyFastPathAction {
+  action: "ui.highlight" | "ui.click";
+  requestId: string;
+  params: {
+    selector: string;
+    message?: string;
+    duration_ms?: number;
+    source: typeof POINTY_FAST_PATH_SOURCE;
+  };
+  target: PointyFastPathTarget;
+  reason: "locate" | "click" | "unsafe_click_demoted";
+}
+
+export function normalizePointyText(value: string): string {
+  return value
+    .replace(/đ/g, "d")
+    .replace(/Đ/g, "d")
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/đ/g, "d")
+    .replace(/Đ/g, "d")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function hasAnyTerm(prompt: string, terms: string[]): boolean {
+  return terms.some((term) => prompt.includes(term));
+}
+
+function coerceTarget(value: unknown): PointyFastPathTarget | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const id = typeof raw.id === "string" ? raw.id.trim() : "";
+  const selector = typeof raw.selector === "string" ? raw.selector.trim() : "";
+  if (!id || !selector) return null;
+  return {
+    id,
+    selector,
+    label: typeof raw.label === "string" ? raw.label.trim() : undefined,
+    click_safe: raw.click_safe === true,
+    click_kind: typeof raw.click_kind === "string" ? raw.click_kind.trim() : undefined,
+  };
+}
+
+export function getPointyTargetsFromContext(ctx: HostContext | null): PointyFastPathTarget[] {
+  const targets = ctx?.page?.metadata?.available_targets;
+  if (!Array.isArray(targets)) return [];
+  return targets.map(coerceTarget).filter((target): target is PointyFastPathTarget => Boolean(target));
+}
+
+function aliasScore(prompt: string, target: PointyFastPathTarget): number {
+  const idText = normalizePointyText(target.id);
+  for (const alias of TARGET_ALIASES) {
+    const aliasMatchesPrompt = alias.terms.some((term) => prompt.includes(term));
+    if (!aliasMatchesPrompt) continue;
+    if (alias.ids.some((id) => idText.includes(normalizePointyText(id)))) {
+      return 40;
+    }
+  }
+  return 0;
+}
+
+function targetScore(prompt: string, target: PointyFastPathTarget): number {
+  const idText = normalizePointyText(target.id);
+  const selectorText = normalizePointyText(target.selector);
+  const labelText = normalizePointyText(target.label || "");
+  const labelWords = labelText.split(" ").filter((word) => word.length >= 3);
+  let score = aliasScore(prompt, target);
+
+  if (labelText && prompt.includes(labelText)) score += 35;
+  if (idText && prompt.includes(idText)) score += 24;
+  if (selectorText && prompt.includes(selectorText)) score += 12;
+  if (labelWords.length > 0) {
+    const matchedWords = labelWords.filter((word) => prompt.includes(word)).length;
+    score += matchedWords * 6;
+    if (matchedWords === labelWords.length) score += 12;
+  }
+
+  if (target.click_safe) score += 2;
+  return score;
+}
+
+function selectTarget(prompt: string, targets: PointyFastPathTarget[]): PointyFastPathTarget | null {
+  let best: { target: PointyFastPathTarget; score: number } | null = null;
+  for (const target of targets) {
+    const score = targetScore(prompt, target);
+    if (score <= 0) continue;
+    if (!best || score > best.score) {
+      best = { target, score };
+    }
+  }
+  return best && best.score >= 12 ? best.target : null;
+}
+
+function isUnsafeClickTarget(prompt: string, target: PointyFastPathTarget): boolean {
+  const combined = normalizePointyText(
+    `${prompt} ${target.id} ${target.label || ""} ${target.click_kind || ""}`,
+  );
+  return hasAnyTerm(combined, UNSAFE_CLICK_TERMS);
+}
+
+function makeRequestId(): string {
+  const random = globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2, 12);
+  return `pointy-fast-${random}`;
+}
+
+export function buildPointyFastPathAction(
+  prompt: string,
+  ctx: HostContext | null,
+): PointyFastPathAction | null {
+  const normalizedPrompt = normalizePointyText(prompt);
+  if (!normalizedPrompt) return null;
+  const wantsLocate = hasAnyTerm(normalizedPrompt, LOCATE_TERMS);
+  const wantsClick = hasAnyTerm(normalizedPrompt, CLICK_TERMS);
+  if (!wantsLocate && !wantsClick) return null;
+
+  const target = selectTarget(normalizedPrompt, getPointyTargetsFromContext(ctx));
+  if (!target) return null;
+
+  const label = target.label || target.id;
+  if (wantsClick && target.click_safe && !isUnsafeClickTarget(normalizedPrompt, target)) {
+    return {
+      action: "ui.click",
+      requestId: makeRequestId(),
+      params: {
+        selector: target.id,
+        message: `Wiii dang mo ${label} cho ban.`,
+        source: POINTY_FAST_PATH_SOURCE,
+      },
+      target,
+      reason: "click",
+    };
+  }
+
+  return {
+    action: "ui.highlight",
+    requestId: makeRequestId(),
+    params: {
+      selector: target.id,
+      message: `Day la ${label}. Wiii tro vao de ban thay ngay.`,
+      duration_ms: wantsClick ? 5600 : 5200,
+      source: POINTY_FAST_PATH_SOURCE,
+    },
+    target,
+    reason: wantsClick ? "unsafe_click_demoted" : "locate",
+  };
+}

--- a/wiii-desktop/src/lib/pointy-fast-path.ts
+++ b/wiii-desktop/src/lib/pointy-fast-path.ts
@@ -42,7 +42,17 @@ const UNSAFE_CLICK_TERMS = [
   "hoan thanh",
 ];
 
-const TARGET_ALIASES: Array<{ ids: string[]; terms: string[] }> = [
+interface PointyTargetAlias {
+  ids: string[];
+  terms: string[];
+}
+
+interface ScoredPointyTarget {
+  target: PointyFastPathTarget;
+  score: number;
+}
+
+const TARGET_ALIASES: PointyTargetAlias[] = [
   {
     ids: ["browse-courses", "browse-courses-link", "browse-courses-button"],
     terms: ["kham pha khoa hoc", "kham pha", "browse courses", "browse"],
@@ -154,7 +164,7 @@ function targetScore(prompt: string, target: PointyFastPathTarget): number {
 }
 
 function selectTarget(prompt: string, targets: PointyFastPathTarget[]): PointyFastPathTarget | null {
-  let best: { target: PointyFastPathTarget; score: number } | null = null;
+  let best: ScoredPointyTarget | null = null;
   for (const target of targets) {
     const score = targetScore(prompt, target);
     if (score <= 0) continue;
@@ -181,6 +191,9 @@ export function buildPointyFastPathAction(
   prompt: string,
   ctx: HostContext | null,
 ): PointyFastPathAction | null {
+  const lastSource = ctx?.host_action_feedback?.last_action_result?.params?.source;
+  if (lastSource === POINTY_FAST_PATH_SOURCE) return null;
+
   const normalizedPrompt = normalizePointyText(prompt);
   if (!normalizedPrompt) return null;
   const wantsLocate = hasAnyTerm(normalizedPrompt, LOCATE_TERMS);
@@ -197,7 +210,7 @@ export function buildPointyFastPathAction(
       requestId: makeRequestId(),
       params: {
         selector: target.id,
-        message: `Wiii dang mo ${label} cho ban.`,
+        message: `Wiii đang mở ${label} cho bạn.`,
         source: POINTY_FAST_PATH_SOURCE,
       },
       target,
@@ -210,7 +223,7 @@ export function buildPointyFastPathAction(
     requestId: makeRequestId(),
     params: {
       selector: target.id,
-      message: `Day la ${label}. Wiii tro vao de ban thay ngay.`,
+      message: `Đây là ${label}. Wiii trỏ vào để bạn thấy ngay.`,
       duration_ms: wantsClick ? 5600 : 5200,
       source: POINTY_FAST_PATH_SOURCE,
     },

--- a/wiii-desktop/src/pointy-host/__tests__/bridge.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/bridge.test.ts
@@ -89,6 +89,13 @@ describe("resolveSelector", () => {
     expect(resolveSelector('[data-wiii-id="login-btn"]')?.tagName).toBe("BUTTON");
     expect(resolveSelector("login-btn")?.tagName).toBe("BUTTON");
   });
+  it("prefers data-wiii-id over matching custom-element tag names", () => {
+    document.body.innerHTML = `
+      <profile-link id="wrong-target"></profile-link>
+      <button data-wiii-id="profile-link">Profile</button>
+    `;
+    expect(resolveSelector("profile-link")?.tagName).toBe("BUTTON");
+  });
 });
 
 describe("describeTarget", () => {

--- a/wiii-desktop/src/pointy-host/__tests__/bridge.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/bridge.test.ts
@@ -7,6 +7,7 @@ import {
   _testing,
   createBridge,
   describeTarget,
+  handleClick,
   handleHighlight,
   handleNavigate,
   handleScrollTo,
@@ -86,6 +87,7 @@ describe("resolveSelector", () => {
     document.body.innerHTML = `<button id="b1" data-wiii-id="login-btn">Login</button>`;
     expect(resolveSelector("#b1")?.tagName).toBe("BUTTON");
     expect(resolveSelector('[data-wiii-id="login-btn"]')?.tagName).toBe("BUTTON");
+    expect(resolveSelector("login-btn")?.tagName).toBe("BUTTON");
   });
 });
 
@@ -125,6 +127,31 @@ describe("handleScrollTo", () => {
     document.body.innerHTML = `<section id="ch1">Chapter 1</section>`;
     const result = await handleScrollTo({ selector: "#ch1" });
     expect(result.success).toBe(true);
+  });
+});
+
+describe("handleClick", () => {
+  it("clicks only targets explicitly marked safe", async () => {
+    document.body.innerHTML = `<button data-wiii-id="browse-courses" data-wiii-click-safe="true" data-wiii-click-kind="navigation">Browse</button>`;
+    const target = document.querySelector("button")!;
+    const clickSpy = vi.spyOn(target, "click");
+    const result = await handleClick({ selector: '[data-wiii-id="browse-courses"]' });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.clicked).toBe(true);
+    expect(result.data?.click_kind).toBe("navigation");
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe targets", async () => {
+    document.body.innerHTML = `<button data-wiii-id="submit-quiz">Submit</button>`;
+    const target = document.querySelector("button")!;
+    const clickSpy = vi.spyOn(target, "click");
+    const result = await handleClick({ selector: '[data-wiii-id="submit-quiz"]' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("unsafe_click_target");
+    expect(clickSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/wiii-desktop/src/pointy-host/__tests__/cursor.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/cursor.test.ts
@@ -20,11 +20,11 @@ afterEach(() => {
 });
 
 describe("computeTargetPoint", () => {
-  it("lands above-right of element center", () => {
+  it("lands the collaborator pointer tip on the element center", () => {
     const rect = { left: 100, top: 200, width: 40, height: 20 } as DOMRect;
     const p = computeTargetPoint(rect);
-    expect(p.x).toBe(100 + 20 + 8);
-    expect(p.y).toBe(200 + 10 - 8);
+    expect(p.x).toBe(100 + 20 - 5);
+    expect(p.y).toBe(200 + 10 - 4);
   });
 });
 
@@ -44,7 +44,10 @@ describe("moveCursorToRect", () => {
     expect(cursors.length).toBe(1);
     const el = cursors[0] as SVGSVGElement;
     expect(el.getAttribute("data-wiii-pointy")).toBe("cursor");
+    expect(el.getAttribute("data-wiii-pointy-scope")).toBe("iframe");
+    expect(el.textContent).toContain("Wiii");
     expect(el.style.opacity).toBe("1");
+    expect(["moving", "pointing"]).toContain(el.getAttribute("data-wiii-pointy-state"));
   });
 
   it("re-uses the cursor element when called twice", () => {
@@ -92,6 +95,7 @@ describe("moveCursorToRect — animation fallback", () => {
       expect(result).toBeNull();
       const el = document.querySelector(`#${_testing.CURSOR_ID}`) as SVGSVGElement;
       expect(el.style.transform).toContain("translate(");
+      expect(el.getAttribute("data-wiii-pointy-state")).toBe("pointing");
     } finally {
       (SVGElement.prototype as unknown as { animate?: unknown }).animate = animateBackup;
     }
@@ -99,7 +103,7 @@ describe("moveCursorToRect — animation fallback", () => {
 });
 
 describe("moveCursorToRect — duration clamping", () => {
-  it("clamps duration to [200, 2000]", () => {
+  it("clamps duration to [220, 1400]", () => {
     const rect = { left: 10, top: 10, width: 10, height: 10 } as DOMRect;
     // We only assert no throw + cursor created. Vitest jsdom does not expose
     // Animation.effect timing reliably, so deeper assertion is not stable.

--- a/wiii-desktop/src/pointy-host/__tests__/spotlight.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/spotlight.test.ts
@@ -46,8 +46,11 @@ describe("showSpotlight", () => {
     const target = document.querySelector('[data-wiii-id="cta"]')!;
     showSpotlight(target, { message: "Nhấn vào đây để bắt đầu", duration_ms: 1000 });
     const overlay = document.querySelector(`#${_testing.OVERLAY_ID}`) as HTMLDivElement;
+    const ring = document.querySelector(`#${_testing.TARGET_RING_ID}`) as HTMLDivElement;
     const tooltip = document.querySelector(`#${_testing.TOOLTIP_ID}`) as HTMLDivElement;
     expect(overlay).not.toBeNull();
+    expect(ring).not.toBeNull();
+    expect(ring.style.opacity).toBe("1");
     expect(tooltip).not.toBeNull();
     expect(tooltip.textContent).toBe("Nhấn vào đây để bắt đầu");
     expect(overlay.style.background).toContain("radial-gradient");

--- a/wiii-desktop/src/pointy-host/bridge.ts
+++ b/wiii-desktop/src/pointy-host/bridge.ts
@@ -10,6 +10,7 @@ import { hideCursor, moveCursorToRect } from "./cursor";
 import { hideSpotlight, showSpotlight } from "./spotlight";
 import { runTour } from "./tour";
 import type {
+  ClickParams,
   HighlightParams,
   NavigateParams,
   PointyConfig,
@@ -54,10 +55,19 @@ export function resolveSelector(selector: unknown): Element | null {
   if (!trimmed) return null;
   if (typeof document === "undefined") return null;
   try {
-    return document.querySelector(trimmed);
+    const direct = document.querySelector(trimmed);
+    if (direct) return direct;
   } catch {
-    return null;
+    // Treat a bare semantic id such as "browse-courses" as data-wiii-id.
   }
+  if (/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+    try {
+      return document.querySelector(`[data-wiii-id="${trimmed.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"]`);
+    } catch {
+      return null;
+    }
+  }
+  return null;
 }
 
 export async function handleHighlight(params: HighlightParams): Promise<PointyResult> {
@@ -135,6 +145,35 @@ export async function handleShowTour(params: ShowTourParams): Promise<PointyResu
   });
 }
 
+export async function handleClick(params: ClickParams): Promise<PointyResult> {
+  const target = resolveSelector(params.selector);
+  if (!target) return fail(`selector_not_found:${params.selector}`);
+  if (!(target instanceof HTMLElement) || target.getAttribute("data-wiii-click-safe") !== "true") {
+    return fail(`unsafe_click_target:${params.selector}`);
+  }
+  if (
+    target.hasAttribute("disabled")
+    || target.getAttribute("aria-disabled") === "true"
+    || (target instanceof HTMLButtonElement && target.disabled)
+  ) {
+    return fail(`disabled_click_target:${params.selector}`);
+  }
+  if ("scrollIntoView" in target && typeof target.scrollIntoView === "function") {
+    target.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+  moveCursorToRect(target.getBoundingClientRect(), { duration_ms: 260 });
+  showSpotlight(target, {
+    message: params.message || "Wiii dang mo muc nay cho ban.",
+    duration_ms: 900,
+  });
+  target.click();
+  return ok({
+    summary: `Da bam element: ${describeTarget(target)}`,
+    clicked: true,
+    click_kind: target.getAttribute("data-wiii-click-kind") || "safe",
+  });
+}
+
 export function describeTarget(el: Element): string {
   const labels: string[] = [];
   const id = el.getAttribute("data-wiii-id") || el.id;
@@ -208,6 +247,8 @@ async function dispatch(req: PointyRequest, config: PointyConfig): Promise<Point
       return handleNavigate(req.params as unknown as NavigateParams, config);
     case "ui.show_tour":
       return handleShowTour(req.params as unknown as ShowTourParams);
+    case "ui.click":
+      return handleClick(req.params as unknown as ClickParams);
     default:
       return fail(`unsupported_action:${req.action}`);
   }

--- a/wiii-desktop/src/pointy-host/bridge.ts
+++ b/wiii-desktop/src/pointy-host/bridge.ts
@@ -54,18 +54,20 @@ export function resolveSelector(selector: unknown): Element | null {
   const trimmed = selector.trim();
   if (!trimmed) return null;
   if (typeof document === "undefined") return null;
+  if (/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+    try {
+      const escaped = trimmed.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+      const semantic = document.querySelector(`[data-wiii-id="${escaped}"]`);
+      if (semantic) return semantic;
+    } catch {
+      return null;
+    }
+  }
   try {
     const direct = document.querySelector(trimmed);
     if (direct) return direct;
   } catch {
-    // Treat a bare semantic id such as "browse-courses" as data-wiii-id.
-  }
-  if (/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
-    try {
-      return document.querySelector(`[data-wiii-id="${trimmed.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"]`);
-    } catch {
-      return null;
-    }
+    return null;
   }
   return null;
 }

--- a/wiii-desktop/src/pointy-host/cursor.ts
+++ b/wiii-desktop/src/pointy-host/cursor.ts
@@ -165,12 +165,17 @@ export function hideCursor(): void {
 
 /** Remove the cursor element entirely (for cleanup / tests). */
 export function destroyCursor(): void {
+  if (activeAnimation) {
+    activeAnimation.onfinish = null;
+    activeAnimation.oncancel = null;
+    activeAnimation.cancel();
+    activeAnimation = null;
+  }
   if (cursorEl && cursorEl.parentNode) {
     cursorEl.parentNode.removeChild(cursorEl);
   }
   cursorEl = null;
   lastPos = null;
-  activeAnimation = null;
 }
 
 export const _testing = {

--- a/wiii-desktop/src/pointy-host/cursor.ts
+++ b/wiii-desktop/src/pointy-host/cursor.ts
@@ -1,27 +1,33 @@
 /**
  * Wiii Pointy — animated cursor overlay.
  *
- * Renders a single SVG circle with a "W" letter (Wiii brand orange #F97316)
- * that animates from its current position to the target element's bounding
- * rect. Pure DOM + Web Animations API; no React, no framework.
+ * Renders a Browser-Use-like collaborator cursor with a compact Wiii badge.
+ * Pure DOM + Web Animations API; no React, no framework.
  */
 
 const CURSOR_ID = "wiii-pointy-cursor";
-const CURSOR_SIZE = 36;
+const CURSOR_WIDTH = 124;
+const CURSOR_HEIGHT = 62;
+const CURSOR_TIP_X = 5;
+const CURSOR_TIP_Y = 4;
+const CURSOR_SIZE = CURSOR_WIDTH;
 const BRAND_ORANGE = "#F97316";
-const BRAND_CREAM = "#FAF5EE";
+const POINTER_BLACK = "#111827";
+const LIVE_GREEN = "#22C55E";
 
 let cursorEl: SVGSVGElement | null = null;
 let lastPos: { x: number; y: number } | null = null;
+let activeAnimation: Animation | null = null;
 
 function createCursor(): SVGSVGElement {
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   svg.setAttribute("id", CURSOR_ID);
-  svg.setAttribute("width", String(CURSOR_SIZE));
-  svg.setAttribute("height", String(CURSOR_SIZE));
-  svg.setAttribute("viewBox", "0 0 36 36");
+  svg.setAttribute("width", String(CURSOR_WIDTH));
+  svg.setAttribute("height", String(CURSOR_HEIGHT));
+  svg.setAttribute("viewBox", `0 0 ${CURSOR_WIDTH} ${CURSOR_HEIGHT}`);
   svg.setAttribute("aria-hidden", "true");
   svg.setAttribute("data-wiii-pointy", "cursor");
+  svg.setAttribute("data-wiii-pointy-scope", "iframe");
 
   const css = svg.style;
   css.position = "fixed";
@@ -29,14 +35,36 @@ function createCursor(): SVGSVGElement {
   css.top = "0px";
   css.zIndex = "2147483646";
   css.pointerEvents = "none";
-  css.transformOrigin = "center";
-  css.filter = "drop-shadow(0 4px 8px rgba(0,0,0,0.25))";
+  css.transformOrigin = `${CURSOR_TIP_X}px ${CURSOR_TIP_Y}px`;
+  css.filter = "drop-shadow(0 12px 26px rgba(15,23,42,0.26))";
   css.opacity = "0";
   css.transition = "opacity 200ms ease-out";
+  css.overflow = "visible";
+  css.willChange = "transform, opacity";
 
   svg.innerHTML = `
-    <circle cx="18" cy="18" r="16" fill="${BRAND_ORANGE}" stroke="${BRAND_CREAM}" stroke-width="2"/>
-    <text x="18" y="23" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="16" font-weight="700" fill="${BRAND_CREAM}">W</text>
+    <style>
+      #${CURSOR_ID} .wiii-pointy-live-ring {
+        transform-origin: 105px 43px;
+        animation: wiii-pointy-live-pulse 1.25s ease-out infinite;
+      }
+      #${CURSOR_ID}[data-wiii-pointy-state="moving"] .wiii-pointy-badge {
+        filter: drop-shadow(0 0 10px rgba(249,115,22,0.28));
+      }
+      @keyframes wiii-pointy-live-pulse {
+        0% { opacity: 0.52; transform: scale(0.72); }
+        100% { opacity: 0; transform: scale(1.8); }
+      }
+    </style>
+    <path d="M5 4 L5 35 L15 25 L22 44 L31 40 L24 23 L40 23 Z" fill="${POINTER_BLACK}" stroke="white" stroke-width="2.6" stroke-linejoin="round"/>
+    <g class="wiii-pointy-badge">
+      <rect x="36" y="9" width="82" height="38" rx="19" fill="rgba(255,255,255,0.96)" stroke="rgba(17,24,39,0.12)" stroke-width="1"/>
+      <circle cx="55" cy="28" r="11" fill="${BRAND_ORANGE}"/>
+      <text x="55" y="32" text-anchor="middle" font-family="Aptos Rounded,Nunito Sans,Segoe UI,sans-serif" font-size="11" font-weight="900" fill="white">W</text>
+      <text x="83" y="32" text-anchor="middle" font-family="Aptos Rounded,Nunito Sans,Segoe UI,sans-serif" font-size="14" font-weight="850" fill="${POINTER_BLACK}">Wiii</text>
+      <circle class="wiii-pointy-live-ring" cx="105" cy="43" r="5" fill="${LIVE_GREEN}"/>
+      <circle cx="105" cy="43" r="4" fill="${LIVE_GREEN}" stroke="white" stroke-width="1.8"/>
+    </g>
   `;
   return svg;
 }
@@ -55,8 +83,8 @@ function ensureCursor(): SVGSVGElement {
  */
 export function computeTargetPoint(rect: DOMRect): { x: number; y: number } {
   return {
-    x: rect.left + rect.width / 2 + 8,
-    y: rect.top + rect.height / 2 - 8,
+    x: rect.left + rect.width / 2 - CURSOR_TIP_X,
+    y: rect.top + rect.height / 2 - CURSOR_TIP_Y,
   };
 }
 
@@ -65,6 +93,19 @@ export function computeOriginPoint(): { x: number; y: number } {
   const w = typeof window !== "undefined" ? window.innerWidth : 1024;
   const h = typeof window !== "undefined" ? window.innerHeight : 768;
   return { x: w - CURSOR_SIZE, y: h / 2 };
+}
+
+function computeArcPoint(
+  start: { x: number; y: number },
+  target: { x: number; y: number },
+): { x: number; y: number } {
+  const dx = target.x - start.x;
+  const dy = target.y - start.y;
+  const distance = Math.hypot(dx, dy);
+  return {
+    x: start.x + dx * 0.56,
+    y: start.y + dy * 0.48 - Math.min(distance * 0.18, 72),
+  };
 }
 
 export interface MoveCursorOptions {
@@ -79,28 +120,41 @@ export function moveCursorToRect(rect: DOMRect, opts: MoveCursorOptions = {}): A
   const start = lastPos ?? computeOriginPoint();
   lastPos = target;
 
+  activeAnimation?.cancel();
+  activeAnimation = null;
   cursor.style.opacity = "1";
-  const duration = Math.max(200, Math.min(opts.duration_ms ?? 600, 2000));
+  cursor.setAttribute("data-wiii-pointy-state", "moving");
+  const duration = Math.max(220, Math.min(opts.duration_ms ?? 620, 1400));
+  const finalTransform = `translate(${target.x}px, ${target.y}px) scale(1)`;
+  const arc = computeArcPoint(start, target);
 
   if (typeof cursor.animate !== "function") {
-    cursor.style.transform = `translate(${target.x}px, ${target.y}px)`;
+    cursor.style.transform = finalTransform;
+    cursor.setAttribute("data-wiii-pointy-state", "pointing");
     opts.onComplete?.();
     return null;
   }
 
   const animation = cursor.animate(
     [
-      { transform: `translate(${start.x}px, ${start.y}px) scale(0.9)` },
-      { transform: `translate(${target.x}px, ${target.y}px) scale(1.05)`, offset: 0.85 },
-      { transform: `translate(${target.x}px, ${target.y}px) scale(1.0)` },
+      { transform: `translate(${start.x}px, ${start.y}px) scale(0.92) rotate(-2deg)` },
+      { transform: `translate(${arc.x}px, ${arc.y}px) scale(1.08) rotate(-7deg)`, offset: 0.58 },
+      { transform: `translate(${target.x}px, ${target.y}px) scale(1.02) rotate(1deg)`, offset: 0.86 },
+      { transform: finalTransform },
     ],
     {
       duration,
-      easing: "cubic-bezier(0.34, 1.56, 0.64, 1)",
+      easing: "cubic-bezier(0.22, 1, 0.36, 1)",
       fill: "forwards",
     },
   );
-  animation.onfinish = () => opts.onComplete?.();
+  activeAnimation = animation;
+  animation.onfinish = () => {
+    cursor.style.transform = finalTransform;
+    cursor.setAttribute("data-wiii-pointy-state", "pointing");
+    activeAnimation = null;
+    opts.onComplete?.();
+  };
   return animation;
 }
 
@@ -116,6 +170,7 @@ export function destroyCursor(): void {
   }
   cursorEl = null;
   lastPos = null;
+  activeAnimation = null;
 }
 
 export const _testing = {

--- a/wiii-desktop/src/pointy-host/index.ts
+++ b/wiii-desktop/src/pointy-host/index.ts
@@ -11,9 +11,8 @@
  *     });
  *   </script>
  *
- * The bundle is **read-only** in V1: highlight, scroll_to, navigate,
- * show_tour. No auto-click, no auto-fill. Default tutor mode keeps the
- * student in control.
+ * The bundle is tutor-safe in V1: highlight, scroll_to, navigate, show_tour,
+ * and fail-closed safe-click. No auto-fill.
  */
 import { createBridge, type BridgeHandle } from "./bridge";
 import { destroyCursor, hideCursor } from "./cursor";
@@ -94,6 +93,22 @@ const DEFAULT_TOOLS: PointyToolDefinition[] = [
     mutates_state: false,
     requires_confirmation: false,
   },
+  {
+    name: "ui.click",
+    description:
+      'Bam target dieu huong an toan da duoc host danh dau data-wiii-click-safe="true". Fail-closed neu target khong an toan.',
+    input_schema: {
+      type: "object",
+      properties: {
+        selector: { type: "string", description: "Stable data-wiii-id/CSS selector with click_safe=true" },
+        message: { type: "string", description: "Tooltip shown before the click" },
+      },
+      required: ["selector"],
+    },
+    surface: "page",
+    mutates_state: false,
+    requires_confirmation: false,
+  },
 ];
 
 let activeBridge: BridgeHandle | null = null;
@@ -159,6 +174,7 @@ export type {
   HighlightParams,
   ScrollToParams,
   NavigateParams,
+  ClickParams,
   ShowTourParams,
   TourStep,
 } from "./types";

--- a/wiii-desktop/src/pointy-host/index.ts
+++ b/wiii-desktop/src/pointy-host/index.ts
@@ -96,7 +96,7 @@ const DEFAULT_TOOLS: PointyToolDefinition[] = [
   {
     name: "ui.click",
     description:
-      'Bam target dieu huong an toan da duoc host danh dau data-wiii-click-safe="true". Fail-closed neu target khong an toan.',
+      'Bấm vào mục điều hướng an toàn đã được host đánh dấu data-wiii-click-safe="true". Từ chối mặc định nếu mục tiêu không an toàn.',
     input_schema: {
       type: "object",
       properties: {

--- a/wiii-desktop/src/pointy-host/spotlight.ts
+++ b/wiii-desktop/src/pointy-host/spotlight.ts
@@ -6,12 +6,14 @@
  */
 
 const OVERLAY_ID = "wiii-pointy-overlay";
+const TARGET_RING_ID = "wiii-pointy-target-ring";
 const TOOLTIP_ID = "wiii-pointy-tooltip";
 const BRAND_ORANGE = "#F97316";
 const BRAND_CREAM = "#FAF5EE";
 const PADDING = 8;
 
 let overlayEl: HTMLDivElement | null = null;
+let targetRingEl: HTMLDivElement | null = null;
 let tooltipEl: HTMLDivElement | null = null;
 let activeTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -27,6 +29,25 @@ function createOverlay(): HTMLDivElement {
     pointerEvents: "none",
     background: "transparent",
     transition: "background 250ms ease-out",
+  });
+  return el;
+}
+
+function createTargetRing(): HTMLDivElement {
+  const el = document.createElement("div");
+  el.id = TARGET_RING_ID;
+  el.setAttribute("data-wiii-pointy", "target-ring");
+  el.setAttribute("aria-hidden", "true");
+  Object.assign(el.style, {
+    position: "fixed",
+    zIndex: "2147483646",
+    pointerEvents: "none",
+    border: `3px solid ${BRAND_ORANGE}`,
+    borderRadius: "14px",
+    boxShadow: "0 0 0 7px rgba(249,115,22,0.18), 0 0 28px rgba(249,115,22,0.46)",
+    opacity: "0",
+    transform: "scale(0.96)",
+    transition: "opacity 180ms ease-out, transform 180ms ease-out",
   });
   return el;
 }
@@ -58,16 +79,20 @@ function createTooltip(): HTMLDivElement {
   return el;
 }
 
-function ensureElements(): { overlay: HTMLDivElement; tooltip: HTMLDivElement } {
+function ensureElements(): { overlay: HTMLDivElement; targetRing: HTMLDivElement; tooltip: HTMLDivElement } {
   if (!overlayEl || !overlayEl.isConnected) {
     overlayEl = createOverlay();
     document.body.appendChild(overlayEl);
+  }
+  if (!targetRingEl || !targetRingEl.isConnected) {
+    targetRingEl = createTargetRing();
+    document.body.appendChild(targetRingEl);
   }
   if (!tooltipEl || !tooltipEl.isConnected) {
     tooltipEl = createTooltip();
     document.body.appendChild(tooltipEl);
   }
-  return { overlay: overlayEl, tooltip: tooltipEl };
+  return { overlay: overlayEl, targetRing: targetRingEl, tooltip: tooltipEl };
 }
 
 /** Position tooltip below the target by default; flip above if it would overflow. */
@@ -97,7 +122,7 @@ export interface SpotlightOptions {
 }
 
 export function showSpotlight(target: Element, opts: SpotlightOptions = {}): void {
-  const { overlay, tooltip } = ensureElements();
+  const { overlay, targetRing, tooltip } = ensureElements();
   const rect = target.getBoundingClientRect();
 
   // Radial dim with a hole punched around the target.
@@ -105,6 +130,17 @@ export function showSpotlight(target: Element, opts: SpotlightOptions = {}): voi
   const cy = rect.top + rect.height / 2;
   const r = Math.max(rect.width, rect.height) / 2 + PADDING;
   overlay.style.background = `radial-gradient(circle at ${cx}px ${cy}px, transparent 0px, transparent ${r}px, rgba(15,23,42,0.45) ${r + 24}px)`;
+
+  const ringPad = Math.max(6, Math.min(14, Math.max(rect.width, rect.height) * 0.08));
+  Object.assign(targetRing.style, {
+    left: `${Math.max(4, rect.left - ringPad)}px`,
+    top: `${Math.max(4, rect.top - ringPad)}px`,
+    width: `${rect.width + ringPad * 2}px`,
+    height: `${rect.height + ringPad * 2}px`,
+    borderRadius: `${Math.min(18, Math.max(10, ringPad + 8))}px`,
+    opacity: "1",
+    transform: "scale(1)",
+  });
 
   if (opts.message) {
     tooltip.textContent = opts.message;
@@ -131,7 +167,7 @@ export function showSpotlight(target: Element, opts: SpotlightOptions = {}): voi
     clearTimeout(activeTimer);
     activeTimer = null;
   }
-  const ms = Math.max(800, Math.min(opts.duration_ms ?? 2200, 8000));
+  const ms = Math.max(1500, Math.min(opts.duration_ms ?? 7000, 20000));
   activeTimer = setTimeout(() => {
     hideSpotlight();
     opts.onClose?.();
@@ -144,6 +180,10 @@ export function hideSpotlight(): void {
     activeTimer = null;
   }
   if (overlayEl) overlayEl.style.background = "transparent";
+  if (targetRingEl) {
+    targetRingEl.style.opacity = "0";
+    targetRingEl.style.transform = "scale(0.98)";
+  }
   if (tooltipEl) {
     tooltipEl.style.opacity = "0";
     tooltipEl.style.transform = "translateY(4px)";
@@ -155,16 +195,19 @@ export function destroySpotlight(): void {
     clearTimeout(activeTimer);
     activeTimer = null;
   }
-  for (const el of [overlayEl, tooltipEl]) {
+  for (const el of [overlayEl, targetRingEl, tooltipEl]) {
     if (el && el.parentNode) el.parentNode.removeChild(el);
   }
   overlayEl = null;
+  targetRingEl = null;
   tooltipEl = null;
 }
 
 export const _testing = {
   OVERLAY_ID,
+  TARGET_RING_ID,
   TOOLTIP_ID,
   getOverlay: () => overlayEl,
+  getTargetRing: () => targetRingEl,
   getTooltip: () => tooltipEl,
 };

--- a/wiii-desktop/src/pointy-host/types.ts
+++ b/wiii-desktop/src/pointy-host/types.ts
@@ -4,11 +4,11 @@
  * The pointy bundle runs INSIDE the parent (host) page, listening for
  * `wiii:action-request` messages emitted by the Wiii iframe (Sprint 222
  * HostActionBridge). It executes UI tutoring actions (highlight, scroll,
- * navigate, multi-step tour) on the host DOM and replies via
+ * navigate, safe-click, multi-step tour) on the host DOM and replies via
  * `wiii:action-response`.
  *
- * V1 tool surface is read-only: no auto-click, no auto-fill. Default tutor
- * mode keeps the user in control.
+ * V1 safe-click is fail-closed: no auto-fill, and click only works on targets
+ * explicitly marked `data-wiii-click-safe="true"`.
  */
 
 /** Identity reserved for the Wiii iframe's PostMessage envelope. */
@@ -20,6 +20,7 @@ export const POINTY_ACTIONS = [
   "ui.scroll_to",
   "ui.navigate",
   "ui.show_tour",
+  "ui.click",
 ] as const;
 export type PointyAction = (typeof POINTY_ACTIONS)[number];
 
@@ -95,6 +96,11 @@ export interface ShowTourParams {
   steps: TourStep[];
   /** Step index to start at; defaults to 0. */
   start_at?: number;
+}
+
+export interface ClickParams {
+  selector: string;
+  message?: string;
 }
 
 export interface PointyConfig {

--- a/wiii-desktop/src/stores/host-context-store.ts
+++ b/wiii-desktop/src/stores/host-context-store.ts
@@ -34,6 +34,13 @@ export interface HostContext {
   editable_scope?: Record<string, unknown> | null;
   entity_refs?: Array<Record<string, unknown>> | null;
   user_state?: Record<string, unknown> | null;
+  host_action_feedback?: {
+    last_action_result?: {
+      params?: {
+        source?: string;
+      } | null;
+    } | null;
+  } | null;
   content?: { snippet?: string; structured?: unknown } | null;
   available_actions?: Array<{
     action?: string;
@@ -174,7 +181,8 @@ function legacyToHostContext(
   studentState?: Record<string, unknown> | null,
   actions?: Array<Record<string, unknown>> | null,
 ): HostContext {
-  const metadata: Record<string, unknown> = {};
+  const metadata = Object.create(null) as Record<string, unknown>;
+  const blockedMetadataKeys = new Set(["__proto__", "prototype", "constructor"]);
   const metaKeys = [
     "action",
     "workflow_stage",
@@ -209,7 +217,13 @@ function legacyToHostContext(
     }
   }
   for (const [key, val] of Object.entries(legacy)) {
-    if (topLevelKeys.has(key) || key in metadata || val === undefined || val === null) {
+    if (
+      blockedMetadataKeys.has(key) ||
+      topLevelKeys.has(key) ||
+      Object.prototype.hasOwnProperty.call(metadata, key) ||
+      val === undefined ||
+      val === null
+    ) {
       continue;
     }
     metadata[key] = val;

--- a/wiii-desktop/src/stores/host-context-store.ts
+++ b/wiii-desktop/src/stores/host-context-store.ts
@@ -74,6 +74,7 @@ export interface HostCapabilities {
 }
 
 interface LegacyPageContext {
+  [key: string]: unknown;
   page_type?: string;
   page_title?: string;
   connector_id?: string;
@@ -187,11 +188,31 @@ function legacyToHostContext(
     "quiz_options",
     "assignment_description",
   ] as const;
+  const topLevelKeys = new Set([
+    "page_type",
+    "page_title",
+    "connector_id",
+    "host_user_id",
+    "host_workspace_id",
+    "host_organization_id",
+    "user_role",
+    "selection",
+    "editable_scope",
+    "entity_refs",
+    "content_snippet",
+    "structured",
+  ]);
   for (const key of metaKeys) {
     const val = legacy[key as keyof LegacyPageContext];
     if (val !== undefined && val !== null) {
       metadata[key] = val;
     }
+  }
+  for (const [key, val] of Object.entries(legacy)) {
+    if (topLevelKeys.has(key) || key in metadata || val === undefined || val === null) {
+      continue;
+    }
+    metadata[key] = val;
   }
 
   return {


### PR DESCRIPTION
## Summary

Checkpoint for the Wiii production hardening / LangGraph-removal path.

- Adds a native Wiii chat runtime surface and native Agentic RAG / CRAG LLM socket coverage so remaining LangGraph references can be isolated behind compatibility boundaries.
- Hardens NVIDIA direct and streaming behavior, runtime metadata parity, provider/model surfacing, SSE finalization/idle behavior, and local demo smoke gates.
- Improves Wiii Pointy host fast-path handling, cursor/bridge resilience, and host context tests for LMS-style iframe cooperation.
- Extends the pipeline simplification plan with the current checkpoint state and next cleanup boundaries.

Refs #170, #130, #168, #184.

## Local runtime smoke evidence

Docker local was recreated with ignored local `.env` setting `ENABLE_DEV_LOGIN=true` so the dev-login JWT path is available. No `.env*` file is committed.

Pinned NVIDIA smoke:

```bash
cd maritime-ai-service
python scripts/local_demo_smoke.py --backend-url http://localhost:8000 --frontend-url http://127.0.0.1:1420 --provider nvidia --model deepseek-ai/deepseek-v4-flash --expect-provider nvidia --expect-model deepseek-ai/deepseek-v4-flash --message "Xin chao Wiii, tra loi mot cau ngan de kiem tra demo local."
```

Result: `10 passed, 0 failed`; sync chat `30.6s`; SSE V3 `first_event=0.1s`, `first_answer=8.9s`, `total=10.7s`.

## Verification

```bash
cd maritime-ai-service
python -m pytest tests/unit/test_local_demo_smoke.py -q
python -m pytest tests/unit/test_runtime_endpoint_smoke.py tests/unit/test_native_chat_runtime.py tests/unit/test_agentic_rag_runtime_llm_socket.py -q
python -m pytest tests/unit/test_local_demo_smoke.py tests/unit/test_runtime_endpoint_smoke.py tests/unit/test_native_chat_runtime.py tests/unit/test_agentic_rag_runtime_llm_socket.py tests/unit/test_chat_stream_transport.py tests/unit/test_direct_execution_streaming.py tests/unit/test_direct_node_provider_errors.py tests/unit/test_direct_prompts_identity_contract.py tests/unit/test_direct_response_runtime.py tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_embedding_runtime.py tests/unit/test_graph_stream_agent_handlers.py tests/unit/test_logging_config.py tests/unit/test_middleware.py tests/unit/test_model_catalog.py tests/unit/test_nvidia_provider.py tests/unit/test_openai_stream_runtime.py tests/unit/test_query_rewriter.py tests/unit/test_sprint222_host_adapters.py tests/unit/engine/context/test_pointy_actions.py tests/unit/engine/context/test_pointy_fast_path.py -q
python -m ruff check app/ scripts/local_demo_smoke.py tests/unit/ --select=E9,F63,F7

cd ../wiii-desktop
npx vitest run src/pointy-host/__tests__/bridge.test.ts src/pointy-host/__tests__/cursor.test.ts src/pointy-host/__tests__/spotlight.test.ts src/__tests__/host-context-store.test.ts src/__tests__/pointy-fast-path.test.ts src/__tests__/sprint110-hardening.test.ts
npm run build:pointy

cd ..
git diff --check
```

Observed results:

- Backend focused runtime suite: `228 passed, 1 warning`.
- Local demo smoke unit: `13 passed`.
- Runtime endpoint/native/RAG focused subset: `29 passed`.
- Desktop focused Vitest: `76 passed`.
- `build:pointy`: pass.
- Ruff: pass.
- `git diff --check`: pass with only pre-existing CRLF normalization warnings on selected files.

## Risk and rollback

High-risk surfaces touched: provider routing, streaming contracts, memory/context injection, RAG/CRAG LLM calls, LMS/Pointy host bridge behavior, and local demo auth smoke.

Rollback: revert this PR. There is no database migration and no committed secret/config file. Local-only recovery is to unset ignored `ENABLE_DEV_LOGIN=true` or recreate the Docker app from the previous image/branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safe-click UI action with data-attribute validation for host environments.
  * Introduced fast-path intent matching for UI navigation/click requests.
  * Enhanced native OpenAI-compatible streaming support with tool calling.

* **Bug Fixes**
  * Simplified SSE keepalive handling by removing redundant state tracking.
  * Improved embed asset caching in development mode.
  * Increased SSE idle timeout tolerance for longer startup cold paths.

* **Security**
  * API keys and tokens no longer appear in object representation output.
  * Reduced OpenAI SDK log verbosity in production.

* **Documentation**
  * Updated framework transition plan reflecting native runtime architecture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->