### PR TITLE
feat: fast-path ultra-short SSE social turns

### DIFF
--- a/maritime-ai-service/app/services/chat_stream_coordinator.py
+++ b/maritime-ai-service/app/services/chat_stream_coordinator.py
@@ -151,6 +151,104 @@ async def generate_stream_v3_events(
             "_use_multi_agent",
             getattr(settings, "use_multi_agent", True),
         )
+        has_attachments = bool(
+            getattr(chat_request, "images", None)
+            or getattr(chat_request, "attachments", None)
+            or getattr(chat_request, "files", None)
+        )
+        if not has_attachments:
+            from app.engine.multi_agent.direct_social import (
+                _build_simple_social_fast_path,
+            )
+
+            fast_social = _build_simple_social_fast_path(
+                getattr(chat_request, "message", "") or ""
+            )
+            if fast_social is not None:
+                full_answer, fast_thinking = fast_social
+                processing_time = time.time() - start_time
+                runtime_llm = resolve_runtime_llm_metadata(
+                    {
+                        "provider": (
+                            requested_provider
+                            if requested_provider and requested_provider != "auto"
+                            else None
+                        ),
+                        "model": getattr(chat_request, "model", None),
+                        "runtime_authoritative": False,
+                    }
+                )
+                routing_metadata = {
+                    "method": "transport_fast_social_path",
+                    "intent": "social",
+                    "final_agent": "direct",
+                    "confidence": 1.0,
+                }
+                fast_events = [
+                    await create_status_event(
+                        "Mình bắt nhịp được rồi, trả lời ngay nhé.",
+                        node="direct",
+                        details={
+                            "mode": "transport_fast_social_path",
+                            "visibility": "status_only",
+                        },
+                    ),
+                    await create_answer_event(full_answer),
+                    await create_metadata_event(
+                        processing_time=processing_time,
+                        confidence=1.0,
+                        agent_type="direct",
+                        model=runtime_llm["model"],
+                        provider=runtime_llm["provider"],
+                        failover=runtime_llm["failover"],
+                        session_id=effective_session_id_str,
+                        thinking=fast_thinking,
+                        thinking_content=fast_thinking,
+                        streaming_version="v3-fast-social",
+                        request_id=request_id,
+                        routing_metadata=routing_metadata,
+                        runtime_authoritative=False,
+                        fast_path=True,
+                        llm_invoked=False,
+                    ),
+                    await create_done_event(processing_time),
+                ]
+
+                for event in fast_events:
+                    chunks, event_counter, should_stop = serialize_stream_event(
+                        event=event,
+                        event_counter=event_counter,
+                        enable_artifacts=settings.enable_artifacts,
+                        presentation_state=presentation_state,
+                    )
+                    for chunk in chunks:
+                        yield chunk
+                    if should_stop:
+                        return
+
+                try:
+                    orchestrator.finalize_response_turn(
+                        session_id=effective_session_id,
+                        user_id=str(chat_request.user_id),
+                        user_role=chat_request.role,
+                        message=chat_request.message,
+                        response_text=full_answer,
+                        context=finalization_context,
+                        domain_id=resolved_domain_id,
+                        organization_id=resolved_org_id,
+                        current_agent="direct",
+                        background_save=background_save,
+                        save_response_immediately=True,
+                        include_lms_insights=True,
+                        continuity_channel="web",
+                        transport_type="stream",
+                    )
+                except Exception as finalize_err:
+                    logger.warning(
+                        "[STREAM-V3] Fast social finalization failed: %s",
+                        finalize_err,
+                    )
+                return
 
         if not use_multi_agent:
             logger.warning("[STREAM-V3] Multi-Agent disabled, using sync fallback path")

