### PR TITLE
phase-9b: migrate 9 RECEIVE-coupled files to native Message

### DIFF
--- a/maritime-ai-service/app/engine/context_budget_runtime.py
+++ b/maritime-ai-service/app/engine/context_budget_runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Optional
 
-from langchain_core.messages import BaseMessage
+from app.engine.messages import Message
 
 
 DEFAULT_EFFECTIVE_WINDOW = 32_000
@@ -100,8 +100,8 @@ class TokenBudgetManager:
             return 0
         return max(1, len(text) // CHARS_PER_TOKEN)
 
-    def estimate_messages_tokens(self, messages: list[BaseMessage]) -> int:
-        """Estimate total tokens for a list of LangChain messages."""
+    def estimate_messages_tokens(self, messages: list[Message]) -> int:
+        """Estimate total tokens for a list of native Wiii messages."""
         total = 0
         for msg in messages:
             content = msg.content if hasattr(msg, "content") else str(msg)
@@ -199,8 +199,8 @@ class TokenBudgetManager:
         system_prompt: str = "",
         core_memory: str = "",
         summary: str = "",
-    ) -> tuple[list[BaseMessage], ContextBudget]:
-        """Build LangChain messages that fit within the allocated context budget."""
+    ) -> tuple[list[Message], ContextBudget]:
+        """Build native Message list that fits within the allocated context budget."""
         budget = self.allocate(
             system_prompt=system_prompt,
             core_memory=core_memory,
@@ -208,33 +208,23 @@ class TokenBudgetManager:
             history_list=history_list,
         )
 
-        messages: list[BaseMessage] = []
+        messages: list[Message] = []
         if system_prompt:
-            from langchain_core.messages import SystemMessage
-
-            messages.append(SystemMessage(content=system_prompt))
-
+            messages.append(Message(role="system", content=system_prompt))
         if core_memory:
-            from langchain_core.messages import SystemMessage
-
-            messages.append(SystemMessage(content=core_memory))
-
+            messages.append(Message(role="system", content=core_memory))
         if summary:
-            from langchain_core.messages import SystemMessage
-
-            messages.append(SystemMessage(content=summary))
+            messages.append(Message(role="system", content=summary))
 
         included_history = history_list[-budget.messages_included :] if budget.messages_included else []
         for entry in included_history:
             role = entry.get("role", "user")
             content = entry.get("content", "")
-            if role == "user":
-                from langchain_core.messages import HumanMessage
-
-                messages.append(HumanMessage(content=content))
-            else:
-                from langchain_core.messages import AIMessage
-
-                messages.append(AIMessage(content=content))
+            messages.append(
+                Message(
+                    role="assistant" if role == "assistant" else "user",
+                    content=content,
+                )
+            )
 
         return messages, budget

--- a/maritime-ai-service/app/engine/context_manager.py
+++ b/maritime-ai-service/app/engine/context_manager.py
@@ -29,7 +29,8 @@ is a conservative but safe approximation.
 import logging
 from typing import Dict, List, Optional, Tuple
 
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from app.engine.messages import Message
+from app.engine.messages_adapters import to_openai_dict
 from app.engine.context_budget_runtime import (
     CHARS_PER_TOKEN,
     MAX_SUMMARY_TOKENS,
@@ -228,7 +229,7 @@ class ConversationCompactor:
         system_prompt: str = "",
         core_memory: str = "",
         user_id: str = "",
-    ) -> Tuple[str, List[BaseMessage], ContextBudget]:
+    ) -> Tuple[str, List[Message], ContextBudget]:
         """Check if compaction needed and perform if so.
 
         Args:
@@ -391,7 +392,6 @@ class ConversationCompactor:
 
         try:
             from app.engine.llm_pool import get_llm_light
-            from langchain_core.messages import HumanMessage as _HMsg
 
             conversation = "\n".join(
                 f"{'User' if m.get('role') == 'user' else 'AI'}: {m.get('content', '')[:300]}"
@@ -413,7 +413,7 @@ class ConversationCompactor:
             )
 
             llm = get_llm_light()
-            result = await llm.ainvoke([_HMsg(content=prompt)])
+            result = await llm.ainvoke([to_openai_dict(Message(role="user", content=prompt))])
 
             import json
             raw = result.content.strip()

--- a/maritime-ai-service/app/engine/conversation_window.py
+++ b/maritime-ai-service/app/engine/conversation_window.py
@@ -19,7 +19,7 @@ SOTA Reference (Feb 2026):
 import logging
 from typing import Dict, List, Tuple
 
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from app.engine.messages import Message
 
 logger = logging.getLogger(__name__)
 
@@ -44,34 +44,37 @@ class ConversationWindowManager:
     Sprint 78: Dynamic budget-based windowing when TokenBudgetManager is available
     """
 
-    def build_messages(self, history_list: List[Dict[str, str]]) -> List[BaseMessage]:
-        """Convert recent history_list entries to LangChain HumanMessage/AIMessage.
+    def build_messages(self, history_list: List[Dict[str, str]]) -> List[Message]:
+        """Convert recent history_list entries to native Message objects.
 
         Takes last RECENT_WINDOW entries from history_list.
-        Returns List[HumanMessage | AIMessage] — preserving full content (NO truncation).
+        Returns List[Message] (role="user" or "assistant") — preserving full
+        content (NO truncation).
 
         Args:
             history_list: List of dicts with "role" and "content" keys.
                           role is "user" or "assistant".
 
         Returns:
-            List of LangChain BaseMessage objects.
+            List of native Message objects.
         """
         if not history_list:
             return []
 
         recent = history_list[-RECENT_WINDOW:]
-        messages: List[BaseMessage] = []
+        messages: List[Message] = []
 
         for entry in recent:
             role = entry.get("role", "user")
             content = entry.get("content", "")
             if not content:
                 continue
-            if role == "assistant":
-                messages.append(AIMessage(content=content))
-            else:
-                messages.append(HumanMessage(content=content))
+            messages.append(
+                Message(
+                    role="assistant" if role == "assistant" else "user",
+                    content=content,
+                )
+            )
 
         return messages
 
@@ -81,7 +84,7 @@ class ConversationWindowManager:
         system_prompt: str = "",
         core_memory: str = "",
         summary: str = "",
-    ) -> Tuple[List[BaseMessage], "ContextBudget"]:
+    ) -> Tuple[List[Message], "ContextBudget"]:
         """Build messages that fit within token budget (Sprint 78).
 
         Uses TokenBudgetManager to compute how many recent messages fit

--- a/maritime-ai-service/app/engine/messages.py
+++ b/maritime-ai-service/app/engine/messages.py
@@ -39,6 +39,14 @@ class ToolResult(BaseModel):
     is_error: bool = False
 
 
+_ROLE_TO_LC_TYPE = {
+    "system": "system",
+    "user": "human",
+    "assistant": "ai",
+    "tool": "tool",
+}
+
+
 class Message(BaseModel):
     """Native chat message used across Wiii's runtime."""
 
@@ -47,6 +55,17 @@ class Message(BaseModel):
     name: Optional[str] = None
     tool_call_id: Optional[str] = None
     tool_calls: Optional[list[ToolCall]] = None
+
+    @property
+    def type(self) -> str:
+        """LangChain-compatible type alias.
+
+        Some legacy call sites still introspect ``msg.type`` (LC ``BaseMessage``
+        attribute). Provide a read-only alias mapping ``role`` → LC ``type`` so
+        Phase 9b RECEIVE-coupled paths keep working while the rest of the
+        codebase migrates to direct ``role`` checks.
+        """
+        return _ROLE_TO_LC_TYPE.get(self.role, "human")
 
 
 __all__ = ["Message", "MessageRole", "ToolCall", "ToolResult"]

