### PR TITLE
phase-10: production wiring (replay + rotation, Postgres event log, edge endpoints)

### DIFF
--- a/maritime-ai-service/app/api/edge_endpoints.py
+++ b/maritime-ai-service/app/api/edge_endpoints.py
@@ -1,0 +1,196 @@
+"""Edge endpoints — OpenAI Chat Completions + Anthropic Messages compat layer.
+
+Phase 10d of the runtime migration epic (issue #207). External clients hit
+Wiii using their native SDK without rewriting wire payloads. Each endpoint:
+
+1. Parses the raw provider-shaped request body.
+2. Converts to a canonical ``TurnRequest`` via the corresponding Phase 4
+   adapter (``adapters/openai_compat.py``, ``adapters/anthropic_compat.py``).
+3. Bridges to the existing ``ChatService`` for execution. The native
+   runtime takes over dispatch in a follow-up phase; until then we reuse
+   the proven path so this module never blocks production traffic.
+4. Re-renders the response in the upstream wire shape so SDKs keep working.
+
+Feature-gated by ``settings.enable_native_runtime``. The router mounts at
+``/v1`` (not ``/api/v1/v1``) so clients can swap ``base_url`` without
+extra path acrobatics.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+
+from app.api.deps import RequireAuth
+from app.core.security import resolve_interaction_role
+from app.engine.runtime.adapters.anthropic_compat import (
+    anthropic_messages_to_turn_request,
+)
+from app.engine.runtime.adapters.openai_compat import (
+    openai_chat_completions_to_turn_request,
+)
+from app.engine.runtime.turn_request import TurnRequest
+from app.models.schemas import ChatRequest, InternalChatResponse, UserRole
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Edge"])
+
+
+def _ensure_enabled() -> None:
+    """Reject requests when the native runtime gate is off."""
+    from app.core.config import settings
+
+    if not getattr(settings, "enable_native_runtime", False):
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": {
+                    "type": "service_unavailable",
+                    "message": "Native runtime edge endpoints not enabled",
+                }
+            },
+        )
+
+
+def _last_user_message(turn: TurnRequest) -> str:
+    """Pull the most recent non-empty user-role text from a TurnRequest."""
+    for msg in reversed(turn.messages):
+        if msg.role == "user" and msg.content:
+            return msg.content
+    raise HTTPException(
+        status_code=400,
+        detail={
+            "error": {
+                "type": "invalid_request",
+                "message": "messages must include at least one user-role entry",
+            }
+        },
+    )
+
+
+def _resolve_session_id(body: dict, auth: RequireAuth) -> str:
+    """Pick a stable session id without leaking auth internals into the body."""
+    session = body.get("session_id")
+    if isinstance(session, str) and session:
+        return session
+    return f"edge-{auth.user_id}"
+
+
+def _to_chat_request(turn: TurnRequest, *, auth: RequireAuth) -> ChatRequest:
+    """Bridge a TurnRequest into the existing ChatService input schema."""
+    role = resolve_interaction_role(auth)
+    return ChatRequest(
+        user_id=str(auth.user_id),
+        message=_last_user_message(turn),
+        role=UserRole(role),
+        session_id=turn.session_id,
+        organization_id=auth.organization_id or turn.org_id,
+        domain_id=turn.domain_id,
+    )
+
+
+async def _process(turn: TurnRequest, *, auth: RequireAuth) -> InternalChatResponse:
+    chat_request = _to_chat_request(turn, auth=auth)
+    from app.services.chat_service import get_chat_service
+
+    return await get_chat_service().process_message(chat_request)
+
+
+def _openai_completion_response(
+    *, internal: InternalChatResponse, model: str
+) -> dict[str, Any]:
+    return {
+        "id": f"chatcmpl-{uuid.uuid4().hex}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": internal.message,
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        },
+        "system_fingerprint": "wiii-runtime-v1",
+    }
+
+
+def _anthropic_messages_response(
+    *, internal: InternalChatResponse, model: str
+) -> dict[str, Any]:
+    return {
+        "id": f"msg_{uuid.uuid4().hex}",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": [{"type": "text", "text": internal.message}],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {"input_tokens": 0, "output_tokens": 0},
+    }
+
+
+@router.post("/v1/chat/completions", tags=["Edge"])
+async def openai_chat_completions(
+    request: Request,
+    auth: RequireAuth,
+) -> dict[str, Any]:
+    """OpenAI-compat endpoint at ``POST /v1/chat/completions``."""
+    _ensure_enabled()
+    body = await request.json()
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="body must be a JSON object")
+
+    turn = openai_chat_completions_to_turn_request(
+        body,
+        user_id=str(auth.user_id),
+        session_id=_resolve_session_id(body, auth),
+        org_id=auth.organization_id,
+        role=resolve_interaction_role(auth),
+    )
+    internal = await _process(turn, auth=auth)
+    return _openai_completion_response(
+        internal=internal,
+        model=body.get("model") or "wiii-default",
+    )
+
+
+@router.post("/v1/messages", tags=["Edge"])
+async def anthropic_messages(
+    request: Request,
+    auth: RequireAuth,
+) -> dict[str, Any]:
+    """Anthropic-compat endpoint at ``POST /v1/messages``."""
+    _ensure_enabled()
+    body = await request.json()
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="body must be a JSON object")
+
+    turn = anthropic_messages_to_turn_request(
+        body,
+        user_id=str(auth.user_id),
+        session_id=_resolve_session_id(body, auth),
+        org_id=auth.organization_id,
+        role=resolve_interaction_role(auth),
+    )
+    internal = await _process(turn, auth=auth)
+    return _anthropic_messages_response(
+        internal=internal,
+        model=body.get("model") or "wiii-default",
+    )
+
+
+__all__ = ["router"]

--- a/maritime-ai-service/app/api/edge_endpoints.py
+++ b/maritime-ai-service/app/api/edge_endpoints.py
@@ -18,6 +18,7 @@ extra path acrobatics.
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 import uuid
@@ -45,7 +46,7 @@ def _ensure_enabled() -> None:
     """Reject requests when the native runtime gate is off."""
     from app.core.config import settings
 
-    if not getattr(settings, "enable_native_runtime", False):
+    if not settings.enable_native_runtime:
         raise HTTPException(
             status_code=503,
             detail={
@@ -55,6 +56,22 @@ def _ensure_enabled() -> None:
                 }
             },
         )
+
+
+async def _read_json_body(request: Request) -> dict:
+    """Parse the request body or surface a 400 for malformed JSON.
+
+    FastAPI's default behaviour bubbles ``json.JSONDecodeError`` up to the
+    generic exception handler (500). Edge clients expect a structured 400
+    so they can correct their wire format without alarming on-call.
+    """
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="body must be valid JSON")
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="body must be a JSON object")
+    return body
 
 
 def _last_user_message(turn: TurnRequest) -> str:
@@ -150,9 +167,7 @@ async def openai_chat_completions(
 ) -> dict[str, Any]:
     """OpenAI-compat endpoint at ``POST /v1/chat/completions``."""
     _ensure_enabled()
-    body = await request.json()
-    if not isinstance(body, dict):
-        raise HTTPException(status_code=400, detail="body must be a JSON object")
+    body = await _read_json_body(request)
 
     turn = openai_chat_completions_to_turn_request(
         body,
@@ -175,9 +190,7 @@ async def anthropic_messages(
 ) -> dict[str, Any]:
     """Anthropic-compat endpoint at ``POST /v1/messages``."""
     _ensure_enabled()
-    body = await request.json()
-    if not isinstance(body, dict):
-        raise HTTPException(status_code=400, detail="body must be a JSON object")
+    body = await _read_json_body(request)
 
     turn = anthropic_messages_to_turn_request(
         body,

--- a/maritime-ai-service/app/engine/runtime/eval_recorder.py
+++ b/maritime-ai-service/app/engine/runtime/eval_recorder.py
@@ -169,17 +169,28 @@ class EvalRecorder:
         return sorted(p.stem for p in partition.glob("*.jsonl"))
 
     async def list_days(self, *, org_id: Optional[str] = None) -> list[str]:
-        """List ``YYYY-MM-DD`` partition directories present for an org."""
+        """List ``YYYY-MM-DD`` partition directories present for an org.
+
+        Validates each candidate via ``strptime`` so junk like ``2026-XX-01``
+        or ``abcd-ef-gh`` is filtered out — callers can rely on every
+        returned name being a real calendar date.
+        """
+        from datetime import datetime
+
         org = _safe_segment(org_id, default="_personal")
         org_dir = self.base_dir / org
         if not org_dir.exists():
             return []
-        # Filter to plausible date-shaped dirs to skip noise.
-        return sorted(
-            d.name
-            for d in org_dir.iterdir()
-            if d.is_dir() and len(d.name) == 10 and d.name[4] == "-"
-        )
+        valid: list[str] = []
+        for d in org_dir.iterdir():
+            if not d.is_dir() or len(d.name) != 10:
+                continue
+            try:
+                datetime.strptime(d.name, "%Y-%m-%d")
+            except ValueError:
+                continue
+            valid.append(d.name)
+        return sorted(valid)
 
     async def prune_older_than(
         self, *, retention_days: int, today: Optional[str] = None
@@ -223,7 +234,10 @@ class EvalRecorder:
                         try:
                             day_dir.rmdir()
                         except OSError:
-                            pass
+                            # Directory not empty (race with a concurrent
+                            # writer) or perm error — leave it for the next
+                            # cron tick. Do not count as removed.
+                            continue
                         count += 1
                 if count:
                     removed[org_dir.name] = count

--- a/maritime-ai-service/app/engine/runtime/eval_recorder.py
+++ b/maritime-ai-service/app/engine/runtime/eval_recorder.py
@@ -168,6 +168,67 @@ class EvalRecorder:
             return []
         return sorted(p.stem for p in partition.glob("*.jsonl"))
 
+    async def list_days(self, *, org_id: Optional[str] = None) -> list[str]:
+        """List ``YYYY-MM-DD`` partition directories present for an org."""
+        org = _safe_segment(org_id, default="_personal")
+        org_dir = self.base_dir / org
+        if not org_dir.exists():
+            return []
+        # Filter to plausible date-shaped dirs to skip noise.
+        return sorted(
+            d.name
+            for d in org_dir.iterdir()
+            if d.is_dir() and len(d.name) == 10 and d.name[4] == "-"
+        )
+
+    async def prune_older_than(
+        self, *, retention_days: int, today: Optional[str] = None
+    ) -> dict[str, int]:
+        """Delete partition directories older than ``retention_days``.
+
+        Returns a per-org count of partitions removed. Idempotent — safe to
+        call from a daily cron. Pass ``today`` (YYYY-MM-DD) for tests; in
+        production it defaults to UTC today.
+        """
+        from datetime import date, datetime, timedelta, timezone
+
+        if retention_days <= 0:
+            return {}
+
+        if today is None:
+            today_dt = datetime.now(timezone.utc).date()
+        else:
+            today_dt = datetime.strptime(today, "%Y-%m-%d").date()
+        cutoff: date = today_dt - timedelta(days=retention_days)
+
+        if not self.base_dir.exists():
+            return {}
+
+        removed: dict[str, int] = {}
+        async with self._lock:
+            for org_dir in self.base_dir.iterdir():
+                if not org_dir.is_dir():
+                    continue
+                count = 0
+                for day_dir in list(org_dir.iterdir()):
+                    if not day_dir.is_dir() or len(day_dir.name) != 10:
+                        continue
+                    try:
+                        day_dt = datetime.strptime(day_dir.name, "%Y-%m-%d").date()
+                    except ValueError:
+                        continue
+                    if day_dt < cutoff:
+                        for jsonl in day_dir.glob("*.jsonl"):
+                            jsonl.unlink()
+                        try:
+                            day_dir.rmdir()
+                        except OSError:
+                            pass
+                        count += 1
+                if count:
+                    removed[org_dir.name] = count
+        return removed
+
 
 def diff_records(original: EvalRecord, replayed: dict[str, Any]) -> dict[str, Any]:
     """Compute simple regression metrics between an original record and a replay.