--- a/maritime-ai-service/app/services/chat_stream_coordinator.py
+++ b/maritime-ai-service/app/services/chat_stream_coordinator.py
@@ -101,8 +101,25 @@ async def generate_stream_v3_events(
     try:
         request_id = str(request_headers.get("X-Request-ID") or request_headers.get("x-request-id") or "").strip() or None
         requested_provider = getattr(chat_request, "provider", None)
-        if requested_provider and requested_provider != "auto":
-            from app.services.llm_selectability_service import ensure_provider_is_selectable
+        has_attachments = bool(
+            getattr(chat_request, "images", None)
+            or getattr(chat_request, "attachments", None)
+            or getattr(chat_request, "files", None)
+        )
+        fast_social = None
+        if not has_attachments:
+            from app.engine.multi_agent.direct_social import (
+                _build_simple_social_fast_path,
+            )
+
+            fast_social = _build_simple_social_fast_path(
+                getattr(chat_request, "message", "") or ""
+            )
+
+        if requested_provider and requested_provider != "auto" and fast_social is None:
+            from app.services.llm_selectability_service import (
+                ensure_provider_is_selectable,
+            )
 
             ensure_provider_is_selectable(requested_provider)
 
@@ -151,107 +168,114 @@ async def generate_stream_v3_events(
             "_use_multi_agent",
             getattr(settings, "use_multi_agent", True),
         )
-        has_attachments = bool(
-            getattr(chat_request, "images", None)
-            or getattr(chat_request, "attachments", None)
-            or getattr(chat_request, "files", None)
-        )
-        if not has_attachments:
-            from app.engine.multi_agent.direct_social import (
-                _build_simple_social_fast_path,
-            )
-
-            fast_social = _build_simple_social_fast_path(
-                getattr(chat_request, "message", "") or ""
-            )
-            if fast_social is not None:
-                full_answer, fast_thinking = fast_social
-                processing_time = time.time() - start_time
-                runtime_llm = resolve_runtime_llm_metadata(
-                    {
-                        "provider": (
-                            requested_provider
-                            if requested_provider and requested_provider != "auto"
-                            else None
-                        ),
-                        "model": getattr(chat_request, "model", None),
-                        "runtime_authoritative": False,
-                    }
-                )
-                routing_metadata = {
-                    "method": "transport_fast_social_path",
-                    "intent": "social",
-                    "final_agent": "direct",
-                    "confidence": 1.0,
+        if fast_social is not None:
+            full_answer, fast_thinking = fast_social
+            processing_time = time.time() - start_time
+            runtime_llm = resolve_runtime_llm_metadata(
+                {
+                    "provider": (
+                        requested_provider
+                        if requested_provider and requested_provider != "auto"
+                        else None
+                    ),
+                    "model": getattr(chat_request, "model", None),
+                    "runtime_authoritative": False,
                 }
-                fast_events = [
-                    await create_status_event(
-                        "Mình bắt nhịp được rồi, trả lời ngay nhé.",
-                        node="direct",
-                        details={
-                            "mode": "transport_fast_social_path",
-                            "visibility": "status_only",
-                        },
-                    ),
-                    await create_answer_event(full_answer),
-                    await create_metadata_event(
-                        processing_time=processing_time,
-                        confidence=1.0,
-                        agent_type="direct",
-                        model=runtime_llm["model"],
-                        provider=runtime_llm["provider"],
-                        failover=runtime_llm["failover"],
-                        session_id=effective_session_id_str,
-                        thinking=fast_thinking,
-                        thinking_content=fast_thinking,
-                        streaming_version="v3-fast-social",
-                        request_id=request_id,
-                        routing_metadata=routing_metadata,
-                        runtime_authoritative=False,
-                        fast_path=True,
-                        llm_invoked=False,
-                    ),
-                    await create_done_event(processing_time),
-                ]
+            )
+            routing_metadata = {
+                "method": "transport_fast_social_path",
+                "intent": "social",
+                "final_agent": "direct",
+                "confidence": 1.0,
+            }
+            fast_events = [
+                await create_status_event(
+                    "Mình bắt nhịp được rồi, trả lời ngay nhé.",
+                    node="direct",
+                    details={
+                        "mode": "transport_fast_social_path",
+                        "visibility": "status_only",
+                    },
+                ),
+                await create_answer_event(full_answer),
+                await create_metadata_event(
+                    processing_time=processing_time,
+                    confidence=1.0,
+                    agent_type="direct",
+                    model=runtime_llm["model"],
+                    provider=runtime_llm["provider"],
+                    failover=runtime_llm["failover"],
+                    session_id=effective_session_id_str,
+                    thinking=fast_thinking,
+                    thinking_content=fast_thinking,
+                    streaming_version="v3-fast-social",
+                    request_id=request_id,
+                    routing_metadata=routing_metadata,
+                    runtime_authoritative=False,
+                    fast_path=True,
+                    llm_invoked=False,
+                ),
+                await create_done_event(processing_time),
+            ]
 
-                for event in fast_events:
-                    chunks, event_counter, should_stop = serialize_stream_event(
-                        event=event,
-                        event_counter=event_counter,
-                        enable_artifacts=settings.enable_artifacts,
-                        presentation_state=presentation_state,
-                    )
-                    for chunk in chunks:
-                        yield chunk
-                    if should_stop:
-                        return
+            for event in fast_events:
+                chunks, event_counter, should_stop = serialize_stream_event(
+                    event=event,
+                    event_counter=event_counter,
+                    enable_artifacts=settings.enable_artifacts,
+                    presentation_state=presentation_state,
+                )
+                for chunk in chunks:
+                    yield chunk
+                if should_stop:
+                    return
 
-                try:
-                    orchestrator.finalize_response_turn(
-                        session_id=effective_session_id,
-                        user_id=str(chat_request.user_id),
-                        user_role=chat_request.role,
-                        message=chat_request.message,
-                        response_text=full_answer,
-                        context=finalization_context,
-                        domain_id=resolved_domain_id,
-                        organization_id=resolved_org_id,
-                        current_agent="direct",
-                        background_save=background_save,
-                        save_response_immediately=True,
-                        include_lms_insights=True,
-                        continuity_channel="web",
-                        transport_type="stream",
-                    )
-                except Exception as finalize_err:
-                    logger.warning(
-                        "[STREAM-V3] Fast social finalization failed: %s",
-                        finalize_err,
-                    )
-                return
+            try:
+                orchestrator.finalize_response_turn(
+                    session_id=effective_session_id,
+                    user_id=str(chat_request.user_id),
+                    user_role=chat_request.role,
+                    message=chat_request.message,
+                    response_text=full_answer,
+                    context=finalization_context,
+                    domain_id=resolved_domain_id,
+                    organization_id=resolved_org_id,
+                    current_agent="direct",
+                    background_save=background_save,
+                    save_response_immediately=True,
+                    include_lms_insights=True,
+                    continuity_channel="web",
+                    transport_type="stream",
+                )
+            except Exception as finalize_err:
+                logger.warning(
+                    "[STREAM-V3] Fast social finalization failed: %s",
+                    finalize_err,
+                )
+            return
 
         if not use_multi_agent:
             logger.warning("[STREAM-V3] Multi-Agent disabled, using sync fallback path")
+            fallback_status = await create_status_event(
+                "Wiii đang mở đường trả lời nhanh...",
+                node="direct",
+                details={
+                    "mode": "fallback",
+                    "subtype": "heartbeat",
+                    "visibility": "status_only",
+                },
+            )
+            chunks, event_counter, should_stop = serialize_stream_event(
+                event=fallback_status,
+                event_counter=event_counter,
+                enable_artifacts=settings.enable_artifacts,
+                presentation_state=presentation_state,
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
+
             fallback_result = await orchestrator.process_without_multi_agent(
                 finalization_context,
             )
@@ -376,6 +400,25 @@ async def generate_stream_v3_events(
             return
 
         _provider = requested_provider
+        context_status = await create_status_event(
+            "Wiii đang gom ngữ cảnh và trí nhớ...",
+            node="context",
+            details={
+                "mode": "native_turn",
+                "subtype": "heartbeat",
+                "visibility": "status_only",
+            },
+        )
+        chunks, event_counter, should_stop = serialize_stream_event(
+            event=context_status,
+            event_counter=event_counter,
+            enable_artifacts=settings.enable_artifacts,
+            presentation_state=presentation_state,
+        )
+        for chunk in chunks:
+            yield chunk
+        if should_stop:
+            return
 
         try:
             execution_input = await (

--- a/maritime-ai-service/app/services/chat_stream_coordinator.py
+++ b/maritime-ai-service/app/services/chat_stream_coordinator.py
@@ -101,25 +101,8 @@ async def generate_stream_v3_events(
     try:
         request_id = str(request_headers.get("X-Request-ID") or request_headers.get("x-request-id") or "").strip() or None
         requested_provider = getattr(chat_request, "provider", None)
-        has_attachments = bool(
-            getattr(chat_request, "images", None)
-            or getattr(chat_request, "attachments", None)
-            or getattr(chat_request, "files", None)
-        )
-        fast_social = None
-        if not has_attachments:
-            from app.engine.multi_agent.direct_social import (
-                _build_simple_social_fast_path,
-            )
-
-            fast_social = _build_simple_social_fast_path(
-                getattr(chat_request, "message", "") or ""
-            )
-
-        if requested_provider and requested_provider != "auto" and fast_social is None:
-            from app.services.llm_selectability_service import (
-                ensure_provider_is_selectable,
-            )
+        if requested_provider and requested_provider != "auto":
+            from app.services.llm_selectability_service import ensure_provider_is_selectable
 
             ensure_provider_is_selectable(requested_provider)
 
@@ -168,6 +151,21 @@ async def generate_stream_v3_events(
             "_use_multi_agent",
             getattr(settings, "use_multi_agent", True),
         )
+        has_attachments = bool(
+            getattr(chat_request, "images", None)
+            or getattr(chat_request, "attachments", None)
+            or getattr(chat_request, "files", None)
+        )
+        fast_social = None
+        if not has_attachments:
+            from app.engine.multi_agent.direct_social import (
+                _build_simple_social_fast_path,
+            )
+
+            fast_social = _build_simple_social_fast_path(
+                getattr(chat_request, "message", "") or ""
+            )
+
         if fast_social is not None:
             full_answer, fast_thinking = fast_social
             processing_time = time.time() - start_time

--- a/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
@@ -1,3 +1,4 @@
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -119,6 +120,96 @@ async def test_generate_stream_v3_events_finalizes_answer_after_stream():
         ]
         == "stream"
     )
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_v3_events_fast_social_bypasses_graph_context():
+    orchestrator = MagicMock()
+    prepared_turn = SimpleNamespace(
+        request_scope=RequestScope("org-1", "maritime"),
+        session_id="session-1",
+        validation=SimpleNamespace(blocked=False),
+        chat_context=SimpleNamespace(user_name="Minh"),
+    )
+    orchestrator.prepare_turn = AsyncMock(return_value=prepared_turn)
+
+    async def fail_stream_fn(**_kwargs):
+        raise AssertionError("fast social path should not enter graph streaming")
+        yield  # pragma: no cover
+
+    chunks = []
+    async for chunk in generate_stream_v3_events(
+        chat_request=_make_request(
+            message="hello",
+            provider="nvidia",
+            model="deepseek-ai/deepseek-v4-flash",
+        ),
+        request_headers={"X-Request-ID": "req-fast-social"},
+        background_save=MagicMock(),
+        start_time=time.time(),
+        orchestrator=orchestrator,
+        stream_fn=fail_stream_fn,
+    ):
+        chunks.append(chunk)
+
+    joined = "\n".join(chunks)
+    assert "event: answer" in joined
+    assert "Wiii" in joined
+    assert '"streaming_version": "v3-fast-social"' in joined
+    assert '"llm_invoked": false' in joined
+    assert '"transport_fast_social_path"' in joined
+    assert '"request_id": "req-fast-social"' in joined
+    orchestrator.build_multi_agent_execution_input.assert_not_called()
+    orchestrator.finalize_response_turn.assert_called_once()
+    assert (
+        orchestrator.finalize_response_turn.call_args.kwargs["response_text"]
+        != ""
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_v3_events_does_not_fast_path_pointy_questions():
+    orchestrator = MagicMock()
+    prepared_turn = SimpleNamespace(
+        request_scope=RequestScope("org-1", "maritime"),
+        session_id="session-1",
+        validation=SimpleNamespace(blocked=False),
+        chat_context=SimpleNamespace(user_name="Minh"),
+    )
+    orchestrator.prepare_turn = AsyncMock(return_value=prepared_turn)
+    orchestrator.build_multi_agent_execution_input = AsyncMock(
+        return_value=SimpleNamespace(
+            query="Wiii oi, nut Kham pha khoa hoc o dau?",
+            user_id="user-1",
+            session_id="session-1",
+            context={"conversation_history": ""},
+            domain_id="maritime",
+            thinking_effort=None,
+            provider=None,
+            model=None,
+        )
+    )
+
+    async def fake_stream_fn(**kwargs):
+        assert kwargs["query"] == "Wiii oi, nut Kham pha khoa hoc o dau?"
+        yield SimpleNamespace(type="answer", content="Tool path stays active")
+        yield SimpleNamespace(type="done", content={"processing_time": 0.1})
+
+    chunks = []
+    async for chunk in generate_stream_v3_events(
+        chat_request=_make_request(
+            message="Wiii oi, nut Kham pha khoa hoc o dau?"
+        ),
+        request_headers={},
+        background_save=MagicMock(),
+        start_time=time.time(),
+        orchestrator=orchestrator,
+        stream_fn=fake_stream_fn,
+    ):
+        chunks.append(chunk)
+
+    assert any("Tool path stays active" in chunk for chunk in chunks)
+    orchestrator.build_multi_agent_execution_input.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -362,7 +453,7 @@ async def test_generate_stream_v3_events_includes_request_id_and_routing_metadat
         chat_context=SimpleNamespace(
             user_name="Minh",
             user_id="user-1",
-            message="hẹ hẹ",
+            message="Explain Rule 5",
             user_role=UserRole.STUDENT,
             session_id="session-1",
         ),
@@ -376,8 +467,8 @@ async def test_generate_stream_v3_events_includes_request_id_and_routing_metadat
                 "mode": "local_direct_llm",
                 "model": "glm-5",
                 "routing_metadata": {
-                    "method": "always_on_social_fast_path",
-                    "intent": "social",
+                    "method": "fallback_direct_path",
+                    "intent": "teaching",
                 },
             },
         )
@@ -385,7 +476,7 @@ async def test_generate_stream_v3_events_includes_request_id_and_routing_metadat
 
     chunks = []
     async for chunk in generate_stream_v3_events(
-        chat_request=_make_request(message="hẹ hẹ"),
+        chat_request=_make_request(message="Explain Rule 5"),
         request_headers={"X-Request-ID": "req-fast-social"},
         background_save=MagicMock(),
         start_time=0.0,
@@ -398,7 +489,7 @@ async def test_generate_stream_v3_events_includes_request_id_and_routing_metadat
     metadata_chunk = metadata_chunks[0]
     assert '"request_id": "req-fast-social"' in metadata_chunk
     assert '"routing_metadata": {' in metadata_chunk
-    assert '"always_on_social_fast_path"' in metadata_chunk
+    assert '"fallback_direct_path"' in metadata_chunk
 
 
 @pytest.mark.asyncio

--- a/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
@@ -208,6 +208,8 @@ async def test_generate_stream_v3_events_does_not_fast_path_pointy_questions():
     ):
         chunks.append(chunk)
 
+    joined = "\n".join(chunks)
+    assert "Wiii đang gom ngữ cảnh và trí nhớ" in joined
     assert any("Tool path stays active" in chunk for chunk in chunks)
     orchestrator.build_multi_agent_execution_input.assert_awaited_once()
 
@@ -434,8 +436,10 @@ async def test_generate_stream_v3_events_uses_sync_fallback_when_multi_agent_dis
     ):
         chunks.append(chunk)
 
+    joined = "\n".join(chunks)
     orchestrator.process_without_multi_agent.assert_awaited_once()
     orchestrator.build_multi_agent_execution_input.assert_not_called()
+    assert "Wiii đang mở đường trả lời nhanh" in joined
     assert any("Fast local fallback response" in chunk for chunk in chunks)
     assert any('"streaming_version": "v3-local_direct_llm"' in chunk for chunk in chunks)
     assert any('"last_reason_code": "auth_error"' in chunk for chunk in chunks)

--- a/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
@@ -138,19 +138,24 @@ async def test_generate_stream_v3_events_fast_social_bypasses_graph_context():
         yield  # pragma: no cover
 
     chunks = []
-    async for chunk in generate_stream_v3_events(
-        chat_request=_make_request(
-            message="hello",
-            provider="nvidia",
-            model="deepseek-ai/deepseek-v4-flash",
-        ),
-        request_headers={"X-Request-ID": "req-fast-social"},
-        background_save=MagicMock(),
-        start_time=time.time(),
-        orchestrator=orchestrator,
-        stream_fn=fail_stream_fn,
-    ):
-        chunks.append(chunk)
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "app.services.llm_selectability_service.ensure_provider_is_selectable",
+            lambda _provider: None,
+        )
+        async for chunk in generate_stream_v3_events(
+            chat_request=_make_request(
+                message="hello",
+                provider="nvidia",
+                model="deepseek-ai/deepseek-v4-flash",
+            ),
+            request_headers={"X-Request-ID": "req-fast-social"},
+            background_save=MagicMock(),
+            start_time=time.time(),
+            orchestrator=orchestrator,
+            stream_fn=fail_stream_fn,
+        ):
+            chunks.append(chunk)
 
     joined = "\n".join(chunks)
     assert "event: answer" in joined

--- a/wiii-desktop/src/__tests__/sprint110-hardening.test.ts
+++ b/wiii-desktop/src/__tests__/sprint110-hardening.test.ts
@@ -115,6 +115,16 @@ describe("useSSEStream — type-safe metadata", () => {
     expect(pointyStep).toBeGreaterThan(successGuard);
     expect(code).not.toContain("Wiii dang tro tren trang");
   });
+
+  it("surfaces status_only heartbeats as the live timer status only", async () => {
+    const src = await import("@/hooks/useSSEStream?raw");
+    const code = (src as any).default || src;
+    const heartbeatGuard = code.indexOf("if (!isEphemeralHeartbeat)");
+    const liveStatus = code.indexOf("store.setStreamingStep(label);", code.indexOf("onStatus:"));
+    expect(liveStatus).toBeGreaterThan(-1);
+    expect(heartbeatGuard).toBeGreaterThan(liveStatus);
+    expect(code).toContain("keep them out of the persistent step/phase timeline");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/wiii-desktop/src/hooks/useSSEStream.ts
+++ b/wiii-desktop/src/hooks/useSSEStream.ts
@@ -778,10 +778,10 @@ export function useSSEStream() {
           store.appendWorkerStatus(data.node, label);
         }
 
-        if (label && !isEphemeralHeartbeat) {
-          store.setStreamingStep(label);
-        }
         if (label) {
+          // Show status_only heartbeats as the current live timer status,
+          // but keep them out of the persistent step/phase timeline.
+          store.setStreamingStep(label);
           if (!isEphemeralHeartbeat) {
             store.addStreamingStep(label, data.node);
             store.appendPhaseStatus(label, data.node, data.step_id);


### PR DESCRIPTION
## Summary
- Closes #191.
- Adds a guarded `/chat/stream/v3` transport fast-path for ultra-short social turns such as `hello` before building full graph context.
- Reuses the existing direct social classifier so Pointy/tool prompts like `Wiii oi, nut Kham pha khoa hoc o dau?` still enter normal graph streaming.
- Emits explicit metadata: `streaming_version=v3-fast-social`, `fast_path=true`, `llm_invoked=false`, and `routing_metadata.method=transport_fast_social_path`.
- Keeps post-response finalization so conversation history and memory continuity still run after the immediate answer/done sequence.

## Stacking Note
This PR is stacked on #190 (`codex/native-runtime-hardening-checkpoint`). Once #190 lands, this PR should be retargeted/rebased onto `main`.

## Verification
- `python -m pytest tests/unit/test_chat_stream_coordinator.py -q` -> 10 passed
- `python -m pytest tests/unit/test_chat_stream_coordinator.py tests/unit/test_graph_routing.py -q` -> 88 passed
- `python -m pytest tests/unit/test_chat_stream_coordinator.py tests/unit/test_graph_routing.py tests/unit/test_sprint100_unified_prompt.py -q` -> 125 passed
- `python -m ruff check app/services/chat_stream_coordinator.py tests/unit/test_chat_stream_coordinator.py tests/unit/test_sprint100_unified_prompt.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
- Low-to-medium runtime UX risk: this short-circuits only classifier-approved ultra-short social messages after validation and user-message persistence.
- Tool/RAG/Pointy prompts remain guarded by existing classifier blockers and a new regression test.
- Metadata marks `llm_invoked=false` to avoid claiming provider execution when no provider was called.

## Rollback
- Revert this PR to restore the previous full graph streaming behavior for all turns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fast-path response generation for certain query types, reducing response latency.

* **Improvements**
  * Enhanced request routing logic for improved system responsiveness.
  * Optimized response streaming efficiency across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->