### PR TITLE
chore(runtime): Phase 0 — drop drift langchain deps + scaffold runtime/

### DIFF
--- a/maritime-ai-service/app/core/config/_settings_base_fields.py
+++ b/maritime-ai-service/app/core/config/_settings_base_fields.py
@@ -638,6 +638,24 @@ class BaseSettingsFieldsMixin:
     # Unified LLM Client
     enable_unified_client: bool = Field(default=True, description="Enable UnifiedLLMClient (AsyncOpenAI SDK)")
 
+    # Runtime Migration Epic (#207) — feature gate for the lane-first /
+    # harness-split / native-message runtime built in Phases 0–7. Phase 0
+    # ships scaffold only; flipping this on becomes meaningful from
+    # Phase 4 onward. Kept default False so the existing path is canonical
+    # until per-org canary rollout in Phase 7.
+    enable_native_runtime: bool = Field(
+        default=False,
+        description="Enable lane-first native runtime (Runtime Migration Epic #207).",
+    )
+
+    # Issue #206 — bound sync supervisor structured-route call.
+    supervisor_route_sync_timeout_seconds: float = Field(
+        default=10.0,
+        ge=1.0,
+        le=120.0,
+        description="Bound (s) for sync SupervisorAgent._route_structured before falling back to rule-based routing.",
+    )
+
     # Google Gemini OpenAI-compatible endpoint URL
     google_openai_compat_url: str = Field(
         default="https://generativelanguage.googleapis.com/v1beta/openai/",

--- a/maritime-ai-service/app/core/feature_tiers.py
+++ b/maritime-ai-service/app/core/feature_tiers.py
@@ -156,6 +156,7 @@ FEATURE_TIER_GROUPS: Final[dict[FeatureTier, frozenset[str]]] = {
             "enable_rls",
             "enable_scheduler",
             "enable_scrapling",
+            "enable_native_runtime",
             "enable_skill_creation",
             "enable_skill_export",
             "enable_skill_metrics",

--- a/maritime-ai-service/app/engine/runtime/__init__.py
+++ b/maritime-ai-service/app/engine/runtime/__init__.py
@@ -1,0 +1,22 @@
+"""Wiii native runtime — replaces LangChain/LangGraph orchestration.
+
+Runtime Migration Epic (#207). Phase 0 lays the scaffold; Phase 1–7 fill in
+messages, tools, providers, lane-first routing, harness/session split, eval
+harness, and final cleanup.
+
+Module map (incremental):
+- ``lane.py``    — Phase 0 stub, full impl Phase 4 — execution lane enum
+- ``spec.py``    — Phase 0 stub, full impl Phase 4 — canonical model spec
+
+Patterns borrowed from public engineering writing as of May 2026:
+- Anthropic Managed Agents — harness/session/sandbox split
+- OpenAI Codex App Server — same harness drives every surface
+- Unsloth — lane-first architecture + canonical model config
+
+See ``.Codex/reports/RUNTIME-MIGRATION-EPIC-2026-05-02.md`` for the full
+plan and per-phase briefs.
+"""
+from .lane import ExecutionLane
+from .spec import RuntimeModelSpec
+
+__all__ = ["ExecutionLane", "RuntimeModelSpec"]

--- a/maritime-ai-service/app/engine/runtime/lane.py
+++ b/maritime-ai-service/app/engine/runtime/lane.py
@@ -1,0 +1,66 @@
+"""Execution lane enum — borrowed from Unsloth pattern.
+
+Resolved BEFORE provider selection. Routes do not need to know
+implementation detail; lane switching stays behind a stable interface.
+
+Phase 0: enum only (this file). Phase 4 will add the lane resolver
+that maps a ``TurnRequest`` + ``RuntimeIntent`` to one of these values.
+"""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ExecutionLane(str, Enum):
+    """Where a single turn actually executes.
+
+    Each lane has different capability guarantees (streaming shape, tool
+    support, structured-output reliability, vision support, latency
+    profile). The runtime picks one lane, then resolves the concrete
+    provider/model **inside** that lane — not the other way around.
+    """
+
+    CLOUD_NATIVE_SDK = "cloud_native_sdk"
+    """Direct provider SDK (``anthropic``, ``openai``, ``google-genai``).
+
+    Used when the turn needs provider-specific features (Anthropic
+    extended thinking, OpenAI Realtime audio, Gemini grounding) that
+    OpenAI-compatible HTTP cannot expose.
+    """
+
+    OPENAI_COMPATIBLE_HTTP = "openai_compatible_http"
+    """``AsyncOpenAI`` against any OpenAI-compatible endpoint.
+
+    Default lane for chat/completion calls. Backed by
+    ``UnifiedLLMClient``. Wiii's main path post-Phase-3.
+    """
+
+    LOCAL_WORKER = "local_worker"
+    """Local subprocess inference (Ollama, llama.cpp, sandboxed Python).
+
+    Borrowed from Unsloth's worker-isolation pattern: incompatible
+    dependency stacks (e.g. ``transformers`` major version conflicts)
+    live in dedicated processes so the API host stays light.
+    """
+
+    TOOL_ORCHESTRATED = "tool_orchestrated"
+    """Multi-step agent loop with tool calling.
+
+    Used when the turn requires the agentic ReAct loop (browser agent,
+    code studio, RAG with adaptive retrieval). Built on whichever cloud
+    or compatible lane the underlying tier resolves to.
+    """
+
+    EMBEDDING = "embedding"
+    """Embedding-only call (no chat completion).
+
+    Vector store insertion, query embedding, semantic similarity. Lower
+    latency budget; no tool dispatch overhead.
+    """
+
+    VISION_EXTRACTION = "vision_extraction"
+    """Image/PDF extraction with vision-capable model.
+
+    Different streaming shape and timeout profile than chat. Kept
+    separate so capability checks do not have to special-case it.
+    """

--- a/maritime-ai-service/app/engine/runtime/spec.py
+++ b/maritime-ai-service/app/engine/runtime/spec.py
@@ -1,0 +1,63 @@
+"""Canonical resolved runtime config.
+
+Resolves provider/model/endpoint/auth/capability AT ROUTE TIME, not
+request time. Borrowed from Unsloth ``ModelConfig`` pattern.
+
+Phase 0: minimal stub (this file). Phase 4 will:
+- Add capability detection from real metadata (chat templates, model
+  config) rather than static booleans
+- Add a resolver factory that builds ``RuntimeModelSpec`` from a
+  ``TurnRequest`` + ``RuntimeIntent`` + provider registry state
+- Wire the resolver into ``LLMPool`` so every dispatch path sees the
+  same canonical object
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeModelSpec:
+    """One authoritative object for a turn's resolved runtime contract.
+
+    Wiii's equivalent of Unsloth's ``ModelConfig``, but tuned for
+    cloud-provider routing instead of local-model loading.
+
+    All capability flags default to ``True`` for cloud chat models and
+    are narrowed by the resolver based on the lane and provider.
+    """
+
+    provider: str
+    """Provider key matching ``LLMPool`` registry, e.g. ``"google"``,
+    ``"openai"``, ``"ollama"``, ``"anthropic"``."""
+
+    model: str
+    """Concrete model name as the provider expects it,
+    e.g. ``"gemini-3.1-flash-lite-preview"``."""
+
+    endpoint: Optional[str] = None
+    """Override base URL for OpenAI-compatible endpoints. ``None`` means
+    the provider's official endpoint."""
+
+    tier: str = "moderate"
+    """One of ``"deep"``, ``"moderate"``, ``"light"``. Drives
+    ``LLMPool`` failover semantics."""
+
+    supports_streaming: bool = True
+    supports_tools: bool = True
+    supports_structured_output: bool = True
+    supports_vision: bool = False
+    supports_reasoning: bool = False
+    """``reasoning`` here means the model exposes a separate thinking
+    channel (Claude extended thinking, OpenAI o-series). Distinct from
+    chain-of-thought in the user-visible response."""
+
+    context_window: int = 0
+    """Effective context window in tokens. ``0`` = unknown (Phase 4
+    will populate from a model catalog)."""
+
+    timeout_profile: Optional[str] = None
+    """Optional timeout profile name (e.g.
+    ``TIMEOUT_PROFILE_STRUCTURED``) consumed by lane resolvers when
+    bounding LLM calls."""

--- a/maritime-ai-service/pyproject.toml
+++ b/maritime-ai-service/pyproject.toml
@@ -28,12 +28,11 @@ dependencies = [
     "sqlalchemy>=2.0.25",
     "asyncpg>=0.29.0",
     "alembic>=1.13.0",
-    "langchain>=1.2.11",
+    # langchain (meta), -openai, -google-genai, -ollama removed in Runtime
+    # Migration Phase 0 (drift fix, 2026-05-02) — 0 imports in app/.
+    # langchain-core kept until Phase 1–4 (messages → tools → providers).
     "langchain-core>=1.2.18",
     # langgraph REMOVED (De-LangGraphing Phase 3) — replaced by WiiiRunner
-    "langchain-openai>=0.0.5",
-    "langchain-google-genai>=4.2.1",
-    "langchain-ollama>=0.3.0,<2.0.0",
     "google-genai>=1.66.0,<2.0.0",
     "opensandbox>=0.1.5,<0.2.0",
     "opensandbox-code-interpreter>=0.1.1,<0.2.0",

--- a/maritime-ai-service/tests/unit/engine/runtime/test_scaffold.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_scaffold.py
@@ -1,0 +1,80 @@
+"""Phase 0 scaffold smoke tests — Runtime Migration Epic #207.
+
+These tests just lock in the public surface introduced by Phase 0. They
+deliberately stay shallow: full lane-resolver + capability-detection
+coverage lands in Phase 4.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ── ExecutionLane enum ──
+
+def test_execution_lane_has_six_canonical_values():
+    from app.engine.runtime import ExecutionLane
+
+    expected = {
+        "cloud_native_sdk",
+        "openai_compatible_http",
+        "local_worker",
+        "tool_orchestrated",
+        "embedding",
+        "vision_extraction",
+    }
+    assert {lane.value for lane in ExecutionLane} == expected
+
+
+def test_execution_lane_is_string_enum():
+    from app.engine.runtime import ExecutionLane
+
+    assert ExecutionLane.OPENAI_COMPATIBLE_HTTP == "openai_compatible_http"
+    assert isinstance(ExecutionLane.CLOUD_NATIVE_SDK.value, str)
+
+
+# ── RuntimeModelSpec dataclass ──
+
+def test_runtime_model_spec_has_sensible_defaults():
+    from app.engine.runtime import RuntimeModelSpec
+
+    spec = RuntimeModelSpec(provider="google", model="gemini-3.1-flash-lite-preview")
+    assert spec.provider == "google"
+    assert spec.tier == "moderate"
+    assert spec.supports_streaming is True
+    assert spec.supports_tools is True
+    assert spec.supports_vision is False
+    assert spec.supports_reasoning is False
+
+
+def test_runtime_model_spec_is_frozen():
+    from app.engine.runtime import RuntimeModelSpec
+    from dataclasses import FrozenInstanceError
+
+    spec = RuntimeModelSpec(provider="openai", model="gpt-4o-mini")
+    with pytest.raises(FrozenInstanceError):
+        spec.provider = "anthropic"  # type: ignore[misc]
+
+
+def test_runtime_model_spec_uses_slots():
+    """Slots prevent typo-driven attribute leaks at runtime."""
+    from app.engine.runtime import RuntimeModelSpec
+
+    spec = RuntimeModelSpec(provider="ollama", model="qwen3:8b")
+    with pytest.raises((AttributeError, TypeError)):
+        spec.provicer = "typo"  # type: ignore[attr-defined]
+
+
+# ── Feature flag ──
+
+def test_enable_native_runtime_flag_defaults_off():
+    from app.core.config import settings
+
+    assert settings.enable_native_runtime is False, (
+        "Phase 0 ships scaffold only; flag must remain off until Phase 4+."
+    )
+
+
+def test_supervisor_route_timeout_setting_default():
+    from app.core.config import settings
+
+    assert settings.supervisor_route_sync_timeout_seconds == 10.0


### PR DESCRIPTION
## Summary

Runtime Migration Epic [#207](https://github.com/meiiie/wiii/issues/207), **Phase 0** (Week 1). Mechanical drift cleanup + scaffold for the lane-first / harness-split runtime that Phase 1–7 will build on. **No behaviour change** — scaffold is unwired; new flag `enable_native_runtime` defaults `False`.

## What changes

- **`pyproject.toml`** — drop 4 unused `langchain-*` deps:
  - `langchain` (meta), `langchain-openai`, `langchain-google-genai`, `langchain-ollama` — **0 imports under `app/`**
  - Brief said 3; audit found 4 (the meta-package was also drift)
  - Kept `langchain-core` for Phase 1–4 to remove progressively (39 + 30 + 12 imports)
- **`app/engine/runtime/{__init__,lane,spec}.py`** — Phase 0 scaffold:
  - `ExecutionLane` str-enum (6 values, Unsloth pattern)
  - `RuntimeModelSpec` frozen-slots dataclass (canonical model config, Phase 4 will plug in capability detection)
- **`app/core/config/_settings_base_fields.py`**:
  - `enable_native_runtime: bool = False` — Epic gate, off until per-org canary Phase 7
  - `supervisor_route_sync_timeout_seconds: float = 10.0` (1.0–120.0) — wires PR #208 bound into pydantic-settings instead of hard-coded constant
- **`tests/unit/engine/runtime/test_scaffold.py`** — 7 shallow specs locking the public surface

## Out of scope (Phase 1+)

- Two manual integration scripts (`tests/integration/test_manual_react.py`, `test_semantic_memory_direct.py`) still reference `langchain_google_genai` — wrapped in try/except + `sys.exit`, out of unit-CI scope. Phase 3 will migrate them to `UnifiedLLMClient`.
- No imports in `app/` are touched (Phase 1 starts that).

## Risk & rollback

Risk: **low**. Drift removal (4 deps with 0 active imports) + purely-additive scaffold. Existing runtime path unchanged.

Rollback: revert this commit. The 4 langchain deps re-pin trivially; new `app/engine/runtime/` folder is unreferenced by other modules.

## Verification (targeted per AGENTS.md "smallest meaningful set" — CI runs full)

- `pip install -e maritime-ai-service/` → succeeds, no langchain extras leftover
- `pytest tests/unit/engine/runtime/ tests/unit/test_supervisor_route_timeout.py -q` → **13/13 pass** in 2.3s
- `pytest tests/unit/ --collect-only -q` → **12045 tests collected, 0 import errors** (catches indirect breakage from dep removal without running the full ~15min suite)
- `ruff check app/engine/runtime/ app/core/config/_settings_base_fields.py tests/unit/engine/runtime/ --select=E9,F63,F7` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)