### PR TITLE
phase-8: ship 3 deferred follow-ups (langsmith stub + anthropic adapter + record=True wiring)

### DIFF
--- a/maritime-ai-service/app/core/langsmith.py
+++ b/maritime-ai-service/app/core/langsmith.py
@@ -1,18 +1,22 @@
-"""
-LangSmith Observability Integration (Sprint 144b)
+"""LangSmith observability integration — runtime-migration-aware stub.
 
-Sets LANGCHAIN_TRACING_V2 environment variables at startup so that
-LangChain/LangGraph automatically traces every LLM call, tool invocation,
-and graph node to the LangSmith dashboard.
+History: this module wired ``langchain_core.tracers.LangChainTracer`` into
+every LLM call so traces showed up in the LangSmith dashboard. Phase 7 of
+the runtime migration epic (#207) drops the LangChain-tracer dependency
+because Wiii no longer routes through ``BaseChatModel`` callbacks.
 
-Three public functions:
-  - configure_langsmith(settings)  — called once at app startup
-  - is_langsmith_enabled()         — boolean check
-  - get_langsmith_callback(...)    — per-request callback with metadata tags
+The ``langsmith`` SDK itself stays a top-level dep — it is independent of
+``langchain-core`` and supports direct trace posting. A future PR can
+restore observability by calling ``langsmith.Client`` from a runtime hook
+that wraps ``UnifiedLLMClient`` invocations. Until that lands, this
+module keeps the public surface (``configure_langsmith`` /
+``is_langsmith_enabled`` / ``get_langsmith_callback``) so call sites do
+not need to branch — every callback request just returns ``None``.
 """
+
+from __future__ import annotations
 
 import logging
-import os
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
@@ -21,44 +25,35 @@ _langsmith_enabled: bool = False
 
 
 def configure_langsmith(settings: Any) -> None:
-    """
-    Set LangChain tracing environment variables from app settings.
+    """Capture intent — actual tracing wiring lives in the future direct hook.
 
-    Must be called BEFORE LLM Pool initialization so that LangChain
-    picks up the env vars when constructing providers.
-
-    Args:
-        settings: Pydantic Settings instance with langsmith_* fields.
+    Reads ``settings.enable_langsmith`` for a debug log only; sets no env
+    vars now that the LangChain auto-tracer has been removed.
     """
     global _langsmith_enabled
 
-    if not settings.enable_langsmith:
+    if not getattr(settings, "enable_langsmith", False):
         logger.debug("[LANGSMITH] Disabled via config")
         return
 
-    api_key = settings.langsmith_api_key
+    api_key = getattr(settings, "langsmith_api_key", "")
     if not api_key:
         logger.warning(
-            "[LANGSMITH] enable_langsmith=True but langsmith_api_key is empty. "
-            "Tracing will NOT be activated."
+            "[LANGSMITH] enable_langsmith=True but langsmith_api_key is empty."
         )
         return
 
-    os.environ["LANGCHAIN_TRACING_V2"] = "true"
-    os.environ["LANGCHAIN_API_KEY"] = api_key
-    os.environ["LANGCHAIN_PROJECT"] = settings.langsmith_project
-    os.environ["LANGCHAIN_ENDPOINT"] = settings.langsmith_endpoint
-
     _langsmith_enabled = True
     logger.info(
-        "[LANGSMITH] Tracing enabled — project=%s, endpoint=%s",
-        settings.langsmith_project,
-        settings.langsmith_endpoint,
+        "[LANGSMITH] Flag enabled (project=%s) — tracing will be wired by a "
+        "follow-up direct integration; LangChain auto-tracer was removed in "
+        "the runtime-migration epic (#207).",
+        getattr(settings, "langsmith_project", "wiii"),
     )
 
 
 def is_langsmith_enabled() -> bool:
-    """Return True if LangSmith tracing was successfully configured."""
+    """Return True if the flag was honoured and an API key was supplied."""
     return _langsmith_enabled
 
 
@@ -68,54 +63,8 @@ def get_langsmith_callback(
     domain_id: str = "",
     model_provider: str = "",
 ) -> Optional[Any]:
+    """Always returns ``None`` — see module docstring.
+
+    Kept as a stable surface so hot paths can call it unconditionally.
     """
-    Create a per-request LangChainTracer callback with metadata tags.
-
-    Tags enable filtering in the LangSmith dashboard by user, session,
-    and domain.  Returns None when LangSmith is disabled or if the
-    langsmith SDK is not installed.
-
-    Args:
-        user_id: User identifier for dashboard filtering.
-        session_id: Session identifier.
-        domain_id: Domain plugin ID.
-
-    Returns:
-        LangChainTracer instance or None.
-    """
-    if not _langsmith_enabled:
-        return None
-
-    try:
-        from langsmith import Client
-        from langchain_core.tracers import LangChainTracer
-
-        tags = []
-        if domain_id:
-            tags.append(f"domain:{domain_id}")
-        if user_id:
-            tags.append(f"user:{user_id}")
-
-        metadata = {}
-        if user_id:
-            metadata["user_id"] = user_id
-        if session_id:
-            metadata["session_id"] = session_id
-        if domain_id:
-            metadata["domain_id"] = domain_id
-        if model_provider:
-            metadata["model_provider"] = model_provider
-
-        client = Client()
-        return LangChainTracer(
-            client=client,
-            project_name=os.environ.get("LANGCHAIN_PROJECT", "wiii"),
-            tags=tags,
-            extra={"metadata": metadata} if metadata else None,
-        )
-    except ImportError:
-        logger.debug("[LANGSMITH] langsmith or langchain_core.tracers not installed")
-        return None
-    except Exception as e:
-        logger.warning("[LANGSMITH] Failed to create callback: %s", e)
-        return None
+    return None

--- a/maritime-ai-service/app/engine/runtime/adapters/__init__.py
+++ b/maritime-ai-service/app/engine/runtime/adapters/__init__.py
@@ -6,10 +6,12 @@ normalises a different incoming wire format into the canonical
 endpoint was hit.
 """
 
+from .anthropic_compat import anthropic_messages_to_turn_request
 from .openai_compat import openai_chat_completions_to_turn_request
 from .wiii_native import wiii_chat_request_to_turn_request
 
 __all__ = [
     "wiii_chat_request_to_turn_request",
     "openai_chat_completions_to_turn_request",
+    "anthropic_messages_to_turn_request",
 ]

--- a/maritime-ai-service/app/engine/runtime/adapters/anthropic_compat.py
+++ b/maritime-ai-service/app/engine/runtime/adapters/anthropic_compat.py
@@ -1,0 +1,195 @@
+"""Adapter: Anthropic Messages API request → ``TurnRequest``.
+
+Phase 4 of the runtime migration epic (issue #207), shipped after the
+OpenAI compat adapter to keep the lane-first surface consistent across
+all three edge protocols.
+
+Anthropic's wire shape is content-block-typed (``text`` blocks +
+``tool_use`` blocks + ``tool_result`` blocks) rather than the OpenAI flat
+``role`` + ``content`` + ``tool_calls`` shape. This adapter normalises
+those typed blocks into a single ``Message`` per turn, with tool calls
+flattened back into the canonical ``ToolCall`` list.
+
+Pure conversion function — dict in, ``TurnRequest`` out. Identity is
+supplied out-of-band (auth header / X-User-ID), not from the request.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from app.engine.messages import Message, ToolCall
+from app.engine.runtime.turn_request import TurnRequest
+
+_VALID_ROLES = {"user", "assistant"}
+
+
+def _join_text(blocks: list[Any]) -> str:
+    """Concatenate text content from a list of typed Anthropic content blocks."""
+    parts: list[str] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "text":
+            text = block.get("text", "")
+            if text:
+                parts.append(text)
+    return "\n".join(parts)
+
+
+def _collect_tool_uses(blocks: list[Any]) -> Optional[list[ToolCall]]:
+    """Pull ``tool_use`` blocks from an assistant message's content list."""
+    calls: list[ToolCall] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "tool_use":
+            continue
+        calls.append(
+            ToolCall(
+                id=block.get("id") or "",
+                name=block.get("name") or "",
+                arguments=block.get("input") or {},
+            )
+        )
+    return calls or None
+
+
+def _split_tool_results(blocks: list[Any]) -> list[Message]:
+    """Anthropic encodes tool results as a ``user`` message with one or more
+    ``tool_result`` content blocks. Wiii's canonical ``Message`` puts each
+    tool result on its own row with role ``tool`` so downstream code does
+    not need to deconstruct typed blocks again.
+    """
+    out: list[Message] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "tool_result":
+            continue
+        # Anthropic tool_result content can be a string or another typed
+        # block list — flatten to text.
+        result_content = block.get("content")
+        if isinstance(result_content, list):
+            text = _join_text(result_content)
+        elif isinstance(result_content, str):
+            text = result_content
+        else:
+            text = "" if result_content is None else str(result_content)
+        out.append(
+            Message(
+                role="tool",
+                content=text,
+                tool_call_id=block.get("tool_use_id") or "",
+            )
+        )
+    return out
+
+
+def _normalise_message(raw: dict) -> list[Message]:
+    """One Anthropic message → one or more native Messages.
+
+    Most messages map 1:1, but a ``user`` message that carries
+    ``tool_result`` blocks expands into one ``tool`` Message per result.
+    """
+    role = raw.get("role")
+    if role not in _VALID_ROLES:
+        role = "user"
+
+    content = raw.get("content")
+    # Plain-string body is allowed.
+    if isinstance(content, str):
+        return [Message(role=role, content=content)]
+    if not isinstance(content, list):
+        return [Message(role=role, content="")]
+
+    if role == "assistant":
+        return [
+            Message(
+                role="assistant",
+                content=_join_text(content),
+                tool_calls=_collect_tool_uses(content),
+            )
+        ]
+
+    # role == "user"
+    tool_messages = _split_tool_results(content)
+    text = _join_text(content)
+    msgs: list[Message] = []
+    if text:
+        msgs.append(Message(role="user", content=text))
+    msgs.extend(tool_messages)
+    if not msgs:
+        msgs.append(Message(role="user", content=""))
+    return msgs
+
+
+def _has_image_block(raw_messages: list[dict]) -> bool:
+    for raw in raw_messages:
+        content = raw.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "image":
+                return True
+    return False
+
+
+def anthropic_messages_to_turn_request(
+    body: dict,
+    *,
+    user_id: str,
+    session_id: str,
+    org_id: Optional[str] = None,
+    domain_id: Optional[str] = None,
+    role: str = "student",
+) -> TurnRequest:
+    """Convert an Anthropic ``POST /v1/messages`` body into a ``TurnRequest``.
+
+    Recognised body fields: ``model``, ``messages``, ``system``,
+    ``tools``, ``stream``, ``temperature``, ``top_p``, ``max_tokens``,
+    ``tool_choice``. Unknown fields ride in ``metadata`` for observability.
+    """
+    raw_messages = body.get("messages") or []
+
+    messages: list[Message] = []
+    system_prompt = body.get("system")
+    if isinstance(system_prompt, str) and system_prompt:
+        messages.append(Message(role="system", content=system_prompt))
+    elif isinstance(system_prompt, list):
+        joined = _join_text(system_prompt)
+        if joined:
+            messages.append(Message(role="system", content=joined))
+
+    for raw in raw_messages:
+        if isinstance(raw, dict):
+            messages.extend(_normalise_message(raw))
+
+    requested_capabilities: list[str] = []
+    if body.get("tools"):
+        requested_capabilities.append("tools")
+    if _has_image_block(raw_messages):
+        requested_capabilities.append("vision")
+
+    metadata: dict[str, Any] = {
+        "anthropic_model": body.get("model"),
+        "original_messages": raw_messages,
+    }
+    for opt_key in ("temperature", "top_p", "max_tokens", "tool_choice"):
+        if opt_key in body:
+            metadata[opt_key] = body[opt_key]
+
+    return TurnRequest(
+        messages=messages,
+        user_id=user_id,
+        session_id=session_id,
+        org_id=org_id,
+        domain_id=domain_id,
+        role=role,
+        requested_streaming=bool(body.get("stream", False)),
+        requested_capabilities=requested_capabilities,
+        metadata=metadata,
+    )
+
+
+__all__ = ["anthropic_messages_to_turn_request"]

--- a/maritime-ai-service/app/services/chat_orchestrator.py
+++ b/maritime-ai-service/app/services/chat_orchestrator.py
@@ -413,11 +413,12 @@ class ChatOrchestrator:
     async def process(
         self,
         request: ChatRequest,
-        background_save: Optional[Callable] = None
+        background_save: Optional[Callable] = None,
+        record: bool = False,
     ) -> InternalChatResponse:
         """
         Process a chat request through the full pipeline.
-        
+
         Pipeline:
         1. Get/create session
         2. Validate input
@@ -425,11 +426,15 @@ class ChatOrchestrator:
         4. Process with agent
         5. Format output
         6. Schedule background tasks
-        
+        7. Optional eval snapshot (Phase 6 of #207, gated by settings.enable_eval_recording)
+
         Args:
             request: ChatRequest from API
             background_save: FastAPI BackgroundTasks.add_task
-            
+            record: When True AND settings.enable_eval_recording=True,
+                snapshot this turn into the JSONL eval log. Per-call
+                opt-in lets canary traffic flag itself for replay.
+
         Returns:
             InternalChatResponse ready for API serialization
         """
@@ -519,7 +524,78 @@ class ChatOrchestrator:
             transport_type="sync",
         )
 