--- a/maritime-ai-service/app/engine/runtime/session_event_log.py
+++ b/maritime-ai-service/app/engine/runtime/session_event_log.py
@@ -142,19 +142,181 @@ class InMemorySessionEventLog:
             return 0
 
 
+class PostgresSessionEventLog:
+    """Durable Postgres backend for the append-only session event log.
+
+    Phase 10 of the runtime migration epic (issue #207). Promotes
+    ``InMemorySessionEventLog`` to a real Postgres-backed implementation
+    using the existing ``asyncpg`` pool (``app.core.database``).
+
+    Concurrency: append computes ``seq = COALESCE(MAX(seq), 0) + 1`` in
+    the same statement and relies on the ``session_events_seq_unique``
+    constraint shipped by Alembic 047. If two concurrent writers pick the
+    same ``seq``, the second one hits the unique violation; we retry up
+    to ``MAX_APPEND_RETRIES`` times. In practice the contention window is
+    < 1ms so 3 retries is plenty.
+
+    Multi-tenant: ``org_id`` is recorded and used as a filter on read.
+    Callers responsible for not leaking session_id across tenants — the
+    backend itself does not enforce a session-to-org binding because a
+    session may be personal (NULL org) and migrate to an org later.
+    """
+
+    MAX_APPEND_RETRIES = 3
+
+    async def _pool(self):
+        from app.core.database import get_asyncpg_pool
+
+        return await get_asyncpg_pool()
+
+    async def append(
+        self,
+        *,
+        session_id: str,
+        event_type: str,
+        payload: dict,
+        org_id: Optional[str] = None,
+    ) -> SessionEvent:
+        import asyncpg
+        import json
+
+        pool = await self._pool()
+        payload_json = json.dumps(dict(payload), ensure_ascii=False)
+
+        last_exc: Optional[Exception] = None
+        for _ in range(self.MAX_APPEND_RETRIES):
+            try:
+                async with pool.acquire() as conn:
+                    row = await conn.fetchrow(
+                        """
+                        INSERT INTO session_events
+                            (session_id, org_id, event_type, payload, seq)
+                        VALUES (
+                            $1, $2, $3, $4::jsonb,
+                            (SELECT COALESCE(MAX(seq), 0) + 1
+                             FROM session_events
+                             WHERE session_id = $1)
+                        )
+                        RETURNING id, session_id, org_id, event_type,
+                                  payload, seq, created_at
+                        """,
+                        session_id,
+                        org_id,
+                        event_type,
+                        payload_json,
+                    )
+                return _row_to_event(row)
+            except asyncpg.UniqueViolationError as exc:  # contention retry
+                last_exc = exc
+                continue
+        raise RuntimeError(
+            "PostgresSessionEventLog.append exceeded retries"
+        ) from last_exc
+
+    async def get_events(
+        self,
+        *,
+        session_id: str,
+        org_id: Optional[str] = None,
+        since_seq: Optional[int] = None,
+    ) -> list[SessionEvent]:
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            params: list = [session_id]
+            where = ["session_id = $1"]
+            if org_id is not None:
+                params.append(org_id)
+                where.append(f"org_id = ${len(params)}")
+            if since_seq is not None:
+                params.append(since_seq)
+                where.append(f"seq > ${len(params)}")
+
+            sql = (
+                "SELECT id, session_id, org_id, event_type, payload, seq, "
+                "       created_at "
+                "FROM session_events "
+                f"WHERE {' AND '.join(where)} "
+                "ORDER BY seq ASC"
+            )
+            rows = await conn.fetch(sql, *params)
+        return [_row_to_event(r) for r in rows]
+
+    async def latest_seq(
+        self, *, session_id: str, org_id: Optional[str] = None
+    ) -> int:
+        pool = await self._pool()
+        async with pool.acquire() as conn:
+            if org_id is None:
+                seq = await conn.fetchval(
+                    "SELECT COALESCE(MAX(seq), 0) "
+                    "FROM session_events WHERE session_id = $1",
+                    session_id,
+                )
+            else:
+                seq = await conn.fetchval(
+                    "SELECT COALESCE(MAX(seq), 0) "
+                    "FROM session_events "
+                    "WHERE session_id = $1 AND org_id = $2",
+                    session_id,
+                    org_id,
+                )
+        return int(seq or 0)
+
+
+def _row_to_event(row) -> SessionEvent:
+    """Materialise an asyncpg row → ``SessionEvent``.
+
+    ``payload`` arrives as a JSON string from asyncpg (jsonb column with
+    no codec registered) so we json.loads it. Defensive against ``None``.
+    """
+    import json
+
+    raw_payload = row["payload"] if row else None
+    if isinstance(raw_payload, str):
+        try:
+            payload_dict = json.loads(raw_payload)
+        except (json.JSONDecodeError, TypeError):
+            payload_dict = {}
+    elif isinstance(raw_payload, dict):
+        payload_dict = raw_payload
+    else:
+        payload_dict = {}
+
+    return SessionEvent(
+        session_id=row["session_id"],
+        event_type=row["event_type"],
+        payload=payload_dict,
+        seq=int(row["seq"]),
+        org_id=row["org_id"],
+    )
+
+
 _singleton: Optional[SessionEventLog] = None
 
 
 def get_session_event_log() -> SessionEventLog:
     """Return the configured event log instance.
 
-    Phase 5 ships only the in-memory backend; the Postgres backend lands
-    in Phase 5b alongside the wake/replay path. The feature flag
-    ``enable_session_event_log`` will switch the default.
+    Routes to ``PostgresSessionEventLog`` when ``enable_session_event_log``
+    is True; otherwise falls back to in-memory. The Postgres backend
+    requires the asyncpg pool from ``app.core.database`` to be configured
+    — when the flag is on but the pool is unreachable, callers get the
+    Postgres backend object and individual ``append`` calls raise.
     """
     global _singleton
