### PR TITLE
feat: show immediate live status while streaming

### DIFF
--- a/wiii-desktop/src/__tests__/sprint110-hardening.test.ts
+++ b/wiii-desktop/src/__tests__/sprint110-hardening.test.ts
@@ -125,6 +125,24 @@ describe("useSSEStream — type-safe metadata", () => {
     expect(heartbeatGuard).toBeGreaterThan(liveStatus);
     expect(code).toContain("keep them out of the persistent step/phase timeline");
   });
+
+  it("sets an immediate live status before the first SSE event arrives", async () => {
+    const src = await import("@/hooks/useSSEStream?raw");
+    const code = (src as any).default || src;
+    const startStreaming = code.indexOf("chatStore.startStreaming();");
+    const immediateStatus = code.indexOf('chatStore.setStreamingStep("Wiii đang nghe bạn...");');
+    expect(immediateStatus).toBeGreaterThan(startStreaming);
+  });
+
+  it("keeps silent SSE keepalives visible without creating timeline noise", async () => {
+    const src = await import("@/hooks/useSSEStream?raw");
+    const code = (src as any).default || src;
+    const keepAlive = code.indexOf("onKeepAlive: () => {");
+    const quietGuard = code.indexOf("if (!hasStreamingOutput())", keepAlive);
+    expect(keepAlive).toBeGreaterThan(-1);
+    expect(quietGuard).toBeGreaterThan(keepAlive);
+    expect(code).toContain("Wiii vẫn đang giữ kết nối và xử lý");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/wiii-desktop/src/hooks/useSSEStream.ts
+++ b/wiii-desktop/src/hooks/useSSEStream.ts
@@ -515,6 +515,7 @@ export function useSSEStream() {
 
       // Start streaming
       chatStore.startStreaming();
+      chatStore.setStreamingStep("Wiii đang nghe bạn...");
       useCharacterStore.getState().clearSoulEmotion();
 
       // Sprint 153b: Clear stale think/progress tool IDs from previous streams
@@ -1036,6 +1037,9 @@ export function useSSEStream() {
       },
       onKeepAlive: () => {
         traceEvent("keepalive");
+        if (!hasStreamingOutput()) {
+          useChatStore.getState().setStreamingStep("Wiii vẫn đang giữ kết nối và xử lý...");
+        }
       },
     };
 


### PR DESCRIPTION
## Summary
- Shows an immediate live Wiii status right after a chat stream starts, before the first SSE event arrives.
- Updates quiet SSE keepalive handling so silent streams still feel alive while no answer/thinking/tool output exists.
- Adds source-level coverage for immediate status and keepalive status behavior.

## Verification
- cd wiii-desktop && npx vitest run src/__tests__/sprint110-hardening.test.ts
- cd wiii-desktop && npx tsc --noEmit
- git diff --check

## Risk and rollback
- Risk: low; this only updates ephemeral streaming status text and does not persist timeline/phase content.
- Rollback: revert this PR to return to generic streaming timer copy.

Tracking: #170