+        if record and getattr(settings, "enable_eval_recording", False):
+            await self._record_eval_turn(
+                request=request,
+                response=response,
+                result=result,
+                session_id=session_id,
+                org_id=org_id,
+            )
+
         return response
+
+    async def _record_eval_turn(
+        self,
+        *,
+        request: ChatRequest,
+        response: InternalChatResponse,
+        result: "ProcessingResult",
+        session_id: str,
+        org_id: Optional[str],
+    ) -> None:
+        """Snapshot one turn into the eval JSONL log (Phase 6 of #207).
+
+        Fail-soft: a recorder I/O error must never bubble up into the
+        chat response — log and move on.
+        """
+        try:
+            from pathlib import Path
+
+            from app.engine.runtime.eval_recorder import EvalRecord, EvalRecorder
+
+            base_dir = Path(getattr(settings, "eval_recording_dir", "eval_recordings"))
+            recorder = EvalRecorder(base_dir=base_dir)
+
+            request_payload: dict = {
+                "message": getattr(request, "message", ""),
+                "user_id": str(getattr(request, "user_id", "")),
+                "role": (
+                    getattr(request, "role").value
+                    if hasattr(getattr(request, "role", None), "value")
+                    else str(getattr(request, "role", ""))
+                ),
+                "domain_id": getattr(request, "domain_id", None),
+                "organization_id": getattr(request, "organization_id", None),
+            }
+
+            metadata = dict(result.metadata or {})
+            metadata.setdefault("current_agent", metadata.get("current_agent", ""))
+
+            sources_payload: list[dict] = []
+            for src in getattr(response, "sources", None) or []:
+                if hasattr(src, "model_dump"):
+                    sources_payload.append(src.model_dump())
+                elif isinstance(src, dict):
+                    sources_payload.append(src)
+
+            tool_calls_payload: list[dict] = []
+            for call in metadata.get("tool_calls", []) or []:
+                if isinstance(call, dict):
+                    tool_calls_payload.append(call)
+
+            record_obj = EvalRecord(
+                session_id=session_id,
+                org_id=org_id,
+                request=request_payload,
+                response=getattr(response, "response", "") or "",
+                tool_calls=tool_calls_payload,
+                sources=sources_payload,
+                metadata=metadata,
+            )
+            await recorder.write(record_obj)
+        except Exception as exc:  # noqa: BLE001 — fail-soft on I/O
+            logger.warning("[EVAL_RECORDER] failed to record turn: %s", exc)
 
     def _should_use_local_direct_llm_fallback(self) -> bool:
         """Use direct local inference when local mode is enabled without cloud retrieval support."""

