### PR TITLE
phase-9c: drop langchain-core dep + raw MCP SDK + 13 test file cleanup

### DIFF
--- a/maritime-ai-service/app/mcp/client.py
+++ b/maritime-ai-service/app/mcp/client.py
@@ -1,19 +1,22 @@
-"""
-MCP Client â€” Connects to external MCP servers and loads tools.
+"""MCP Client — connects to external MCP servers using the raw ``mcp`` SDK.
 
-Sprint 56: Uses langchain-mcp-adapters for LangGraph-compatible tool loading.
-Supports stdio, HTTP (Streamable HTTP), and SSE transports.
+Phase 9c (runtime migration epic #207): replaced ``langchain_mcp_adapters``
+with the official ``mcp`` Python SDK. The wrapper exposes a small native
+``MCPTool`` shape (``name``, ``description``, ``parameters``, ``ainvoke``)
+so the downstream consumers (``ToolRegistry`` + ``WiiiChatModel.bind_tools``)
+do not need to learn the LangChain ``BaseTool`` interface.
 
-Sprint 193: Added register_discovered_tools() â€” bridges MCP external tools
-into ToolRegistry for unified tool management.
+Sprint 56 introduced the manager; Sprint 193 added the
+``register_discovered_tools()`` bridge into ``ToolRegistry``.
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 from dataclasses import dataclass, field, fields
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from app.mcp.policy import infer_external_tool_registration
 
@@ -33,100 +36,209 @@ class MCPServerConfig:
     enabled: bool = True
 
 
+class MCPTool:
+    """Lightweight wrapper around an MCP tool definition.
+
+    Exposes the duck-typed surface required by ``ToolRegistry.register`` and
+    ``WiiiChatModel.bind_tools``:
+
+    - ``name`` / ``description`` — string metadata
+    - ``parameters`` — JSON schema dict (OpenAI tool format)
+    - ``ainvoke(arguments)`` — async dispatcher that calls back through the
+      live ``ClientSession``
+    """
+
+    __slots__ = ("name", "description", "parameters", "_session", "_server_name")
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        description: str,
+        parameters: Dict[str, Any],
+        session: Any,
+        server_name: str,
+    ) -> None:
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+        self._session = session
+        self._server_name = server_name
+
+    async def ainvoke(self, arguments: Optional[Dict[str, Any]] = None) -> str:
+        """Call the underlying MCP tool. Returns the textual result."""
+        result = await self._session.call_tool(self.name, arguments or {})
+        # MCP `call_tool` returns CallToolResult with `.content` as a list of
+        # content blocks (TextContent / ImageContent / EmbeddedResource). Most
+        # downstream consumers expect a plain string; flatten text blocks.
+        text_parts: list[str] = []
+        for block in getattr(result, "content", None) or []:
+            block_text = getattr(block, "text", None)
+            if isinstance(block_text, str):
+                text_parts.append(block_text)
+        return "\n".join(text_parts)
+
+
 class MCPToolManager:
-    """
-    Manages MCP client connections and tool loading.
+    """Manages MCP client connections and discovered tools.
 
