### PR TITLE
stream: expose runner latency timeline

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/graph_stream_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph_stream_runtime.py
@@ -280,6 +280,17 @@ async def emit_stream_finalization_impl(
         )
         request_id = str((context or {}).get("request_id") or "").strip() or None
         routing_metadata = effective_state.get("routing_metadata") or {}
+        runtime_latency = None
+        raw_runtime_latency = effective_state.get("_runtime_latency")
+        if isinstance(raw_runtime_latency, dict):
+            runtime_latency = {
+                "elapsed_ms": raw_runtime_latency.get("elapsed_ms"),
+                "timeline": [
+                    dict(item)
+                    for item in raw_runtime_latency.get("timeline", [])
+                    if isinstance(item, dict)
+                ],
+            }
         agent_type = routing_metadata.get("final_agent") or effective_state.get("next_agent") or "rag_agent"
         if record_llm_runtime_observation is not None:
             try:
@@ -327,6 +338,7 @@ async def emit_stream_finalization_impl(
             evidence_images=effective_state.get("evidence_images", []),
             thread_id=meta_thread_id,
             routing_metadata=routing_metadata,
+            runtime_latency=runtime_latency,
             request_id=request_id,
         )
 

--- a/maritime-ai-service/app/engine/multi_agent/runner.py
+++ b/maritime-ai-service/app/engine/multi_agent/runner.py
@@ -21,10 +21,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 from app.core.config import settings
-from app.engine.multi_agent.stream_events import make_graph_event, make_graph_done
+from app.engine.multi_agent.stream_events import make_bus_event, make_graph_event
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.guardrails import run_input_guardrails, run_output_guardrails
 from app.engine.multi_agent.next_step import (
@@ -48,6 +48,60 @@ _NODE_AGGREGATOR = "aggregator"
 
 _MAX_DISPATCH_ITERATIONS = 2  # Safety limit for aggregator→supervisor loop
 _MAX_HANDOFF_COUNT = 2  # Max agent-to-agent handoffs per request
+
+
+_RUNTIME_STEP_MESSAGES = {
+    _NODE_GUARDIAN: "Wiii đang kiểm tra an toàn...",
+    _NODE_SUPERVISOR: "Wiii đang định tuyến câu hỏi...",
+    "rag_agent": "Wiii đang tra cứu tri thức...",
+    "tutor_agent": "Wiii đang soạn phần giải thích...",
+    "memory_agent": "Wiii đang nối lại trí nhớ...",
+    "direct": "Wiii đang gọi model để trả lời...",
+    "code_studio_agent": "Wiii đang chuẩn bị Code Studio...",
+    "product_search_agent": "Wiii đang tìm tín hiệu sản phẩm...",
+    "colleague_agent": "Wiii đang hỏi thêm một góc nhìn...",
+    _NODE_PARALLEL_DISPATCH: "Wiii đang chia việc cho các agent...",
+    _NODE_AGGREGATOR: "Wiii đang tổng hợp báo cáo agent...",
+    _NODE_SYNTHESIZER: "Wiii đang chốt câu trả lời cuối...",
+}
+
+
+def _ensure_runtime_latency(state: AgentState) -> dict[str, Any]:
+    if "_runtime_latency_started_at" not in state:
+        state["_runtime_latency_started_at"] = time.perf_counter()
+    latency = state.setdefault("_runtime_latency", {"timeline": []})
+    if not isinstance(latency, dict):
+        latency = {"timeline": []}
+        state["_runtime_latency"] = latency
+    timeline = latency.setdefault("timeline", [])
+    if not isinstance(timeline, list):
+        latency["timeline"] = []
+    return latency
+
+
+def _runtime_elapsed_ms(state: AgentState) -> int:
+    started_at = state.get("_runtime_latency_started_at")
+    if not isinstance(started_at, (int, float)):
+        started_at = time.perf_counter()
+        state["_runtime_latency_started_at"] = started_at
+    return int((time.perf_counter() - started_at) * 1000)
+
+
+def _record_runtime_timeline_entry(
+    state: AgentState,
+    entry: dict[str, Any],
+) -> dict[str, Any]:
+    latency = _ensure_runtime_latency(state)
+    timeline = latency.setdefault("timeline", [])
+    timeline.append(entry)
+    latency["elapsed_ms"] = _runtime_elapsed_ms(state)
+    return entry
+
+
+def _export_runtime_latency(state: AgentState) -> dict[str, Any]:
+    latency = _ensure_runtime_latency(state)
+    latency["elapsed_ms"] = _runtime_elapsed_ms(state)
+    return latency
 
 
 class WiiiRunner:
@@ -130,6 +184,116 @@ class WiiiRunner:
         if self._hooks:
             await self._hooks.emit_route(from_step, to_step, state)
 
+    @staticmethod
+    def _push_runtime_status(
+        queue: Optional[asyncio.Queue],
+        *,
+        state: AgentState,
+        node_name: str,
+        stage: str,
+        content: str,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        """Push a status-only bus event before long-running runtime work."""
+        if queue is None:
+            return
+        details: dict[str, Any] = {
+            "visibility": "status_only",
+            "subtype": "runtime_status",
+            "stage": stage,
+            "node_name": node_name,
+            "elapsed_ms": _runtime_elapsed_ms(state),
+        }
+        if extra:
+            details.update(extra)
+        queue.put_nowait(
+            make_bus_event(
+                {
+                    "type": "status",
+                    "content": content,
+                    "node": node_name,
+                    "details": details,
+                }
+            )
+        )
+
+    @classmethod
+    def _push_runtime_route_status(
+        cls,
+        queue: Optional[asyncio.Queue],
+        *,
+        state: AgentState,
+        from_step: str,
+        to_step: str,
+    ) -> None:
+        _record_runtime_timeline_entry(
+            state,
+            {
+                "stage": "runtime_route",
+                "from": from_step,
+                "to": to_step,
+                "status": "ok",
+                "elapsed_ms": _runtime_elapsed_ms(state),
+            },
+        )
+        cls._push_runtime_status(
+            queue,
+            state=state,
+            node_name=from_step or "runner",
+            stage="runtime_route",
+            content=f"Wiii chuyển luồng sang {to_step}...",
+            extra={"route_from": from_step, "route_to": to_step},
+        )
+
+    @classmethod
+    def _start_runtime_step(
+        cls,
+        queue: Optional[asyncio.Queue],
+        *,
+        name: str,
+        state: AgentState,
+    ) -> dict[str, Any]:
+        entry = _record_runtime_timeline_entry(
+            state,
+            {
+                "stage": "runtime_step",
+                "node": name,
+                "status": "running",
+                "started_ms": _runtime_elapsed_ms(state),
+            },
+        )
+        cls._push_runtime_status(
+            queue,
+            state=state,
+            node_name=name,
+            stage="runtime_step_start",
+            content=_RUNTIME_STEP_MESSAGES.get(name, f"Wiii đang chạy {name}..."),
+        )
+        return entry
+
+    @staticmethod
+    def _finish_runtime_step(
+        *,
+        source_state: AgentState,
+        result_state: AgentState,
+        entry: dict[str, Any],
+        started_at: float,
+        status: str,
+    ) -> AgentState:
+        if result_state is not source_state:
+            result_state.setdefault(
+                "_runtime_latency_started_at",
+                source_state.get("_runtime_latency_started_at"),
+            )
+            result_state.setdefault(
+                "_runtime_latency",
+                source_state.get("_runtime_latency", {"timeline": []}),
+            )
+        entry["duration_ms"] = int((time.perf_counter() - started_at) * 1000)
+        entry["status"] = status
+        _export_runtime_latency(result_state)
+        return result_state
+
     # ------------------------------------------------------------------
     # Sync execution (replaces graph.ainvoke)
     # ------------------------------------------------------------------
@@ -161,6 +325,12 @@ class WiiiRunner:
 
         route = guardian_route(state)
         await self._emit_route(_NODE_GUARDIAN, route, state)
+        self._push_runtime_route_status(
+            None,
+            state=state,
+            from_step=_NODE_GUARDIAN,
+            to_step=route,
+        )
 
         if route == _NODE_SYNTHESIZER:
             state["current_agent"] = _NODE_SYNTHESIZER
@@ -182,7 +352,15 @@ class WiiiRunner:
                 break
 
             elif isinstance(step, NextStepHandoff):
-                await self._emit_route(state.get("current_agent", ""), step.target_agent, state)
+                current_agent = state.get("current_agent", "")
+                await self._emit_route(current_agent, step.target_agent, state)
+                if current_agent != step.target_agent:
+                    self._push_runtime_route_status(
+                        None,
+                        state=state,
+                        from_step=current_agent,
+                        to_step=step.target_agent,
+                    )
                 state["current_agent"] = step.target_agent
                 state["next_agent"] = step.target_agent
 
@@ -227,7 +405,11 @@ class WiiiRunner:
         await self._emit_run_start(state)
 
         # 1. Guardian
-        state = await self._run_step(_NODE_GUARDIAN, state)
+        state = await self._run_step(
+            _NODE_GUARDIAN,
+            state,
+            stream_queue=merged_queue,
+        )
 
         # Keep streaming semantics aligned with run(): extended input
         # guardrails are part of the active runtime contract, not only sync API.
@@ -244,10 +426,20 @@ class WiiiRunner:
 
         route = guardian_route(state)
         await self._emit_route(_NODE_GUARDIAN, route, state)
+        self._push_runtime_route_status(
+            merged_queue,
+            state=state,
+            from_step=_NODE_GUARDIAN,
+            to_step=route,
+        )
 
         if route == _NODE_SYNTHESIZER:
             state["current_agent"] = _NODE_SYNTHESIZER
-            state = await self._run_step(_NODE_SYNTHESIZER, state)
+            state = await self._run_step(
+                _NODE_SYNTHESIZER,
+                state,
+                stream_queue=merged_queue,
+            )
             await run_output_guardrails(state)
             self._push_queue(merged_queue, _NODE_SYNTHESIZER, state)
             elapsed = (time.perf_counter() - t_start) * 1000
@@ -260,13 +452,25 @@ class WiiiRunner:
         state["_handoff_count"] = 0
 
         for turn in range(max_turns):
-            step = await self._resolve_next_step(state, turn)
+            step = await self._resolve_next_step(
+                state,
+                turn,
+                stream_queue=merged_queue,
+            )
 
             if isinstance(step, NextStepFinalOutput):
                 break
 
             elif isinstance(step, NextStepHandoff):
-                await self._emit_route(state.get("current_agent", ""), step.target_agent, state)
+                current_agent = state.get("current_agent", "")
+                await self._emit_route(current_agent, step.target_agent, state)
+                if current_agent != step.target_agent:
+                    self._push_runtime_route_status(
+                        merged_queue,
+                        state=state,
+                        from_step=current_agent,
+                        to_step=step.target_agent,
+                    )
                 state["current_agent"] = step.target_agent
                 state["next_agent"] = step.target_agent
 
@@ -276,18 +480,30 @@ class WiiiRunner:
                     await self._emit_run_end(state, elapsed)
                     return state
 
-                state = await self._run_step(step.target_agent, state)
+                state = await self._run_step(
+                    step.target_agent,
+                    state,
+                    stream_queue=merged_queue,
+                )
                 self._push_queue(merged_queue, step.target_agent, state)
 
             elif isinstance(step, NextStepRunAgain):
-                state = await self._run_step(step.agent_name, state)
+                state = await self._run_step(
+                    step.agent_name,
+                    state,
+                    stream_queue=merged_queue,
+                )
                 self._push_queue(merged_queue, step.agent_name, state)
 
             state["_orchestrator_turn"] = turn + 1
             self._preserve_thinking(state)
 
         # Synthesize
-        state = await self._run_step(_NODE_SYNTHESIZER, state)
+        state = await self._run_step(
+            _NODE_SYNTHESIZER,
+            state,
+            stream_queue=merged_queue,
+        )
         await run_output_guardrails(state)
         self._push_queue(merged_queue, _NODE_SYNTHESIZER, state)
 
@@ -299,7 +515,13 @@ class WiiiRunner:
     # NextStep resolution
     # ------------------------------------------------------------------
 
-    async def _resolve_next_step(self, state: AgentState, turn: int) -> NextStep:
+    async def _resolve_next_step(
+        self,
+        state: AgentState,
+        turn: int,
+        *,
+        stream_queue: Optional[asyncio.Queue] = None,
+    ) -> NextStep:
         """Determine the next step in the orchestrator loop.
 
         - Turn 0: run supervisor, route to agent
@@ -307,13 +529,23 @@ class WiiiRunner:
         """
         if turn == 0:
             # First turn: run supervisor routing
-            state = await self._run_step(_NODE_SUPERVISOR, state)
+            state = await self._run_step(
+                _NODE_SUPERVISOR,
+                state,
+                stream_queue=stream_queue,
+            )
             from app.engine.multi_agent.graph_support import route_decision
 
             agent_name = route_decision(state)
             state["current_agent"] = agent_name
             state["next_agent"] = agent_name
             await self._emit_route(_NODE_SUPERVISOR, agent_name, state)
+            self._push_runtime_route_status(
+                stream_queue,
+                state=state,
+                from_step=_NODE_SUPERVISOR,
+                to_step=agent_name,
+            )
             return NextStepHandoff(target_agent=agent_name, reason="supervisor_route")
 
         # Subsequent turns: check for agent-initiated handoff
@@ -445,23 +677,41 @@ class WiiiRunner:
         if aggregator keeps routing back to supervisor.
         """
         # Run parallel_dispatch
-        state = await self._run_step(_NODE_PARALLEL_DISPATCH, state)
+        state = await self._run_step(
+            _NODE_PARALLEL_DISPATCH,
+            state,
+            stream_queue=merged_queue,
+        )
         self._push_queue(merged_queue, _NODE_PARALLEL_DISPATCH, state)
 
         # Run aggregator
-        state = await self._run_step(_NODE_AGGREGATOR, state)
+        state = await self._run_step(
+            _NODE_AGGREGATOR,
+            state,
+            stream_queue=merged_queue,
+        )
         self._push_queue(merged_queue, _NODE_AGGREGATOR, state)
 
         # Aggregator route: synthesizer or back to supervisor (with loop limit)
         for _iteration in range(_MAX_DISPATCH_ITERATIONS):
             next_route = self._resolve_aggregator_route(state)
             await self._emit_route(_NODE_AGGREGATOR, next_route, state)
+            self._push_runtime_route_status(
+                merged_queue,
+                state=state,
+                from_step=_NODE_AGGREGATOR,
+                to_step=next_route,
+            )
 
             if next_route != _NODE_SUPERVISOR:
                 break
 
             # Loop back: supervisor → agent → (continue or break)
-            state = await self._run_step(_NODE_SUPERVISOR, state)
+            state = await self._run_step(
+                _NODE_SUPERVISOR,
+                state,
+                stream_queue=merged_queue,
+            )
             self._push_queue(merged_queue, _NODE_SUPERVISOR, state)
 
             from app.engine.multi_agent.graph_support import route_decision
@@ -469,17 +719,35 @@ class WiiiRunner:
             agent_name = route_decision(state)
             state["current_agent"] = agent_name
             await self._emit_route(_NODE_SUPERVISOR, agent_name, state)
+            self._push_runtime_route_status(
+                merged_queue,
+                state=state,
+                from_step=_NODE_SUPERVISOR,
+                to_step=agent_name,
+            )
 
             node_fn = self._get_node(agent_name)
             if node_fn:
-                state = await self._run_step(agent_name, state)
+                state = await self._run_step(
+                    agent_name,
+                    state,
+                    stream_queue=merged_queue,
+                )
                 self._push_queue(merged_queue, agent_name, state)
 
             # After agent execution, run aggregator again to decide next step
-            state = await self._run_step(_NODE_AGGREGATOR, state)
+            state = await self._run_step(
+                _NODE_AGGREGATOR,
+                state,
+                stream_queue=merged_queue,
+            )
             self._push_queue(merged_queue, _NODE_AGGREGATOR, state)
 
-        return await self._run_step(_NODE_SYNTHESIZER, state)
+        return await self._run_step(
+            _NODE_SYNTHESIZER,
+            state,
+            stream_queue=merged_queue,
+        )
 
     @staticmethod
     def _resolve_aggregator_route(state: AgentState) -> str:
@@ -512,7 +780,13 @@ class WiiiRunner:
     # Single step execution (with hooks)
     # ------------------------------------------------------------------
 
-    async def _run_step(self, name: str, state: AgentState) -> AgentState:
+    async def _run_step(
+        self,
+        name: str,
+        state: AgentState,
+        *,
+        stream_queue: Optional[asyncio.Queue] = None,
+    ) -> AgentState:
         """Run a single node function with error handling and lifecycle hooks.
 
         Critical nodes (guardian, supervisor, synthesizer) re-raise on failure.
@@ -527,17 +801,35 @@ class WiiiRunner:
         self._inject_tier_info(name, state)
 
         t_start = time.perf_counter()
+        timeline_entry = self._start_runtime_step(
+            stream_queue,
+            name=name,
+            state=state,
+        )
         await self._emit_step_start(name, state)
 
         try:
             result = await node_fn(state)
             duration_ms = (time.perf_counter() - t_start) * 1000
             await self._emit_step_end(name, result, duration_ms)
-            return result
+            return self._finish_runtime_step(
+                source_state=state,
+                result_state=result,
+                entry=timeline_entry,
+                started_at=t_start,
+                status="ok",
+            )
         except Exception as exc:
             duration_ms = (time.perf_counter() - t_start) * 1000
             await self._emit_step_error(name, state, exc)
             logger.error("[RUNNER] Node %s failed (%.1fms): %s", name, duration_ms, exc)
+            self._finish_runtime_step(
+                source_state=state,
+                result_state=state,
+                entry=timeline_entry,
+                started_at=t_start,
+                status="error",
+            )
             # Critical infrastructure nodes re-raise; agent nodes degrade gracefully
             if name in (_NODE_GUARDIAN, _NODE_SUPERVISOR, _NODE_SYNTHESIZER):
                 raise

--- a/maritime-ai-service/tests/unit/test_graph_stream_runtime.py
+++ b/maritime-ai-service/tests/unit/test_graph_stream_runtime.py
@@ -278,3 +278,56 @@ async def test_emit_stream_finalization_matches_sync_runtime_metadata_contract()
     assert "user-provider" in stream_metadata["thread_id"]
     assert "session-provider" in stream_metadata["thread_id"]
     assert events[-1].type == "done"
+
+
+@pytest.mark.asyncio
+async def test_emit_stream_finalization_includes_runtime_latency_timeline():
+    runtime_latency = {
+        "elapsed_ms": 42,
+        "timeline": [
+            {
+                "stage": "runtime_step",
+                "node": "supervisor",
+                "status": "ok",
+                "started_ms": 3,
+                "duration_ms": 17,
+            },
+            {
+                "stage": "runtime_route",
+                "from": "supervisor",
+                "to": "direct",
+                "status": "ok",
+                "elapsed_ms": 21,
+            },
+        ],
+    }
+    final_state = {
+        "session_id": "session-latency",
+        "grader_score": 8.0,
+        "final_response": "ok",
+        "routing_metadata": {"final_agent": "direct"},
+        "_runtime_latency": runtime_latency,
+    }
+
+    events = [
+        event
+        async for event in emit_stream_finalization_impl(
+            final_state=final_state,
+            session_id="session-latency",
+            context={"user_id": "user-latency"},
+            start_time=0.0,
+            resolve_runtime_llm_metadata=lambda *_args, **_kwargs: {
+                "provider": "nvidia",
+                "model": "deepseek-ai/deepseek-v4-flash",
+                "runtime_authoritative": True,
+            },
+            create_sources_event=create_sources_event,
+            create_metadata_event=create_metadata_event,
+            create_done_event=create_done_event,
+            registry=_RegistryStub(),
+            trace_id="trace-latency",
+        )
+    ]
+
+    metadata_event = next(event for event in events if event.type == "metadata")
+    assert metadata_event.content["runtime_latency"] == runtime_latency

--- a/maritime-ai-service/tests/unit/test_runner_stream_latency.py
+++ b/maritime-ai-service/tests/unit/test_runner_stream_latency.py
@@ -1,0 +1,112 @@
+import asyncio
+
+import pytest
+
+from app.engine.multi_agent.runner import (
+    WiiiRunner,
+    _NODE_GUARDIAN,
+    _NODE_SUPERVISOR,
+    _NODE_SYNTHESIZER,
+)
+
+
+async def _allow_input_guardrails(_state, *, guardian_passed=True):
+    return True, None
+
+
+async def _allow_output_guardrails(_state):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_run_streaming_emits_supervisor_status_before_supervisor_finishes(
+    monkeypatch,
+):
+    import app.engine.multi_agent.runner as runner_mod
+
+    monkeypatch.setattr(
+        runner_mod,
+        "run_input_guardrails",
+        _allow_input_guardrails,
+    )
+    monkeypatch.setattr(
+        runner_mod,
+        "run_output_guardrails",
+        _allow_output_guardrails,
+    )
+
+    supervisor_started = asyncio.Event()
+    finish_supervisor = asyncio.Event()
+    runner = WiiiRunner()
+
+    async def guardian_node(state):
+        state["guardian_passed"] = True
+        return state
+
+    async def supervisor_node(state):
+        supervisor_started.set()
+        await finish_supervisor.wait()
+        state["next_agent"] = "direct"
+        state["routing_metadata"] = {
+            "final_agent": "direct",
+            "intent": "social",
+            "method": "test",
+        }
+        return state
+
+    async def direct_node(state):
+        state["current_agent"] = "direct"
+        state["final_response"] = "Wiii da co du noi dung de ket thuc luot nay."
+        state["grader_score"] = 8.0
+        return state
+
+    async def synthesizer_node(state):
+        return state
+
+    runner.register_node(_NODE_GUARDIAN, guardian_node)
+    runner.register_node(_NODE_SUPERVISOR, supervisor_node)
+    runner.register_node("direct", direct_node)
+    runner.register_node(_NODE_SYNTHESIZER, synthesizer_node)
+
+    merged_queue = asyncio.Queue()
+    run_task = asyncio.create_task(
+        runner.run_streaming(
+            {"query": "hi", "session_id": "session-1"},
+            merged_queue=merged_queue,
+        )
+    )
+
+    seen = []
+    while True:
+        msg_type, payload = await asyncio.wait_for(merged_queue.get(), timeout=1)
+        seen.append((msg_type, payload))
+        if (
+            msg_type == "bus"
+            and payload.get("type") == "status"
+            and payload.get("details", {}).get("stage") == "runtime_step_start"
+            and payload.get("details", {}).get("node_name") == _NODE_SUPERVISOR
+        ):
+            break
+
+    assert supervisor_started.is_set()
+    assert not any(
+        msg_type == "graph" and _NODE_SUPERVISOR in payload
+        for msg_type, payload in seen
+    )
+
+    finish_supervisor.set()
+    final_state = await asyncio.wait_for(run_task, timeout=1)
+    runtime_latency = final_state["_runtime_latency"]
+    assert any(
+        item.get("stage") == "runtime_step"
+        and item.get("node") == _NODE_SUPERVISOR
+        and item.get("status") == "ok"
+        and item.get("duration_ms") is not None
+        for item in runtime_latency["timeline"]
+    )
+    assert any(
+        item.get("stage") == "runtime_route"
+        and item.get("from") == _NODE_SUPERVISOR
+        and item.get("to") == "direct"
+        for item in runtime_latency["timeline"]
+    )


### PR DESCRIPTION
## Summary
- Link issue: Closes #202; follows #201 and parent #170.
- Add WiiiRunner runtime latency tracking for `runtime_step` start/duration and `runtime_route` transitions.
- Emit early `status_only` bus events before long-running runner nodes start, so FE can update live status instead of appearing silent.
- Include `runtime_latency.timeline` in final SSE metadata for post-turn diagnosis of slow supervisor/router/agent stages.
- Add focused tests for slow supervisor early-status behavior and metadata export.

## Verification
- `cd maritime-ai-service && python -m pytest tests/unit/test_runner_stream_latency.py tests/unit/test_graph_stream_runtime.py tests/unit/test_chat_stream_coordinator.py -q` -> 19 passed
- `cd maritime-ai-service && python -m pytest tests/unit/test_runner_hooks.py tests/unit/test_runner_node_surface.py tests/unit/test_agent_tier_config.py tests/unit/test_next_step_types.py tests/unit/test_self_correction_and_thinking.py tests/unit/test_runner_stream_latency.py -q` -> 78 passed
- `cd maritime-ai-service && python -m pytest tests/unit/test_graph_stream_runtime.py tests/unit/test_chat_stream_coordinator.py tests/unit/test_graph_stream_merge_runtime.py -q` -> 19 passed
- `cd maritime-ai-service && python -m pytest tests/unit/test_thinking_lifecycle.py tests/unit/test_sprint74_streaming_quality.py -q` -> 69 passed
- `cd maritime-ai-service && python -m ruff check app/engine/multi_agent/runner.py app/engine/multi_agent/graph_stream_runtime.py tests/unit/test_runner_stream_latency.py tests/unit/test_graph_stream_runtime.py --select=E9,F63,F7` -> All checks passed
- `git diff --check` -> passed

## Risk
- Backend streaming surface change: status-only events now come from runner node boundaries as well as existing stream shell/status sources.
- These events are marked `visibility=status_only`, so the desktop should update current live status without polluting persistent step/phase history.
- Final metadata now includes `runtime_latency`; consumers that display raw metadata may see the new diagnostic object.

## Rollback
- Revert this PR. It does not change provider/model selection, prompt semantics, DB schema, or committed frontend build output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime performance metrics (latency, elapsed time) now tracked and included in operation metadata
  * Per-request execution timeline with status events emitted during streaming operations, enabling real-time performance visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->