--- a/maritime-ai-service/docs/architecture/RUNTIME-MIGRATION-FINAL-STATE.md
+++ b/maritime-ai-service/docs/architecture/RUNTIME-MIGRATION-FINAL-STATE.md
@@ -18,6 +18,16 @@
 
 ## What's deferred (and why)
 
+### Phase 8 follow-ups shipped (2026-05-03 evening)
+
+After the initial 7-PR series merged, a follow-up branch (``codex/runtime-phase-8-finish-langchain-removal``) chipped at the deferred list:
+
+- ``app/core/langsmith.py`` — dropped the ``langchain_core.tracers`` import. ``get_langsmith_callback`` now returns ``None``. The ``langsmith`` SDK stays a top-level dep so a future direct integration can wire observability without re-introducing langchain-core.
+- ``app/engine/runtime/adapters/anthropic_compat.py`` — third edge protocol adapter joining ``wiii_native`` + ``openai_compat``. Anthropic ``tool_use`` blocks round-trip into native ``ToolCall``; ``tool_result`` blocks split into standalone role=``tool`` Messages.
+- ``ChatOrchestrator.process(record=True)`` wiring — per-call opt-in eval recording, gated by ``settings.enable_eval_recording``. Fail-soft on recorder I/O errors so production traffic is never blocked.
+
+What's still open after Phase 8: ``WiiiChatModel(BaseChatModel)`` rewrite (the gating step for actually removing ``langchain-core`` from the dependency manifest) and the 9 RECEIVE-coupled history files. Both depend on the BaseChatModel rewrite first.
+
 ### `langchain-core` package — kept in `pyproject.toml`
 
 22 references remain in `app/` across 11 files. All of them sit in two deferred buckets:

--- a/maritime-ai-service/tests/unit/engine/runtime/adapters/test_adapters.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/adapters/test_adapters.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from app.engine.messages import Message
 from app.engine.runtime.adapters import (
+    anthropic_messages_to_turn_request,
     openai_chat_completions_to_turn_request,
     wiii_chat_request_to_turn_request,
 )
@@ -169,3 +170,165 @@ def test_openai_compat_temperature_and_max_tokens_into_metadata():
     req = openai_chat_completions_to_turn_request(body, user_id="u", session_id="s")
     assert req.metadata["temperature"] == 0.3
     assert req.metadata["max_tokens"] == 256
+
+
+# ── Anthropic Messages adapter ──
+
+def test_anthropic_compat_text_only_user_message():
+    body = {
+        "model": "claude-foo",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    req = anthropic_messages_to_turn_request(body, user_id="u", session_id="s")
+    assert [m.role for m in req.messages] == ["user"]
+    assert req.messages[0].content == "hi"
+    assert req.metadata["anthropic_model"] == "claude-foo"
+
+
+def test_anthropic_compat_system_prompt_prepends_system_message():
+    body = {
+        "system": "You are Wiii.",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    req = anthropic_messages_to_turn_request(body, user_id="u", session_id="s")
+    assert req.messages[0].role == "system"
+    assert req.messages[0].content == "You are Wiii."
+    assert req.messages[1].role == "user"
+
+
+def test_anthropic_compat_assistant_text_block():
+    body = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "ack"}],
+            }
+        ],
+    }
+    req = anthropic_messages_to_turn_request(body, user_id="u", session_id="s")
+    assert req.messages[0].role == "assistant"
+    assert req.messages[0].content == "ack"
+    assert req.messages[0].tool_calls is None
+
+
+def test_anthropic_compat_assistant_tool_use_block_round_trip():
+    body = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "calling search"},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "search",
+                        "input": {"q": "x"},
+                    },
+                ],
+            }
+        ],
+    }
+    req = anthropic_messages_to_turn_request(body, user_id="u", session_id="s")
+    msg = req.messages[0]
+    assert msg.role == "assistant"
+    assert msg.content == "calling search"
+    assert msg.tool_calls and msg.tool_calls[0].name == "search"
+    assert msg.tool_calls[0].arguments == {"q": "x"}
+
+
+def test_anthropic_compat_user_tool_result_block_split_into_tool_message():
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": "search result",
+                    }
+                ],
+            }
+        ],
+    }
+    req = anthropic_messages_to_turn_request(body, user_id="u", session_id="s")
+    assert [m.role for m in req.messages] == ["tool"]
+    assert req.messages[0].tool_call_id == "toolu_1"
+    assert req.messages[0].content == "search result"
+
+
+def test_anthropic_compat_user_mixed_tool_result_and_text():
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "follow-up"},
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": "result",
+                    },
+                ],
+            }
+        ],
+    }
+    req = anthropic_messages_to_turn_request(body, user_id="u", session_id="s")
+    roles = [m.role for m in req.messages]
+    assert roles == ["user", "tool"]
+
+
+def test_anthropic_compat_image_block_sets_vision_capability():
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is this?"},
+                    {
+                        "type": "image",
+                        "source": {"type": "base64", "media_type": "image/png", "data": "..."},
+                    },
+                ],
+            }
+        ],
+    }
+    req = anthropic_messages_to_turn_request(body, user_id="u", session_id="s")
+    assert "vision" in req.requested_capabilities
+
+
+def test_anthropic_compat_tools_capability_and_streaming_flag():
+    body = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [{"name": "search"}],
+        "stream": True,
+    }
+    req = anthropic_messages_to_turn_request(body, user_id="u", session_id="s")
+    assert "tools" in req.requested_capabilities
+    assert req.requested_streaming is True
+
+
+def test_anthropic_compat_unknown_role_falls_back_to_user():
+    body = {"messages": [{"role": "system_extra", "content": "x"}]}
+    req = anthropic_messages_to_turn_request(body, user_id="u", session_id="s")
+    assert req.messages[0].role == "user"
+
+
+def test_anthropic_compat_tool_result_with_typed_content_blocks():
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": [{"type": "text", "text": "structured result"}],
+                    }
+                ],
+            }
+        ],
+    }
+    req = anthropic_messages_to_turn_request(body, user_id="u", session_id="s")
+    assert req.messages[0].role == "tool"
+    assert req.messages[0].content == "structured result"