-    Connects to external MCP servers at startup, loads their tools,
-    and makes them available as LangChain-compatible tools for use
-    in LangGraph agent nodes.
+    Uses ``contextlib.AsyncExitStack`` to keep transport context managers
+    open across the manager's lifetime; ``shutdown()`` unwinds them.
     """
 
-    _client: Optional[object] = None
-    _tools: List = []
+    _exit_stack: Optional[contextlib.AsyncExitStack] = None
+    _sessions: Dict[str, Any] = {}
+    _tools: List[MCPTool] = []
     _initialized: bool = False
     _configs: List[MCPServerConfig] = []
 
     @classmethod
     async def initialize(cls, configs: List[MCPServerConfig]) -> None:
-        """
-        Initialize MCP client connections.
-
-        Args:
-            configs: List of MCP server configurations to connect to.
-        """
+        """Connect to each enabled MCP server and load its tools."""
         if not configs:
-            logger.info("No MCP server configs provided â€” skipping initialization")
+            logger.info("No MCP server configs provided — skipping initialization")
             cls._initialized = True
             return
 
         enabled_configs = [c for c in configs if c.enabled]
         if not enabled_configs:
-            logger.info("All MCP servers disabled â€” skipping initialization")
+            logger.info("All MCP servers disabled — skipping initialization")
             cls._initialized = True
             return
 
         try:
-            from langchain_mcp_adapters.client import MultiServerMCPClient
-        except ImportError:
+            from mcp import ClientSession  # type: ignore[import-not-found]
+            from mcp.client.stdio import StdioServerParameters, stdio_client  # type: ignore[import-not-found]
+            from mcp.client.streamable_http import streamablehttp_client  # type: ignore[import-not-found]
+        except ImportError as exc:
             logger.warning(
-                "langchain-mcp-adapters not installed â€” MCP Client unavailable. "
-                "Install with: pip install langchain-mcp-adapters>=0.1.0"
+                "mcp SDK not installed — MCP Client unavailable (%s). "
+                "Install with: pip install mcp~=1.27.0",
+                exc,
             )
-            cls._initialized = True
-            return
-
-        server_dict = {}
-        for config in enabled_configs:
-            server_entry = {"transport": config.transport}
-
-            if config.transport == "stdio":
-                if not config.command:
-                    logger.warning(
-                        "MCP server '%s' missing command â€” skipped",
-                        config.name,
-                    )
-                    continue
-                server_entry["command"] = config.command
-                server_entry["args"] = config.args
-
-            elif config.transport in ("http", "sse"):
-                if not config.url:
-                    logger.warning(
-                        "MCP server '%s' missing URL â€” skipped",
-                        config.name,
-                    )
-                    continue
-                server_entry["url"] = config.url
-                if config.headers:
-                    server_entry["headers"] = config.headers
-
-            server_dict[config.name] = server_entry
-
-        if not server_dict:
-            logger.info("No valid MCP server configs â€” skipping")
             cls._initialized = True
             return
 
         try:
-            cls._client = MultiServerMCPClient(server_dict)
-            cls._tools = await cls._client.get_tools()
-            cls._configs = enabled_configs
+            from mcp.client.sse import sse_client  # type: ignore[import-not-found]
+        except ImportError:
+            sse_client = None  # SSE transport optional
+            logger.debug("mcp SDK SSE transport unavailable — http/stdio still work")
+
+        exit_stack = contextlib.AsyncExitStack()
+        await exit_stack.__aenter__()
+
+        sessions: Dict[str, Any] = {}
+        tools: List[MCPTool] = []
+
+        for config in enabled_configs:
+            try:
+                if config.transport == "stdio":
+                    if not config.command:
+                        logger.warning(
+                            "MCP server '%s' missing command — skipped",
+                            config.name,
+                        )
+                        continue
+                    params = StdioServerParameters(
+                        command=config.command,
+                        args=config.args or [],
+                    )
+                    transport = await exit_stack.enter_async_context(
+                        stdio_client(params)
+                    )
+                    read, write = transport[0], transport[1]
+                elif config.transport == "http":
+                    if not config.url:
+                        logger.warning(
+                            "MCP server '%s' missing URL — skipped",
+                            config.name,
+                        )
+                        continue
+                    transport = await exit_stack.enter_async_context(
+                        streamablehttp_client(
+                            config.url,
+                            headers=config.headers or {},
+                        )
+                    )
+                    read, write = transport[0], transport[1]
+                elif config.transport == "sse":
+                    if not config.url:
+                        logger.warning(
+                            "MCP server '%s' missing URL — skipped",
+                            config.name,
+                        )
+                        continue
+                    if sse_client is None:
+                        logger.warning(
+                            "MCP server '%s' uses SSE transport but mcp SDK has no sse_client — skipped",
+                            config.name,
+                        )
+                        continue
+                    transport = await exit_stack.enter_async_context(
+                        sse_client(
+                            config.url,
+                            headers=config.headers or {},
+                        )
+                    )
+                    read, write = transport[0], transport[1]
+                else:
+                    logger.warning(
+                        "MCP server '%s' unknown transport '%s' — skipped",
+                        config.name,
+                        config.transport,
+                    )
+                    continue
+
+                session = await exit_stack.enter_async_context(
+                    ClientSession(read, write)
+                )
+                await session.initialize()
+                sessions[config.name] = session
+
+                listing = await session.list_tools()
+                for tool_def in getattr(listing, "tools", None) or []:
+                    tools.append(
+                        MCPTool(
+                            name=getattr(tool_def, "name", ""),
+                            description=getattr(tool_def, "description", "") or "",
+                            parameters=(
+                                getattr(tool_def, "inputSchema", None)
+                                or getattr(tool_def, "input_schema", None)
+                                or {}
+                            ),
+                            session=session,
+                            server_name=config.name,
+                        )
+                    )
+
+            except Exception as exc:
+                logger.warning(
+                    "MCP server '%s' connection failed: %s",
+                    config.name,
+                    exc,
+                )
+
+        if not sessions:
+            await exit_stack.aclose()
+            logger.info("No MCP server connected — initialization complete with 0 tools")
             cls._initialized = True
-            logger.info(
-                "[OK] MCP Client initialized: %d tools "
-                "from %d server(s)",
-                len(cls._tools),
-                len(server_dict),
-            )
-        except Exception as e:
-            logger.warning("MCP Client initialization failed: %s", e)
-            cls._tools = []
-            cls._initialized = True
+            return
+
+        cls._exit_stack = exit_stack
+        cls._sessions = sessions
+        cls._tools = tools
+        cls._configs = enabled_configs
+        cls._initialized = True
+        logger.info(
+            "[OK] MCP Client initialized: %d tool(s) across %d server(s)",
+            len(tools),
+            len(sessions),
+        )
 
     @classmethod
-    def get_tools(cls) -> List:
-        """Get all loaded MCP tools (LangChain-compatible)."""
+    def get_tools(cls) -> List[MCPTool]:
+        """Get all loaded MCP tools."""
         return cls._tools
 
     @classmethod
@@ -137,16 +249,14 @@ class MCPToolManager:
     @classmethod
     async def shutdown(cls) -> None:
         """Close MCP client connections."""
-        if cls._client is not None:
+        if cls._exit_stack is not None:
             try:
-                if hasattr(cls._client, "close"):
-                    await cls._client.close()
-                elif hasattr(cls._client, "__aexit__"):
-                    await cls._client.__aexit__(None, None, None)
-            except Exception as e:
-                logger.warning("MCP Client shutdown error: %s", e)
+                await cls._exit_stack.aclose()
+            except Exception as exc:
+                logger.warning("MCP Client shutdown error: %s", exc)
             finally:
-                cls._client = None
+                cls._exit_stack = None
+        cls._sessions = {}
         cls._tools = []
         cls._initialized = False
         logger.info("MCP Client shut down")
@@ -154,19 +264,15 @@ class MCPToolManager:
     @classmethod
     def reset(cls) -> None:
         """Reset all state. Used in tests."""
-        cls._client = None
+        cls._exit_stack = None
+        cls._sessions = {}
         cls._tools = []
         cls._initialized = False
         cls._configs = []
 
     @classmethod
     def register_discovered_tools(cls) -> int:
-        """
-        Bridge discovered external MCP tools into ToolRegistry.
-
-        Browser automation tools are classified as privileged writes so they do
-        not silently enter the system as generic read-only tools.
-        """
+        """Bridge discovered external MCP tools into ``ToolRegistry``."""
         if not cls._initialized or not cls._tools:
             return 0
 
@@ -185,7 +291,7 @@ class MCPToolManager:
             registry = get_tool_registry()
         except ImportError:
             logger.warning(
-                "ToolRegistry not available â€” cannot register MCP tools"
+                "ToolRegistry not available — cannot register MCP tools"
             )
             return 0
 
@@ -200,7 +306,7 @@ class MCPToolManager:
 
                 if registry.get_info(name) is not None:
                     logger.debug(
-                        "MCP tool '%s' already in registry â€” skipped",
+                        "MCP tool '%s' already in registry — skipped",
                         name,
                     )
                     continue
@@ -213,11 +319,11 @@ class MCPToolManager:
                     roles=roles,
                 )
                 count += 1
-            except Exception as e:
+            except Exception as exc:
                 logger.warning(
                     "Failed to register MCP tool '%s': %s",
                     getattr(tool, "name", "?"),
-                    e,
+                    exc,
                 )
 
         if count:
@@ -226,18 +332,13 @@ class MCPToolManager:
 
     @classmethod
     def parse_configs(cls, json_str: str) -> List[MCPServerConfig]:
-        """
-        Parse MCP server configs from JSON string (settings.mcp_server_configs).
-
-        Unknown keys are ignored so runtime helper metadata can coexist with the
-        persisted config shape without breaking parsing.
-        """
+        """Parse MCP server configs from JSON string (settings.mcp_server_configs)."""
         try:
             raw = json.loads(json_str)
             if not isinstance(raw, list):
                 return []
             configs = []
-            allowed_fields = {field.name for field in fields(MCPServerConfig)}
+            allowed_fields = {f.name for f in fields(MCPServerConfig)}
             for item in raw:
                 if isinstance(item, dict):
                     filtered = {
@@ -247,8 +348,8 @@ class MCPToolManager:
                     }
                     configs.append(MCPServerConfig(**filtered))
             return configs
-        except (json.JSONDecodeError, TypeError) as e:
-            logger.warning("Failed to parse MCP server configs: %s", e)
+        except (json.JSONDecodeError, TypeError) as exc:
+            logger.warning("Failed to parse MCP server configs: %s", exc)
             return []
 
     @classmethod
@@ -265,8 +366,8 @@ class MCPToolManager:
                     configs,
                     [MCPServerConfig(**browser_config)],
                 )
-        except Exception as e:
-            logger.warning("Failed to resolve browser MCP config: %s", e)
+        except Exception as exc:
+            logger.warning("Failed to resolve browser MCP config: %s", exc)
 
         return configs
 

--- a/maritime-ai-service/docs/architecture/RUNTIME-MIGRATION-FINAL-STATE.md
+++ b/maritime-ai-service/docs/architecture/RUNTIME-MIGRATION-FINAL-STATE.md
@@ -1,7 +1,7 @@
 # Runtime Migration Epic #207 — Final state report
 
-> **As of**: 2026-05-03
-> **Status**: Phases 0–6 shipped + Phase 7 partial (this PR). LangChain dependency reduced to a small deferred surface; full removal pending the wake/replay path (5b) and `WiiiChatModel` rewrite.
+> **As of**: 2026-05-03 (updated after Phase 9 worker session)
+> **Status**: All langchain runtime surface eliminated. `langchain-core` + `langchain-mcp-adapters` dropped from manifest; `langsmith` SDK dropped (stub keeps public surface). Remaining work is operational gates (Phase 5b harness wake/replay, canary rollout) — none of which still depend on LangChain code.
 
 ## What shipped
 
@@ -18,6 +18,16 @@
 
 ## What's deferred (and why)
 
+### Phase 9 langchain removal — DONE (2026-05-03)
+
+The Phase 9 worker session shipped the gating rewrites in three branches:
+
+- ``codex/runtime-phase-9a-wiii-chat-model`` — ``WiiiChatModel`` rewritten without ``BaseChatModel`` inheritance. Returns native ``Message`` and ``StreamChunk`` types. Streaming compat preserved via Option A (``StreamChunk.message`` self-pointing shim + ``__add__`` accumulator).
+- ``codex/runtime-phase-9b-receive-coupled`` — 9 RECEIVE-coupled history paths migrated to native ``Message`` / ``ToolCall``: ``conversation_window``, ``context_manager``, ``context_budget_runtime``, ``tutor_node:1318`` placeholder, ``tutor_tool_dispatch_runtime``, ``product_search_runtime``, ``code_studio_tool_rounds``, ``direct_tool_rounds_runtime``, ``widget_surface``. ``Message.type`` LC-compat alias added so legacy introspectors keep working.
+- ``codex/runtime-phase-9c-drop-langchain-core`` — ``app/mcp/client.py`` rewritten against the raw ``mcp`` SDK (``ClientSession`` + ``AsyncExitStack``); ``langchain-core`` removed from ``pyproject.toml``; ``langchain-mcp-adapters`` and ``langsmith`` removed from ``requirements.txt``; the no-op stub at ``app/core/langsmith.py`` is left in place so the two consumer call sites do not need to branch.
+
+After 9c, ``grep -rE "from langchain|import langchain" app/`` returns 0 lines.
+
 ### Phase 8 follow-ups shipped (2026-05-03 evening)
 
 After the initial 7-PR series merged, a follow-up branch (``codex/runtime-phase-8-finish-langchain-removal``) chipped at the deferred list:
@@ -26,28 +36,11 @@ After the initial 7-PR series merged, a follow-up branch (``codex/runtime-phase-
 - ``app/engine/runtime/adapters/anthropic_compat.py`` — third edge protocol adapter joining ``wiii_native`` + ``openai_compat``. Anthropic ``tool_use`` blocks round-trip into native ``ToolCall``; ``tool_result`` blocks split into standalone role=``tool`` Messages.
 - ``ChatOrchestrator.process(record=True)`` wiring — per-call opt-in eval recording, gated by ``settings.enable_eval_recording``. Fail-soft on recorder I/O errors so production traffic is never blocked.
 
-What's still open after Phase 8: ``WiiiChatModel(BaseChatModel)`` rewrite (the gating step for actually removing ``langchain-core`` from the dependency manifest) and the 9 RECEIVE-coupled history files. Both depend on the BaseChatModel rewrite first.
+What was still open after Phase 8 — the ``WiiiChatModel(BaseChatModel)`` rewrite, the 9 RECEIVE-coupled history files, and the dependency-manifest cleanup — was all addressed in the Phase 9 worker session above.
 
-### `langchain-core` package — kept in `pyproject.toml`
+### `langchain-core` package — REMOVED Phase 9c (2026-05-03)
 
-22 references remain in `app/` across 11 files. All of them sit in two deferred buckets:
-
-**RECEIVE-coupled** (Phase 1 left them; need Phase 5b harness wake/replay first):
-- `app/engine/context_budget_runtime.py`
-- `app/engine/context_manager.py`
-- `app/engine/conversation_window.py`
-- `app/engine/multi_agent/agents/tutor_node.py:1319` — lazy `AIMessage` placeholder
-- `app/engine/multi_agent/agents/tutor_tool_dispatch_runtime.py`
-- `app/engine/multi_agent/agents/product_search_runtime.py`
-- `app/engine/multi_agent/code_studio_tool_rounds.py`
-- `app/engine/multi_agent/direct_tool_rounds_runtime.py`
-- `app/engine/multi_agent/widget_surface.py`
-
-**Provider implementation**:
-- `app/engine/llm_providers/wiii_chat_model.py` — `class WiiiChatModel(BaseChatModel)`. Removing the inheritance requires re-implementing `_generate` / `_agenerate` / `_astream` / `bind_tools` / `with_structured_output` to satisfy ~50 consumer call sites. Lane-first dispatcher (Phase 4) provides the prerequisite, but the actual rewrite is its own PR.
-
-**Observability**:
-- `app/core/langsmith.py` — LangSmith tracer integration. Independent product decision; not in scope for the runtime migration.
+Zero ``from langchain*`` imports remain in ``app/``. ``pyproject.toml`` no longer declares ``langchain-core``; ``requirements.txt`` no longer declares ``langchain-mcp-adapters`` or ``langsmith``. The ``app/core/langsmith.py`` stub kept the public surface (``configure_langsmith`` / ``is_langsmith_enabled`` / ``get_langsmith_callback``) so call sites stay untouched; a future direct LangSmith integration can re-add the SDK in its own PR.
 
 ### Operational gates from Phase 5–7 brief
 
@@ -69,24 +62,24 @@ What's still open after Phase 8: ``WiiiChatModel(BaseChatModel)`` rewrite (the g
 
 ## Surface reduction summary
 
-| Surface | Before | After this epic |
+| Surface | Before | After Phase 9 |
 |---|---|---|
-| `langchain_core.messages` import | 22+ files (all paths) | 9 files (RECEIVE-coupled only) |
+| `langchain_core.messages` import | 22+ files (all paths) | 0 |
 | `langchain_core.tools` import | 30 files | 0 in `app/`; 1 in `tests/integration/test_manual_react.py` (legacy fallback only) |
-| `langchain_core.language_models` import | 13 files | 1 file (`wiii_chat_model.py` class definition) |
-| `BaseChatModel` type-hint usage | ~70 references | ~7 (only inside `wiii_chat_model.py`) |
+| `langchain_core.language_models` import | 13 files | 0 |
+| `BaseChatModel` type-hint / inheritance usage | ~70 references | 0 |
+| `langchain_mcp_adapters` import | 1 file (`app/mcp/client.py`) | 0 (rewritten against raw `mcp` SDK) |
 | `langchain` meta package | declared in `pyproject.toml` | removed in Phase 0 |
 | `langchain-openai` / `-google-genai` / `-ollama` | declared in `pyproject.toml` | removed in Phase 0 |
+| `langchain-core` package | declared in `pyproject.toml` + `requirements.txt` | removed in Phase 9c |
+| `langchain-mcp-adapters` package | declared in `requirements.txt` | removed in Phase 9c |
+| `langsmith` package | declared in `requirements.txt` | removed in Phase 9c (stub kept; future direct integration can re-add) |
 
 ## What this means for follow-up work
 
-The migration's *runtime* goal is reached: every SEND-side path, every tool definition, and every pure-type-hint provider seam is native Wiii code. The remaining `langchain_core` surface is:
+The runtime migration's goal is reached. Every SEND-side path, every tool definition, every provider seam, and every RECEIVE-coupled history rebuild are native Wiii code. ``WiiiChatModel`` is a plain Pydantic ``BaseModel`` returning native ``Message`` / ``StreamChunk``. The MCP client uses the raw ``mcp`` SDK directly. The dependency manifest has zero ``langchain*`` packages.
 
-- 1 class implementation (`WiiiChatModel`) — easy single-PR rewrite once consumers are confirmed to need only the duck-typed methods we already mirror.
-- 9 RECEIVE-coupled history-rebuild paths — refactor candidates once `SessionEventLog` becomes the source of truth (Phase 5b wiring).
-- 1 observability integration (`langsmith.py`) — separate concern.
-
-The eval recorder (Phase 6a) is the regression net for that follow-up work. With it shipped — even as a foundation only — every future change can be replayed against the prior production trace.
+The eval recorder (Phase 6a) is the regression net for any future runtime change. With it shipped — even as a foundation only — every future change can be replayed against the prior production trace.
 
 ## Atomic commits index
 

--- a/maritime-ai-service/pyproject.toml
+++ b/maritime-ai-service/pyproject.toml
@@ -28,10 +28,9 @@ dependencies = [
     "sqlalchemy>=2.0.25",
     "asyncpg>=0.29.0",
     "alembic>=1.13.0",
-    # langchain (meta), -openai, -google-genai, -ollama removed in Runtime
-    # Migration Phase 0 (drift fix, 2026-05-02) — 0 imports in app/.
-    # langchain-core kept until Phase 1–4 (messages → tools → providers).
-    "langchain-core>=1.2.18",
+    # langchain meta + -openai/-google-genai/-ollama removed Phase 0 (drift).
+    # langchain-core removed Phase 9c (2026-05-03) — replaced by native
+    # app/engine/messages.py + messages_adapters.py + WiiiChatModel rewrite.
     # langgraph REMOVED (De-LangGraphing Phase 3) — replaced by WiiiRunner
     "google-genai>=1.66.0,<2.0.0",
     "opensandbox>=0.1.5,<0.2.0",

--- a/maritime-ai-service/requirements.txt
+++ b/maritime-ai-service/requirements.txt
@@ -26,8 +26,9 @@ pgvector==0.2.5
 # --- AI CORE STACK (PINNED to tested minor versions) ---
 # Phase 0: langchain + langchain-community removed (0 imports in app/)
 # Phase 1-2: langchain-openai, langchain-google-genai, langchain-ollama, langchain-text-splitters removed
-# All providers now use WiiiChatModel (AsyncOpenAI SDK wrapper)
-langchain-core>=1.2.18,<1.4.0
+# Phase 9a-c (2026-05-03): langchain-core + langchain-mcp-adapters removed.
+# All providers now use WiiiChatModel (AsyncOpenAI SDK wrapper); MCP client
+# uses the raw mcp SDK directly (see app/mcp/client.py).
 
 # LangGraph REMOVED (De-LangGraphing Phase 3) — replaced by WiiiRunner (app/engine/multi_agent/runner.py)
 # langgraph, langgraph-checkpoint, langgraph-checkpoint-postgres, langgraph-prebuilt — all removed
@@ -40,7 +41,6 @@ openai~=2.32.0
 # MCP Support (Sprint 56: Model Context Protocol)
 mcp~=1.27.0
 fastapi-mcp~=0.4.0
-langchain-mcp-adapters>=0.2.2,<1.0.0
 opensandbox>=0.1.5,<0.2.0
 opensandbox-code-interpreter>=0.1.1,<0.2.0
 
@@ -88,8 +88,11 @@ opentelemetry-api>=1.41.1
 opentelemetry-sdk>=1.41.1
 opentelemetry-exporter-otlp>=1.41.1
 
-# LangSmith (Sprint 144b: LLM tracing dashboard)
-langsmith>=0.7.36,<1.0.0
+# LangSmith dropped Phase 9c (2026-05-03) — the LangChain auto-tracer was
+# removed in Phase 7 (#217); the stub in app/core/langsmith.py keeps the
+# public surface (configure_langsmith / is_langsmith_enabled /
+# get_langsmith_callback) so call sites stay untouched. A future direct
+# integration can re-add the SDK in its own PR.
 
 # Structured Logging (SOTA 2026)
 structlog>=25.5.0

--- a/maritime-ai-service/tests/unit/test_mcp_client.py
+++ b/maritime-ai-service/tests/unit/test_mcp_client.py
@@ -2,6 +2,8 @@
 Tests for app.mcp.client — MCP Client (MCPToolManager).
 
 Sprint 56: MCP Support.
+Phase 9c: rewritten against the raw ``mcp`` SDK; no more
+``langchain_mcp_adapters`` dependency.
 """
 
 import pytest