-    if _singleton is None:
-        _singleton = InMemorySessionEventLog()
+    if _singleton is not None:
+        return _singleton
+
+    try:
+        from app.core.config import settings
+
+        if getattr(settings, "enable_session_event_log", False):
+            _singleton = PostgresSessionEventLog()
+            return _singleton
+    except Exception:  # noqa: BLE001 — settings may be unavailable at import time
+        logger.debug("[session_event_log] settings unavailable; using in-memory")
+
+    _singleton = InMemorySessionEventLog()
     return _singleton
 
 
@@ -168,5 +330,6 @@ __all__ = [
     "SessionEvent",
     "SessionEventLog",
     "InMemorySessionEventLog",
+    "PostgresSessionEventLog",
     "get_session_event_log",
 ]

--- a/maritime-ai-service/app/engine/runtime/session_event_log.py
+++ b/maritime-ai-service/app/engine/runtime/session_event_log.py
@@ -309,12 +309,16 @@ def get_session_event_log() -> SessionEventLog:
 
     try:
         from app.core.config import settings
-
-        if getattr(settings, "enable_session_event_log", False):
-            _singleton = PostgresSessionEventLog()
-            return _singleton
-    except Exception:  # noqa: BLE001 — settings may be unavailable at import time
+    except (ImportError, AttributeError):
+        # Settings not importable yet (e.g. CLI tools, very early bootstrap).
+        # Falling back to in-memory keeps the interface usable.
         logger.debug("[session_event_log] settings unavailable; using in-memory")
+        _singleton = InMemorySessionEventLog()
+        return _singleton
+
+    if settings.enable_session_event_log:
+        _singleton = PostgresSessionEventLog()
+        return _singleton
 
     _singleton = InMemorySessionEventLog()
     return _singleton

--- a/maritime-ai-service/app/main.py
+++ b/maritime-ai-service/app/main.py
@@ -20,6 +20,7 @@ from app.main_app_factory_support import (
     configure_exception_handlers,
     configure_session_middleware,
     include_api_router,
+    include_edge_endpoints,
     mount_frontend_assets,
     mount_mcp_server,
     register_agent_card_route,
@@ -80,6 +81,7 @@ def create_application() -> FastAPI:
         general_exception_handler=general_exception_handler,
     )
     include_api_router(app)
+    include_edge_endpoints(app)
     register_agent_card_route(app, logger)
     mount_mcp_server(app, logger)
     mount_frontend_assets(app, logger)

