### PR TITLE
phase-6a: eval recorder foundation — JSONL snapshot + summary script

### DIFF
--- a/maritime-ai-service/app/core/config/_settings_base_fields.py
+++ b/maritime-ai-service/app/core/config/_settings_base_fields.py
@@ -656,6 +656,19 @@ class BaseSettingsFieldsMixin:
         ),
     )
 
+    enable_eval_recording: bool = Field(
+        default=False,
+        description=(
+            "Record per-turn EvalRecord JSONL for nightly replay (Phase 6 of #207). "
+            "Default OFF; opt-in per environment to avoid storage costs."
+        ),
+    )
+
+    eval_recording_dir: str = Field(
+        default="eval_recordings",
+        description="Base directory for JSONL eval records when enable_eval_recording=True.",
+    )
+
     # Issue #206 — bound sync supervisor structured-route call.
     supervisor_route_sync_timeout_seconds: float = Field(
         default=10.0,

--- a/maritime-ai-service/app/core/feature_tiers.py
+++ b/maritime-ai-service/app/core/feature_tiers.py
@@ -156,6 +156,7 @@ FEATURE_TIER_GROUPS: Final[dict[FeatureTier, frozenset[str]]] = {
             "enable_rls",
             "enable_scheduler",
             "enable_scrapling",
+            "enable_eval_recording",
             "enable_native_runtime",
             "enable_session_event_log",
             "enable_skill_creation",

--- a/maritime-ai-service/app/engine/runtime/eval_recorder.py
+++ b/maritime-ai-service/app/engine/runtime/eval_recorder.py
@@ -1,0 +1,214 @@
+"""Eval recorder — production-runtime-as-eval-substrate.
+
+Phase 6 of the runtime migration epic (issue #207). The deliberate
+philosophy here, borrowed from Anthropic's
+``demystifying-evals-for-ai-agents``: the **same code path** that serves
+production traffic also writes the records consumed by the regression
+suite. There is no separate "eval system" — there is one runtime, with
+recording optionally turned on.
+
+This module ships only the snapshot format and the JSONL writer. Wiring
+into ``ChatOrchestrator.process(record=True)`` and the replay script
+land in follow-up PRs once the on-disk shape is locked in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+_SAFE_SEGMENT = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _safe_segment(value: Optional[str], default: str) -> str:
+    """Sanitise a path segment so eval recordings can't escape ``base_dir``.
+
+    Maps unknown / empty values to ``default`` and replaces every
+    non-``[A-Za-z0-9._-]`` character with ``_``. Anchors path traversal
+    attempts (``..``) to a literal underscore.
+    """
+    cleaned = _SAFE_SEGMENT.sub("_", value or "")
+    cleaned = cleaned.strip("._-")
+    return cleaned or default
+
+
+class EvalRecord(BaseModel):
+    """One turn snapshot — the durable unit of eval replay.
+
+    Fields are intentionally flat so JSONL diffing stays trivial. Caller
+    fills only what is observable; everything else has a sane default.
+    """
+
+    record_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    """Unique ID for this turn snapshot."""
+
+    session_id: str
+    """Session this turn belongs to. Must match SessionEventLog.session_id."""
+
+    org_id: Optional[str] = None
+    """Multi-tenant org scope; ``None`` for personal workspace."""
+
+    timestamp: str = Field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    """ISO-8601 UTC. Used as the partition key for storage."""
+
+    request: dict
+    """Serialized ``TurnRequest`` (or arbitrary call args)."""
+
+    retrieved_docs: list[dict] = Field(default_factory=list)
+    """RAG retrieval — list of ``{doc_id, score, snippet}`` (best-effort)."""
+
+    tool_calls: list[dict] = Field(default_factory=list)
+    """Each entry: ``{name, args, result}``. Order matches model output."""
+
+    response: str = ""
+    """Final assistant text shown to the user."""
+
+    sources: list[dict] = Field(default_factory=list)
+    """Citations: ``{id, page, bbox, content_type, ...}``."""
+
+    metadata: dict = Field(default_factory=dict)
+    """Provider, model, latency_ms, token counts, host action emissions."""
+
+    replay_seed: Optional[str] = None
+    """Optional deterministic seed so future replay can reproduce stochastic
+    sampling. ``None`` = non-deterministic (default)."""
+
+
+class EvalRecorder:
+    """Append-only JSONL writer with date + org partitioning.
+
+    Storage layout::
+
+        {base_dir}/{org_id}/{YYYY-MM-DD}/{session_id}.jsonl
+
+    Concurrency: a single asyncio.Lock guards the directory tree to keep
+    the JSONL append atomic from the recorder's point of view. The file
+    handle is opened in append mode per-write so multiple recorders
+    against the same file do not need to coordinate further (the kernel
+    serialises ``write()`` of a single line up to ``PIPE_BUF`` bytes;
+    eval lines are far smaller than that limit).
+
+    Sandbox: ``record_id`` and dynamic path segments (``org_id`` /
+    ``session_id``) are sanitised so a hostile input cannot write outside
+    ``base_dir``.
+    """
+
+    def __init__(self, base_dir: Path):
+        self.base_dir = Path(base_dir)
+        self._lock = asyncio.Lock()
+
+    def _path_for(self, record: EvalRecord) -> Path:
+        org = _safe_segment(record.org_id, default="_personal")
+        day = _safe_segment(record.timestamp[:10], default="unknown-date")
+        session = _safe_segment(record.session_id, default="_unknown")
+        return self.base_dir / org / day / f"{session}.jsonl"
+
+    async def write(self, record: EvalRecord) -> Path:
+        """Append a single record to its partition file. Returns the path written."""
+        path = self._path_for(record)
+        async with self._lock:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            line = record.model_dump_json() + "\n"
+            # ``newline=""`` keeps the literal "\n" byte on Windows so JSONL
+            # tools downstream see a UNIX-style line-terminated stream.
+            with path.open("a", encoding="utf-8", newline="") as f:
+                f.write(line)
+        return path
+
+    async def read_session(
+        self, *, session_id: str, org_id: Optional[str] = None, day: str
+    ) -> list[EvalRecord]:
+        """Read every record for a single session on a given day partition.
+
+        ``day`` is the ``YYYY-MM-DD`` partition; callers normally derive
+        it from ``record.timestamp[:10]``.
+        """
+        org = _safe_segment(org_id, default="_personal")
+        day = _safe_segment(day, default="unknown-date")
+        session = _safe_segment(session_id, default="_unknown")
+        path = self.base_dir / org / day / f"{session}.jsonl"
+        if not path.exists():
+            return []
+        records: list[EvalRecord] = []
+        async with self._lock:
+            with path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        records.append(EvalRecord.model_validate_json(line))
+                    except Exception as exc:  # noqa: BLE001 — log + skip
+                        logger.warning(
+                            "[EvalRecorder] skipped malformed record: %s", exc
+                        )
+        return records
+
+    async def list_sessions(
+        self, *, org_id: Optional[str] = None, day: str
+    ) -> list[str]:
+        """List session IDs that have recordings on a given day."""
+        org = _safe_segment(org_id, default="_personal")
+        day = _safe_segment(day, default="unknown-date")
+        partition = self.base_dir / org / day
+        if not partition.exists():
+            return []
+        return sorted(p.stem for p in partition.glob("*.jsonl"))
+
+
+def diff_records(original: EvalRecord, replayed: dict[str, Any]) -> dict[str, Any]:
+    """Compute simple regression metrics between an original record and a replay.
+
+    Pure helper — no LLM judging. Higher = more similar.
+    """
+    orig_text = (original.response or "").strip()
+    new_text = str(replayed.get("response", "")).strip()
+
+    orig_tokens = set(orig_text.lower().split())
+    new_tokens = set(new_text.lower().split())
+    if orig_tokens or new_tokens:
+        token_jaccard = len(orig_tokens & new_tokens) / max(
+            1, len(orig_tokens | new_tokens)
+        )
+    else:
+        token_jaccard = 1.0
+
+    orig_tools = [(c.get("name"), c.get("args")) for c in original.tool_calls]
+    new_tools = [
+        (c.get("name"), c.get("args")) for c in (replayed.get("tool_calls") or [])
+    ]
+
+    orig_source_ids = {s.get("id") for s in original.sources if s.get("id")}
+    new_source_ids = {
+        s.get("id") for s in (replayed.get("sources") or []) if s.get("id")
+    }
+    if orig_source_ids:
+        sources_overlap = len(orig_source_ids & new_source_ids) / len(orig_source_ids)
+    else:
+        sources_overlap = 1.0
+
+    return {
+        "token_jaccard": token_jaccard,
+        "tool_calls_match": orig_tools == new_tools,
+        "sources_overlap": sources_overlap,
+        "latency_delta_ms": (
+            replayed.get("latency_ms", 0)
+            - original.metadata.get("latency_ms", 0)
+        ),
+    }
+
+
+__all__ = ["EvalRecord", "EvalRecorder", "diff_records"]

--- a/maritime-ai-service/scripts/eval_summary.py
+++ b/maritime-ai-service/scripts/eval_summary.py
@@ -1,0 +1,168 @@
+"""Eval recordings summary — operational tool, not a test runner.
+
+Reads the JSONL files written by ``EvalRecorder`` for a given day +
+optional org and prints aggregate stats so an operator can spot-check
+recording health without spinning up the chat stack.
+
+Full replay (re-running ``ChatOrchestrator.process`` against each
+record + diffing the response) lands once Phase 6's
+``record=True`` integration ships. This script is the read side of the
+contract.
+
+Usage::
+
+    python scripts/eval_summary.py --day 2026-05-03
+    python scripts/eval_summary.py --day 2026-05-03 --org org-1
+    python scripts/eval_summary.py --base-dir /var/wiii/eval --day 2026-05-03 --as-json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import statistics
+import sys
+from pathlib import Path
+
+# Make ``app.*`` importable when this script runs from the repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.engine.runtime.eval_recorder import EvalRecorder  # noqa: E402
+
+
+async def _summarise(base_dir: Path, day: str, org: str | None) -> dict:
+    recorder = EvalRecorder(base_dir=base_dir)
+    sessions = await recorder.list_sessions(org_id=org, day=day)
+
+    total_records = 0
+    response_lengths: list[int] = []
+    latencies: list[float] = []
+    tool_call_count = 0
+    sources_count = 0
+
+    per_session: list[dict] = []
+    for session_id in sessions:
+        records = await recorder.read_session(
+            session_id=session_id, org_id=org, day=day
+        )
+        if not records:
+            continue
+        per_session.append(
+            {
+                "session_id": session_id,
+                "record_count": len(records),
+                "first_timestamp": records[0].timestamp,
+                "last_timestamp": records[-1].timestamp,
+            }
+        )
+        total_records += len(records)
+        for r in records:
+            if r.response:
+                response_lengths.append(len(r.response))
+            latency = r.metadata.get("latency_ms")
+            if isinstance(latency, (int, float)):
+                latencies.append(float(latency))
+            tool_call_count += len(r.tool_calls)
+            sources_count += len(r.sources)
+
+    summary: dict = {
+        "base_dir": str(base_dir),
+        "day": day,
+        "org": org or "_personal",
+        "session_count": len(per_session),
+        "record_count": total_records,
+        "tool_call_count": tool_call_count,
+        "sources_count": sources_count,
+        "response_length": _stats(response_lengths),
+        "latency_ms": _stats(latencies),
+        "sessions": per_session,
+    }
+    return summary
+
+
+def _stats(values: list[float]) -> dict:
+    if not values:
+        return {"n": 0, "mean": None, "median": None, "p95": None}
+    sorted_values = sorted(values)
+    p95_index = max(0, int(round(0.95 * (len(sorted_values) - 1))))
+    return {
+        "n": len(values),
+        "mean": round(statistics.fmean(values), 2),
+        "median": round(statistics.median(values), 2),
+        "p95": round(sorted_values[p95_index], 2),
+    }
+
+
+def _print_human(summary: dict) -> None:
+    print(f"Day: {summary['day']}  Org: {summary['org']}")
+    print(f"Base dir: {summary['base_dir']}")
+    print(
+        f"Sessions: {summary['session_count']}  "
+        f"Records: {summary['record_count']}  "
+        f"Tool calls: {summary['tool_call_count']}  "
+        f"Sources: {summary['sources_count']}"
+    )
+    if summary["response_length"]["n"]:
+        rl = summary["response_length"]
+        print(
+            "Response length (chars): "
+            f"mean={rl['mean']} median={rl['median']} p95={rl['p95']} (n={rl['n']})"
+        )
+    if summary["latency_ms"]["n"]:
+        lat = summary["latency_ms"]
+        print(
+            "Latency (ms): "
+            f"mean={lat['mean']} median={lat['median']} p95={lat['p95']} (n={lat['n']})"
+        )
+    if summary["sessions"]:
+        print("\nSessions:")
+        for s in summary["sessions"]:
+            print(
+                f"  {s['session_id']:32s}  "
+                f"records={s['record_count']:4d}  "
+                f"first={s['first_timestamp']}"
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--base-dir",
+        default="eval_recordings",
+        help="Base directory containing eval JSONL partitions (default: eval_recordings).",
+    )
+    parser.add_argument(
+        "--day",
+        required=True,
+        help="Partition day in YYYY-MM-DD form.",
+    )
+    parser.add_argument(
+        "--org",
+        default=None,
+        help="Org ID to scope the summary; omit for the personal partition.",
+    )
+    parser.add_argument(
+        "--as-json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of human-readable text.",
+    )
+    args = parser.parse_args()
+
+    base_dir = Path(args.base_dir)
+    if not base_dir.exists():
+        print(f"[eval_summary] base_dir does not exist: {base_dir}", file=sys.stderr)
+        return 2
+
+    summary = asyncio.run(_summarise(base_dir, args.day, args.org))
+
+    if args.as_json:
+        json.dump(summary, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+    else:
+        _print_human(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/maritime-ai-service/tests/unit/engine/runtime/test_eval_recorder.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_eval_recorder.py
@@ -1,0 +1,192 @@
+"""Phase 6 eval recorder — Runtime Migration #207.
+
+Locks in JSONL on-disk shape, partition layout, path-traversal safety,
+and the simple diff metric helper. Anything that consumes recordings
+later (replay scripts, regression CI, dashboards) relies on this exact
+contract.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from app.engine.runtime.eval_recorder import (
+    EvalRecord,
+    EvalRecorder,
+    diff_records,
+)
+
+
+def _make_record(**overrides) -> EvalRecord:
+    base = {
+        "session_id": "s1",
+        "request": {"messages": [{"role": "user", "content": "hi"}]},
+    }
+    base.update(overrides)
+    return EvalRecord(**base)
+
+
+# ── EvalRecord shape ──
+
+def test_eval_record_defaults():
+    rec = _make_record()
+    assert rec.record_id  # uuid generated
+    assert rec.org_id is None
+    assert re.match(r"^\d{4}-\d{2}-\d{2}T", rec.timestamp)
+    assert rec.retrieved_docs == []
+    assert rec.tool_calls == []
+    assert rec.response == ""
+    assert rec.sources == []
+    assert rec.metadata == {}
+    assert rec.replay_seed is None
+
+
+def test_eval_record_round_trips_through_json():
+    rec = _make_record(response="hello", metadata={"latency_ms": 42})
+    blob = rec.model_dump_json()
+    revived = EvalRecord.model_validate_json(blob)
+    assert revived.response == "hello"
+    assert revived.metadata == {"latency_ms": 42}
+
+
+# ── Recorder write/read ──
+
+@pytest.fixture
+def recorder(tmp_path: Path) -> EvalRecorder:
+    return EvalRecorder(base_dir=tmp_path)
+
+
+async def test_write_creates_partitioned_file(tmp_path: Path, recorder: EvalRecorder):
+    rec = _make_record(org_id="org-1", session_id="sess-A")
+    path = await recorder.write(rec)
+    expected_day = rec.timestamp[:10]
+    assert path == tmp_path / "org-1" / expected_day / "sess-A.jsonl"
+    assert path.exists()
+
+
+async def test_write_falls_back_for_personal_org(recorder: EvalRecorder):
+    rec = _make_record(org_id=None)
+    path = await recorder.write(rec)
+    assert "_personal" in path.parts
+
+
+async def test_write_appends_one_record_per_call(recorder: EvalRecorder):
+    rec1 = _make_record(response="r1")
+    rec2 = _make_record(response="r2")
+    path1 = await recorder.write(rec1)
+    path2 = await recorder.write(rec2)
+    assert path1 == path2  # same partition (same session/day)
+    lines = path1.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["response"] == "r1"
+    assert json.loads(lines[1])["response"] == "r2"
+
+
+async def test_write_path_traversal_is_neutralised(recorder: EvalRecorder, tmp_path: Path):
+    """Hostile session_id must not escape base_dir."""
+    rec = _make_record(session_id="../../../etc/passwd", org_id="../escape")
+    path = await recorder.write(rec)
+    # Path stays under base_dir.
+    assert tmp_path in path.parents
+    # Dangerous segments collapsed to underscores.
+    assert ".." not in path.parts
+
+
+async def test_read_session_returns_appended_records(recorder: EvalRecorder):
+    rec1 = _make_record(response="r1")
+    rec2 = _make_record(response="r2")
+    await recorder.write(rec1)
+    await recorder.write(rec2)
+    day = rec1.timestamp[:10]
+    records = await recorder.read_session(session_id="s1", day=day)
+    assert [r.response for r in records] == ["r1", "r2"]
+
+
+async def test_read_session_missing_partition_returns_empty(recorder: EvalRecorder):
+    records = await recorder.read_session(session_id="missing", day="2026-01-01")
+    assert records == []
+
+
+async def test_read_session_skips_malformed_lines(tmp_path: Path, recorder: EvalRecorder):
+    rec = _make_record(response="ok")
+    path = await recorder.write(rec)
+    # Inject a garbage line between valid ones.
+    with path.open("a", encoding="utf-8") as f:
+        f.write("not-json-at-all\n")
+    rec2 = _make_record(response="next")
+    await recorder.write(rec2)
+    day = rec.timestamp[:10]
+    records = await recorder.read_session(session_id="s1", day=day)
+    # Only the two valid lines come back.
+    assert [r.response for r in records] == ["ok", "next"]
+
+
+async def test_list_sessions(recorder: EvalRecorder):
+    a = _make_record(session_id="a")
+    b = _make_record(session_id="b")
+    await recorder.write(a)
+    await recorder.write(b)
+    day = a.timestamp[:10]
+    listed = await recorder.list_sessions(day=day)
+    assert listed == ["a", "b"]
+
+
+# ── diff_records ──
+
+def test_diff_identical_response_full_overlap():
+    rec = _make_record(response="hello world")
+    diff = diff_records(rec, {"response": "hello world", "tool_calls": [], "sources": []})
+    assert diff["token_jaccard"] == 1.0
+    assert diff["tool_calls_match"] is True
+    assert diff["sources_overlap"] == 1.0
+
+
+def test_diff_partial_word_overlap():
+    rec = _make_record(response="alpha beta gamma")
+    diff = diff_records(rec, {"response": "alpha beta delta"})
+    # 2 shared / 4 union = 0.5
+    assert diff["token_jaccard"] == pytest.approx(0.5)
+
+
+def test_diff_tool_call_mismatch_is_flagged():
+    rec = _make_record(
+        tool_calls=[{"name": "search", "args": {"q": "x"}}],
+        response="r",
+    )
+    diff = diff_records(
+        rec,
+        {
+            "response": "r",
+            "tool_calls": [{"name": "search", "args": {"q": "y"}}],
+            "sources": [],
+        },
+    )
+    assert diff["tool_calls_match"] is False
+
+
+def test_diff_source_overlap_partial():
+    rec = _make_record(
+        sources=[{"id": "doc1"}, {"id": "doc2"}, {"id": "doc3"}],
+    )
+    diff = diff_records(
+        rec,
+        {"response": "", "tool_calls": [], "sources": [{"id": "doc1"}, {"id": "doc4"}]},
+    )
+    # 1 shared / 3 in original = ~0.333
+    assert diff["sources_overlap"] == pytest.approx(1 / 3)
+
+
+def test_diff_latency_delta_signed():
+    rec = _make_record(metadata={"latency_ms": 100})
+    diff = diff_records(rec, {"response": "", "latency_ms": 75})
+    assert diff["latency_delta_ms"] == -25
+
+
+def test_diff_handles_empty_responses():
+    rec = _make_record(response="")
+    diff = diff_records(rec, {"response": "", "tool_calls": [], "sources": []})
+    assert diff["token_jaccard"] == 1.0  # both empty → identical


### PR DESCRIPTION
## Mục tiêu

Phase 6 của Runtime Migration Epic [#207](https://github.com/meiiie/wiii/issues/207) — **eval harness as production tooling** (the moat). Triết lý từ Anthropic ``demystifying-evals-for-ai-agents``: production runtime CHÍNH LÀ eval substrate, không có hệ thống eval riêng.

PR này ship FOUNDATION (on-disk format + writer + summary script). Wiring vào ``ChatOrchestrator.process(record=True)`` + replay HTML report + CI nightly cron land ở follow-up PR — lock JSONL shape trước.

## Foundation (mới)

### ``app/engine/runtime/eval_recorder.py``

- ``EvalRecord`` Pydantic: ``record_id`` (uuid), ``session_id``, ``org_id``, ``timestamp`` (ISO-8601 UTC), ``request``, ``retrieved_docs``, ``tool_calls``, ``response``, ``sources``, ``metadata``, ``replay_seed``
- ``EvalRecorder.write/read_session/list_sessions``: asyncio.Lock-guarded JSONL append. Layout: ``{base_dir}/{org_id}/{YYYY-MM-DD}/{session_id}.jsonl``
- **Path-traversal hardening**: ``org_id`` / ``session_id`` / ``day`` đi qua ``_safe_segment()`` — non-``[A-Za-z0-9._-]`` chars collapse thành underscore, hostile inputs không escape ``base_dir``
- Cross-platform JSONL: ``newline=""`` + literal ``\n`` để Windows không double-translate CRLF làm corrupt JSONL parser
- Skip-malformed-line trên ``read_session`` để 1 bad write không poison cả partition
- ``diff_records()`` helper: token Jaccard similarity + tool-call equality + source overlap + signed latency delta (no LLM judging — Phase 7+)

### ``scripts/eval_summary.py``

- CLI operational tool — spot-check eval JSONL partitions không cần spin up chat stack
- Report: session count, record count, tool calls, sources, response length stats (mean/median/p95), latency stats
- ``--as-json`` mode để CI consume

### Feature flags (default OFF, EXPERIMENTAL tier)

- ``enable_eval_recording: bool = False`` — opt-in per environment
- ``eval_recording_dir: str = "eval_recordings"`` — base directory

## Verification gates

| Gate | Result |
|---|---|
| 16 contract test (record shape, JSONL round-trip, partition layout, path-traversal safety, malformed-line tolerance, 4 diff metrics) | ✅ 16/16 pass |
| ``test_feature_tiers`` sau khi register flag mới | ✅ 5/5 pass |
| Wider scope (656 tests, "runtime or eval or feature_tier or messages") | ✅ 655 pass + 1 skipped, 0 fail |
| ``scripts/eval_summary.py`` smoke (handles missing base_dir gracefully) | ✅ exit code 2 với error message |

## Deferred sang follow-up PR

- ``ChatOrchestrator.process(record=True)`` wiring — touch production code path, defer cho fresh PR có deeper testing
- ``scripts/replay_eval.py`` — full replay với HTML diff report (cần ChatOrchestrator integration trước)
- ``.github/workflows/nightly-eval-replay.yml`` cron — cần real traffic data đầu tiên
- Proof-of-concept regression catch — cần chat traffic ghi xuống JSONL
- Storage rotation policy (7d local, monthly archive)

## Out of scope

- Không thay thế ``tests/eval_*`` files hiện tại (complement, không replace)
- Không multi-judge LLM grading (use simple metrics first; Phase 7+)
- Không default ON ở production (opt-in per-org canary)

## Liên quan

- Epic: #207 (KHÔNG ``Closes`` — còn 1 phase + integration follow-up)
- Phase brief: ``.Codex/reports/runtime-migration-briefs/phase-6-eval-harness.md``
- Phase 5a đã merged