--- a/maritime-ai-service/tests/unit/test_sprint144b_langsmith.py
+++ b/maritime-ai-service/tests/unit/test_sprint144b_langsmith.py
@@ -66,8 +66,11 @@ class TestConfigureLangsmith:
         assert not is_langsmith_enabled()
         assert "LANGCHAIN_TRACING_V2" not in os.environ
 
-    def test_enabled_sets_env_vars(self):
-        """When enabled with a valid API key, all 4 env vars are set."""
+    def test_enabled_marks_module_state_without_setting_langchain_env(self):
+        """Phase 8 of #207: the LangChain auto-tracer was removed. The flag
+        still flips ``is_langsmith_enabled`` so a future direct hook can pick
+        it up, but no LANGCHAIN_* env vars are exported anymore.
+        """
         from app.core.langsmith import configure_langsmith, is_langsmith_enabled
 
         settings = _make_settings(
@@ -79,10 +82,10 @@ class TestConfigureLangsmith:
         configure_langsmith(settings)
 
         assert is_langsmith_enabled()
-        assert os.environ["LANGCHAIN_TRACING_V2"] == "true"
-        assert os.environ["LANGCHAIN_API_KEY"] == "lsv2_pt_test123"
-        assert os.environ["LANGCHAIN_PROJECT"] == "test-project"
-        assert os.environ["LANGCHAIN_ENDPOINT"] == "https://custom.endpoint.com"
+        assert "LANGCHAIN_TRACING_V2" not in os.environ
+        assert "LANGCHAIN_API_KEY" not in os.environ
+        assert "LANGCHAIN_PROJECT" not in os.environ
+        assert "LANGCHAIN_ENDPOINT" not in os.environ
 
     def test_enabled_without_api_key_stays_disabled(self):
         """When enabled but API key is None/empty, tracing is NOT activated."""
@@ -173,8 +176,14 @@ class TestGetLangsmithCallback:
             # ImportError path — returns None
             assert result is None
 
-    def test_returns_callback_when_enabled(self):
-        """When enabled and SDK available, returns a LangChainTracer."""
+    def test_returns_none_after_langchain_tracer_removal(self):
+        """Phase 8 of #207: get_langsmith_callback always returns None now.
+
+        The LangChainTracer import was dropped to remove the langchain-core
+        dependency from this module. A future direct LangSmith integration
+        will re-introduce a non-None return; until then, callers receive
+        None unconditionally — even when the flag is enabled.
+        """
         from app.core.langsmith import configure_langsmith, get_langsmith_callback
 
         settings = _make_settings(
@@ -183,38 +192,8 @@ class TestGetLangsmithCallback:
         )
         configure_langsmith(settings)
 
-        # Mock the langsmith + langchain imports inside get_langsmith_callback
-        mock_client_cls = MagicMock()
-        mock_tracer_cls = MagicMock()
-        mock_tracer_instance = MagicMock()
-        mock_tracer_cls.return_value = mock_tracer_instance
-
-        with patch("app.core.langsmith.Client", mock_client_cls, create=True), \
-             patch("app.core.langsmith.LangChainTracer", mock_tracer_cls, create=True):
-            # We need to patch the imports inside the function
-            pass
-
-        # Instead, test via the full import path
-        mock_client = MagicMock()
-        mock_tracer = MagicMock()
-
-        with patch.dict("sys.modules", {
-            "langsmith": MagicMock(Client=MagicMock(return_value=mock_client)),
-            "langchain_core": MagicMock(),
-            "langchain_core.tracers": MagicMock(LangChainTracer=MagicMock(return_value=mock_tracer)),
-        }):
-            # Re-import to pick up mocked modules
-            import importlib
-            import app.core.langsmith as mod
-            importlib.reload(mod)
-            mod._langsmith_enabled = True
-            os.environ["LANGCHAIN_PROJECT"] = "wiii"
-
-            result = mod.get_langsmith_callback("user1", "sess1", "maritime")
-            assert result is not None
-
-        # Restore module state
-        _reset_module()
+        result = get_langsmith_callback("user1", "sess1", "maritime")
+        assert result is None
 
     def test_graceful_on_exception(self):
         """If callback creation raises, returns None instead of crashing."""


### PR DESCRIPTION
## Mục tiêu

Phase 8 — chip away at the deferred list từ ``docs/architecture/RUNTIME-MIGRATION-FINAL-STATE.md`` mà KHÔNG cần ``WiiiChatModel`` rewrite. 3 follow-up additive thay đổi.

## Honest scope (vs user ask "triệt để xóa langchain")

**Đã làm trong PR này** (low/med risk, additive):
- ✅ ``app/core/langsmith.py`` stub: bỏ ``langchain_core.tracers`` import. ``get_langsmith_callback`` luôn trả ``None`` cho đến khi có direct LangSmith hook tương lai (``langsmith`` SDK độc lập với ``langchain-core`` nên dep không bị block bởi observability).
- ✅ ``app/engine/runtime/adapters/anthropic_compat.py``: edge protocol adapter thứ 3 (sau wiii_native + openai_compat). Tool-use blocks round-trip vào native ToolCall, tool_result blocks split thành role=tool Messages.
- ✅ ``ChatOrchestrator.process(record=True)`` wiring: per-call opt-in eval JSONL recording. Gated by ``settings.enable_eval_recording``. Fail-soft (recorder I/O error log warning, không block chat response).

**KHÔNG làm trong PR này** (high risk, cần dedicated session):
- ❌ ``WiiiChatModel(BaseChatModel)`` rewrite — đây là **GATING STEP** cho ``langchain-core`` dep removal. 50+ consumer call sites rely on BaseChatModel auto-conversion + LangChain return types (``ChatResult``, ``ChatGenerationChunk``). Rewrite cần:
  - Audit 50+ consumer
  - Re-implement _generate, _agenerate, _astream, bind_tools, with_structured_output không inheritance
  - Stream protocol verification
  - Per-call-site test
  - Karpathy: "Don't add features beyond brief / surface assumptions if uncertain" — quá lớn để rush trong session này, cần dedicated PR có deeper testing.
- ❌ 9 RECEIVE-coupled history file migration — phụ thuộc WiiiChatModel rewrite trước
- ❌ ``langchain-core`` removal khỏi ``pyproject.toml`` — sau khi 2 above xong
- ❌ ``PostgresSessionEventLog`` + ``wake()`` — Phase 5b
- ❌ Subagent context isolation — risky vì source-flow integrity Sprint 189b 73/73
- ❌ Operational items (canary, LMS GA, p50 benchmark, nightly CI) — không phải single-PR work

## Verification gates

| Gate | Result |
|---|---|
| 22 adapter test (anthropic + openai_compat + wiii_native) | ✅ 22/22 pass |
| 12 langsmith test (after assertions updated to match tracer-removed contract) | ✅ 12/12 pass |
| 99 chat_orchestrator + runtime test | ✅ 99/99 pass |
| Wider scope (694 tests, "runtime or messages or langsmith or chat_orchestrator or eval or feature_tier") | ✅ 692 pass + 1 skipped (after fixing 2 langsmith test that asserted old behaviour) |

## Surface impact

- ``app/core/langsmith.py`` đi từ 4 langchain_core imports → 0
- ``runtime/adapters/`` từ 2 file → 3 file (cover trio: native + OpenAI + Anthropic)
- ``ChatOrchestrator.process()`` thêm 1 param ``record: bool = False`` (default off, backward compat)
- ``langchain_core.*`` references trong app/: 22 → 21 (chỉ ``langsmith.py`` import bị xoá)

## Liên quan

- Epic: #207 (KHÔNG ``Closes`` — vẫn deferred WiiiChatModel rewrite + RECEIVE files + dep removal)
- Final-state doc updated: ``docs/architecture/RUNTIME-MIGRATION-FINAL-STATE.md`` Phase 8 follow-ups section