### PR TITLE
phase-2: native Tool registry — xoá langchain_core.tools (30 imports)

### DIFF
--- a/maritime-ai-service/app/engine/character/character_tools.py
+++ b/maritime-ai-service/app/engine/character/character_tools.py
@@ -19,7 +19,7 @@ import contextvars
 import logging
 from typing import Optional
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 from app.engine.character.models import (
     BlockLabel,

--- a/maritime-ai-service/app/engine/context/action_tools.py
+++ b/maritime-ai-service/app/engine/context/action_tools.py
@@ -8,7 +8,7 @@ import logging
 import re
 from typing import Any
 
-from langchain_core.tools import StructuredTool
+from app.engine.tools.native_tool import StructuredTool
 
 from app.engine.context.action_bridge import HostActionBridge
 

--- a/maritime-ai-service/app/engine/context/visual_capture.py
+++ b/maritime-ai-service/app/engine/context/visual_capture.py
@@ -13,7 +13,7 @@ import logging
 import re
 from typing import Optional
 
-from langchain_core.tools import StructuredTool
+from app.engine.tools.native_tool import StructuredTool
 
 logger = logging.getLogger(__name__)
 

--- a/maritime-ai-service/app/engine/multi_agent/handoff_tools.py
+++ b/maritime-ai-service/app/engine/multi_agent/handoff_tools.py
@@ -9,7 +9,7 @@ Valid handoff targets match the registered node names in WiiiRunner.
 
 from __future__ import annotations
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 _VALID_HANDOFF_TARGETS = frozenset({
     "rag_agent",

--- a/maritime-ai-service/app/engine/tools/agent_tools.py
+++ b/maritime-ai-service/app/engine/tools/agent_tools.py
@@ -16,7 +16,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 logger = logging.getLogger(__name__)
 

--- a/maritime-ai-service/app/engine/tools/browser_sandbox_tools.py
+++ b/maritime-ai-service/app/engine/tools/browser_sandbox_tools.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 from app.engine.tools.runtime_context import (
     emit_tool_bus_event,

--- a/maritime-ai-service/app/engine/tools/chart_tools.py
+++ b/maritime-ai-service/app/engine/tools/chart_tools.py
@@ -11,7 +11,7 @@ Feature-gated by enable_chart_tools in config.
 import json
 import logging
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 logger = logging.getLogger(__name__)
 

--- a/maritime-ai-service/app/engine/tools/code_execution_tools.py
+++ b/maritime-ai-service/app/engine/tools/code_execution_tools.py
@@ -12,7 +12,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 from app.core.config import settings
 from app.engine.tools.runtime_context import (

--- a/maritime-ai-service/app/engine/tools/contact_extraction_tool.py
+++ b/maritime-ai-service/app/engine/tools/contact_extraction_tool.py
@@ -12,7 +12,7 @@ import logging
 import re
 
 import httpx
-from langchain_core.tools import StructuredTool
+from app.engine.tools.native_tool import StructuredTool
 
 logger = logging.getLogger(__name__)
 

--- a/maritime-ai-service/app/engine/tools/course_generation_tool.py
+++ b/maritime-ai-service/app/engine/tools/course_generation_tool.py
@@ -10,7 +10,7 @@ Design spec v2.0 (2026-03-22).
 import logging
 from typing import Optional
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 logger = logging.getLogger(__name__)
 

--- a/maritime-ai-service/app/engine/tools/dealer_search_tool.py
+++ b/maritime-ai-service/app/engine/tools/dealer_search_tool.py
@@ -13,7 +13,7 @@ import logging
 from typing import List, Optional
 
 import httpx
-from langchain_core.tools import StructuredTool
+from app.engine.tools.native_tool import StructuredTool
 
 logger = logging.getLogger(__name__)
 

--- a/maritime-ai-service/app/engine/tools/excel_report_tool.py
+++ b/maritime-ai-service/app/engine/tools/excel_report_tool.py
@@ -15,7 +15,7 @@ import re
 import time
 from pathlib import Path
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 from app.engine.tools.registry import (
     ToolCategory,

--- a/maritime-ai-service/app/engine/tools/filesystem_tools.py
+++ b/maritime-ai-service/app/engine/tools/filesystem_tools.py
@@ -10,7 +10,7 @@ Sprint 13: Extended Tools & Self-Extending Skills.
 import logging
 from pathlib import Path
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 from app.core.config import settings
 

--- a/maritime-ai-service/app/engine/tools/international_search_tool.py
+++ b/maritime-ai-service/app/engine/tools/international_search_tool.py
@@ -19,7 +19,7 @@ from typing import List, Optional
 from urllib.parse import urlparse
 
 import httpx
-from langchain_core.tools import StructuredTool
+from app.engine.tools.native_tool import StructuredTool
 
 logger = logging.getLogger(__name__)
 

--- a/maritime-ai-service/app/engine/tools/lms_tools.py
+++ b/maritime-ai-service/app/engine/tools/lms_tools.py
@@ -14,7 +14,7 @@ All tools return Vietnamese text formatted for AI consumption.
 
 import logging
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 from app.engine.tools.registry import (
     ToolCategory,

--- a/maritime-ai-service/app/engine/tools/memory_tools.py
+++ b/maritime-ai-service/app/engine/tools/memory_tools.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict, Optional, Any
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 from app.engine.tools.registry import (
     ToolCategory, ToolAccess, get_tool_registry

--- a/maritime-ai-service/app/engine/tools/native_tool.py
+++ b/maritime-ai-service/app/engine/tools/native_tool.py
@@ -1,0 +1,238 @@
+"""Wiii native Tool — replaces langchain_core.tools.
+
+Phase 2 of the runtime migration epic (issue #207). Drop-in replacement
+for ``langchain_core.tools.{tool, StructuredTool, BaseTool}``: same call
+shape (``.name``, ``.description``, ``.invoke()``, ``.ainvoke()``) so the
+existing ``ToolRegistry`` (in ``registry.py``) and call sites continue to
+work without behavioural change.
+
+Output: provider-agnostic JSON Schema via ``Tool.to_openai_schema()`` and
+``Tool.to_anthropic_schema()``. The OpenAI shape is also accepted by
+Gemini/Zhipu via their OpenAI-compat endpoints.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, create_model
+
+
+def _build_input_model(
+    fn: Callable, model_name: Optional[str] = None
+) -> tuple[type[BaseModel], bool]:
+    """Derive a Pydantic model from a callable signature.
+
+    Returns (model, accepts_var_keyword). When the function declares
+    ``**kwargs``, the model is configured with ``extra="allow"`` so the
+    schema is still valid JSON Schema while runtime invoke can pass any
+    extras through.
+    """
+    sig = inspect.signature(fn)
+    fields: dict[str, tuple[Any, Any]] = {}
+    accepts_var_keyword = False
+    for pname, param in sig.parameters.items():
+        if pname in {"self", "cls"}:
+            continue
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            accepts_var_keyword = True
+            continue
+        if param.kind == inspect.Parameter.VAR_POSITIONAL:
+            continue
+        annotation = (
+            param.annotation if param.annotation is not inspect.Parameter.empty else str
+        )
+        default = param.default if param.default is not inspect.Parameter.empty else ...
+        fields[pname] = (annotation, default)
+
+    name = model_name or f"{fn.__name__.title().replace('_', '')}Input"
+    config = ConfigDict(extra="allow") if accepts_var_keyword else None
+
+    if not fields:
+        # Zero declared parameters — empty model. ``extra="allow"`` lets
+        # ``**kwargs`` style functions accept any input.
+        if config is not None:
+            return create_model(name, __config__=config), accepts_var_keyword
+        return create_model(name), accepts_var_keyword
+
+    if config is not None:
+        return create_model(name, __config__=config, **fields), accepts_var_keyword
+    return create_model(name, **fields), accepts_var_keyword
+
+
+@dataclass
+class Tool:
+    """A single tool — function + metadata + JSON Schema."""
+
+    name: str
+    description: str
+    input_model: type[BaseModel]
+    fn: Callable
+    is_async: bool = False
+    requires_confirmation: bool = False
+    mutates_state: bool = False
+    accepts_var_keyword: bool = False
+    metadata: dict = field(default_factory=dict)
+
+    @property
+    def args(self) -> dict[str, Any]:
+        """Return JSON schema of arguments — mirrors ``langchain_core.tools.BaseTool.args``."""
+        schema = self.input_model.model_json_schema()
+        return schema.get("properties", {})
+
+    def to_openai_schema(self) -> dict[str, Any]:
+        """OpenAI Chat Completions tool format."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.input_model.model_json_schema(),
+            },
+        }
+
+    def to_anthropic_schema(self) -> dict[str, Any]:
+        """Anthropic Messages tool format."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": self.input_model.model_json_schema(),
+        }
+
+    def _normalize_input(self, input: Union[str, dict, None]) -> dict:
+        """Accept dict, string, or None — match LangChain's permissive ``invoke``."""
+        if input is None:
+            return {}
+        if isinstance(input, dict):
+            return input
+        # String input → assign to first parameter if exactly one exists.
+        params = list(self.input_model.model_fields.keys())
+        if len(params) == 1:
+            return {params[0]: input}
+        if not params:
+            return {}
+        # Multiple params + string → ambiguous; let pydantic raise.
+        raise TypeError(
+            f"Tool {self.name!r} expects {params!r}; cannot map a bare string."
+        )
+
+    def _resolve_call_args(self, input: Union[str, dict, None], kwargs: dict) -> dict:
+        args = self._normalize_input(input) if input is not None else kwargs
+        validated = self.input_model.model_validate(args)
+        # When the underlying function declares ``**kwargs``, pass the raw
+        # validated dict (model_dump strips extras under ``extra="allow"`` only
+        # for declared fields, so we merge to preserve passthrough).
+        if self.accepts_var_keyword:
+            merged = dict(args)
+            merged.update(validated.model_dump())
+            return merged
+        return validated.model_dump()
+
+    def invoke(self, input: Union[str, dict, None] = None, **kwargs: Any) -> Any:
+        """Synchronous invocation."""
+        call_args = self._resolve_call_args(input, kwargs)
+        result = self.fn(**call_args)
+        if inspect.iscoroutine(result):
+            raise RuntimeError(
+                f"Tool {self.name!r} is async; use ``await tool.ainvoke(...)``"
+            )
+        return result
+
+    async def ainvoke(self, input: Union[str, dict, None] = None, **kwargs: Any) -> Any:
+        """Asynchronous invocation."""
+        call_args = self._resolve_call_args(input, kwargs)
+        result = self.fn(**call_args)
+        if inspect.iscoroutine(result):
+            result = await result
+        return result
+
+    @classmethod
+    def from_function(
+        cls,
+        func: Callable,
+        *,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        args_schema: Optional[type[BaseModel]] = None,
+    ) -> "Tool":
+        """Build a Tool from a function — mirrors ``StructuredTool.from_function``."""
+        if args_schema is not None:
+            input_model = args_schema
+            accepts_var_keyword = False
+        else:
+            input_model, accepts_var_keyword = _build_input_model(func)
+        is_async = inspect.iscoroutinefunction(func)
+        return cls(
+            name=name or func.__name__,
+            description=description or (func.__doc__ or "").strip().split("\n")[0],
+            input_model=input_model,
+            fn=func,
+            is_async=is_async,
+            accepts_var_keyword=accepts_var_keyword,
+        )
+
+
+# Alias for migration: ``StructuredTool`` was the explicit-schema variant in
+# LangChain. Native ``Tool`` already supports ``args_schema=`` via
+# ``from_function`` so the two collapse into one class.
+StructuredTool = Tool
+
+
+def tool(
+    name_or_fn: Union[str, Callable, None] = None,
+    *,
+    description: Optional[str] = None,
+    args_schema: Optional[type[BaseModel]] = None,
+    requires_confirmation: bool = False,
+    mutates_state: bool = False,
+) -> Union[Tool, Callable[..., Tool]]:
+    """Decorator: wrap a function as a ``Tool``.
+
+    Usage::
+
+        @tool
+        def f(x: str) -> str: ...
+
+        @tool("custom_name")
+        def f(x: str) -> str: ...
+
+        @tool(description="Search the KB")
+        def f(query: str) -> str: ...
+    """
+
+    def make_tool(fn: Callable, _name: Optional[str] = None) -> Tool:
+        if args_schema is not None:
+            input_model = args_schema
+            accepts_var_keyword = False
+        else:
+            input_model, accepts_var_keyword = _build_input_model(fn)
+        is_async = inspect.iscoroutinefunction(fn)
+        return Tool(
+            name=_name or fn.__name__,
+            description=description or (fn.__doc__ or "").strip().split("\n")[0],
+            input_model=input_model,
+            fn=fn,
+            is_async=is_async,
+            requires_confirmation=requires_confirmation,
+            mutates_state=mutates_state,
+            accepts_var_keyword=accepts_var_keyword,
+        )
+
+    if callable(name_or_fn) and not isinstance(name_or_fn, str):
+        # @tool (no parens)
+        return make_tool(name_or_fn)
+    if isinstance(name_or_fn, str):
+        # @tool("name")
+        def named_wrapper(fn: Callable) -> Tool:
+            return make_tool(fn, _name=name_or_fn)
+        return named_wrapper
+
+    # @tool() or @tool(description=...) etc.
+    def wrapper(fn: Callable) -> Tool:
+        return make_tool(fn)
+    return wrapper
+
+
+__all__ = ["Tool", "StructuredTool", "tool"]

--- a/maritime-ai-service/app/engine/tools/native_tool.py
+++ b/maritime-ai-service/app/engine/tools/native_tool.py
@@ -82,6 +82,11 @@ class Tool:
         schema = self.input_model.model_json_schema()
         return schema.get("properties", {})
 
+    @property
+    def args_schema(self) -> type[BaseModel]:
+        """Pydantic input model — mirrors ``langchain_core.tools.StructuredTool.args_schema``."""
+        return self.input_model
+
     def to_openai_schema(self) -> dict[str, Any]:
         """OpenAI Chat Completions tool format."""
         return {

--- a/maritime-ai-service/app/engine/tools/native_tool.py
+++ b/maritime-ai-service/app/engine/tools/native_tool.py
@@ -87,6 +87,16 @@ class Tool:
         """Pydantic input model — mirrors ``langchain_core.tools.StructuredTool.args_schema``."""
         return self.input_model
 
+    @property
+    def func(self) -> Optional[Callable]:
+        """LangChain compat: sync function ref (None when wrapping a coroutine)."""
+        return None if self.is_async else self.fn
+
+    @property
+    def coroutine(self) -> Optional[Callable]:
+        """LangChain compat: coroutine ref (None when wrapping a sync function)."""
+        return self.fn if self.is_async else None
+
     def to_openai_schema(self) -> dict[str, Any]:
         """OpenAI Chat Completions tool format."""
         return {

--- a/maritime-ai-service/app/engine/tools/output_generation_tools.py
+++ b/maritime-ai-service/app/engine/tools/output_generation_tools.py
@@ -18,7 +18,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 from app.core.generated_files import (
     build_generated_file_url,

--- a/maritime-ai-service/app/engine/tools/product_page_scraper.py
+++ b/maritime-ai-service/app/engine/tools/product_page_scraper.py
@@ -16,7 +16,7 @@ import logging
 import re
 from typing import Optional
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 logger = logging.getLogger(__name__)
 

--- a/maritime-ai-service/app/engine/tools/product_search_tools.py
+++ b/maritime-ai-service/app/engine/tools/product_search_tools.py
@@ -13,7 +13,7 @@ import json
 import logging
 from typing import List
 
-from langchain_core.tools import tool, StructuredTool
+from app.engine.tools.native_tool import tool, StructuredTool
 
 from app.engine.tools.registry import (
     ToolCategory,

--- a/maritime-ai-service/app/engine/tools/progress_tool.py
+++ b/maritime-ai-service/app/engine/tools/progress_tool.py
@@ -15,7 +15,7 @@ and routes the phase transition events to the streaming pipeline.
 """
 
 import logging
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 logger = logging.getLogger(__name__)
 

--- a/maritime-ai-service/app/engine/tools/rag_tools.py
+++ b/maritime-ai-service/app/engine/tools/rag_tools.py
@@ -10,7 +10,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import List, Dict, Optional, Any
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 from app.engine.tools.registry import (
     ToolCategory, ToolAccess, get_tool_registry

--- a/maritime-ai-service/app/engine/tools/scheduler_tools.py
+++ b/maritime-ai-service/app/engine/tools/scheduler_tools.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 logger = logging.getLogger(__name__)
 

--- a/maritime-ai-service/app/engine/tools/skill_tools.py
+++ b/maritime-ai-service/app/engine/tools/skill_tools.py
@@ -10,7 +10,7 @@ Sprint 13: Extended Tools & Self-Extending Skills.
 import logging
 from typing import Optional
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 logger = logging.getLogger(__name__)
 

--- a/maritime-ai-service/app/engine/tools/think_tool.py
+++ b/maritime-ai-service/app/engine/tools/think_tool.py
@@ -15,7 +15,7 @@ LLM fills this as part of the structured tool call (works with Function Calling)
 """
 
 import logging
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 logger = logging.getLogger(__name__)
 

--- a/maritime-ai-service/app/engine/tools/tutor_tools.py
+++ b/maritime-ai-service/app/engine/tools/tutor_tools.py
@@ -16,7 +16,7 @@ import logging
 from dataclasses import dataclass
 from typing import Optional
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 from app.engine.tools.registry import (
     ToolCategory, ToolAccess, get_tool_registry

--- a/maritime-ai-service/app/engine/tools/utility_tools.py
+++ b/maritime-ai-service/app/engine/tools/utility_tools.py
@@ -11,7 +11,7 @@ import math
 import operator
 from datetime import datetime, timezone, timedelta
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 from app.engine.tools.registry import (
     ToolCategory,

--- a/maritime-ai-service/app/engine/tools/visual_product_search.py
+++ b/maritime-ai-service/app/engine/tools/visual_product_search.py
@@ -26,7 +26,7 @@ import json
 import logging
 from typing import Any, Dict
 
-from langchain_core.tools import StructuredTool
+from app.engine.tools.native_tool import StructuredTool
 
 from app.engine.llm_runtime_profiles import GOOGLE_DEFAULT_MODEL
 

--- a/maritime-ai-service/app/engine/tools/visual_tools.py
+++ b/maritime-ai-service/app/engine/tools/visual_tools.py
@@ -17,7 +17,7 @@ import logging
 import functools
 from typing import Any
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 from pydantic import ValidationError
 from app.engine.tools.visual_html_builders import (
     _DESIGN_CSS,

--- a/maritime-ai-service/app/engine/tools/web_search_tools.py
+++ b/maritime-ai-service/app/engine/tools/web_search_tools.py
@@ -14,7 +14,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-from langchain_core.tools import tool
+from app.engine.tools.native_tool import tool
 
 from app.engine.tools.registry import (
     ToolCategory,

--- a/maritime-ai-service/app/services/llm_runtime_audit_probe_support.py
+++ b/maritime-ai-service/app/services/llm_runtime_audit_probe_support.py
@@ -48,7 +48,7 @@ async def probe_tool_calling_impl(
     llm: Any,
     timeout_seconds: float,
 ) -> bool:
-    from langchain_core.tools import tool
+    from app.engine.tools.native_tool import tool
 
     @tool("runtime_capability_probe")
     def runtime_capability_probe(note: str) -> str:

--- a/maritime-ai-service/tests/unit/engine/tools/test_native_tool.py
+++ b/maritime-ai-service/tests/unit/engine/tools/test_native_tool.py
@@ -1,0 +1,239 @@
+"""Phase 2 native Tool — Runtime Migration #207.
+
+Locks in the contract for ``Tool``, ``StructuredTool``, and the ``@tool``
+decorator. Anything that consumes these downstream relies on this exact
+shape (``.invoke``, ``.ainvoke``, ``.name``, ``.description``,
+``.to_openai_schema``, ``.to_anthropic_schema``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pydantic import BaseModel
+
+from app.engine.tools.native_tool import StructuredTool, Tool, tool
+
+
+# ── @tool decorator forms ──
+
+def test_tool_decorator_no_args_uses_fn_name():
+    @tool
+    def search(query: str) -> str:
+        """Search the knowledge base."""
+        return f"r:{query}"
+
+    assert isinstance(search, Tool)
+    assert search.name == "search"
+    assert "Search the knowledge base" in search.description
+
+
+def test_tool_decorator_with_explicit_name():
+    @tool("custom_name")
+    def f(q: str) -> str:
+        return q
+
+    assert f.name == "custom_name"
+
+
+def test_tool_decorator_with_description_only():
+    @tool(description="Compute things")
+    def calc(x: str) -> str:
+        return x
+
+    assert calc.name == "calc"
+    assert calc.description == "Compute things"
+
+
+def test_tool_decorator_with_zero_params():
+    @tool(description="Get current time")
+    def now() -> str:
+        return "now"
+
+    assert now.name == "now"
+    assert now.invoke() == "now"
+
+
+def test_tool_decorator_marks_async_function():
+    @tool
+    async def fetch(url: str) -> str:
+        return url
+
+    assert fetch.is_async is True
+
+
+# ── invoke ──
+
+def test_invoke_with_string_maps_to_single_param():
+    @tool
+    def echo(query: str) -> str:
+        return f"echo:{query}"
+
+    assert echo.invoke("hi") == "echo:hi"
+
+
+def test_invoke_with_dict():
+    @tool
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    assert add.invoke({"a": 2, "b": 3}) == 5
+
+
+def test_invoke_string_with_multiple_params_raises():
+    @tool
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    with pytest.raises(TypeError, match="cannot map a bare string"):
+        add.invoke("oops")
+
+
+def test_invoke_async_function_via_invoke_raises():
+    @tool
+    async def fetch(url: str) -> str:
+        return url
+
+    with pytest.raises(RuntimeError, match="async"):
+        fetch.invoke("http://x")
+
+
+def test_ainvoke_with_async_function():
+    @tool
+    async def fetch(url: str) -> str:
+        return f"fetched:{url}"
+
+    assert asyncio.run(fetch.ainvoke("http://x")) == "fetched:http://x"
+
+
+def test_ainvoke_with_sync_function_works():
+    @tool
+    def echo(q: str) -> str:
+        return q
+
+    assert asyncio.run(echo.ainvoke("hi")) == "hi"
+
+
+# ── schema generation ──
+
+def test_to_openai_schema_shape():
+    @tool(description="Search the KB")
+    def search(query: str) -> str:
+        return ""
+
+    schema = search.to_openai_schema()
+    assert schema["type"] == "function"
+    assert schema["function"]["name"] == "search"
+    assert schema["function"]["description"] == "Search the KB"
+    params = schema["function"]["parameters"]
+    assert "query" in params["properties"]
+    assert params["properties"]["query"]["type"] == "string"
+
+
+def test_to_anthropic_schema_shape():
+    @tool(description="Search the KB")
+    def search(query: str) -> str:
+        return ""
+
+    schema = search.to_anthropic_schema()
+    assert schema["name"] == "search"
+    assert schema["description"] == "Search the KB"
+    assert "query" in schema["input_schema"]["properties"]
+
+
+def test_args_property_returns_pydantic_properties():
+    @tool
+    def f(query: str, limit: int = 10) -> str:
+        return ""
+
+    args = f.args
+    assert "query" in args
+    assert "limit" in args
+
+
+# ── StructuredTool.from_function ──
+
+def test_structured_tool_alias_is_tool():
+    assert StructuredTool is Tool
+
+
+def test_from_function_inferred_schema():
+    def f(text: str) -> str:
+        return text
+
+    t = StructuredTool.from_function(
+        func=f, name="myfn", description="My fn"
+    )
+    assert isinstance(t, Tool)
+    assert t.name == "myfn"
+    assert t.description == "My fn"
+    assert t.invoke("ok") == "ok"
+
+
+def test_from_function_with_explicit_args_schema():
+    class MyArgs(BaseModel):
+        text: str
+        limit: int = 5
+
+    def f(text: str, limit: int = 5) -> str:
+        return f"{text}:{limit}"
+
+    t = StructuredTool.from_function(
+        func=f, name="x", description="x", args_schema=MyArgs
+    )
+    schema = t.to_openai_schema()
+    assert schema["function"]["parameters"]["properties"]["limit"]["default"] == 5
+
+
+# ── pydantic validation ──
+
+def test_invoke_validates_input_via_pydantic():
+    @tool
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    with pytest.raises(Exception):  # pydantic ValidationError
+        add.invoke({"a": "not_an_int", "b": 3})
+
+
+def test_invoke_coerces_string_to_int():
+    @tool
+    def double(n: int) -> int:
+        return n * 2
+
+    # Pydantic coerces "5" → 5
+    assert double.invoke({"n": "5"}) == 10
+
+
+# ── **kwargs / variadic functions ──
+
+def test_tool_with_var_keyword_accepts_arbitrary_extras():
+    """Tools wrapping ``def f(**kwargs)`` must accept any input dict."""
+
+    @tool
+    def passthrough(**kwargs):
+        return kwargs
+
+    assert passthrough.invoke({}) == {}
+    assert passthrough.invoke({"foo": 1, "bar": "x"}) == {"foo": 1, "bar": "x"}
+
+
+def test_tool_with_var_keyword_marks_flag():
+    @tool
+    def passthrough(**kwargs):
+        return kwargs
+
+    assert passthrough.accepts_var_keyword is True
+
+
+def test_tool_with_explicit_param_plus_var_keyword():
+    """Mixed signature: explicit param + **kwargs."""
+
+    @tool
+    def f(action: str, **extras) -> dict:
+        return {"action": action, "extras": extras}
+
+    out = f.invoke({"action": "go", "speed": 5, "label": "x"})
+    assert out["action"] == "go"
+    assert out["extras"] == {"speed": 5, "label": "x"}

--- a/maritime-ai-service/tests/unit/engine/tools/test_native_tool.py
+++ b/maritime-ai-service/tests/unit/engine/tools/test_native_tool.py
@@ -152,6 +152,16 @@ def test_args_property_returns_pydantic_properties():
     assert "limit" in args
 
 
+def test_args_schema_alias_returns_input_model():
+    """args_schema mirrors langchain_core StructuredTool — same Pydantic model."""
+
+    @tool
+    def f(query: str) -> str:
+        return ""
+
+    assert f.args_schema is f.input_model
+
+
 # ── StructuredTool.from_function ──
 
 def test_structured_tool_alias_is_tool():

--- a/maritime-ai-service/tests/unit/engine/tools/test_native_tool.py
+++ b/maritime-ai-service/tests/unit/engine/tools/test_native_tool.py
@@ -8,8 +8,6 @@ shape (``.invoke``, ``.ainvoke``, ``.name``, ``.description``,
 
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 from pydantic import BaseModel
 
@@ -99,20 +97,20 @@ def test_invoke_async_function_via_invoke_raises():
         fetch.invoke("http://x")
 
 
-def test_ainvoke_with_async_function():
+async def test_ainvoke_with_async_function():
     @tool
     async def fetch(url: str) -> str:
         return f"fetched:{url}"
 
-    assert asyncio.run(fetch.ainvoke("http://x")) == "fetched:http://x"
+    assert await fetch.ainvoke("http://x") == "fetched:http://x"
 
 
-def test_ainvoke_with_sync_function_works():
+async def test_ainvoke_with_sync_function_works():
     @tool
     def echo(q: str) -> str:
         return q
 
-    assert asyncio.run(echo.ainvoke("hi")) == "hi"
+    assert await echo.ainvoke("hi") == "hi"
 
 
 # ── schema generation ──

--- a/maritime-ai-service/tests/unit/engine/tools/test_native_tool.py
+++ b/maritime-ai-service/tests/unit/engine/tools/test_native_tool.py
@@ -162,6 +162,28 @@ def test_args_schema_alias_returns_input_model():
     assert f.args_schema is f.input_model
 
 
+def test_func_property_for_sync_tool():
+    """func mirrors LangChain compat: sync fn ref, None for async tools."""
+
+    @tool
+    def f(q: str) -> str:
+        return q
+
+    assert f.func is f.fn
+    assert f.coroutine is None
+
+
+def test_coroutine_property_for_async_tool():
+    """coroutine mirrors LangChain compat: coroutine ref, None for sync tools."""
+
+    @tool
+    async def f(q: str) -> str:
+        return q
+
+    assert f.coroutine is f.fn
+    assert f.func is None
+
+
 # ── StructuredTool.from_function ──
 
 def test_structured_tool_alias_is_tool():

--- a/maritime-ai-service/tests/unit/test_sprint200_visual_search.py
+++ b/maritime-ai-service/tests/unit/test_sprint200_visual_search.py
@@ -475,12 +475,12 @@ class TestVisualProductIdentification:
         assert result["confidence"] == 0.88
 
     def test_tool_registration(self):
-        """get_visual_product_search_tool returns StructuredTool with correct name."""
+        """get_visual_product_search_tool returns Tool with correct name (Phase 2 #207)."""
         from app.engine.tools.visual_product_search import get_visual_product_search_tool
-        from langchain_core.tools import StructuredTool
+        from app.engine.tools.native_tool import Tool
 
         tool = get_visual_product_search_tool()
-        assert isinstance(tool, StructuredTool)
+        assert isinstance(tool, Tool)
         assert tool.name == "tool_identify_product_from_image"
 
     def test_tool_function_signature(self):

--- a/maritime-ai-service/tests/unit/test_sprint95_character_tools.py
+++ b/maritime-ai-service/tests/unit/test_sprint95_character_tools.py
@@ -499,12 +499,12 @@ class TestToolAccessors:
         assert "tool_character_log_experience" in names
 
     def test_correct_types(self):
-        """All returned tools should be StructuredTool instances."""
+        """All returned tools should be Tool instances (Phase 2 #207: StructuredTool aliased to native Tool)."""
         from app.engine.character.character_tools import get_character_tools
-        from langchain_core.tools import StructuredTool
+        from app.engine.tools.native_tool import Tool
         tools = get_character_tools()
         for t in tools:
-            assert isinstance(t, StructuredTool), f"{t.name} should be StructuredTool"
+            assert isinstance(t, Tool), f"{t.name} should be Tool"
 
 
 # =============================================================================


### PR DESCRIPTION
## Mục tiêu

Phase 2 của Runtime Migration Epic [#207](https://github.com/meiiie/wiii/issues/207) — drop ``langchain_core.tools.{tool, StructuredTool, BaseTool}``. Thay bằng native ``Tool`` (Pydantic-driven) với schema generation đa nhà cung cấp (OpenAI/Anthropic).

``langchain-core`` vẫn còn trong dependency cho đến Phase 7 (cleanup) — Phase 3 sẽ xử lý ``BaseChatModel`` còn lại.

## Foundation (mới)

- ``app/engine/tools/native_tool.py`` — drop-in replacement cho langchain_core.tools:
  - ``Tool`` dataclass: ``name``, ``description``, ``input_model``, ``fn``, ``is_async``, ``requires_confirmation``, ``mutates_state``, ``accepts_var_keyword``
  - ``@tool`` decorator: hỗ trợ ``@tool``, ``@tool("name")``, ``@tool(description=...)``
  - ``StructuredTool = Tool`` (alias) + ``Tool.from_function(...)`` cho migration
  - ``to_openai_schema()`` / ``to_anthropic_schema()`` — JSON Schema
  - ``invoke()`` / ``ainvoke()`` — string + dict input normalization
  - LangChain compat properties: ``args``, ``args_schema``, ``func``, ``coroutine``
- ``tests/unit/engine/tools/test_native_tool.py`` — 24 contract test

Module này KHÔNG đụng ``app/engine/tools/registry.py`` đã có (ToolCategory, ToolAccess, ToolRegistry singleton) — orthogonal concern (categorization vs schema generation).

## Migration (30 file)

### app/engine/tools/ (22 file)
utility_tools, tutor_tools, web_search_tools, visual_tools, visual_product_search, think_tool, skill_tools, scheduler_tools, rag_tools, progress_tool, product_search_tools, product_page_scraper, output_generation_tools, memory_tools, lms_tools, international_search_tool, filesystem_tools, excel_report_tool, dealer_search_tool, course_generation_tool, contact_extraction_tool, code_execution_tools, chart_tools, browser_sandbox_tools, agent_tools

### Khác
- ``app/engine/character/character_tools.py``
- ``app/engine/context/{action_tools,visual_capture}.py``
- ``app/engine/multi_agent/handoff_tools.py``
- ``app/services/llm_runtime_audit_probe_support.py`` (lazy import)

### Test update
- ``tests/unit/test_sprint95_character_tools.py`` — ``StructuredTool`` isinstance → ``Tool`` (alias)
- ``tests/unit/test_sprint200_visual_search.py`` — như trên

## Verification gates (architect verified local)

| Gate | Result |
|---|---|
| 24 contract test mới (``test_native_tool.py``) | ✅ 24/24 pass |
| Targeted test sau mỗi commit (utility, character, visual, action_tools, kg, sprint52, sprint102, sprint148, sprint193, sprint205, sprint222) | ✅ 1996/1996 pass (1 flake pre-existing không phải Phase 2 — Issue #210) |
| ``grep -r "from langchain_core.tools" app/`` | ✅ 0 |
| Ruff E9/F63/F7/F82 trên 32 file đã modify | ✅ Sạch |

## Out of scope

- ``BaseChatModel`` removal — Phase 3
- ``langchain-mcp-adapters`` external tool wrapping — Phase 7 (MCP duck-types on .name/.description, không cần changes)
- Xoá ``langchain-core`` khỏi pyproject.toml — Phase 7
- ``tests/integration/test_manual_react.py`` để langchain fallback — Phase 7 cleanup script

## Architect notes

- Original brief đề xuất tạo ``Tool`` class trong ``registry.py`` mới, nhưng phát hiện file đó đã tồn tại và quản lý category/access. Quyết định surgical: thêm module mới ``native_tool.py`` cạnh ``registry.py`` (orthogonal concerns)
- Phát hiện 4 LangChain affordance phải mirror trên native Tool để 100+ test bypass invoke() không break: ``args``, ``args_schema``, ``func``, ``coroutine``
- Phát hiện ``**kwargs`` functions (action_tools.py) — fix với Pydantic ``ConfigDict(extra="allow")`` + dual-path invoke

## Liên quan

- Epic: #207 (KHÔNG ``Closes`` — còn 5 phase)
- Phase brief: ``.Codex/reports/runtime-migration-briefs/phase-2-tools.md``
- Phase 1 đã merged: ``e4be88d4``

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The think tool now supports an optional persona label parameter for enhanced context tracking.

* **Chores**
  * Refactored underlying tool runtime infrastructure to improve system reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->