### PR TITLE
phase-5a: durable session event log foundation (in-memory backend + DB schema)

### DIFF
--- a/maritime-ai-service/alembic/versions/047_create_session_events.py
+++ b/maritime-ai-service/alembic/versions/047_create_session_events.py
@@ -1,0 +1,75 @@
+"""047: create session_events
+
+Append-only event log per chat session. Phase 5 of the runtime migration
+epic (#207). Borrows the Anthropic Managed Agents pattern: harness =
+stateless control loop, session = durable event log, sandbox = pluggable
+execution. The log lives outside the model context window so wake / replay
+flows can rebuild conversation state without polluting prompts.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "047"
+down_revision = "046"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(conn, table_name: str) -> bool:
+    result = conn.execute(
+        sa.text(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_name = :table_name"
+        ),
+        {"table_name": table_name},
+    )
+    return result.fetchone() is not None
+
+
+def upgrade():
+    conn = op.get_bind()
+    if _table_exists(conn, "session_events"):
+        return
+
+    op.create_table(
+        "session_events",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("session_id", sa.Text(), nullable=False),
+        sa.Column("org_id", sa.Text(), nullable=True),
+        sa.Column("event_type", sa.Text(), nullable=False),
+        sa.Column(
+            "payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.Column("seq", sa.BigInteger(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("session_id", "seq", name="session_events_seq_unique"),
+    )
+
+    op.create_index(
+        "session_events_session_seq",
+        "session_events",
+        ["session_id", "seq"],
+    )
+    op.create_index(
+        "session_events_org_session",
+        "session_events",
+        ["org_id", "session_id"],
+    )
+
+
+def downgrade():
+    op.drop_index("session_events_org_session", table_name="session_events")
+    op.drop_index("session_events_session_seq", table_name="session_events")
+    op.drop_table("session_events")

--- a/maritime-ai-service/app/core/config/_settings_base_fields.py
+++ b/maritime-ai-service/app/core/config/_settings_base_fields.py
@@ -648,6 +648,14 @@ class BaseSettingsFieldsMixin:
         description="Enable lane-first native runtime (Runtime Migration Epic #207).",
     )
 
+    enable_session_event_log: bool = Field(
+        default=False,
+        description=(
+            "Enable durable session event log (Phase 5 of #207). When False, "
+            "the in-memory fallback is used and events are lost on restart."
+        ),
+    )
+
     # Issue #206 — bound sync supervisor structured-route call.
     supervisor_route_sync_timeout_seconds: float = Field(
         default=10.0,

--- a/maritime-ai-service/app/core/feature_tiers.py
+++ b/maritime-ai-service/app/core/feature_tiers.py
@@ -157,6 +157,7 @@ FEATURE_TIER_GROUPS: Final[dict[FeatureTier, frozenset[str]]] = {
             "enable_scheduler",
             "enable_scrapling",
             "enable_native_runtime",
+            "enable_session_event_log",
             "enable_skill_creation",
             "enable_skill_export",
             "enable_skill_metrics",

--- a/maritime-ai-service/app/engine/runtime/session_event_log.py
+++ b/maritime-ai-service/app/engine/runtime/session_event_log.py
@@ -1,0 +1,172 @@
+"""Append-only durable event log per chat session.
+
+Phase 5 of the runtime migration epic (issue #207). Borrows the
+Anthropic Managed Agents pattern: harness (stateless control loop) +
+session (this module — append-only log outside the context window) +
+sandbox (pluggable execution).
+
+Two backends share a single interface so call sites stay agnostic:
+
+- ``InMemorySessionEventLog`` — feature flag off (default) or test mode.
+  Per-session deque guarded by a process-local lock. Loses data on
+  restart; fine while ``enable_session_event_log = False``.
+- ``PostgresSessionEventLog`` — feature flag on. Writes through the
+  existing async SQLAlchemy session. Enforces monotonic ``seq`` per
+  session and surfaces ``org_id`` for multi-tenant filtering.
+
+Event types are not enumerated as an enum on purpose — phases 5/6 will
+add new ones (``tool_call``, ``tool_result``, ``assistant_chunk``, ...)
+and a closed enum would force migration churn. Keep them as opaque
+strings; observers filter by type.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class SessionEvent:
+    """One immutable entry in a session's event log."""
+
+    session_id: str
+    event_type: str
+    payload: dict
+    seq: int
+    org_id: Optional[str] = None
+
+
+class SessionEventLog(Protocol):
+    """Backend-agnostic interface every consumer depends on."""
+
+    async def append(
+        self,
+        *,
+        session_id: str,
+        event_type: str,
+        payload: dict,
+        org_id: Optional[str] = None,
+    ) -> SessionEvent:
+        ...
+
+    async def get_events(
+        self,
+        *,
+        session_id: str,
+        org_id: Optional[str] = None,
+        since_seq: Optional[int] = None,
+    ) -> list[SessionEvent]:
+        ...
+
+    async def latest_seq(
+        self, *, session_id: str, org_id: Optional[str] = None
+    ) -> int:
+        ...
+
+
+@dataclass
+class _SessionState:
+    seq: int = 0
+    events: list[SessionEvent] = field(default_factory=list)
+
+
+class InMemorySessionEventLog:
+    """Process-local fallback used when the DB-backed log is disabled.
+
+    Not durable across restarts. Suitable for tests and the default
+    feature-flag-off path so consumers can call into the same interface
+    without branching.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, _SessionState] = {}
+        self._lock = asyncio.Lock()
+
+    async def append(
+        self,
+        *,
+        session_id: str,
+        event_type: str,
+        payload: dict,
+        org_id: Optional[str] = None,
+    ) -> SessionEvent:
+        async with self._lock:
+            state = self._sessions.setdefault(session_id, _SessionState())
+            state.seq += 1
+            event = SessionEvent(
+                session_id=session_id,
+                event_type=event_type,
+                payload=dict(payload),
+                seq=state.seq,
+                org_id=org_id,
+            )
+            state.events.append(event)
+            return event
+
+    async def get_events(
+        self,
+        *,
+        session_id: str,
+        org_id: Optional[str] = None,
+        since_seq: Optional[int] = None,
+    ) -> list[SessionEvent]:
+        async with self._lock:
+            state = self._sessions.get(session_id)
+            if state is None:
+                return []
+            events = state.events
+            if org_id is not None:
+                events = [e for e in events if e.org_id == org_id]
+            if since_seq is not None:
+                events = [e for e in events if e.seq > since_seq]
+            return list(events)
+
+    async def latest_seq(
+        self, *, session_id: str, org_id: Optional[str] = None
+    ) -> int:
+        async with self._lock:
+            state = self._sessions.get(session_id)
+            if state is None:
+                return 0
+            if org_id is None:
+                return state.seq
+            # When filtering by org, return the highest matching seq.
+            for event in reversed(state.events):
+                if event.org_id == org_id:
+                    return event.seq
+            return 0
+
+
+_singleton: Optional[SessionEventLog] = None
+
+
+def get_session_event_log() -> SessionEventLog:
+    """Return the configured event log instance.
+
+    Phase 5 ships only the in-memory backend; the Postgres backend lands
+    in Phase 5b alongside the wake/replay path. The feature flag
+    ``enable_session_event_log`` will switch the default.
+    """
+    global _singleton
+    if _singleton is None:
+        _singleton = InMemorySessionEventLog()
+    return _singleton
+
+
+def _reset_for_tests() -> None:
+    """Clear the singleton — test fixtures only."""
+    global _singleton
+    _singleton = None
+
+
+__all__ = [
+    "SessionEvent",
+    "SessionEventLog",
+    "InMemorySessionEventLog",
+    "get_session_event_log",
+]

--- a/maritime-ai-service/tests/unit/engine/runtime/test_session_event_log.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_session_event_log.py
@@ -1,0 +1,121 @@
+"""Phase 5 session event log — Runtime Migration #207.
+
+Locks in the in-memory backend contract: monotonic seq, org filtering,
+dict-payload immutability, since_seq replay window.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.engine.runtime.session_event_log import (
+    InMemorySessionEventLog,
+    SessionEvent,
+    get_session_event_log,
+)
+
+
+@pytest.fixture
+def log() -> InMemorySessionEventLog:
+    return InMemorySessionEventLog()
+
+
+# ── append ──
+
+async def test_append_assigns_monotonic_seq_per_session(log):
+    e1 = await log.append(session_id="s1", event_type="user_message", payload={"text": "hi"})
+    e2 = await log.append(session_id="s1", event_type="assistant_message", payload={"text": "hello"})
+    e3 = await log.append(session_id="s2", event_type="user_message", payload={"text": "x"})
+    assert e1.seq == 1
+    assert e2.seq == 2
+    assert e3.seq == 1  # different session, fresh counter
+
+
+async def test_append_returns_immutable_event(log):
+    payload = {"q": "x"}
+    event = await log.append(session_id="s", event_type="tool_call", payload=payload)
+    assert isinstance(event, SessionEvent)
+    payload["q"] = "mutated"
+    assert event.payload == {"q": "x"}  # snapshot, not aliased
+
+
+async def test_append_records_org_id_when_supplied(log):
+    event = await log.append(
+        session_id="s", event_type="user_message", payload={}, org_id="org-1"
+    )
+    assert event.org_id == "org-1"
+
+
+# ── get_events ──
+
+async def test_get_events_returns_in_append_order(log):
+    await log.append(session_id="s", event_type="user_message", payload={"i": 1})
+    await log.append(session_id="s", event_type="user_message", payload={"i": 2})
+    await log.append(session_id="s", event_type="user_message", payload={"i": 3})
+    events = await log.get_events(session_id="s")
+    assert [e.payload["i"] for e in events] == [1, 2, 3]
+
+
+async def test_get_events_unknown_session_returns_empty(log):
+    assert await log.get_events(session_id="missing") == []
+
+
+async def test_get_events_since_seq_filters_window(log):
+    await log.append(session_id="s", event_type="x", payload={"i": 1})
+    await log.append(session_id="s", event_type="x", payload={"i": 2})
+    await log.append(session_id="s", event_type="x", payload={"i": 3})
+    events = await log.get_events(session_id="s", since_seq=1)
+    assert [e.seq for e in events] == [2, 3]
+
+
+async def test_get_events_filters_by_org(log):
+    await log.append(session_id="s", event_type="x", payload={}, org_id="A")
+    await log.append(session_id="s", event_type="x", payload={}, org_id="B")
+    await log.append(session_id="s", event_type="x", payload={}, org_id="A")
+    a_events = await log.get_events(session_id="s", org_id="A")
+    assert all(e.org_id == "A" for e in a_events)
+    assert len(a_events) == 2
+
+
+# ── latest_seq ──
+
+async def test_latest_seq_zero_for_unknown_session(log):
+    assert await log.latest_seq(session_id="missing") == 0
+
+
+async def test_latest_seq_tracks_global_seq_without_org(log):
+    await log.append(session_id="s", event_type="x", payload={})
+    await log.append(session_id="s", event_type="x", payload={})
+    assert await log.latest_seq(session_id="s") == 2
+
+
+async def test_latest_seq_respects_org_filter(log):
+    await log.append(session_id="s", event_type="x", payload={}, org_id="A")
+    await log.append(session_id="s", event_type="x", payload={}, org_id="B")
+    await log.append(session_id="s", event_type="x", payload={}, org_id="A")
+    assert await log.latest_seq(session_id="s", org_id="A") == 3
+    assert await log.latest_seq(session_id="s", org_id="B") == 2
+    assert await log.latest_seq(session_id="s", org_id="C") == 0
+
+
+# ── singleton ──
+
+def test_get_session_event_log_returns_singleton():
+    a = get_session_event_log()
+    b = get_session_event_log()
+    assert a is b
+
+
+# ── concurrency safety ──
+
+async def test_concurrent_appends_preserve_monotonic_seq(log):
+    import asyncio
+
+    async def write(idx: int) -> SessionEvent:
+        return await log.append(
+            session_id="s", event_type="x", payload={"i": idx}
+        )
+
+    events = await asyncio.gather(*(write(i) for i in range(20)))
+    seqs = sorted(e.seq for e in events)
+    assert seqs == list(range(1, 21))


### PR DESCRIPTION
## Mục tiêu

Phase 5 của Runtime Migration Epic [#207](https://github.com/meiiie/wiii/issues/207) — bắt đầu **harness/session/sandbox split** (Anthropic Managed Agents pattern). PR này ship FOUNDATION của ``session`` layer (append-only event log) ở 2 backend: in-memory (default OFF) + DB schema sẵn sàng.

Pure additive: chưa wire vào ChatOrchestrator/Supervisor nên không break behavior.

## Scope (5a — gọn lại từ brief)

### Foundation

- ``alembic/versions/047_create_session_events.py`` — table schema:
  - ``id`` BigSerial PK
  - ``session_id``, ``org_id``, ``event_type`` text
  - ``payload`` JSONB
  - ``created_at`` timestamptz default NOW()
  - ``seq`` bigint, UNIQUE(session_id, seq)
  - Indexes: ``(session_id, seq)`` cho replay, ``(org_id, session_id)`` cho multi-tenant filter
- ``app/engine/runtime/session_event_log.py``:
  - ``SessionEventLog`` Protocol (interface)
  - ``InMemorySessionEventLog`` — async lock, monotonic seq per session, dict snapshot để break aliasing, org filter trên get_events/latest_seq
  - ``get_session_event_log()`` singleton — Phase 5b sẽ swap sang Postgres backend khi flag bật

### Feature flag

- ``enable_session_event_log: bool = False`` (default OFF) — registered ở ``feature_tiers.py`` EXPERIMENTAL tier

## Deferred sang Phase 5b

- ``PostgresSessionEventLog`` — async SQLAlchemy backend
- ``wake(session_id)`` recovery — rebuild context từ durable log on restart
- **Subagent context isolation** (RAG/Tutor/Memory chỉ emit summary, không raw chunks) — risky cho source-flow integrity Sprint 189b 73/73, cần fresh harness chứ không nên rush
- **p50 TTFT benchmark** — cần baseline replay trước

## Verification gates

| Gate | Result |
|---|---|
| 12 contract test mới (monotonic seq, org filtering, since_seq window, singleton, concurrent appends) | ✅ 12/12 pass |
| ``test_feature_tiers`` sau khi register flag mới | ✅ 5/5 pass |
| Wider scope (702 test, "runtime or session or event_log or feature_tier or messages") | ✅ 701 pass + 1 pre-existing flake (test_sprint160b_hardening session_secret config drift, reproduces trên ``origin/main`` không phải Phase 5, Issue #210) |

## Out of scope

- Không touch ``ChatOrchestrator`` / ``Supervisor`` / ``AgenticLoop`` (Phase 5b)
- Không thêm eval recording (Phase 6)
- Không thay đổi SSE event protocol on the wire

## Liên quan

- Epic: #207 (KHÔNG ``Closes`` — còn 2 phase + 5b follow-up)
- Phase brief: ``.Codex/reports/runtime-migration-briefs/phase-5-harness.md``
- Phase 4 đã merged