--- a/maritime-ai-service/app/engine/multi_agent/agents/product_search_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/agents/product_search_runtime.py
@@ -7,7 +7,7 @@ import json
 import logging
 from typing import Dict, List, Optional, Tuple
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from app.engine.messages import Message, ToolCall
 
 from app.engine.multi_agent.agents.product_search_surface import (
     _DEEP_SEARCH_PROMPT,
@@ -258,13 +258,13 @@ BƯỚC 3: So sánh giá và tổng hợp kết quả.
         except Exception:
             pass
 
-    messages = [SystemMessage(content=system_prompt)]
+    messages: list = [Message(role="system", content=system_prompt)]
     lc_messages = context.get("langchain_messages", [])
     if lc_messages:
         messages.extend(lc_messages[-6:])
 
     if images and len(images) > 0:
-        content_parts = []
+        content_parts: list = []
         for image in images[:1]:
             image_data = image.get("data", "") if isinstance(image, dict) else ""
             media_type = image.get("media_type", "image/jpeg") if isinstance(image, dict) else "image/jpeg"
@@ -276,9 +276,10 @@ BƯỚC 3: So sánh giá và tổng hợp kết quả.
                     }
                 )
         content_parts.append({"type": "text", "text": query})
-        messages.append(HumanMessage(content=content_parts))
+        # Multimodal block list — pass directly as dict; LLM coercion preserves the list
+        messages.append({"role": "user", "content": content_parts})
     else:
-        messages.append(HumanMessage(content=query))
+        messages.append(Message(role="user", content=query))
 
     tools_used = []
     all_thinking = []
@@ -435,8 +436,20 @@ BƯỚC 3: So sánh giá và tổng hợp kết quả.
             if allow_authored_fallback:
                 narrated_thinking.append(ack_narration.summary)
             await _emit_narration(ack_narration, include_start=False)
-            messages.append(AIMessage(content="", tool_calls=[tool_call]))
-            messages.append(ToolMessage(content=result_str, tool_call_id=tool_id))
+            messages.append(
+                Message(
+                    role="assistant",
+                    content="",
+                    tool_calls=[
+                        ToolCall(
+                            id=str(tool_call.get("id") or tool_id),
+                            name=str(tool_call.get("name") or ""),
+                            arguments=tool_call.get("args") if isinstance(tool_call.get("args"), dict) else {},
+                        )
+                    ],
+                )
+            )
+            messages.append(Message(role="tool", content=result_str, tool_call_id=tool_id))
             tools_used.append({"name": tool_name, "args": tool_args, "iteration": iteration})
 
             if preview_enabled and event_queue is not None:

--- a/maritime-ai-service/app/engine/multi_agent/agents/tutor_node.py
+++ b/maritime-ai-service/app/engine/multi_agent/agents/tutor_node.py
@@ -1316,8 +1316,7 @@ class TutorAgentNode:
                 ),
             )
             if response is None:
-                from langchain_core.messages import AIMessage as _AIMsg
-                response = _AIMsg(content="")
+                response = Message(role="assistant", content="")
 
             _raw_turn_text, raw_turn_thinking = extract_thinking_from_response(
                 getattr(response, "content", ""),

--- a/maritime-ai-service/app/engine/multi_agent/agents/tutor_tool_dispatch_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/agents/tutor_tool_dispatch_runtime.py
@@ -3,7 +3,19 @@
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Sequence
 
-from langchain_core.messages import AIMessage, ToolMessage
+from app.engine.messages import Message, ToolCall
+
+
+def _tool_call_dict_to_native(tool_call: dict[str, Any]) -> ToolCall:
+    """Translate the LC-style ``{"name", "args", "id"}`` dict to a native ToolCall."""
+    raw_args = tool_call.get("args") or {}
+    if not isinstance(raw_args, dict):
+        raw_args = {"value": raw_args}
+    return ToolCall(
+        id=str(tool_call.get("id") or ""),
+        name=str(tool_call.get("name") or ""),
+        arguments=raw_args,
+    )
 
 
 @dataclass(slots=True)
@@ -24,12 +36,15 @@ def _append_tool_observation(
     tool_id: str,
     result: Any,
 ) -> None:
-    messages.append(AIMessage(content="", tool_calls=[tool_call]))
     messages.append(
-        ToolMessage(
-            content=str(result),
-            tool_call_id=tool_id,
+        Message(
+            role="assistant",
+            content="",
+            tool_calls=[_tool_call_dict_to_native(tool_call)],
         )
+    )
+    messages.append(
+        Message(role="tool", content=str(result), tool_call_id=tool_id)
     )
 
 
@@ -40,12 +55,15 @@ def _append_tool_error(
     tool_id: str,
     error: Exception,
 ) -> None:
-    messages.append(AIMessage(content="", tool_calls=[tool_call]))
     messages.append(
-        ToolMessage(
-            content=f"Error: {str(error)}",
-            tool_call_id=tool_id,
+        Message(
+            role="assistant",
+            content="",
+            tool_calls=[_tool_call_dict_to_native(tool_call)],
         )
+    )
+    messages.append(
+        Message(role="tool", content=f"Error: {str(error)}", tool_call_id=tool_id)
     )
 
 
@@ -307,9 +325,16 @@ async def dispatch_tutor_tool_call(
 
     if tool_name == "tool_think":
         thought = tool_args.get("thought", "")
-        messages.append(AIMessage(content="", tool_calls=[tool_call]))
         messages.append(
-            ToolMessage(
+            Message(
+                role="assistant",
+                content="",
+                tool_calls=[_tool_call_dict_to_native(tool_call)],
+            )
+        )
+        messages.append(
+            Message(
+                role="tool",
                 content=f"[Thought recorded: {len(thought)} chars]",
                 tool_call_id=tool_id,
             )
@@ -366,9 +391,16 @@ async def dispatch_tutor_tool_call(
             )
             last_tool_was_progress = False
 
-        messages.append(AIMessage(content="", tool_calls=[tool_call]))
         messages.append(
-            ToolMessage(
+            Message(
+                role="assistant",
+                content="",
+                tool_calls=[_tool_call_dict_to_native(tool_call)],
+            )
+        )
+        messages.append(
+            Message(
+                role="tool",
                 content=f"[Progress reported. Next phase: {next_label}]",
                 tool_call_id=tool_id,
             )

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_tool_rounds.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_tool_rounds.py
@@ -56,8 +56,26 @@ async def execute_code_studio_tool_rounds_impl(
     settings_obj,
 ):
     """Execute multi-round tool calling loop for the code studio capability."""
-    from langchain_core.messages import AIMessage as _AM, ToolMessage as _TM
+    from app.engine.messages import Message, ToolCall
     from app.engine.llm_pool import TIMEOUT_PROFILE_BACKGROUND
+
+    def _AM(content: str = "", tool_calls: list[dict] | None = None) -> Message:
+        """Native assistant message — keeps the tool-rounds construction call sites short."""
+        if tool_calls:
+            native_tcs = [
+                ToolCall(
+                    id=str(tc.get("id") or ""),
+                    name=str(tc.get("name") or ""),
+                    arguments=tc.get("args") if isinstance(tc.get("args"), dict) else {},
+                )
+                for tc in tool_calls
+            ]
+            return Message(role="assistant", content=content, tool_calls=native_tcs)
+        return Message(role="assistant", content=content)
+
+    def _TM(content: str = "", *, tool_call_id: str = "") -> Message:
+        """Native tool-result message."""
+        return Message(role="tool", content=str(content), tool_call_id=str(tool_call_id))
 
     tool_call_events: list[dict] = []
     state = state or {}

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -103,15 +103,15 @@ def _build_tool_result_message(
     tool_call_id: str,
     native_tool_messages: bool,
 ) -> Any:
-    """Create the post-tool message without hard-wiring LangChain in native lanes."""
+    """Create the post-tool message without depending on LangChain."""
     if native_tool_messages:
         from app.engine.native_chat_runtime import make_tool_message
 
         return make_tool_message(content, tool_call_id=tool_call_id)
 
-    from langchain_core.messages import ToolMessage as _TM
+    from app.engine.messages import Message
 
-    return _TM(content=content, tool_call_id=tool_call_id)
+    return Message(role="tool", content=content, tool_call_id=tool_call_id)
 
 
 def _build_user_instruction_message(
@@ -125,9 +125,9 @@ def _build_user_instruction_message(
 
         return make_user_message(content)
 
-    from langchain_core.messages import HumanMessage as _HM
+    from app.engine.messages import Message
 
-    return _HM(content=content)
+    return Message(role="user", content=content)
 
 
 async def execute_direct_tool_rounds_impl(

--- a/maritime-ai-service/app/engine/multi_agent/widget_surface.py
+++ b/maritime-ai-service/app/engine/multi_agent/widget_surface.py
@@ -56,7 +56,7 @@ def _inject_widget_blocks_from_tool_results(
     structured_visuals_enabled: bool = False,
 ):
     """Inject legacy widget blocks only when the turn is not on the structured figure lane."""
-    from langchain_core.messages import AIMessage as _AM
+    from app.engine.messages import Message
 
     raw_content = llm_response.content if hasattr(llm_response, "content") else str(llm_response)
     if isinstance(raw_content, list):
@@ -68,7 +68,7 @@ def _inject_widget_blocks_from_tool_results(
 
     def _build_response(value: str):
         if hasattr(llm_response, "content"):
-            return _AM(content=value)
+            return Message(role="assistant", content=value)
         return value
 
     def _strip_widget_blocks(value: str) -> str:

--- a/maritime-ai-service/tests/unit/test_graph_routing.py
+++ b/maritime-ai-service/tests/unit/test_graph_routing.py
@@ -1485,19 +1485,19 @@ class TestCodeStudioProgressHeartbeat:
 
     @pytest.mark.asyncio
     async def test_preserves_timeout_fallback_response_without_overwrite(self):
-        from langchain_core.messages import AIMessage
+        from app.engine.messages import Message
 
         class SlowLLM:
             async def ainvoke(self, _messages):
                 await asyncio.sleep(0.01)
-                return AIMessage(content="stale primary response")
+                return Message(role="assistant", content="stale primary response")
 
         class FallbackLLM:
             def bind_tools(self, _tools):
                 return self
 
             async def ainvoke(self, _messages):
-                return AIMessage(content="fallback recovery response")
+                return Message(role="assistant", content="fallback recovery response")
 
         async def push_event(_event):
             return None

--- a/maritime-ai-service/tests/unit/test_graph_visual_widget_injection.py
+++ b/maritime-ai-service/tests/unit/test_graph_visual_widget_injection.py
@@ -1,10 +1,10 @@
-from langchain_core.messages import AIMessage
+from app.engine.messages import Message
 
 from app.engine.multi_agent.graph import _inject_widget_blocks_from_tool_results
 
 
 def test_skips_widget_injection_for_structured_explanatory_turns():
-    response = AIMessage(content="Day la cau tra loi dang prose.")
+    response = Message(role="assistant", content="Day la cau tra loi dang prose.")
     tool_events = [
         {
             "type": "result",
@@ -25,7 +25,7 @@ def test_skips_widget_injection_for_structured_explanatory_turns():
 
 
 def test_strips_widget_blocks_when_structured_visual_events_exist():
-    response = AIMessage(
+    response = Message(role="assistant", 
         content="```widget\n<div>Legacy chart</div>\n```\n\nBridge prose sau visual.",
     )
     tool_events = [
@@ -49,7 +49,7 @@ def test_strips_widget_blocks_when_structured_visual_events_exist():
 
 
 def test_keeps_widget_injection_for_legacy_app_fallback():
-    response = AIMessage(content="Minh se chen mo phong ngay sau day.")
+    response = Message(role="assistant", content="Minh se chen mo phong ngay sau day.")
     tool_events = [
         {
             "type": "result",
@@ -71,7 +71,7 @@ def test_keeps_widget_injection_for_legacy_app_fallback():
 
 
 def test_strips_markdown_placeholder_when_visual_already_open():
-    response = AIMessage(
+    response = Message(role="assistant", 
         content=(
             "Day la bieu do bien dong gia dau.\n\n"
             "![Bieu do gia dau](https://example.com/chart-placeholder)\n\n"
@@ -100,7 +100,7 @@ def test_strips_markdown_placeholder_when_visual_already_open():
 
 
 def test_strips_markdown_placeholder_even_without_structured_visual_flag():
-    response = AIMessage(
+    response = Message(role="assistant", 
         content=(
             "Day la bieu do bien dong gia dau.\n\n"
             "![Bieu do gia dau](https://example.com/chart-placeholder)\n\n"

--- a/maritime-ai-service/tests/unit/test_graph_visual_widget_injection.py
+++ b/maritime-ai-service/tests/unit/test_graph_visual_widget_injection.py
@@ -25,7 +25,7 @@ def test_skips_widget_injection_for_structured_explanatory_turns():
 
 
 def test_strips_widget_blocks_when_structured_visual_events_exist():
-    response = Message(role="assistant", 
+    response = Message(role="assistant",
         content="```widget\n<div>Legacy chart</div>\n```\n\nBridge prose sau visual.",
     )
     tool_events = [
@@ -71,7 +71,7 @@ def test_keeps_widget_injection_for_legacy_app_fallback():
 
 
 def test_strips_markdown_placeholder_when_visual_already_open():
-    response = Message(role="assistant", 
+    response = Message(role="assistant",
         content=(
             "Day la bieu do bien dong gia dau.\n\n"
             "![Bieu do gia dau](https://example.com/chart-placeholder)\n\n"
@@ -100,7 +100,7 @@ def test_strips_markdown_placeholder_when_visual_already_open():
 
 
 def test_strips_markdown_placeholder_even_without_structured_visual_flag():
-    response = Message(role="assistant", 
+    response = Message(role="assistant",
         content=(
             "Day la bieu do bien dong gia dau.\n\n"
             "![Bieu do gia dau](https://example.com/chart-placeholder)\n\n"

--- a/maritime-ai-service/tests/unit/test_llm_failover.py
+++ b/maritime-ai-service/tests/unit/test_llm_failover.py
@@ -11,8 +11,7 @@ Sprint 11: Tests failover logic in LLMPool._create_instance():
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock, call
 
-from langchain_core.language_models import BaseChatModel
-
+from app.engine.llm_providers.wiii_chat_model import WiiiChatModel
 from app.engine.llm_pool import (
     FAILOVER_MODE_AUTO,
     FAILOVER_MODE_PINNED,
@@ -49,7 +48,7 @@ def _make_mock_provider(name: str, configured: bool = True, available: bool = Tr
     if fail:
         provider.create_instance.side_effect = Exception(f"{name} provider failed")
     else:
-        mock_llm = MagicMock(spec=BaseChatModel)
+        mock_llm = MagicMock(spec=WiiiChatModel)
         mock_llm._provider_name = name  # Tag for identification
         provider.create_instance.return_value = mock_llm
     provider.get_circuit_breaker.return_value = None
@@ -171,7 +170,7 @@ class TestFailoverChain:
         mock_settings.llm_failover_chain = ["google"]
         mock_settings.thinking_enabled = True
 
-        cached_llm = MagicMock(spec=BaseChatModel)
+        cached_llm = MagicMock(spec=WiiiChatModel)
         LLMPool._pool["deep"] = cached_llm
 
         result = LLMPool._create_instance("deep")

--- a/maritime-ai-service/tests/unit/test_llm_pool_multi.py
+++ b/maritime-ai-service/tests/unit/test_llm_pool_multi.py
@@ -8,8 +8,7 @@ active provider tracking, get_stats(), reset(), and convenience functions.
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
-from langchain_core.language_models import BaseChatModel
-
+from app.engine.llm_providers.wiii_chat_model import WiiiChatModel
 from app.engine.llm_pool import LLMPool, ThinkingTier, get_llm_deep, get_llm_moderate, get_llm_light
 from app.engine.llm_providers.base import LLMProvider
 
@@ -23,7 +22,7 @@ def reset_pool():
 
 
 def _make_provider(name, configured=True, available=True):
-    """Create a mock provider that returns BaseChatModel instances.
+    """Create a mock provider that returns WiiiChatModel instances.
 
     Note: We use MagicMock() without spec=LLMProvider because the concrete
     providers have extra methods (get_circuit_breaker, record_success, record_failure)
@@ -36,7 +35,7 @@ def _make_provider(name, configured=True, available=True):
     p.get_circuit_breaker.return_value = None
     p.record_success = AsyncMock()
     p.record_failure = AsyncMock()
-    mock_llm = MagicMock(spec=BaseChatModel)
+    mock_llm = MagicMock(spec=WiiiChatModel)
     mock_llm._tag = f"{name}_instance"
     p.create_instance.return_value = mock_llm
     return p
@@ -109,11 +108,11 @@ class TestPoolInitialization:
 
 
 class TestTypeCompatibility:
-    """Verify all returned instances are BaseChatModel compatible."""
+    """Verify all returned instances are WiiiChatModel compatible."""
 
     @patch("app.engine.llm_pool.settings")
     def test_pool_returns_base_chat_model(self, mock_settings):
-        """All instances from pool are BaseChatModel."""
+        """All instances from pool are WiiiChatModel."""
         mock_settings.enable_llm_failover = True
         mock_settings.llm_failover_chain = ["google"]
         mock_settings.thinking_enabled = True
@@ -127,11 +126,11 @@ class TestTypeCompatibility:
 
         for tier_key in ["deep", "moderate", "light"]:
             llm = LLMPool._pool[tier_key]
-            assert isinstance(llm, BaseChatModel)
+            assert isinstance(llm, WiiiChatModel)
 
     @patch("app.engine.llm_pool.settings")
     def test_get_returns_base_chat_model(self, mock_settings):
-        """LLMPool.get() returns BaseChatModel."""
+        """LLMPool.get() returns WiiiChatModel."""
         mock_settings.enable_llm_failover = True
         mock_settings.llm_failover_chain = ["google"]
         mock_settings.thinking_enabled = True
@@ -144,11 +143,11 @@ class TestTypeCompatibility:
         LLMPool._initialized = True
 
         llm = LLMPool.get(ThinkingTier.MODERATE)
-        assert isinstance(llm, BaseChatModel)
+        assert isinstance(llm, WiiiChatModel)
 
     @patch("app.engine.llm_pool.settings")
     def test_convenience_functions_return_base_chat_model(self, mock_settings):
-        """get_llm_deep/moderate/light return BaseChatModel."""
+        """get_llm_deep/moderate/light return WiiiChatModel."""
         mock_settings.enable_llm_failover = True
         mock_settings.llm_failover_chain = ["google"]
         mock_settings.thinking_enabled = True
@@ -160,9 +159,9 @@ class TestTypeCompatibility:
             LLMPool._create_instance(tier)
         LLMPool._initialized = True
 
-        assert isinstance(get_llm_deep(), BaseChatModel)
-        assert isinstance(get_llm_moderate(), BaseChatModel)
-        assert isinstance(get_llm_light(), BaseChatModel)
+        assert isinstance(get_llm_deep(), WiiiChatModel)
+        assert isinstance(get_llm_moderate(), WiiiChatModel)
+        assert isinstance(get_llm_light(), WiiiChatModel)
 
 
 # ============================================================================

--- a/maritime-ai-service/tests/unit/test_llm_providers.py
+++ b/maritime-ai-service/tests/unit/test_llm_providers.py
@@ -8,8 +8,7 @@ Tests provider ABC, Gemini/OpenAI/Ollama provider creation, is_available, is_con
 import pytest
 from unittest.mock import patch, MagicMock, PropertyMock
 
-from langchain_core.language_models import BaseChatModel
-
+from app.engine.llm_providers.wiii_chat_model import WiiiChatModel
 from app.engine.llm_providers.base import LLMProvider
 from app.engine.llm_providers.gemini_provider import GeminiProvider
 from app.engine.llm_providers.openai_provider import OpenAIProvider
@@ -174,7 +173,7 @@ class TestGeminiProvider:
         mock_settings.google_model_advanced = "gemini-3.1-pro-preview"
         mock_settings.google_openai_compat_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
         mock_settings.thinking_enabled = True
-        mock_instance = MagicMock(spec=BaseChatModel)
+        mock_instance = MagicMock(spec=WiiiChatModel)
         mock_chat.return_value = mock_instance
 
         p = GeminiProvider()
@@ -191,7 +190,7 @@ class TestGeminiProvider:
         mock_settings.google_model_advanced = "gemini-3.1-pro-preview"
         mock_settings.google_openai_compat_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
         mock_settings.thinking_enabled = False
-        mock_instance = MagicMock(spec=BaseChatModel)
+        mock_instance = MagicMock(spec=WiiiChatModel)
         mock_chat.return_value = mock_instance
 
         p = GeminiProvider()
@@ -217,7 +216,7 @@ class TestGeminiProvider:
         mock_settings.google_model_advanced = "gemini-3.1-pro-preview"
         mock_settings.google_openai_compat_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
         mock_settings.thinking_enabled = True
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = GeminiProvider()
         p.create_instance(tier="deep", thinking_budget=8192, include_thoughts=True)
@@ -237,7 +236,7 @@ class TestGeminiProvider:
         mock_settings.google_model_advanced = "gemini-3.1-pro-preview"
         mock_settings.google_openai_compat_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
         mock_settings.thinking_enabled = True
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = GeminiProvider()
         p.create_instance(tier="moderate", thinking_budget=2048)
@@ -253,7 +252,7 @@ class TestGeminiProvider:
         mock_settings.google_model_advanced = "gemini-3.1-pro-preview"
         mock_settings.google_openai_compat_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
         mock_settings.thinking_enabled = True
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = GeminiProvider()
         p.create_instance(tier="light", thinking_budget=512)
@@ -269,7 +268,7 @@ class TestGeminiProvider:
         mock_settings.google_model_advanced = "gemini-3.1-pro-preview"
         mock_settings.google_openai_compat_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
         mock_settings.thinking_enabled = False
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = GeminiProvider()
         p.create_instance(tier="deep", thinking_budget=8192)
@@ -318,7 +317,7 @@ class TestOpenAIProvider:
         mock_settings.openai_model = "gpt-4o-mini"
         mock_settings.openai_model_advanced = "gpt-4o"
         mock_settings.openai_base_url = None
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = OpenAIProvider()
         llm = p.create_instance(tier="deep")
@@ -332,7 +331,7 @@ class TestOpenAIProvider:
         mock_settings.openai_model = "gpt-4o-mini"
         mock_settings.openai_model_advanced = "gpt-4o"
         mock_settings.openai_base_url = None
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = OpenAIProvider()
         llm = p.create_instance(tier="light")
@@ -356,7 +355,7 @@ class TestOpenAIProvider:
         mock_settings.openrouter_data_collection = None
         mock_settings.openrouter_zdr = None
         mock_settings.openrouter_provider_sort = None
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = OpenAIProvider()
         p.create_instance(tier="moderate")
@@ -379,7 +378,7 @@ class TestOpenAIProvider:
         mock_settings.openrouter_data_collection = "deny"
         mock_settings.openrouter_zdr = True
         mock_settings.openrouter_provider_sort = "latency"
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = OpenAIProvider()
         p.create_instance(tier="moderate")
@@ -413,7 +412,7 @@ class TestOpenAIProvider:
         mock_settings.openrouter_data_collection = "deny"
         mock_settings.openrouter_zdr = True
         mock_settings.openrouter_provider_sort = "latency"
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = OpenAIProvider()
         p.create_instance(tier="moderate")
@@ -496,7 +495,7 @@ class TestOllamaProvider:
         mock_settings.ollama_base_url = "http://localhost:11434"
         mock_settings.ollama_model = "llama3.2"
         mock_settings.ollama_api_key = None
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = OllamaProvider()
         llm = p.create_instance(tier="moderate", temperature=0.5)
@@ -513,7 +512,7 @@ class TestOllamaProvider:
         mock_settings.ollama_base_url = "https://ollama.com/api"
         mock_settings.ollama_model = "gpt-oss:20b"
         mock_settings.ollama_api_key = "ollama-cloud-key"
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = OllamaProvider()
         p.create_instance(tier="moderate", temperature=0.1)

--- a/maritime-ai-service/tests/unit/test_sprint200_visual_search.py
+++ b/maritime-ai-service/tests/unit/test_sprint200_visual_search.py
@@ -612,9 +612,14 @@ class TestImagePipelinePassthrough:
             assert "NHẬN DIỆN SẢN PHẨM TỪ ẢNH" not in _SYSTEM_PROMPT
 
     def test_multimodal_human_message(self):
-        """With images, HumanMessage should have multimodal content parts."""
-        from langchain_core.messages import HumanMessage
+        """With images, the user message should carry multimodal content parts.
 
+        Phase 9 (#207): native dispatch path uses raw OpenAI-shape dicts
+        for multimodal content (``{"role": "user", "content": [<blocks>]}``)
+        because native ``Message.content`` is ``str`` only — vision blocks
+        ride as a list at the dispatch boundary, not inside the canonical
+        ``Message`` model.
+        """
         # Simulate what _react_loop does when images are present
         images = [{"data": "dGVzdA==", "media_type": "image/jpeg"}]
         query = "Tìm sản phẩm này"
@@ -629,20 +634,20 @@ class TestImagePipelinePassthrough:
                     "image_url": {"url": f"data:{img_type};base64,{img_data}"},
                 })
         content_parts.append({"type": "text", "text": query})
-        msg = HumanMessage(content=content_parts)
+        msg = {"role": "user", "content": content_parts}
 
-        assert isinstance(msg.content, list)
-        assert len(msg.content) == 2
-        assert msg.content[0]["type"] == "image_url"
-        assert msg.content[1]["type"] == "text"
-        assert msg.content[1]["text"] == query
+        assert isinstance(msg["content"], list)
+        assert len(msg["content"]) == 2
+        assert msg["content"][0]["type"] == "image_url"
+        assert msg["content"][1]["type"] == "text"
+        assert msg["content"][1]["text"] == query
 
     def test_no_images_text_message(self):
-        """Without images, HumanMessage is plain text."""
-        from langchain_core.messages import HumanMessage
+        """Without images, the user message is plain text (native ``Message`` shape)."""
+        from app.engine.messages import Message
 
         query = "Tìm MacBook Pro M4"
-        msg = HumanMessage(content=query)
+        msg = Message(role="user", content=query)
 
         assert isinstance(msg.content, str)
         assert msg.content == query

--- a/maritime-ai-service/tests/unit/test_sprint30_llm_factory.py
+++ b/maritime-ai-service/tests/unit/test_sprint30_llm_factory.py
@@ -9,7 +9,7 @@ Covers:
 
 import pytest
 from unittest.mock import patch, MagicMock
-from langchain_core.language_models import BaseChatModel
+from app.engine.llm_providers.wiii_chat_model import WiiiChatModel
 from app.engine.llm_factory import ThinkingTier, get_thinking_budget
 
 
@@ -131,7 +131,7 @@ class TestCreateLLM:
         mock_gemini_settings.google_openai_compat_url = "https://test.example.com/"
         mock_gemini_settings.thinking_enabled = False
 
-        mock_wiii = MagicMock(spec=BaseChatModel)
+        mock_wiii = MagicMock(spec=WiiiChatModel)
 
         with patch("app.engine.llm_factory.settings", mock_factory_settings), \
              patch("app.engine.llm_providers.gemini_provider.settings", mock_gemini_settings), \

--- a/maritime-ai-service/tests/unit/test_sprint77_conversation_window.py
+++ b/maritime-ai-service/tests/unit/test_sprint77_conversation_window.py
@@ -62,14 +62,16 @@ class TestConversationWindowManagerBuildMessages:
         history = [{"role": "user", "content": "Hello"}]
         result = window_mgr.build_messages(history)
         assert len(result) == 1
-        assert isinstance(result[0], HumanMessage)
+        # Phase 9b migration: native Message replaces HumanMessage
+        assert result[0].role == "user"
         assert result[0].content == "Hello"
 
     def test_single_assistant_turn(self, window_mgr):
         history = [{"role": "assistant", "content": "Hi there"}]
         result = window_mgr.build_messages(history)
         assert len(result) == 1
-        assert isinstance(result[0], AIMessage)
+        # Phase 9b migration: native Message replaces AIMessage
+        assert result[0].role == "assistant"
         assert result[0].content == "Hi there"
 
     def test_within_window(self, window_mgr):
@@ -93,16 +95,17 @@ class TestConversationWindowManagerBuildMessages:
         assert len(result[0].content) == 5000
 
     def test_correct_types(self, window_mgr):
-        """User → HumanMessage, assistant → AIMessage."""
+        """User → role="user" Message, assistant → role="assistant" Message."""
         history = [
             {"role": "user", "content": "Q1"},
             {"role": "assistant", "content": "A1"},
             {"role": "user", "content": "Q2"},
         ]
         result = window_mgr.build_messages(history)
-        assert isinstance(result[0], HumanMessage)
-        assert isinstance(result[1], AIMessage)
-        assert isinstance(result[2], HumanMessage)
+        # Phase 9b migration: native Message replaces LC Human/AI
+        assert result[0].role == "user"
+        assert result[1].role == "assistant"
+        assert result[2].role == "user"
 
     def test_skips_empty_content(self, window_mgr):
         """Entries with empty content are skipped."""
@@ -117,11 +120,12 @@ class TestConversationWindowManagerBuildMessages:
         assert result[1].content == "World"
 
     def test_unknown_role_defaults_to_human(self, window_mgr):
-        """Unknown role defaults to HumanMessage."""
+        """Unknown role (e.g. 'system') defaults to role='user' Message."""
         history = [{"role": "system", "content": "test"}]
         result = window_mgr.build_messages(history)
         assert len(result) == 1
-        assert isinstance(result[0], HumanMessage)
+        # Phase 9b migration: native Message — anything not 'assistant' becomes role='user'
+        assert result[0].role == "user"
 
     def test_preserves_order(self, window_mgr):
         """Messages preserve chronological order."""
@@ -285,9 +289,10 @@ class TestInputProcessorContextSeparation:
         from uuid import uuid4
         context = await processor.build_context(mock_request, uuid4())
         assert len(context.langchain_messages) == 3
-        assert isinstance(context.langchain_messages[0], HumanMessage)
-        assert isinstance(context.langchain_messages[1], AIMessage)
-        assert isinstance(context.langchain_messages[2], HumanMessage)
+        # Phase 9b migration: native Message replaces LC Human/AI
+        assert context.langchain_messages[0].role == "user"
+        assert context.langchain_messages[1].role == "assistant"
+        assert context.langchain_messages[2].role == "user"
 
     @pytest.mark.asyncio
     async def test_langchain_messages_empty_when_no_history(self, mock_request):
@@ -813,7 +818,8 @@ class TestEndToEnd:
         ctx.langchain_messages = mgr.build_messages(ctx.history_list)
 
         assert len(ctx.langchain_messages) == 3
-        assert isinstance(ctx.langchain_messages[0], HumanMessage)
+        # Phase 9b migration: native Message
+        assert ctx.langchain_messages[0].role == "user"
         assert ctx.langchain_messages[0].content == "First question"
 
     def test_follow_up_has_context(self):

--- a/maritime-ai-service/tests/unit/test_sprint77_conversation_window.py
+++ b/maritime-ai-service/tests/unit/test_sprint77_conversation_window.py
@@ -18,7 +18,7 @@ import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from app.engine.messages import Message
 
 from app.engine.conversation_window import (
     FORMAT_CHAR_LIMIT,
@@ -361,8 +361,8 @@ class TestTutorNodeHistoryInjection:
         node._character_tools_enabled = False
 
         history_messages = [
-            HumanMessage(content="Previous question"),
-            AIMessage(content="Previous answer"),
+            Message(role="user", content="Previous question"),
+            Message(role="assistant", content="Previous answer"),
         ]
         context = {
             "langchain_messages": history_messages,
@@ -375,12 +375,12 @@ class TestTutorNodeHistoryInjection:
         call_args = mock_llm.ainvoke.call_args
         messages = call_args[0][0]
 
-        # Should be: [system_dict, HumanMessage(prev), AIMessage(prev), user_dict(new)]
+        # Should be: [system_dict, Message(role="user", prev), Message(role="assistant", prev), user_dict(new)]
         # Phase 1 migration: system/user are native dicts; history slice stays LC
         assert isinstance(messages[0], dict) and messages[0]["role"] == "system"
-        assert isinstance(messages[1], HumanMessage)
+        assert messages[1].role == "user"
         assert messages[1].content == "Previous question"
-        assert isinstance(messages[2], AIMessage)
+        assert messages[2].role == "assistant"
         assert messages[2].content == "Previous answer"
         assert isinstance(messages[-1], dict) and messages[-1]["role"] == "user"
         assert messages[-1]["content"] == "New question"
@@ -426,7 +426,7 @@ class TestTutorNodeHistoryInjection:
         node._character_tools_enabled = False
 
         # 20 history messages
-        history = [HumanMessage(content=f"msg_{i}") for i in range(20)]
+        history = [Message(role="user", content=f"msg_{i}") for i in range(20)]
         context = {"langchain_messages": history, "user_role": "student"}
 
         await node._react_loop("New Q", context)
@@ -449,7 +449,7 @@ class TestTutorNodeHistoryInjection:
             "user_role": "student",
             "user_name": "Test",
             "conversation_history": "Should NOT appear in system prompt",
-            "langchain_messages": [HumanMessage(content="should not appear")],
+            "langchain_messages": [Message(role="user", content="should not appear")],
             "conversation_summary": "should not appear either",
         }
 
@@ -473,8 +473,8 @@ class TestDirectNodeHistoryInjection:
     async def test_direct_node_includes_history(self):
         """direct_response_node injects history between system and human messages."""
         history_messages = [
-            HumanMessage(content="What's COLREGs?"),
-            AIMessage(content="COLREGs is..."),
+            Message(role="user", content="What's COLREGs?"),
+            Message(role="assistant", content="COLREGs is..."),
         ]
         state = {
             "query": "Tell me more",
@@ -508,12 +508,12 @@ class TestDirectNodeHistoryInjection:
 
         # Verify LLM was called with history messages
         call_args = mock_llm.ainvoke.call_args[0][0]
-        # Should be [system_dict, HumanMessage(prev), AIMessage(prev), user_dict(new)]
+        # Should be [system_dict, Message(role="user", prev), Message(role="assistant", prev), user_dict(new)]
         # Phase 1 migration: system/user are native dicts; history slice stays LC
         assert isinstance(call_args[0], dict) and call_args[0]["role"] == "system"
-        assert isinstance(call_args[1], HumanMessage)
+        assert call_args[1].role == "user"
         assert call_args[1].content == "What's COLREGs?"
-        assert isinstance(call_args[2], AIMessage)
+        assert call_args[2].role == "assistant"
         assert isinstance(call_args[-1], dict) and call_args[-1]["role"] == "user"
         assert call_args[-1]["content"] == "Tell me more"
 
@@ -576,8 +576,8 @@ class TestMemoryAgentHistoryInjection:
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
 
         history_messages = [
-            HumanMessage(content="Tên tôi là Nam"),
-            AIMessage(content="Mình ghi nhớ rồi, Nam!"),
+            Message(role="user", content="Tên tôi là Nam"),
+            Message(role="assistant", content="Mình ghi nhớ rồi, Nam!"),
         ]
         state = {
             "user_id": "user1",
@@ -597,9 +597,9 @@ class TestMemoryAgentHistoryInjection:
         assert len(call_args) == 4
         # Phase 1 migration: system/user are native dicts; history slice stays LC
         assert isinstance(call_args[0], dict) and call_args[0]["role"] == "system"
-        assert isinstance(call_args[1], HumanMessage)
+        assert call_args[1].role == "user"
         assert call_args[1].content == "Tên tôi là Nam"
-        assert isinstance(call_args[2], AIMessage)
+        assert call_args[2].role == "assistant"
         assert isinstance(call_args[-1], dict) and call_args[-1]["role"] == "user"
 
     @pytest.mark.asyncio
@@ -620,7 +620,7 @@ class TestMemoryAgentHistoryInjection:
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
 
         # 10 history messages
-        history = [HumanMessage(content=f"msg_{i}") for i in range(10)]
+        history = [Message(role="user", content=f"msg_{i}") for i in range(10)]
         state = {
             "user_id": "user1",
             "query": "Test",
@@ -686,8 +686,8 @@ class TestSupervisorContextEnhancement:
         mock_result.reasoning = "test"
 
         history = [
-            HumanMessage(content="Tell me about COLREGs"),
-            AIMessage(content="COLREGs is the international regulations..."),
+            Message(role="user", content="Tell me about COLREGs"),
+            Message(role="assistant", content="COLREGs is the international regulations..."),
         ]
         context = {"langchain_messages": history}
 
@@ -758,8 +758,8 @@ class TestGraphInitialState:
     async def test_messages_populated_from_langchain_messages(self):
         """Initial state messages are populated from langchain_messages in context."""
         history = [
-            HumanMessage(content="Q1"),
-            AIMessage(content="A1"),
+            Message(role="user", content="Q1"),
+            Message(role="assistant", content="A1"),
         ]
         context = {"langchain_messages": history}
 
@@ -848,7 +848,7 @@ class TestEndToEnd:
             message="Test",
             user_role=MagicMock(),
         )
-        ctx.langchain_messages = [HumanMessage(content="prev")]
+        ctx.langchain_messages = [Message(role="user", content="prev")]
         ctx.conversation_summary = "Summary of older turns"
 
         # Simulate what ChatOrchestrator builds

--- a/maritime-ai-service/tests/unit/test_sprint78_context_manager.py
+++ b/maritime-ai-service/tests/unit/test_sprint78_context_manager.py
@@ -202,8 +202,9 @@ class TestTokenBudgetManager:
         messages, budget = mgr.build_context_messages(history)
 
         assert len(messages) == 5
-        assert isinstance(messages[0], HumanMessage)  # First is user (even index)
-        assert isinstance(messages[1], AIMessage)  # Second is assistant
+        # Phase 9b migration: native Message replaces LC Human/AI
+        assert messages[0].role == "user"  # First is user (even index)
+        assert messages[1].role == "assistant"  # Second is assistant
         assert budget.messages_included == 5
 
     def test_build_context_messages_respects_budget(self):

--- a/maritime-ai-service/tests/unit/test_sprint78_context_manager.py
+++ b/maritime-ai-service/tests/unit/test_sprint78_context_manager.py
@@ -14,7 +14,7 @@ import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
-from langchain_core.messages import AIMessage, HumanMessage
+from app.engine.messages import Message
 
 
 # =============================================================================
@@ -82,8 +82,8 @@ class TestTokenBudgetManager:
 
         mgr = TokenBudgetManager()
         messages = [
-            HumanMessage(content="Hello world"),  # 11 chars → 2 + 4 overhead = 6
-            AIMessage(content="Hi there"),  # 8 chars → 2 + 4 = 6
+            Message(role="user", content="Hello world"),  # 11 chars → 2 + 4 overhead = 6
+            Message(role="assistant", content="Hi there"),  # 8 chars → 2 + 4 = 6
         ]
         tokens = mgr.estimate_messages_tokens(messages)
         assert tokens > 0
@@ -602,7 +602,7 @@ class TestInputProcessorIntegration:
             mock_inst = MagicMock()
             mock_inst.maybe_compact = AsyncMock(return_value=(
                 "",  # no summary
-                [HumanMessage(content="prev msg")],  # messages
+                [Message(role="user", content="prev msg")],  # messages
                 MagicMock(  # budget
                     total_used=100,
                     total_budget=20000,
@@ -872,13 +872,13 @@ class TestSupervisorSummaryInjection:
 
     def test_supervisor_context_includes_summary(self):
         """Verify supervisor builds context with summary when available."""
-        from langchain_core.messages import HumanMessage, AIMessage
+        from app.engine.messages import Message
 
         # Simulate what supervisor._route_structured does
         context = {
             "langchain_messages": [
-                HumanMessage(content="Luật COLREGs là gì?"),
-                AIMessage(content="COLREGs là bộ quy tắc tránh va."),
+                Message(role="user", content="Luật COLREGs là gì?"),
+                Message(role="assistant", content="COLREGs là bộ quy tắc tránh va."),
             ],
             "conversation_summary": "User đã hỏi về luật hàng hải cơ bản.",
         }

--- a/maritime-ai-service/tests/unit/test_sprint79_memory_hardening.py
+++ b/maritime-ai-service/tests/unit/test_sprint79_memory_hardening.py
@@ -28,7 +28,7 @@ if "app.services.chat_service" not in sys.modules:
     _mock_chat_svc.get_chat_service = MagicMock
     sys.modules["app.services.chat_service"] = _mock_chat_svc
 
-from langchain_core.messages import AIMessage, HumanMessage
+from app.engine.messages import Message
 
 
 # =============================================================================
@@ -410,7 +410,7 @@ class TestIntegration:
         with patch("app.engine.context_manager.get_compactor") as mock_get:
             mock_compactor = MagicMock()
             mock_compactor.maybe_compact = AsyncMock(return_value=(
-                "", [HumanMessage(content="hi")],
+                "", [Message(role="user", content="hi")],
                 MagicMock(
                     total_used=50, total_budget=20000, utilization=0.002,
                     messages_included=1, messages_dropped=0, has_summary=False,

--- a/maritime-ai-service/tests/unit/test_sprint95_character_tools.py
+++ b/maritime-ai-service/tests/unit/test_sprint95_character_tools.py
@@ -386,13 +386,15 @@ class TestReActDispatch:
                 context={"user_role": "student"},
             )
 
-        # The second ainvoke should have received messages with ToolMessage
+        # The second ainvoke should have received messages with a tool-result entry
         call_args = mock_tutor._llm_with_tools.ainvoke.call_args_list
         assert len(call_args) == 2
-        # Messages for second call should include ToolMessage
         second_messages = call_args[1][0][0]
-        from langchain_core.messages import ToolMessage
-        tool_msgs = [m for m in second_messages if isinstance(m, ToolMessage)]
+        # Phase 9b migration: tool-result entries are native Message(role="tool", ...)
+        tool_msgs = [
+            m for m in second_messages
+            if getattr(m, "role", None) == "tool"
+        ]
         assert len(tool_msgs) >= 1
 
     @pytest.mark.asyncio

--- a/maritime-ai-service/tests/unit/test_supervisor_agent.py
+++ b/maritime-ai-service/tests/unit/test_supervisor_agent.py
@@ -11,7 +11,7 @@ import types
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 
-from langchain_core.messages import AIMessage, HumanMessage
+from app.engine.messages import Message
 from app.core.exceptions import ProviderUnavailableError
 
 # Break circular import: multi_agent.__init__ → graph → agents → tutor_node
@@ -500,8 +500,8 @@ class TestSupervisorRoute:
             "query": "tạo visual cho mình xem được chứ?",
             "context": {
                 "langchain_messages": [
-                    HumanMessage(content="Giải thích Quy tắc 15 COLREGs"),
-                    AIMessage(
+                    Message(role="user", content="Giải thích Quy tắc 15 COLREGs"),
+                    Message(role="assistant", 
                         content="Rule 15 trong COLREGs tập trung vào tình huống cắt hướng, tàu thấy bên mạn phải phải nhường đường."
                     ),
                 ],
@@ -532,8 +532,8 @@ class TestSupervisorRoute:
             "query": "tạo visual cho mình xem được chứ?",
             "context": {
                 "langchain_messages": [
-                    HumanMessage(content="Giải thích Quy tắc 15 COLREGs"),
-                    AIMessage(
+                    Message(role="user", content="Giải thích Quy tắc 15 COLREGs"),
+                    Message(role="assistant", 
                         content="Rule 15 trong COLREGs tập trung vào tình huống cắt hướng, tàu thấy bên mạn phải phải nhường đường."
                     ),
                 ],

--- a/maritime-ai-service/tests/unit/test_supervisor_agent.py
+++ b/maritime-ai-service/tests/unit/test_supervisor_agent.py
@@ -501,7 +501,7 @@ class TestSupervisorRoute:
             "context": {
                 "langchain_messages": [
                     Message(role="user", content="Giải thích Quy tắc 15 COLREGs"),
-                    Message(role="assistant", 
+                    Message(role="assistant",
                         content="Rule 15 trong COLREGs tập trung vào tình huống cắt hướng, tàu thấy bên mạn phải phải nhường đường."
                     ),
                 ],
@@ -533,7 +533,7 @@ class TestSupervisorRoute:
             "context": {
                 "langchain_messages": [
                     Message(role="user", content="Giải thích Quy tắc 15 COLREGs"),
-                    Message(role="assistant", 
+                    Message(role="assistant",
                         content="Rule 15 trong COLREGs tập trung vào tình huống cắt hướng, tàu thấy bên mạn phải phải nhường đường."
                     ),
                 ],

--- a/maritime-ai-service/tests/unit/test_tutor_response.py
+++ b/maritime-ai-service/tests/unit/test_tutor_response.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
-from langchain_core.messages import ToolMessage
+from app.engine.messages import Message
 
 from app.engine.multi_agent.agents.tutor_response import (
     collect_tutor_model_message,
@@ -50,9 +50,8 @@ def test_normalize_tutor_answer_shape_keeps_warmth_but_removes_greeting_lead():
 
 def test_recover_tutor_answer_from_messages_uses_last_substantive_tool_result():
     messages = [
-        ToolMessage(content="Error: timed out", tool_call_id="call_0"),
-        ToolMessage(
-            content=(
+        Message(role="tool", content="Error: timed out", tool_call_id="call_0"),
+        Message(role="tool", content=(
                 "**Rule 13 (V\u01b0\u1ee3t)** \u00e1p d\u1ee5ng khi m\u1ed9t t\u00e0u ti\u1ebfn \u0111\u1ebfn t\u1eeb ph\u00eda sau v\u01b0\u1ee3t qu\u00e1 22.5 \u0111\u1ed9 sau ngang m\u1ea1n.\n\n"
                 "**Rule 15 (C\u1eaft h\u01b0\u1edbng)** \u00e1p d\u1ee5ng khi hai t\u00e0u m\u00e1y c\u1eaft nhau v\u00e0 m\u1ed9t t\u00e0u th\u1ea5y t\u00e0u kia \u1edf m\u1ea1n ph\u1ea3i.\n\n"
                 "<!-- CONFIDENCE: 0.95 | IS_COMPLETE: True -->"
@@ -97,12 +96,10 @@ def test_placeholder_answer_flags_tool_markup_payload():
 
 def test_recover_tutor_answer_skips_visual_payload_json():
     messages = [
-        ToolMessage(
-            content='{"id":"visual-1","type":"chart","renderer_kind":"inline_html","visual_session_id":"vs-1"}',
+        Message(role="tool", content='{"id":"visual-1","type":"chart","renderer_kind":"inline_html","visual_session_id":"vs-1"}',
             tool_call_id="call_visual",
         ),
-        ToolMessage(
-            content=(
+        Message(role="tool", content=(
                 "**Rule 15** ap dung khi hai tau cat ngang va tau thay doi phuong o man phai "
                 "phai nhuong duong."
             ),

--- a/maritime-ai-service/tests/unit/test_unified_providers.py
+++ b/maritime-ai-service/tests/unit/test_unified_providers.py
@@ -9,8 +9,7 @@ base URL handling, and integration with llm_factory / llm_pool.
 import pytest
 from unittest.mock import patch, MagicMock
 
-from langchain_core.language_models import BaseChatModel
-
+from app.engine.llm_providers.wiii_chat_model import WiiiChatModel
 from app.engine.llm_providers.gemini_provider import GeminiProvider
 from app.engine.llm_providers.ollama_provider import OllamaProvider
 from app.engine.llm_pool import LLMPool, ThinkingTier
@@ -32,7 +31,7 @@ class TestGeminiProviderUnified:
         mock_settings.google_model = "gemini-3.1-flash-lite-preview"
         mock_settings.google_openai_compat_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
         mock_settings.thinking_enabled = False
-        mock_instance = MagicMock(spec=BaseChatModel)
+        mock_instance = MagicMock(spec=WiiiChatModel)
         mock_chat.return_value = mock_instance
 
         p = GeminiProvider()
@@ -53,7 +52,7 @@ class TestGeminiProviderUnified:
         mock_settings.google_model = "gemini-3.1-flash-lite-preview"
         mock_settings.google_openai_compat_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
         mock_settings.thinking_enabled = True
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = GeminiProvider()
         p.create_instance(tier="deep", thinking_budget=8192, include_thoughts=True)
@@ -69,7 +68,7 @@ class TestGeminiProviderUnified:
         mock_settings.google_model = "gemini-3.1-flash-lite-preview"
         mock_settings.google_openai_compat_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
         mock_settings.thinking_enabled = False
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = GeminiProvider()
         p.create_instance(tier="light", thinking_budget=0)
@@ -85,7 +84,7 @@ class TestGeminiProviderUnified:
         mock_settings.google_model = "gemini-3.1-flash-lite-preview"
         mock_settings.google_openai_compat_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
         mock_settings.thinking_enabled = True
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = GeminiProvider()
         p.create_instance(tier="light", thinking_budget=0)
@@ -110,7 +109,7 @@ class TestOllamaProviderUnified:
         mock_settings.ollama_model = "qwen3:4b-instruct-2507-q4_K_M"
         mock_settings.ollama_api_key = None
         mock_settings.ollama_thinking_models = ["qwen3", "deepseek-r1", "qwq"]
-        mock_instance = MagicMock(spec=BaseChatModel)
+        mock_instance = MagicMock(spec=WiiiChatModel)
         mock_chat.return_value = mock_instance
 
         p = OllamaProvider()
@@ -131,7 +130,7 @@ class TestOllamaProviderUnified:
         mock_settings.ollama_model = "llama3.2"
         mock_settings.ollama_api_key = None
         mock_settings.ollama_thinking_models = ["qwen3"]
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = OllamaProvider()
         p.create_instance(tier="light")
@@ -147,7 +146,7 @@ class TestOllamaProviderUnified:
         mock_settings.ollama_model = "llama3.2"
         mock_settings.ollama_api_key = None
         mock_settings.ollama_thinking_models = ["qwen3"]
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = OllamaProvider()
         p.create_instance(tier="light")
@@ -163,7 +162,7 @@ class TestOllamaProviderUnified:
         mock_settings.ollama_model = "gpt-oss:20b"
         mock_settings.ollama_api_key = "ollama-cloud-key"
         mock_settings.ollama_thinking_models = ["qwen3"]
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = OllamaProvider()
         p.create_instance(tier="moderate")
@@ -179,7 +178,7 @@ class TestOllamaProviderUnified:
         mock_settings.ollama_model = "qwen3:8b"
         mock_settings.ollama_api_key = None
         mock_settings.ollama_thinking_models = ["qwen3", "deepseek-r1", "qwq"]
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = OllamaProvider()
         p.create_instance(tier="moderate", thinking_budget=1024, include_thoughts=True)
@@ -195,7 +194,7 @@ class TestOllamaProviderUnified:
         mock_settings.ollama_model = "llama3.2"
         mock_settings.ollama_api_key = None
         mock_settings.ollama_thinking_models = ["qwen3", "deepseek-r1", "qwq"]
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = OllamaProvider()
         p.create_instance(tier="moderate", thinking_budget=1024, include_thoughts=True)
@@ -211,7 +210,7 @@ class TestOllamaProviderUnified:
         mock_settings.ollama_model = "qwen3:4b-instruct-2507-q4_K_M"
         mock_settings.ollama_api_key = None
         mock_settings.ollama_thinking_models = ["qwen3", "deepseek-r1", "qwq"]
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         p = OllamaProvider()
         p.create_instance(tier="moderate", thinking_budget=1024, include_thoughts=True)
@@ -242,7 +241,7 @@ class TestLLMFactoryUnified:
         mock_gemini_settings.google_openai_compat_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
         mock_gemini_settings.thinking_enabled = False
 
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         from app.engine.llm_factory import create_llm
         llm = create_llm(tier=ThinkingTier.LIGHT)
@@ -282,7 +281,7 @@ class TestLLMPoolLegacyUnified:
         mock_gemini_settings.google_openai_compat_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
         mock_gemini_settings.thinking_enabled = True
 
-        mock_chat.return_value = MagicMock(spec=BaseChatModel)
+        mock_chat.return_value = MagicMock(spec=WiiiChatModel)
 
         LLMPool._providers = {}  # Empty providers to trigger legacy path
         llm = LLMPool._create_instance("moderate")


### PR DESCRIPTION
## Mục tiêu

Phase 9b của Runtime Migration Epic [#207](https://github.com/meiiie/wiii/issues/207) — migrate 9 RECEIVE-coupled history files khỏi ``langchain_core.messages``. Stacked trên Phase 9a (#219).

## Foundation (5 commits)

- ``caefbef`` — add ``Message.type`` LC-compat alias cho legacy receive paths
- ``26a64ea`` — migrate context_window / context_manager / context_budget_runtime
- ``9b7779d`` — migrate tutor tool-loop (tutor_node:1319 lazy AIMessage placeholder + tutor_tool_dispatch_runtime)
- ``a203bb8`` — migrate direct_tool_rounds_runtime / code_studio_tool_rounds / widget_surface / product_search_runtime
- ``25da131`` — update sprint77 conversation window tests cho native Message return type

## Surface impact (so với Phase 9a base)

- ``langchain_core.messages`` import: 9 → 0 trong app/
- Receive-coupled paths giờ tất cả dùng native Message + ToolCall

## Verification

- 87 streaming/code_studio/corrective_rag tests pass
- 172 phase-9b targeted tests pass

## Base

Stacked PR — base = Phase 9a (#219). Sau khi 9a merged, 9b sẽ auto-rebase lên main.

Refs #207