@@ -69,10 +71,15 @@ class TestMCPToolManagerInitialize:
         assert MCPToolManager.get_tools() == []
 
     @pytest.mark.asyncio
-    async def test_missing_langchain_mcp_adapters(self):
+    async def test_missing_mcp_sdk(self):
+        """When the ``mcp`` SDK is missing the manager fails soft."""
         configs = [MCPServerConfig(name="test", transport="http", url="http://test/mcp")]
 
-        with patch.dict("sys.modules", {"langchain_mcp_adapters": None, "langchain_mcp_adapters.client": None}):
+        # Force the lazy import inside ``initialize`` to fail.
+        with patch.dict(
+            "sys.modules",
+            {"mcp": None, "mcp.client.stdio": None, "mcp.client.streamable_http": None},
+        ):
             await MCPToolManager.initialize(configs)
 
         assert MCPToolManager.is_initialized()
@@ -80,46 +87,19 @@ class TestMCPToolManagerInitialize:
 
     @pytest.mark.asyncio
     async def test_stdio_without_command_skipped(self):
-        """stdio config without command is skipped."""
-        import types
-        mock_module = types.ModuleType("langchain_mcp_adapters")
-        mock_client_module = types.ModuleType("langchain_mcp_adapters.client")
-        mock_client_cls = MagicMock()
-        mock_client_instance = MagicMock()
-        mock_client_instance.get_tools = AsyncMock(return_value=[])
-        mock_client_cls.return_value = mock_client_instance
-        mock_client_module.MultiServerMCPClient = mock_client_cls
-        mock_module.client = mock_client_module
-
+        """stdio config without command is skipped — manager still finishes init."""
         configs = [MCPServerConfig(name="bad", transport="stdio")]  # No command
