### PR TITLE
fix(runtime): bound sync supervisor structured-route latency

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/lane_timeout_policy.py
+++ b/maritime-ai-service/app/engine/multi_agent/lane_timeout_policy.py
@@ -165,6 +165,31 @@ def resolve_direct_fallback_provider_allowlist_impl(
     return None
 
 
+def resolve_supervisor_route_timeout_seconds_impl(
+    *,
+    state: object | None,
+    settings_obj: object | None = None,
+) -> float:
+    """Bound the sync supervisor structured-route call.
+
+    Issue #206: sync `/api/v1/chat` exhibited 65.7s `supervisor.route` stalls
+    while the same prompt over SSE V3 routed in 2.6s. This bound caps the
+    structured-route LLM call and lets the existing `except Exception`
+    branch in `SupervisorAgent.route()` fall back to `_rule_based_route()`
+    safely instead of letting the demo/runtime budget exceed its bound.
+
+    Default: 10 seconds (≈ 4× SSE-observed routing latency).
+    Override via `settings.supervisor_route_sync_timeout_seconds` if it
+    exists; otherwise fall back to the constant default.
+    """
+    default_timeout = 10.0
+    if settings_obj is not None:
+        configured = getattr(settings_obj, "supervisor_route_sync_timeout_seconds", None)
+        if isinstance(configured, (int, float)) and configured > 0:
+            return float(configured)
+    return default_timeout
+
+
 def resolve_product_curation_timeout_impl(
     *,
     provider_name: str | None,

--- a/maritime-ai-service/app/engine/multi_agent/supervisor.py
+++ b/maritime-ai-service/app/engine/multi_agent/supervisor.py
@@ -264,9 +264,58 @@ class SupervisorAgent:
         rag_desc = domain_config.get("rag_description", "Tra cứu quy định, luật, thủ tục")
         tutor_desc = domain_config.get("tutor_description", "Giải thích, dạy học, quiz")
 
+        # Issue #206: bound the sync structured-route LLM call so a stalled
+        # provider does not blow the conversation budget. SSE V3 path observes
+        # ~2.6s for the same prompt; we cap sync at ~10s and fall back to
+        # `_rule_based_route()` if exceeded.
+        from app.engine.multi_agent.lane_timeout_policy import (
+            resolve_supervisor_route_timeout_seconds_impl,
+        )
+        from app.engine.multi_agent.runner import _record_runtime_timeline_entry
+
+        route_timeout_s = resolve_supervisor_route_timeout_seconds_impl(
+            state=state,
+            settings_obj=settings,
+        )
+
         try:
             # Sprint 103: Always use structured routing (no feature flag check)
-            return await self._route_structured(query, context, domain_name, rag_desc, tutor_desc, domain_config, state, llm=llm)
+            return await asyncio.wait_for(
+                self._route_structured(
+                    query, context, domain_name, rag_desc, tutor_desc,
+                    domain_config, state, llm=llm,
+                ),
+                timeout=route_timeout_s,
+            )
+
+        except asyncio.TimeoutError:
+            logger.warning(
+                "LLM routing exceeded %.1fs sync bound; falling back to rules",
+                route_timeout_s,
+            )
+            try:
+                _record_runtime_timeline_entry(
+                    state,
+                    {
+                        "stage": "supervisor.route_timeout",
+                        "elapsed_ms": int(route_timeout_s * 1000),
+                        "reason": "structured_route_sync_bound",
+                    },
+                )
+            except Exception:
+                pass  # timeline emit is best-effort, never blocks routing
+            result = self._rule_based_route(query, domain_config)
+            state["routing_metadata"] = {
+                "intent": "unknown",
+                "confidence": 1.0,
+                "reasoning": (
+                    f"rule-based fallback (sync route timeout > {route_timeout_s:.1f}s)"
+                ),
+                "method": "rule_based_timeout",
+                "final_agent": result,
+                "route_timeout_seconds": route_timeout_s,
+            }
+            return result
 
         except ProviderUnavailableError as e:
             logger.warning(

--- a/maritime-ai-service/tests/unit/test_supervisor_route_timeout.py
+++ b/maritime-ai-service/tests/unit/test_supervisor_route_timeout.py
@@ -1,0 +1,157 @@
+"""Issue #206: bounded sync supervisor route latency.
+
+Verifies:
+1. `resolve_supervisor_route_timeout_seconds_impl` returns sensible defaults
+   and honors a settings override.
+2. When `_route_structured` stalls past the bound, `route()` falls back to
+   `_rule_based_route()` with `method="rule_based_timeout"` and emits a
+   timeline entry so sync responses can still report routing latency.
+3. When `_route_structured` returns quickly, the bound is not engaged and
+   the structured route's decision passes through unchanged.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from app.engine.multi_agent.lane_timeout_policy import (
+    resolve_supervisor_route_timeout_seconds_impl,
+)
+from app.engine.multi_agent.supervisor import SupervisorAgent
+
+
+# ── policy resolver ──
+
+def test_route_timeout_default_is_ten_seconds():
+    assert resolve_supervisor_route_timeout_seconds_impl(
+        state={}, settings_obj=None
+    ) == 10.0
+
+
+def test_route_timeout_honors_positive_settings_override():
+    class FakeSettings:
+        supervisor_route_sync_timeout_seconds = 4.5
+
+    assert resolve_supervisor_route_timeout_seconds_impl(
+        state={}, settings_obj=FakeSettings()
+    ) == 4.5
+
+
+def test_route_timeout_ignores_non_positive_override():
+    class FakeSettings:
+        supervisor_route_sync_timeout_seconds = 0
+
+    assert resolve_supervisor_route_timeout_seconds_impl(
+        state={}, settings_obj=FakeSettings()
+    ) == 10.0
+
+
+def test_route_timeout_ignores_invalid_type_override():
+    class FakeSettings:
+        supervisor_route_sync_timeout_seconds = "fifteen"
+
+    assert resolve_supervisor_route_timeout_seconds_impl(
+        state={}, settings_obj=FakeSettings()
+    ) == 10.0
+
+
+# ── route() integration ──
+
+@pytest.fixture
+def supervisor_with_fast_llm():
+    sup = SupervisorAgent()
+    sup._llm = object()  # truthy stand-in; structured route is patched in tests
+    return sup
+
+
+@pytest.mark.asyncio
+async def test_route_falls_back_to_rule_based_when_structured_route_times_out(
+    supervisor_with_fast_llm,
+):
+    """Issue #206 core: stalled structured route → rule-based fallback."""
+    state: dict[str, Any] = {
+        "query": "Hi Wiii, trả lời thật ngắn để kiểm tra flow conversation local.",
+        "context": {},
+        "domain_config": {"domain_name": "AI"},
+    }
+
+    async def _stalled_route(*args, **kwargs):
+        await asyncio.sleep(30)  # well above the test timeout we patch in
+        return "rag_agent"
+
+    fast_path_target = (
+        "app.engine.multi_agent.supervisor.SupervisorAgent._conservative_fast_route"
+    )
+    structured_target = (
+        "app.engine.multi_agent.supervisor.SupervisorAgent._route_structured"
+    )
+    timeout_target = (
+        "app.engine.multi_agent.supervisor.resolve_supervisor_route_timeout_seconds_impl"
+    )
+
+    # NOTE: the timeout impl is imported lazily inside route(); patch the
+    # function at the module where it's resolved at call time.
+    with patch(fast_path_target, return_value=None), \
+         patch(structured_target, side_effect=_stalled_route), \
+         patch(
+             "app.engine.multi_agent.lane_timeout_policy.resolve_supervisor_route_timeout_seconds_impl",
+             return_value=0.05,
+         ):
+        chosen = await supervisor_with_fast_llm.route(state)
+
+    metadata = state.get("routing_metadata") or {}
+    assert metadata.get("method") == "rule_based_timeout"
+    assert metadata.get("final_agent") == chosen
+    assert "timeout" in metadata.get("reasoning", "").lower()
+
+    timeline_entries = (state.get("_runtime_latency") or {}).get("timeline", [])
+    assert any(
+        e.get("stage") == "supervisor.route_timeout" for e in timeline_entries
+    ), f"Expected supervisor.route_timeout in timeline, got {timeline_entries}"
+
+
+@pytest.mark.asyncio
+async def test_route_passes_through_when_structured_route_is_fast(
+    supervisor_with_fast_llm,
+):
+    """Sanity: bound does not engage on fast structured routes."""
+    state: dict[str, Any] = {
+        "query": "Cần hỗ trợ tra cứu quy định.",
+        "context": {},
+        "domain_config": {"domain_name": "AI"},
+    }
+
+    async def _fast_route(*args, **kwargs):
+        # Mark routing_metadata like the real impl would.
+        s = args[6] if len(args) > 6 else kwargs.get("state")
+        if isinstance(s, dict):
+            s["routing_metadata"] = {
+                "intent": "lookup",
+                "confidence": 0.92,
+                "reasoning": "structured route happy path",
+                "method": "structured",
+                "final_agent": "rag_agent",
+            }
+        return "rag_agent"
+
+    fast_path_target = (
+        "app.engine.multi_agent.supervisor.SupervisorAgent._conservative_fast_route"
+    )
+    structured_target = (
+        "app.engine.multi_agent.supervisor.SupervisorAgent._route_structured"
+    )
+
+    with patch(fast_path_target, return_value=None), \
+         patch(structured_target, side_effect=_fast_route):
+        chosen = await supervisor_with_fast_llm.route(state)
+
+    assert chosen == "rag_agent"
+    metadata = state.get("routing_metadata") or {}
+    assert metadata.get("method") == "structured"
+    timeline_entries = (state.get("_runtime_latency") or {}).get("timeline", [])
+    assert not any(
+        e.get("stage") == "supervisor.route_timeout" for e in timeline_entries
+    ), "Timeout entry should not appear on the fast path"


### PR DESCRIPTION
## Summary

Closes #206. Sync `/api/v1/chat` exhibited **65.7s** `supervisor.route` stalls while the same prompt over SSE V3 routed in **2.6s**. Cap the structured-route LLM call with `asyncio.wait_for` and let the existing fallback branch take rule-based routing instead of letting the demo/runtime budget exceed its bound.

This is **Week 0 task 2/2** of the Runtime Migration Epic [#207](https://github.com/meiiie/wiii/issues/207). Task 1/2 (PR #205) merged in `8d468da`. Together these stabilize the supervisor surface so Phase 0+ migrations have a clean test signal.

## What changes

- `lane_timeout_policy.py` — add `resolve_supervisor_route_timeout_seconds_impl` with default 10s (~4× SSE-observed routing latency) and optional `settings.supervisor_route_sync_timeout_seconds` override
- `supervisor.py: SupervisorAgent.route()` — wrap `_route_structured` with `asyncio.wait_for`. On `asyncio.TimeoutError`: fall back to `_rule_based_route()` with `method="rule_based_timeout"` + emit `supervisor.route_timeout` entry on `runtime_latency.timeline` (parity with SSE for the issue's "emit/propagate route timing on sync responses" ask)
- `tests/unit/test_supervisor_route_timeout.py` — 6 new specs

## Test plan

- [x] `pytest tests/unit/test_supervisor_route_timeout.py -q` → **6/6 pass**
- [x] `pytest tests/unit/test_supervisor*.py tests/unit/test_lane_timeout*.py tests/unit/test_runner_stream_latency.py tests/unit/test_chat_stream_coordinator.py -q` → **135/135 pass** (no regressions)
- [x] `ruff check app/engine/multi_agent/supervisor.py app/engine/multi_agent/lane_timeout_policy.py tests/unit/test_supervisor_route_timeout.py --select=E9,F63,F7` → clean

## Risk & rollback

Risk: **low**. Additive bound. Preserves LLM autonomy when the provider responds quickly (default 10s well above observed SSE latency of 2.6s). Existing `ProviderUnavailableError` and generic `Exception` fallback paths unchanged. Issue #206 explicitly scoped this fix **out of full LangChain removal**.

Rollback: revert this commit. The configurable `supervisor_route_sync_timeout_seconds` setting can also be raised at runtime (e.g. to 60.0) to effectively disable the bound while keeping the timeline emit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timeout protection for supervisor route calls with a configurable threshold (default: 10 seconds).
  * Implemented fallback to rule-based routing when structured route requests exceed the timeout limit.

* **Tests**
  * Added comprehensive test coverage for timeout behavior and configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->