--- a/maritime-ai-service/app/main_app_factory_support.py
+++ b/maritime-ai-service/app/main_app_factory_support.py
@@ -116,7 +116,7 @@ def include_edge_endpoints(app: FastAPI) -> None:
     ``enable_native_runtime`` so the routes only register when the lane-
     first runtime is opt-in for that environment.
     """
-    if not getattr(settings, "enable_native_runtime", False):
+    if not settings.enable_native_runtime:
         return
     from app.api.edge_endpoints import router as edge_router
 

--- a/maritime-ai-service/app/main_app_factory_support.py
+++ b/maritime-ai-service/app/main_app_factory_support.py
@@ -109,6 +109,20 @@ def include_api_router(app: FastAPI) -> None:
     app.include_router(api_v1_router, prefix=settings.api_v1_prefix)
 
 
+def include_edge_endpoints(app: FastAPI) -> None:
+    """Mount OpenAI/Anthropic-compat edge endpoints at root ``/v1``.
+
+    Phase 10d of the runtime migration epic (#207). Gated by
+    ``enable_native_runtime`` so the routes only register when the lane-
+    first runtime is opt-in for that environment.
+    """
+    if not getattr(settings, "enable_native_runtime", False):
+        return
+    from app.api.edge_endpoints import router as edge_router
+
+    app.include_router(edge_router)
+
+
 def register_agent_card_route(app: FastAPI, logger_: logging.Logger) -> None:
     if not settings.enable_soul_bridge:
         return

--- a/maritime-ai-service/scripts/replay_eval.py
+++ b/maritime-ai-service/scripts/replay_eval.py
@@ -1,0 +1,359 @@
+"""Replay recorded eval JSONL turns against the live ChatOrchestrator.
+
+Phase 10 of the runtime migration epic (issue #207). Reads JSONL turn
+snapshots written by ``EvalRecorder`` (Phase 6) and re-issues each turn
+through ``ChatOrchestrator.process()`` so the response is regenerated
+with whatever code is on the current branch. Each replayed turn is
+diffed against the original via ``diff_records`` and the totals are
+written to a JSON or HTML report.
+
+This is the moat tool from Anthropic's "Demystifying evals" piece:
+production runtime + replay = regression net. Same code path runs the
+production turn AND replays it, so there is no separate "eval system" to
+drift from production behaviour.
+
+Usage::
+
+    # JSON report
+    python scripts/replay_eval.py --day 2026-05-03 --report-out replay.json
+
+    # HTML report
+    python scripts/replay_eval.py --day 2026-05-03 --report-out replay.html
+
+    # Filter by org and limit (for canary scope)
+    python scripts/replay_eval.py --day 2026-05-03 --org org-1 --limit 50 \\
+        --report-out canary-replay.html
+
+    # Dry-run: read records + compute stats only, no live orchestrator call
+    python scripts/replay_eval.py --day 2026-05-03 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import html
+import json
+import logging
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+# Make ``app.*`` importable when this script runs from the repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.engine.runtime.eval_recorder import (  # noqa: E402
+    EvalRecord,
+    EvalRecorder,
+    diff_records,
+)
+
+logger = logging.getLogger("eval_replay")
+
+
+REGRESSION_THRESHOLDS = {
+    "token_jaccard_min": 0.85,
+    "sources_overlap_min": 0.70,
+    "latency_delta_max_ms": 5000,
+}
+
+
+async def _replay_one(
+    record: EvalRecord, dry_run: bool
+) -> dict[str, Any]:
+    """Replay a single record. Returns a diff dict with metadata."""
+    if dry_run:
+        # Fake a perfect-match replay so the report exercise still works.
+        replayed = {
+            "response": record.response,
+            "tool_calls": record.tool_calls,
+            "sources": record.sources,
+            "latency_ms": record.metadata.get("latency_ms", 0),
+        }
+        diff = diff_records(record, replayed)
+        diff["_dry_run"] = True
+        diff["record_id"] = record.record_id
+        diff["session_id"] = record.session_id
+        return diff
+
+    try:
+        from app.models.schemas import ChatRequest
+        from app.services.chat_orchestrator import ChatOrchestrator
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to import ChatOrchestrator: %s", exc)
+        return {
+            "record_id": record.record_id,
+            "session_id": record.session_id,
+            "_error": f"import-failed: {type(exc).__name__}: {exc}",
+        }
+
+    request_payload = dict(record.request)
+    request = ChatRequest(
+        message=request_payload.get("message", ""),
+        user_id=request_payload.get("user_id", record.session_id),
+        role=request_payload.get("role", "student"),
+        domain_id=request_payload.get("domain_id"),
+        organization_id=request_payload.get("organization_id"),
+    )
+
+    orchestrator = ChatOrchestrator()
+    started = time.monotonic()
+    try:
+        response = await orchestrator.process(request, record=False)
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "record_id": record.record_id,
+            "session_id": record.session_id,
+            "_error": f"replay-failed: {type(exc).__name__}: {exc}",
+        }
+
+    latency_ms = int((time.monotonic() - started) * 1000)
+    replayed = {
+        "response": getattr(response, "response", "") or "",
+        "tool_calls": (response.metadata or {}).get("tool_calls", []),
+        "sources": [
+            s.model_dump() if hasattr(s, "model_dump") else dict(s)
+            for s in (getattr(response, "sources", None) or [])
+        ],
+        "latency_ms": latency_ms,
+    }
+    diff = diff_records(record, replayed)
+    diff["record_id"] = record.record_id
+    diff["session_id"] = record.session_id
+    diff["replay_latency_ms"] = latency_ms
+    return diff
+
+
+def _flag_regressions(diffs: list[dict]) -> list[dict]:
+    """Return only the diffs that fall outside the regression thresholds."""
+    flagged: list[dict] = []
+    for d in diffs:
+        if "_error" in d:
+            flagged.append(d)
+            continue
+        bad = []
+        if d.get("token_jaccard", 1.0) < REGRESSION_THRESHOLDS["token_jaccard_min"]:
+            bad.append("token_jaccard")
+        if d.get("sources_overlap", 1.0) < REGRESSION_THRESHOLDS["sources_overlap_min"]:
+            bad.append("sources_overlap")
+        if d.get("latency_delta_ms", 0) > REGRESSION_THRESHOLDS["latency_delta_max_ms"]:
+            bad.append("latency_delta_ms")
+        if bad:
+            flagged.append({**d, "_flags": bad})
+    return flagged
+
+
+def _aggregate(diffs: list[dict]) -> dict:
+    jaccards = [d["token_jaccard"] for d in diffs if "token_jaccard" in d]
+    overlaps = [d["sources_overlap"] for d in diffs if "sources_overlap" in d]
+    latency_deltas = [
+        d["latency_delta_ms"] for d in diffs if "latency_delta_ms" in d
+    ]
+    tool_match_count = sum(1 for d in diffs if d.get("tool_calls_match"))
+    error_count = sum(1 for d in diffs if "_error" in d)
+
+    return {
+        "total_records": len(diffs),
+        "errors": error_count,
+        "tool_calls_match_rate": (
+            round(tool_match_count / max(1, len(diffs) - error_count), 3)
+            if diffs
+            else 0.0
+        ),
+        "token_jaccard": _stats(jaccards),
+        "sources_overlap": _stats(overlaps),
+        "latency_delta_ms": _stats(latency_deltas),
+    }
+
+
+def _stats(values: list[float]) -> dict:
+    if not values:
+        return {"n": 0}
+    sorted_values = sorted(values)
+    p95_index = max(0, int(round(0.95 * (len(sorted_values) - 1))))
+    return {
+        "n": len(values),
+        "mean": round(statistics.fmean(values), 3),
+        "median": round(statistics.median(values), 3),
+        "p95": round(sorted_values[p95_index], 3),
+    }
+
+
+def _render_html(report: dict) -> str:
+    agg = report["aggregate"]
+    flags = report["flagged"]
+    rows: list[str] = []
+    for f in flags[:200]:
+        rid = html.escape(str(f.get("record_id", "")))
+        sid = html.escape(str(f.get("session_id", "")))
+        if "_error" in f:
+            rows.append(
+                f"<tr class='err'><td>{sid}</td><td>{rid}</td>"
+                f"<td colspan='4'>error: {html.escape(str(f['_error']))}</td></tr>"
+            )
+            continue
+        flags_str = html.escape(",".join(f.get("_flags", [])))
+        rows.append(
+            "<tr>"
+            f"<td>{sid}</td>"
+            f"<td>{rid}</td>"
+            f"<td>{f.get('token_jaccard', '?'):.3f}</td>"
+            f"<td>{f.get('sources_overlap', '?'):.3f}</td>"
+            f"<td>{f.get('latency_delta_ms', '?')}</td>"
+            f"<td>{flags_str}</td>"
+            "</tr>"
+        )
+
+    rows_html = "\n".join(rows) or "<tr><td colspan='6'>No regressions flagged.</td></tr>"
+
+    return f"""<!doctype html>
+<html lang="vi">
+<head>
+<meta charset="utf-8">
+<title>Wiii eval replay — {html.escape(report.get('day', '?'))}</title>
+<style>
+body {{ font-family: -apple-system, system-ui, sans-serif; padding: 2rem; max-width: 1200px; margin: auto; }}
+h1 {{ font-size: 1.4rem; }}
+table {{ border-collapse: collapse; width: 100%; font-size: 0.85rem; }}
+th, td {{ border: 1px solid #ddd; padding: 6px 8px; text-align: left; }}
+th {{ background: #f5f5f5; }}
+.summary {{ display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; margin: 1rem 0; }}
+.card {{ border: 1px solid #ddd; padding: 1rem; border-radius: 4px; }}
+.metric {{ font-size: 1.6rem; font-weight: bold; }}
+.err td {{ background: #fff0f0; }}
+</style>
+</head>
+<body>
+<h1>Wiii eval replay — {html.escape(report.get('day', '?'))} (org={html.escape(report.get('org', '_personal'))})</h1>
+<div class="summary">
+  <div class="card"><div>Records</div><div class="metric">{agg['total_records']}</div></div>
+  <div class="card"><div>Errors</div><div class="metric">{agg['errors']}</div></div>
+  <div class="card"><div>Tool match rate</div><div class="metric">{agg['tool_calls_match_rate']:.0%}</div></div>
+</div>
+<h2>Token Jaccard (response similarity)</h2>
+<pre>{html.escape(json.dumps(agg['token_jaccard'], indent=2))}</pre>
+<h2>Sources overlap</h2>
+<pre>{html.escape(json.dumps(agg['sources_overlap'], indent=2))}</pre>
+<h2>Latency delta (ms)</h2>
+<pre>{html.escape(json.dumps(agg['latency_delta_ms'], indent=2))}</pre>
+<h2>Regressions ({len(flags)} flagged)</h2>
+<table>
+<tr><th>session_id</th><th>record_id</th><th>token_jaccard</th><th>sources_overlap</th><th>latency_Δ ms</th><th>flags</th></tr>
+{rows_html}
+</table>
+<h2>Thresholds</h2>
+<pre>{html.escape(json.dumps(REGRESSION_THRESHOLDS, indent=2))}</pre>
+</body>
+</html>
+"""
+
+
+async def _run(
+    base_dir: Path,
+    day: str,
+    org: Optional[str],
+    limit: Optional[int],
+    dry_run: bool,
+) -> dict:
+    recorder = EvalRecorder(base_dir=base_dir)
+    sessions = await recorder.list_sessions(org_id=org, day=day)
+
+    diffs: list[dict] = []
+    seen = 0
+    for session_id in sessions:
+        if limit is not None and seen >= limit:
+            break
+        records = await recorder.read_session(
+            session_id=session_id, org_id=org, day=day
+        )
+        for record in records:
+            if limit is not None and seen >= limit:
+                break
+            d = await _replay_one(record, dry_run=dry_run)
+            diffs.append(d)
+            seen += 1
+
+    flagged = _flag_regressions(diffs)
+    return {
+        "base_dir": str(base_dir),
+        "day": day,
+        "org": org or "_personal",
+        "dry_run": dry_run,
+        "aggregate": _aggregate(diffs),
+        "flagged": flagged,
+        "all_diffs_count": len(diffs),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--base-dir",
+        default="eval_recordings",
+        help="Base directory containing eval JSONL partitions.",
+    )
+    parser.add_argument(
+        "--day",
+        required=True,
+        help="Partition day in YYYY-MM-DD form.",
+    )
+    parser.add_argument("--org", default=None)
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Max records to replay (canary scope).",
+    )
+    parser.add_argument(
+        "--report-out",
+        default="-",
+        help="Output path for the report (.json or .html). Use '-' for stdout JSON.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip live orchestrator call; pretend replays match the original.",
+    )
+    parser.add_argument(
+        "--fail-on-regression",
+        action="store_true",
+        help="Exit 1 if any record exceeds the regression thresholds.",
+    )
+    args = parser.parse_args()
+
+    base_dir = Path(args.base_dir)
+    if not base_dir.exists():
+        print(f"[replay_eval] base_dir does not exist: {base_dir}", file=sys.stderr)
+        return 2
+
+    report = asyncio.run(
+        _run(base_dir, args.day, args.org, args.limit, args.dry_run)
+    )
+
+    out = args.report_out
+    if out == "-":
+        json.dump(report, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+    elif out.endswith(".html"):
+        Path(out).write_text(_render_html(report), encoding="utf-8")
+        print(f"[replay_eval] HTML report written to {out}", file=sys.stderr)
+    else:
+        Path(out).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        print(f"[replay_eval] JSON report written to {out}", file=sys.stderr)
+
+    if args.fail_on_regression and report["flagged"]:
+        print(
+            f"[replay_eval] {len(report['flagged'])} regression(s) flagged",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/maritime-ai-service/scripts/replay_eval.py
+++ b/maritime-ai-service/scripts/replay_eval.py
@@ -111,7 +111,7 @@ async def _replay_one(
 
     latency_ms = int((time.monotonic() - started) * 1000)
     replayed = {
-        "response": getattr(response, "response", "") or "",
+        "response": getattr(response, "message", "") or "",
         "tool_calls": (response.metadata or {}).get("tool_calls", []),
         "sources": [
             s.model_dump() if hasattr(s, "model_dump") else dict(s)

--- a/maritime-ai-service/tests/unit/api/test_edge_endpoints.py
+++ b/maritime-ai-service/tests/unit/api/test_edge_endpoints.py
@@ -1,0 +1,275 @@
+"""Phase 10d edge endpoints — Runtime Migration #207.
+
+Locks the OpenAI / Anthropic compat surface contract:
+- 503 when ``enable_native_runtime`` is off (default).
+- 200 with the upstream wire shape when on, derived from the existing
+  ChatService output via the Phase 4 protocol adapters.
+- 400 when the body has no user-role message.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from app.api.edge_endpoints import router as edge_router
+from app.api.deps import require_auth
+from app.models.schemas import (
+    AgentType,
+    InternalChatResponse,
+)
+
+
+@pytest.fixture
+def fake_auth():
+    """A minimal authenticated user double — only fields the router touches."""
+    return SimpleNamespace(
+        user_id="user-1",
+        organization_id="org-1",
+        role="student",
+        auth_method="api_key",
+    )
+
+
+@pytest.fixture
+def app(fake_auth):
+    app = FastAPI()
+    app.include_router(edge_router)
+    app.dependency_overrides[require_auth] = lambda: fake_auth
+    return app
+
+
+@pytest.fixture
+def fake_internal_response():
+    return InternalChatResponse(
+        message="Câu trả lời từ Wiii.",
+        agent_type=AgentType.RAG,
+        sources=None,
+        metadata={"latency_ms": 42, "provider": "google", "model": "gemini-flash"},
+    )
+
+
+def _enable_runtime(monkeypatch):
+    """Flip ``enable_native_runtime`` on for the duration of a test."""
+    from app.core import config as config_module
+
+    monkeypatch.setattr(
+        config_module.settings, "enable_native_runtime", True, raising=False
+    )
+
+
+# ── flag-off behaviour ──
+
+@pytest.mark.asyncio
+async def test_chat_completions_503_when_runtime_disabled(app, monkeypatch):
+    from app.core import config as config_module
+
+    monkeypatch.setattr(
+        config_module.settings, "enable_native_runtime", False, raising=False
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["error"]["type"] == "service_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_messages_503_when_runtime_disabled(app, monkeypatch):
+    from app.core import config as config_module
+
+    monkeypatch.setattr(
+        config_module.settings, "enable_native_runtime", False, raising=False
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/v1/messages",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert resp.status_code == 503
+
+
+# ── happy paths ──
+
+@pytest.mark.asyncio
+async def test_openai_completions_returns_chat_completion_envelope(
+    app, monkeypatch, fake_internal_response
+):
+    _enable_runtime(monkeypatch)
+    fake_service = SimpleNamespace(
+        process_message=AsyncMock(return_value=fake_internal_response)
+    )
+    with patch(
+        "app.services.chat_service.get_chat_service", return_value=fake_service
+    ):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "gpt-4o-mini",
+                    "messages": [
+                        {"role": "system", "content": "You are helpful."},
+                        {"role": "user", "content": "Chào Wiii"},
+                    ],
+                },
+            )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["object"] == "chat.completion"
+    assert body["model"] == "gpt-4o-mini"
+    assert body["choices"][0]["message"]["role"] == "assistant"
+    assert body["choices"][0]["message"]["content"] == "Câu trả lời từ Wiii."
+    assert body["choices"][0]["finish_reason"] == "stop"
+    assert body["id"].startswith("chatcmpl-")
+    # ChatService received exactly one call.
+    fake_service.process_message.assert_awaited_once()
+    chat_request = fake_service.process_message.await_args.args[0]
+    assert chat_request.message == "Chào Wiii"
+    assert chat_request.user_id == "user-1"
+    assert chat_request.organization_id == "org-1"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_returns_message_envelope(
+    app, monkeypatch, fake_internal_response
+):
+    _enable_runtime(monkeypatch)
+    fake_service = SimpleNamespace(
+        process_message=AsyncMock(return_value=fake_internal_response)
+    )
+    with patch(
+        "app.services.chat_service.get_chat_service", return_value=fake_service
+    ):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/v1/messages",
+                json={
+                    "model": "claude-sonnet-4",
+                    "system": "You are helpful.",
+                    "messages": [
+                        {"role": "user", "content": "Chào Wiii"},
+                    ],
+                },
+            )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["type"] == "message"
+    assert body["role"] == "assistant"
+    assert body["model"] == "claude-sonnet-4"
+    assert body["content"] == [
+        {"type": "text", "text": "Câu trả lời từ Wiii."}
+    ]
+    assert body["stop_reason"] == "end_turn"
+    assert body["id"].startswith("msg_")
+
+
+# ── error paths ──
+
+@pytest.mark.asyncio
+async def test_completions_rejects_no_user_message(app, monkeypatch):
+    _enable_runtime(monkeypatch)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "system", "content": "Hi only system."}]},
+        )
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["error"]["type"] == "invalid_request"
+
+
+@pytest.mark.asyncio
+async def test_completions_rejects_non_dict_body(app, monkeypatch):
+    _enable_runtime(monkeypatch)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json=["not", "a", "dict"],
+        )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_messages_rejects_no_user_message(app, monkeypatch):
+    _enable_runtime(monkeypatch)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        # Anthropic messages with only assistant turn → no user content.
+        resp = await client.post(
+            "/v1/messages",
+            json={
+                "messages": [
+                    {"role": "assistant", "content": "I'm ready."},
+                ]
+            },
+        )
+    assert resp.status_code == 400
+
+
+# ── session bridging ──
+
+@pytest.mark.asyncio
+async def test_session_id_falls_back_to_user_when_omitted(
+    app, monkeypatch, fake_internal_response
+):
+    _enable_runtime(monkeypatch)
+    fake_service = SimpleNamespace(
+        process_message=AsyncMock(return_value=fake_internal_response)
+    )
+    with patch(
+        "app.services.chat_service.get_chat_service", return_value=fake_service
+    ):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+    assert resp.status_code == 200
+    chat_request = fake_service.process_message.await_args.args[0]
+    assert chat_request.session_id == "edge-user-1"
+
+
+@pytest.mark.asyncio
+async def test_explicit_session_id_propagates(
+    app, monkeypatch, fake_internal_response
+):
+    _enable_runtime(monkeypatch)
+    fake_service = SimpleNamespace(
+        process_message=AsyncMock(return_value=fake_internal_response)
+    )
+    with patch(
+        "app.services.chat_service.get_chat_service", return_value=fake_service
+    ):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/v1/chat/completions",
+                json={
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "session_id": "thread-42",
+                },
+            )
+    assert resp.status_code == 200
+    chat_request = fake_service.process_message.await_args.args[0]
+    assert chat_request.session_id == "thread-42"

--- a/maritime-ai-service/tests/unit/api/test_edge_endpoints.py
+++ b/maritime-ai-service/tests/unit/api/test_edge_endpoints.py
@@ -207,6 +207,36 @@ async def test_completions_rejects_non_dict_body(app, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_completions_rejects_malformed_json_with_400(app, monkeypatch):
+    """Invalid JSON should surface as a structured 400, not a 500."""
+    _enable_runtime(monkeypatch)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            content=b"{not-valid-json,",
+            headers={"Content-Type": "application/json"},
+        )
+    assert resp.status_code == 400
+    assert "valid JSON" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_messages_rejects_malformed_json_with_400(app, monkeypatch):
+    _enable_runtime(monkeypatch)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/v1/messages",
+            content=b"{broken",
+            headers={"Content-Type": "application/json"},
+        )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_messages_rejects_no_user_message(app, monkeypatch):
     _enable_runtime(monkeypatch)
     async with httpx.AsyncClient(

--- a/maritime-ai-service/tests/unit/engine/runtime/test_eval_recorder.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_eval_recorder.py
@@ -159,6 +159,16 @@ async def test_list_days_filters_non_date_dirs(tmp_path: Path, recorder: EvalRec
     assert days == ["2026-05-01"]
 
 
+async def test_list_days_rejects_malformed_dates(tmp_path: Path, recorder: EvalRecorder):
+    """Length+hyphen heuristic alone passes garbage like ``2026-XX-01`` —
+    list_days must validate via strptime so callers can trust the output."""
+    org_dir = tmp_path / "_personal"
+    for name in ("2026-05-01", "2026-XX-01", "abcd-ef-gh", "2026-13-01", "2026-02-30"):
+        (org_dir / name).mkdir(parents=True)
+    days = await recorder.list_days()
+    assert days == ["2026-05-01"]
+
+
 # ── prune_older_than ──
 
 async def test_prune_older_than_removes_old_partitions(tmp_path: Path, recorder: EvalRecorder):

--- a/maritime-ai-service/tests/unit/engine/runtime/test_eval_recorder.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_eval_recorder.py
@@ -135,6 +135,78 @@ async def test_list_sessions(recorder: EvalRecorder):
     assert listed == ["a", "b"]
 
 
+# ── list_days ──
+
+async def test_list_days_empty(recorder: EvalRecorder):
+    assert await recorder.list_days() == []
+
+
+async def test_list_days_returns_date_partitions(tmp_path: Path, recorder: EvalRecorder):
+    # Manually create partitions to simulate multiple days.
+    org_dir = tmp_path / "_personal"
+    for day in ("2026-05-01", "2026-05-02", "2026-05-03"):
+        (org_dir / day).mkdir(parents=True)
+    days = await recorder.list_days()
+    assert days == ["2026-05-01", "2026-05-02", "2026-05-03"]
+
+
+async def test_list_days_filters_non_date_dirs(tmp_path: Path, recorder: EvalRecorder):
+    org_dir = tmp_path / "_personal"
+    (org_dir / "2026-05-01").mkdir(parents=True)
+    (org_dir / "junk-folder").mkdir(parents=True)
+    (org_dir / "2026").mkdir(parents=True)  # too short
+    days = await recorder.list_days()
+    assert days == ["2026-05-01"]
+
+
+# ── prune_older_than ──
+
+async def test_prune_older_than_removes_old_partitions(tmp_path: Path, recorder: EvalRecorder):
+    org_dir = tmp_path / "_personal"
+    # Old: should be removed.
+    old_day = org_dir / "2026-04-01"
+    old_day.mkdir(parents=True)
+    (old_day / "session_x.jsonl").write_text('{"n": 1}\n', encoding="utf-8")
+    # Recent: should stay.
+    recent_day = org_dir / "2026-05-02"
+    recent_day.mkdir(parents=True)
+    (recent_day / "session_y.jsonl").write_text('{"n": 2}\n', encoding="utf-8")
+
+    removed = await recorder.prune_older_than(retention_days=7, today="2026-05-03")
+    assert removed.get("_personal") == 1
+    assert not old_day.exists()
+    assert recent_day.exists()
+
+
+async def test_prune_older_than_zero_retention_is_noop(tmp_path: Path, recorder: EvalRecorder):
+    (tmp_path / "_personal" / "2026-04-01").mkdir(parents=True)
+    removed = await recorder.prune_older_than(retention_days=0)
+    assert removed == {}
+
+
+async def test_prune_older_than_skips_malformed_day_dirs(
+    tmp_path: Path, recorder: EvalRecorder
+):
+    org_dir = tmp_path / "_personal"
+    (org_dir / "junk-folder").mkdir(parents=True)
+    (org_dir / "not-a-date").mkdir(parents=True)
+    removed = await recorder.prune_older_than(retention_days=1, today="2026-05-03")
+    # Both garbage dirs left alone.
+    assert removed == {}
+    assert (org_dir / "junk-folder").exists()
+
+
+async def test_prune_older_than_handles_multiple_orgs(
+    tmp_path: Path, recorder: EvalRecorder
+):
+    for org in ("org-1", "org-2"):
+        old = tmp_path / org / "2026-04-01"
+        old.mkdir(parents=True)
+        (old / "s.jsonl").write_text("{}\n", encoding="utf-8")
+    removed = await recorder.prune_older_than(retention_days=1, today="2026-05-03")
+    assert removed == {"org-1": 1, "org-2": 1}
+
+
 # ── diff_records ──
 
 def test_diff_identical_response_full_overlap():

--- a/maritime-ai-service/tests/unit/engine/runtime/test_session_event_log.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_session_event_log.py
@@ -119,3 +119,196 @@ async def test_concurrent_appends_preserve_monotonic_seq(log):
     events = await asyncio.gather(*(write(i) for i in range(20)))
     seqs = sorted(e.seq for e in events)
     assert seqs == list(range(1, 21))
+
+
+# ── PostgresSessionEventLog ──
+
+class _FakeRow(dict):
+    """Mimic asyncpg.Record minimal interface."""
+
+    def __getitem__(self, key):
+        return super().__getitem__(key)
+
+
+class _FakeConn:
+    def __init__(self, rows=None, fetchval_value=0, raise_unique_n_times: int = 0):
+        self.rows = rows or []
+        self.fetchval_value = fetchval_value
+        self.raise_unique_n_times = raise_unique_n_times
+        self.fetchrow_calls: list[tuple] = []
+        self.fetch_calls: list[tuple] = []
+        self.fetchval_calls: list[tuple] = []
+
+    async def fetchrow(self, sql, *args):
+        self.fetchrow_calls.append((sql, args))
+        if self.raise_unique_n_times > 0:
+            self.raise_unique_n_times -= 1
+            import asyncpg
+            raise asyncpg.UniqueViolationError("duplicate seq")
+        if self.rows:
+            return self.rows.pop(0)
+        # Default: synthesise a row using args.
+        session_id, org_id, event_type, payload_json = args
+        import json
+        return _FakeRow(
+            id=1,
+            session_id=session_id,
+            org_id=org_id,
+            event_type=event_type,
+            payload=payload_json,
+            seq=1,
+            created_at="2026-05-03T00:00:00Z",
+        )
+
+    async def fetch(self, sql, *args):
+        self.fetch_calls.append((sql, args))
+        return self.rows
+
+    async def fetchval(self, sql, *args):
+        self.fetchval_calls.append((sql, args))
+        return self.fetchval_value
+
+
+class _FakePool:
+    def __init__(self, conn: _FakeConn):
+        self._conn = conn
+
+    def acquire(self):
+        outer = self
+
+        class _CtxManager:
+            async def __aenter__(self):
+                return outer._conn
+
+            async def __aexit__(self, *exc):
+                return None
+
+        return _CtxManager()
+
+
+@pytest.fixture
+def fake_conn() -> _FakeConn:
+    return _FakeConn()
+
+
+@pytest.fixture
+def pg_log(monkeypatch, fake_conn: _FakeConn):
+    """PostgresSessionEventLog with the asyncpg pool mocked out."""
+    from app.engine.runtime.session_event_log import PostgresSessionEventLog
+
+    log = PostgresSessionEventLog()
+    fake_pool = _FakePool(fake_conn)
+
+    async def _pool_stub():
+        return fake_pool
+
+    monkeypatch.setattr(log, "_pool", _pool_stub)
+    return log
+
+
+async def test_postgres_append_round_trips_payload(pg_log, fake_conn):
+    event = await pg_log.append(
+        session_id="s1", event_type="user_message", payload={"text": "hi"}, org_id="org-1"
+    )
+    assert event.session_id == "s1"
+    assert event.event_type == "user_message"
+    assert event.payload == {"text": "hi"}
+    assert event.org_id == "org-1"
+    assert event.seq == 1
+    # SQL was issued with the right shape — no jsonb cast missing etc.
+    sql_first, args = fake_conn.fetchrow_calls[0]
+    assert "INSERT INTO session_events" in sql_first
+    assert "$4::jsonb" in sql_first
+    assert args[0] == "s1"
+    assert args[2] == "user_message"
+
+
+async def test_postgres_append_retries_on_unique_violation(pg_log, fake_conn):
+    fake_conn.raise_unique_n_times = 2  # succeed on 3rd try
+    event = await pg_log.append(
+        session_id="s1", event_type="x", payload={}
+    )
+    assert event.seq == 1
+    assert len(fake_conn.fetchrow_calls) == 3
+
+
+async def test_postgres_append_gives_up_after_max_retries(pg_log, fake_conn):
+    fake_conn.raise_unique_n_times = 99  # always fail
+    with pytest.raises(RuntimeError, match="exceeded retries"):
+        await pg_log.append(session_id="s1", event_type="x", payload={})
+
+
+async def test_postgres_get_events_filters_by_org(pg_log, fake_conn):
+    fake_conn.rows = [
+        _FakeRow(
+            id=1, session_id="s", org_id="A", event_type="x",
+            payload='{"i": 1}', seq=1, created_at=None,
+        ),
+        _FakeRow(
+            id=2, session_id="s", org_id="A", event_type="x",
+            payload='{"i": 2}', seq=2, created_at=None,
+        ),
+    ]
+    events = await pg_log.get_events(session_id="s", org_id="A", since_seq=0)
+    sql, args = fake_conn.fetch_calls[0]
+    assert "ORDER BY seq ASC" in sql
+    assert "session_id = $1" in sql
+    assert "org_id = $2" in sql
+    assert "seq > $3" in sql
+    assert args == ("s", "A", 0)
+    assert len(events) == 2
+    assert events[0].payload == {"i": 1}
+
+
+async def test_postgres_latest_seq_with_org(pg_log, fake_conn):
+    fake_conn.fetchval_value = 5
+    seq = await pg_log.latest_seq(session_id="s", org_id="A")
+    assert seq == 5
+    sql, args = fake_conn.fetchval_calls[0]
+    assert "WHERE session_id = $1 AND org_id = $2" in sql
+    assert args == ("s", "A")
+
+
+async def test_postgres_latest_seq_without_org(pg_log, fake_conn):
+    fake_conn.fetchval_value = 0
+    seq = await pg_log.latest_seq(session_id="missing")
+    assert seq == 0
+
+
+async def test_postgres_payload_revives_str_jsonb(pg_log, fake_conn):
+    """asyncpg returns jsonb as str; backend must json.loads."""
+    fake_conn.rows = [
+        _FakeRow(
+            id=1, session_id="s", org_id=None, event_type="x",
+            payload='{"a": 1, "b": "two"}', seq=1, created_at=None,
+        ),
+    ]
+    events = await pg_log.get_events(session_id="s")
+    assert events[0].payload == {"a": 1, "b": "two"}
+
+
+# ── get_session_event_log routing ──
+
+def test_get_session_event_log_returns_inmemory_when_flag_off(monkeypatch):
+    from app.engine.runtime import session_event_log as mod
+
+    mod._reset_for_tests()
+    fake_settings = type("S", (), {"enable_session_event_log": False})()
+    monkeypatch.setattr(
+        "app.core.config.settings", fake_settings, raising=False
+    )
+    log = mod.get_session_event_log()
+    assert isinstance(log, mod.InMemorySessionEventLog)
+
+
+def test_get_session_event_log_returns_postgres_when_flag_on(monkeypatch):
+    from app.engine.runtime import session_event_log as mod
+
+    mod._reset_for_tests()
+    fake_settings = type("S", (), {"enable_session_event_log": True})()
+    monkeypatch.setattr(
+        "app.core.config.settings", fake_settings, raising=False
+    )
+    log = mod.get_session_event_log()
+    assert isinstance(log, mod.PostgresSessionEventLog)
+    mod._reset_for_tests()


### PR DESCRIPTION
## Summary

Phase 10 of the runtime migration epic (#207). Three independent sub-PRs squashed into one branch — all behind feature flags, zero behavioural change for existing call sites.

- **10b — Replay + rotation** (`95f82e9`): `scripts/replay_eval.py` walks the JSONL eval recorder, replays through `ChatOrchestrator.process(record=False)`, aggregates `token_jaccard` / `sources_overlap` / latency deltas, and emits an HTML regression report. `EvalRecorder.list_days()` + `prune_older_than()` give a daily-cron retention story.
- **10c — PostgresSessionEventLog** (`98dcd0d`): promotes the Phase 5 in-memory log to a durable `asyncpg`-backed implementation. Append computes `seq` inline via `COALESCE(MAX(seq), 0) + 1` and relies on `session_events_seq_unique` (Alembic 047) for concurrency; on `UniqueViolationError` we retry up to 3×. Routing through `get_session_event_log()` is gated by `enable_session_event_log` (default off).
- **10d — Edge endpoints** (`a6bbc74`): the Phase 4 protocol adapters finally meet HTTP. New `/v1/chat/completions` and `/v1/messages` routes mounted at root `/v1` so external SDKs can swap `base_url` and run. Each endpoint parses the raw provider body → adapter → `TurnRequest` → bridges into the existing `ChatService` → re-renders the upstream envelope. Gated by `enable_native_runtime`; when off, routes return 503 with a structured error.

## Test plan

- [x] `pytest tests/unit/engine/runtime/` — 86 pass (covers replay + rotation, PostgresSessionEventLog routing + retry semantics)
- [x] `pytest tests/unit/api/test_edge_endpoints.py` — 9 pass (flag-off 503 for both endpoints, OpenAI/Anthropic envelope shape, no-user-message → 400, non-dict body → 400, session_id default + explicit propagation)
- [x] `python -c "from app.main import create_application; create_application()"` boots cleanly with `enable_native_runtime=False` (default — 132 routes, no edge routes)
- [x] Same boot with `enable_native_runtime=True` registers exactly `/v1/chat/completions` + `/v1/messages`

## Out of scope (deferred)

- Wiring `enable_native_runtime=True` into actual production dispatch — the legacy `LLMPool` path stays canonical until the per-org canary in a follow-up phase.
- Operational items: nightly replay cron, p50 benchmark vs legacy, 30-day post-mortem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OpenAI Chat Completions and Anthropic Messages API endpoints for native runtime
  * PostgreSQL option for persistent session event logging  
  * Evaluation recording filesystem management (listing and pruning)
  * New regression testing CLI with HTML reporting, dry-run mode, and organization scoping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->