-
-        with patch.dict("sys.modules", {
-            "langchain_mcp_adapters": mock_module,
-            "langchain_mcp_adapters.client": mock_client_module,
-        }):
-            await MCPToolManager.initialize(configs)
-
+        await MCPToolManager.initialize(configs)
         assert MCPToolManager.is_initialized()
+        assert MCPToolManager.get_tools() == []
 
     @pytest.mark.asyncio
     async def test_http_without_url_skipped(self):
-        """http config without URL is skipped."""
-        import types
-        mock_module = types.ModuleType("langchain_mcp_adapters")
-        mock_client_module = types.ModuleType("langchain_mcp_adapters.client")
-        mock_client_cls = MagicMock()
-        mock_client_module.MultiServerMCPClient = mock_client_cls
-        mock_module.client = mock_client_module
-
+        """http config without URL is skipped — manager still finishes init."""
         configs = [MCPServerConfig(name="bad", transport="http")]  # No URL
-
-        with patch.dict("sys.modules", {
-            "langchain_mcp_adapters": mock_module,
-            "langchain_mcp_adapters.client": mock_client_module,
-        }):
-            await MCPToolManager.initialize(configs)
-
+        await MCPToolManager.initialize(configs)
         assert MCPToolManager.is_initialized()
+        assert MCPToolManager.get_tools() == []
 
 
 class TestMCPToolManagerShutdown:
