### PR TITLE
fix(runtime): fast-path host UI routing

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 import re
@@ -40,6 +41,8 @@ from app.engine.multi_agent.graph_runtime_helpers import (
 )
 
 logger = logging.getLogger(__name__)
+
+_HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS = 24.0
 
 _IDENTITY_LORE_MARKERS = (
     "the wiii lab",
@@ -894,7 +897,7 @@ async def direct_response_node_impl(
                     metadata=build_visual_tool_runtime_metadata(state, query),
                 )
 
-                llm_response, messages, tool_call_events = await execute_direct_tool_rounds(
+                direct_execution = execute_direct_tool_rounds(
                     llm_with_tools,
                     llm_auto,
                     messages,
@@ -911,6 +914,34 @@ async def direct_response_node_impl(
                     allowed_fallback_providers=direct_allowed_fallback_providers,
                     native_tool_messages=native_direct_messages,
                 )
+                if routing_intent == "host_ui_navigation":
+                    try:
+                        llm_response, messages, tool_call_events = await asyncio.wait_for(
+                            direct_execution,
+                            timeout=_HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS,
+                        )
+                    except asyncio.TimeoutError:
+                        from app.engine.native_chat_runtime import make_assistant_message
+
+                        logger.warning(
+                            "[DIRECT] Host UI navigation answer exceeded %.1fs; returning bounded fallback",
+                            _HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS,
+                        )
+                        fallback_answer = (
+                            "Mình đã nhận yêu cầu trỏ trên giao diện rồi. "
+                            "Nếu Wiii chưa highlight ngay, hãy thử mở lại panel Wiii hoặc làm mới trang LMS nhé."
+                        )
+                        await push_event(
+                            {
+                                "type": "answer_delta",
+                                "content": fallback_answer,
+                                "node": "direct",
+                            }
+                        )
+                        llm_response = make_assistant_message(fallback_answer)
+                        tool_call_events = []
+                else:
+                    llm_response, messages, tool_call_events = await direct_execution
 
                 if tool_call_events:
                     state["tool_call_events"] = tool_call_events

--- a/maritime-ai-service/app/engine/multi_agent/lane_timeout_policy.py
+++ b/maritime-ai-service/app/engine/multi_agent/lane_timeout_policy.py
@@ -48,6 +48,15 @@ def _normalize_provider_name(provider_name: str | None) -> str:
     return str(provider_name or "").strip().lower()
 
 
+def _is_host_ui_navigation_route(state: object | None) -> bool:
+    if not isinstance(state, dict):
+        return False
+    metadata = state.get("routing_metadata")
+    if not isinstance(metadata, dict):
+        return False
+    return str(metadata.get("intent") or "").strip().lower() == "host_ui_navigation"
+
+
 def _looks_origin_probe(query: str) -> bool:
     normalized = _normalize_for_intent(query)
     if not normalized:
@@ -66,14 +75,21 @@ def resolve_direct_lane_timeout_policy_impl(
     tools_bound: bool,
 ) -> LaneTimeoutPolicy:
     """Return a provider-aware timeout policy for direct no-tool turns."""
+    from app.engine.llm_pool import TIMEOUT_PROFILE_STRUCTURED
+
+    if _is_host_ui_navigation_route(state):
+        return LaneTimeoutPolicy(
+            timeout_profile=TIMEOUT_PROFILE_STRUCTURED,
+            primary_timeout=8.0,
+            reason="host_ui_navigation",
+        )
+
     if tools_bound:
         return LaneTimeoutPolicy(reason="tool_bound")
 
     normalized_provider = _normalize_provider_name(provider_name)
     if normalized_provider != "zhipu":
         return LaneTimeoutPolicy(reason="provider_default")
-
-    from app.engine.llm_pool import TIMEOUT_PROFILE_STRUCTURED
 
     if _looks_emotional_support_turn(query):
         return LaneTimeoutPolicy(

--- a/maritime-ai-service/app/engine/multi_agent/supervisor_runtime_support.py
+++ b/maritime-ai-service/app/engine/multi_agent/supervisor_runtime_support.py
@@ -9,6 +9,72 @@ from app.engine.multi_agent.supervisor_hint_runtime import (
     _normalize_router_text_impl,
 )
 
+_HOST_UI_ACTION_MARKERS = (
+    "bam",
+    "button",
+    "chi cho",
+    "click",
+    "cuon",
+    "di toi",
+    "dua toi",
+    "highlight",
+    "mo",
+    "navigate",
+    "nhan vao",
+    "nut",
+    "o dau",
+    "open",
+    "scroll",
+    "show me",
+    "tro toi",
+    "where",
+)
+
+_HOST_UI_SURFACE_MARKERS = (
+    "browse courses",
+    "dashboard",
+    "giao dien",
+    "ho so",
+    "kham pha",
+    "khoa hoc cua toi",
+    "lesson",
+    "menu",
+    "my courses",
+    "profile",
+    "sidebar",
+    "tab",
+    "tiep tuc hoc",
+    "tong quan trang",
+    "trang nay",
+)
+
+_HOST_UI_EXPLICIT_MARKERS = (
+    "con tro",
+    "cursor",
+    "host action",
+    "pointy",
+    "ui highlight",
+    "ui scroll",
+    "ui tour",
+)
+
+
+def _contains_any_marker(normalized_query: str, markers: tuple[str, ...]) -> bool:
+    return any(marker in normalized_query for marker in markers)
+
+
+def _looks_host_ui_navigation_turn(normalized_query: str) -> bool:
+    """Detect obvious host UI guidance prompts without stealing learning turns."""
+    query = normalized_query or ""
+    if not query:
+        return False
+    if _contains_any_marker(query, _HOST_UI_EXPLICIT_MARKERS):
+        return True
+    return _contains_any_marker(query, _HOST_UI_ACTION_MARKERS) and _contains_any_marker(
+        query,
+        _HOST_UI_SURFACE_MARKERS,
+    )
+
 
 def resolve_house_routing_provider_impl(
     state: Any,
@@ -234,6 +300,14 @@ def conservative_fast_route_impl(
 
     if looks_clear_social_fn(normalized):
         return (direct_agent_name, "social", 1.0, "obvious social turn")
+
+    if _looks_host_ui_navigation_turn(normalized):
+        return (
+            direct_agent_name,
+            "host_ui_navigation",
+            1.0,
+            "obvious host UI navigation/help turn",
+        )
 
     return None
 

--- a/maritime-ai-service/app/engine/multi_agent/tool_collection.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_collection.py
@@ -130,6 +130,24 @@ def _should_strip_visual_tools_for_analytical_text_turn(
         return False
     return getattr(visual_decision, "presentation_intent", "text") == "text"
 
+
+def _tool_name(tool: Any) -> str:
+    return str(getattr(tool, "name", "") or getattr(tool, "__name__", "") or "").strip()
+
+
+def _is_host_ui_navigation_route(state: Optional[AgentState]) -> bool:
+    if not isinstance(state, dict):
+        return False
+    metadata = state.get("routing_metadata")
+    if not isinstance(metadata, dict):
+        return False
+    return str(metadata.get("intent") or "").strip().lower() == "host_ui_navigation"
+
+
+def _host_action_tools(tools: list[Any]) -> list[Any]:
+    return [tool for tool in tools if _tool_name(tool).startswith("host_action__")]
+
+
 def _collect_direct_tools(query: str, user_role: str = "student", state: Optional[AgentState] = None):
     """Collect tools for direct response node and determine forced calling.
 
@@ -246,6 +264,10 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
                 )
     except Exception as _e:
         logger.debug("[DIRECT] Host action tools unavailable: %s", _e)
+
+    if _is_host_ui_navigation_route(state):
+        scoped_host_tools = _host_action_tools(_direct_tools)
+        return scoped_host_tools, bool(scoped_host_tools)
 
     # Structured visuals re-enable lightweight inline diagram/chart tools for direct,
     # but keep heavy artifact/file generation inside code_studio_agent.

--- a/maritime-ai-service/tests/unit/test_direct_node_provider_errors.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_provider_errors.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -657,3 +658,56 @@ async def test_direct_response_node_strips_tools_for_emotional_support_turns():
     assert result["final_response"] == "Minh o day voi cau day."
     assert captured["tools"] == []
     assert captured["direct_answer_primary_timeout"] == pytest.approx(8.0)
+
+
+@pytest.mark.asyncio
+async def test_direct_response_node_bounds_host_ui_navigation_total_timeout(monkeypatch):
+    events = []
+    state = {
+        "query": "Wiii oi, nut Kham pha khoa hoc o dau?",
+        "context": {
+            "response_language": "vi",
+            "user_role": "student",
+        },
+        "domain_id": "maritime",
+        "domain_config": {},
+        "routing_metadata": {"intent": "host_ui_navigation"},
+        "provider": "nvidia",
+    }
+    kwargs = _base_direct_kwargs()
+    kwargs["capture_public_thinking_event"] = lambda _state, event: events.append(event)
+    kwargs["looks_identity_selfhood_turn"] = lambda *_args, **_kwargs: False
+    kwargs["get_effective_provider"] = lambda *_args, **_kwargs: "nvidia"
+    kwargs["get_explicit_user_provider"] = lambda *_args, **_kwargs: None
+    kwargs["bind_direct_tools"] = lambda llm, *_args, **_kwargs: (llm, llm, None)
+    kwargs["extract_direct_response"] = lambda llm_response, *_args, **_kwargs: (
+        str(getattr(llm_response, "content", "")),
+        "",
+        [],
+    )
+
+    async def _slow_execute(*_args, **_kwargs):
+        await asyncio.sleep(1)
+        return SimpleNamespace(content="too late", tool_calls=[]), [], []
+
+    kwargs["execute_direct_tool_rounds"] = _slow_execute
+    monkeypatch.setattr(
+        "app.engine.multi_agent.direct_node_runtime._HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    with patch(
+        "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_native_llm",
+        return_value=SimpleNamespace(_wiii_provider_name="nvidia"),
+    ):
+        result = await direct_response_node_impl(
+            state,
+            **kwargs,
+        )
+
+    assert "Mình đã nhận yêu cầu trỏ" in result["final_response"]
+    assert any(
+        event.get("type") == "answer_delta"
+        and "Mình đã nhận yêu cầu trỏ" in event.get("content", "")
+        for event in events
+    )

--- a/maritime-ai-service/tests/unit/test_lane_timeout_policy_host_ui.py
+++ b/maritime-ai-service/tests/unit/test_lane_timeout_policy_host_ui.py
@@ -1,0 +1,55 @@
+from app.engine.multi_agent.lane_timeout_policy import (
+    resolve_direct_lane_timeout_policy_impl,
+)
+
+
+def _host_ui_state():
+    return {"routing_metadata": {"intent": "host_ui_navigation"}}
+
+
+def test_host_ui_navigation_gets_provider_agnostic_first_token_sla():
+    policy = resolve_direct_lane_timeout_policy_impl(
+        provider_name="nvidia",
+        query="Wiii oi, nut Kham pha khoa hoc o dau?",
+        state=_host_ui_state(),
+        is_identity_turn=False,
+        is_short_house_chatter=False,
+        use_house_voice_direct=False,
+        tools_bound=False,
+    )
+
+    assert policy.timeout_profile == "structured"
+    assert policy.primary_timeout == 8.0
+    assert policy.reason == "host_ui_navigation"
+
+
+def test_host_ui_navigation_sla_still_applies_when_host_tools_are_bound():
+    policy = resolve_direct_lane_timeout_policy_impl(
+        provider_name="nvidia",
+        query="Wiii oi, highlight nut Kham pha giup toi",
+        state=_host_ui_state(),
+        is_identity_turn=False,
+        is_short_house_chatter=False,
+        use_house_voice_direct=False,
+        tools_bound=True,
+    )
+
+    assert policy.timeout_profile == "structured"
+    assert policy.primary_timeout == 8.0
+    assert policy.reason == "host_ui_navigation"
+
+
+def test_non_host_ui_nvidia_turn_keeps_default_policy():
+    policy = resolve_direct_lane_timeout_policy_impl(
+        provider_name="nvidia",
+        query="giai thich khoa hoc hang hai co ban",
+        state={"routing_metadata": {"intent": "learning"}},
+        is_identity_turn=False,
+        is_short_house_chatter=False,
+        use_house_voice_direct=False,
+        tools_bound=False,
+    )
+
+    assert policy.timeout_profile is None
+    assert policy.primary_timeout is None
+    assert policy.reason == "provider_default"

--- a/maritime-ai-service/tests/unit/test_supervisor_agent.py
+++ b/maritime-ai-service/tests/unit/test_supervisor_agent.py
@@ -286,6 +286,40 @@ class TestSupervisorRoute:
         mock_route.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_route_host_ui_navigation_uses_fast_path(self, mock_llm):
+        sup = _make_supervisor(mock_llm)
+        state = {
+            "query": "Wiii oi, nut Kham pha khoa hoc o dau?",
+            "context": {},
+            "domain_config": {},
+        }
+
+        mock_route = AsyncMock(return_value="memory_agent")
+        with patch.object(sup, "_route_structured", new=mock_route):
+            result = await sup.route(state)
+
+        assert result == "direct"
+        assert state["routing_metadata"]["method"] == "conservative_fast_path"
+        assert state["routing_metadata"]["intent"] == "host_ui_navigation"
+        mock_route.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_route_learning_course_question_does_not_use_host_ui_fast_path(self, mock_llm):
+        sup = _make_supervisor(mock_llm)
+        state = {
+            "query": "giai thich khoa hoc hang hai co ban cho toi",
+            "context": {},
+            "domain_config": {},
+        }
+
+        mock_route = AsyncMock(return_value="tutor_agent")
+        with patch.object(sup, "_route_structured", new=mock_route):
+            result = await sup.route(state)
+
+        assert result == "tutor_agent"
+        mock_route.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_route_to_rag(self, mock_llm, base_state):
         sup = _make_supervisor(mock_llm)
 

--- a/maritime-ai-service/tests/unit/test_tool_collection_host_ui.py
+++ b/maritime-ai-service/tests/unit/test_tool_collection_host_ui.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+
+
+def test_host_ui_route_without_host_caps_does_not_force_generic_tools(monkeypatch):
+    from app.engine.multi_agent import tool_collection as module
+
+    monkeypatch.setattr(module.settings, "enable_character_tools", False, raising=False)
+    monkeypatch.setattr(module.settings, "enable_lms_integration", True, raising=False)
+    monkeypatch.setattr(module.settings, "enable_host_actions", True, raising=False)
+    monkeypatch.setattr(module.settings, "enable_structured_visuals", True, raising=False)
+
+    def fake_load_attr(module_name: str, attr_name: str):
+        if module_name.endswith("utility_tools"):
+            return SimpleNamespace(name=attr_name)
+        if module_name.endswith("web_search_tools"):
+            return SimpleNamespace(name=attr_name)
+        if module_name.endswith("agent_tools") and attr_name == "RAG_KNOWLEDGE_TOOL":
+            return SimpleNamespace(name="tool_rag_knowledge")
+        if module_name.endswith("lms_tools") and attr_name == "get_all_lms_tools":
+            return lambda role="student": [SimpleNamespace(name="tool_lms_courses")]
+        if module_name.endswith("direct_intent"):
+            mapping = {
+                "_normalize_for_intent": lambda query: str(query).lower(),
+                "_needs_direct_knowledge_search": lambda _query: False,
+            }
+            return mapping[attr_name]
+        raise AssertionError(f"Unexpected load: {module_name}.{attr_name}")
+
+    monkeypatch.setattr(module, "_load_attr", fake_load_attr)
+
+    tools, force_tools = module._collect_direct_tools(
+        "Wiii oi, nut Kham pha khoa hoc o dau?",
+        state={"routing_metadata": {"intent": "host_ui_navigation"}, "context": {}},
+    )
+
+    assert tools == []
+    assert force_tools is False
+
+
+def test_host_ui_route_scopes_to_host_action_tools(monkeypatch):
+    from app.engine.multi_agent import tool_collection as module
+
+    monkeypatch.setattr(module.settings, "enable_character_tools", False, raising=False)
+    monkeypatch.setattr(module.settings, "enable_lms_integration", True, raising=False)
+    monkeypatch.setattr(module.settings, "enable_host_actions", True, raising=False)
+    monkeypatch.setattr(module.settings, "enable_structured_visuals", True, raising=False)
+
+    host_tools = [
+        SimpleNamespace(name="host_action__ui_highlight"),
+        SimpleNamespace(name="host_action__ui_click"),
+    ]
+
+    def fake_load_attr(module_name: str, attr_name: str):
+        if module_name.endswith("utility_tools"):
+            return SimpleNamespace(name=attr_name)
+        if module_name.endswith("web_search_tools"):
+            return SimpleNamespace(name=attr_name)
+        if module_name.endswith("agent_tools") and attr_name == "RAG_KNOWLEDGE_TOOL":
+            return SimpleNamespace(name="tool_rag_knowledge")
+        if module_name.endswith("lms_tools") and attr_name == "get_all_lms_tools":
+            return lambda role="student": [SimpleNamespace(name="tool_lms_courses")]
+        if module_name.endswith("action_tools") and attr_name == "generate_host_action_tools":
+            return lambda *args, **kwargs: host_tools
+        if module_name.endswith("direct_intent"):
+            mapping = {
+                "_normalize_for_intent": lambda query: str(query).lower(),
+                "_needs_direct_knowledge_search": lambda _query: False,
+            }
+            return mapping[attr_name]
+        raise AssertionError(f"Unexpected load: {module_name}.{attr_name}")
+
+    monkeypatch.setattr(module, "_load_attr", fake_load_attr)
+
+    tools, force_tools = module._collect_direct_tools(
+        "Wiii oi, nut Kham pha khoa hoc o dau?",
+        state={
+            "routing_metadata": {"intent": "host_ui_navigation"},
+            "context": {},
+            "host_capabilities": {"tools": [{"name": "ui.highlight"}]},
+        },
+    )
+
+    assert [tool.name for tool in tools] == [
+        "host_action__ui_highlight",
+        "host_action__ui_click",
+    ]
+    assert force_tools is True


### PR DESCRIPTION
## Summary
- Fast-route obvious host UI guidance prompts (`Wiii ?i, n?t Kh?m ph? kh?a h?c ? ??u?`) before the structured supervisor LLM path.
- Scope `host_ui_navigation` direct turns to host action tools only, so LMS/RAG/visual generic tools do not steal simple Pointy requests.
- Add a provider-agnostic host UI first-token SLA and a bounded direct fallback so SSE V3 does not hang when the provider tail stalls.

## Evidence
- Before: local Docker smoke timed out around 45s and logs showed structured supervisor/model retries, with one route path around 179s before the direct answer.
- After: Docker smoke on `http://localhost:8000` passes; logs show `conservative_fast_path`, `intent=host_ui_navigation`, supervisor route in 1-4ms, and bounded completion around 25s when the provider tail exceeds the guard.

## Verification
- `python -m pytest tests/unit/test_supervisor_agent.py tests/unit/test_tool_collection_host_ui.py tests/unit/test_lane_timeout_policy_host_ui.py tests/unit/test_supervisor_routing.py tests/unit/test_runner_stream_latency.py tests/unit/test_graph_stream_runtime.py tests/unit/test_chat_stream_coordinator.py tests/unit/test_direct_node_provider_errors.py -q` -> 137 passed
- `python -m ruff check app/engine/multi_agent/supervisor_runtime_support.py app/engine/multi_agent/tool_collection.py app/engine/multi_agent/lane_timeout_policy.py app/engine/multi_agent/direct_node_runtime.py tests/unit/test_supervisor_agent.py tests/unit/test_tool_collection_host_ui.py tests/unit/test_lane_timeout_policy_host_ui.py tests/unit/test_direct_node_provider_errors.py --select=E9,F63,F7` -> All checks passed
- `git diff --check` -> pass
- `python scripts/local_demo_smoke.py --backend-url http://localhost:8000 --skip-frontend --provider nvidia --model deepseek-ai/deepseek-v4-flash --expect-provider nvidia --expect-model deepseek-ai/deepseek-v4-flash --message "Wiii ?i, n?t Kh?m ph? kh?a h?c ? ??u?" --stream-timeout 240 --stream-idle-timeout 90 --max-first-event-seconds 3 --max-stream-total-seconds 60` -> 9 passed, sync chat 25.0s, stream v3 chat 25.7s

## Risk / Rollback
- Risk: the heuristic could classify some UI-like wording as direct. Mitigation: it requires a UI action marker plus a UI surface/target marker, and unit tests keep ordinary learning course questions on the LLM route.
- Rollback: revert this PR; it is contained to routing/tool selection/timeout policy and tests.

Closes #204


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented host UI navigation route detection with specialized 8-second timeout policy.
  * Added fallback Vietnamese message handling for timeout scenarios.
  * Enhanced tool routing to scope operations to host-specific actions for navigation intents.

* **Tests**
  * Added comprehensive test coverage for host UI navigation timeout enforcement, timeout policies, routing decisions, and tool collection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->