@@ -132,15 +112,19 @@ class TestMCPToolManagerShutdown:
 
     @pytest.mark.asyncio
     async def test_shutdown_clears_state(self):
+        # Simulate a previously-initialized manager with a fake exit stack.
         MCPToolManager._initialized = True
         MCPToolManager._tools = [MagicMock()]
-        MCPToolManager._client = MagicMock()
-        MCPToolManager._client.close = AsyncMock()
+        fake_stack = MagicMock()
+        fake_stack.aclose = AsyncMock()
+        MCPToolManager._exit_stack = fake_stack
 
         await MCPToolManager.shutdown()
 
         assert not MCPToolManager.is_initialized()
         assert MCPToolManager.get_tools() == []
+        assert MCPToolManager._exit_stack is None
+        fake_stack.aclose.assert_awaited_once()
 
 
 class TestMCPToolManagerParseConfigs:
@@ -261,3 +245,32 @@ class TestMCPToolManagerRuntimeConfigResolution:
         )
 
         assert [config.name for config in merged] == ["one", "two"]
+
+
+class TestMCPTool:
+    """Test the MCPTool wrapper that bridges mcp SDK tools into Wiii's runtime."""
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_flattens_text_content(self):
+        from app.mcp.client import MCPTool
+
+        text_block = MagicMock()
+        text_block.text = "search result"
+        result_obj = MagicMock()
+        result_obj.content = [text_block]
+
+        session = MagicMock()
+        session.call_tool = AsyncMock(return_value=result_obj)
+
+        tool = MCPTool(
+            name="search",
+            description="Search the docs",
+            parameters={"type": "object", "properties": {}},
+            session=session,
+            server_name="docs-mcp",
+        )
+
+        out = await tool.ainvoke({"query": "Rule 13"})
+
+        assert out == "search result"
+        session.call_tool.assert_awaited_once_with("search", {"query": "Rule 13"})


### PR DESCRIPTION
## Mục tiêu

Phase 9c của Runtime Migration Epic [#207](https://github.com/meiiie/wiii/issues/207) — final cleanup. Xoá ``langchain-core`` + ``langchain-mcp-adapters`` + ``langsmith`` khỏi deps. Stacked trên Phase 9b (#220).

## Foundation (4 commits)

- ``462e9f0`` — rewrite ``app/mcp/client.py`` against raw ``mcp`` SDK (drop ``langchain_mcp_adapters``)
- ``a282104`` — update context manager + sprint95 tool tests cho native Message
- ``1e07e3c`` — drop ``langchain-core``, ``langchain-mcp-adapters``, ``langsmith`` từ pyproject.toml + requirements.txt
- ``2bd562d`` — **(architect cleanup)** migrate 13 unit test files off ``langchain_core``:
  - 5 file: ``MagicMock(spec=BaseChatModel)`` → ``spec=WiiiChatModel`` (test_llm_failover, test_llm_pool_multi, test_llm_providers, test_unified_providers, test_sprint30_llm_factory)
  - 7 file: ``HumanMessage/AIMessage/SystemMessage/ToolMessage(content=x)`` → ``Message(role=..., content=x)``. ``isinstance(x, HumanMessage)`` → ``x.role == "user"``.
  - 1 file (sprint200_visual_search): multimodal ``HumanMessage(content=[blocks])`` → raw OpenAI dict shape

## Verification (architect)

| Gate | Result |
|---|---|
| ``pip uninstall`` 10 langchain* + langsmith packages | ✅ all removed |
| ``pip freeze | grep -iE "langchain|langsmith"`` | ✅ empty |
| App imports OK trên clean env (``WiiiChatModel``, etc.) | ✅ |
| ``grep -rE "^from langchain|^import langchain" app/`` | ✅ 0 matches |
| ``grep -rE "^from langchain|^import langchain" tests/unit/`` | ✅ 0 matches |
| Full unit suite trên CLEAN env | ✅ **12,111 pass / 5 fail / 38 skipped** (53 phút) |
| 5 fail breakdown | All pre-existing flakes (Issue #210): test_sprint30_semantic_memory_repo, test_sprint33_config_validators, test_reasoning_narrator_runtime × 3 — verified via independent re-run |

## Final surface

- ``langchain_core.messages`` import: 22 → **0** trong app/
- ``langchain_core.tools`` import: 30 → **0**
- ``langchain_core.language_models`` import: 13 → **0**
- ``langchain_core.tracers`` / ``langchain_core.callbacks``: → **0**
- ``langchain_mcp_adapters``: 1 → **0**
- ``BaseChatModel`` inheritance: 1 → **0**
- Package manifests: ``langchain-core``, ``langchain-mcp-adapters``, ``langsmith`` → declared no more

## Out of scope (legacy fallback path, kept)

- ``tests/integration/test_manual_react.py`` — manual reproduction script với legacy ``langchain_core.tools`` fallback. Path documented, không phải CI gate.
- ``tests/integration/test_semantic_memory_direct.py`` — manual smoke với ``langchain_google_genai``. Same.

## Base

Stacked PR — base = Phase 9b (#220). Sau khi 9a + 9b merged, 9c sẽ auto-rebase lên main.

Refs #207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated MCP client implementation to use the official MCP SDK directly.

* **Chores**
  * Removed unused dependencies: langchain-core, langchain-mcp-adapters, and langsmith.

* **Documentation**
  * Updated architecture documentation reflecting completion of runtime migration.

* **Tests**
  * Updated test suite to validate new MCP implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->