### PR TITLE
phase-11: wake() + nightly replay CI + deterministic seed

### DIFF
--- a/.github/workflows/nightly-replay-eval.yml
+++ b/.github/workflows/nightly-replay-eval.yml
@@ -1,0 +1,115 @@
+name: Nightly Replay Eval
+
+# Phase 11b of the runtime migration epic (issue #207).
+#
+# This workflow runs the replay_eval harness daily so a regression in the
+# response shape, latency profile, or source overlap shows up in the
+# morning instead of weeks later. Today it operates in HARNESS-VALIDATION
+# mode: it generates synthetic recordings on the fly and replays them in
+# --dry-run. That proves the script + EvalRecorder + diff_records loop
+# works end-to-end without a GOOGLE_API_KEY.
+#
+# When `enable_eval_recording` flips on in production, swap the synthetic
+# generation step for a step that pulls yesterday's real partition into
+# the workspace (artifact, gcsfuse, rsync — whichever the prod box
+# exposes). The replay step itself does not change.
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # 02:00 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-replay-eval
+  cancel-in-progress: false
+
+jobs:
+  replay:
+    runs-on: ubuntu-latest
+
+    env:
+      PYTHONIOENCODING: utf-8
+      ENVIRONMENT: development
+      API_KEY: replay-harness-key
+      GOOGLE_API_KEY: replay-harness-fake-key
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: maritime-ai-service/requirements.txt
+
+      - name: Install dependencies
+        working-directory: maritime-ai-service
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Compute yesterday's partition
+        id: date
+        run: echo "day=$(date -u -d 'yesterday' +%Y-%m-%d)" >> $GITHUB_OUTPUT
+
+      - name: Generate synthetic recordings
+        working-directory: maritime-ai-service
+        env:
+          REPLAY_DAY: ${{ steps.date.outputs.day }}
+        run: |
+          python - <<'PY'
+          import asyncio
+          import os
+          from pathlib import Path
+
+          from app.engine.runtime.eval_recorder import EvalRecord, EvalRecorder
+
+          day = os.environ["REPLAY_DAY"]
+          base = Path("eval_recordings_synthetic")
+          recorder = EvalRecorder(base_dir=base)
+
+          async def main():
+              # 5 baseline records — the dry-run replay will report these
+              # as identical (token_jaccard 1.0, no regression).
+              for i in range(5):
+                  await recorder.write(
+                      EvalRecord(
+                          session_id=f"smoke-{i}",
+                          org_id="smoke-org",
+                          timestamp=f"{day}T00:00:0{i}+00:00",
+                          request={
+                              "messages": [
+                                  {"role": "user", "content": f"hello {i}"}
+                              ]
+                          },
+                          response=f"hello back {i}",
+                          metadata={"latency_ms": 100 + i},
+                      )
+                  )
+
+          asyncio.run(main())
+          print(f"[smoke] wrote 5 synthetic records under {base}/smoke-org/{day}/")
+          PY
+
+      - name: Run replay (dry-run, expect zero regressions)
+        working-directory: maritime-ai-service
+        run: |
+          python scripts/replay_eval.py \
+            --base-dir eval_recordings_synthetic \
+            --day ${{ steps.date.outputs.day }} \
+            --org smoke-org \
+            --dry-run \
+            --report-out replay-report.html \
+            --fail-on-regression
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: replay-report-${{ steps.date.outputs.day }}
+          path: maritime-ai-service/replay-report.html
+          retention-days: 30

--- a/maritime-ai-service/app/engine/llm_providers/wiii_chat_model.py
+++ b/maritime-ai-service/app/engine/llm_providers/wiii_chat_model.py
@@ -446,6 +446,16 @@ class WiiiChatModel(BaseModel):
         if "tool_choice" in api_kwargs:
             api_kwargs["tool_choice"] = _normalize_tool_choice(api_kwargs["tool_choice"])
 
+        # Phase 11c: thread the active replay seed through to OpenAI-compat
+        # providers so eval replays reproduce the original sampling. The
+        # provider-specific param strip below drops ``seed`` for backends
+        # that don't accept it (e.g. Zhipu), so this is safe to set always.
+        from app.engine.runtime.replay_context import get_replay_seed_int
+
+        replay_seed = get_replay_seed_int()
+        if replay_seed is not None:
+            api_kwargs["seed"] = replay_seed
+
         return _strip_unsupported_params(api_kwargs, self.base_url)
 
     async def ainvoke(self, messages: Iterable[Any], **kwargs: Any) -> Message:

--- a/maritime-ai-service/app/engine/runtime/replay_context.py
+++ b/maritime-ai-service/app/engine/runtime/replay_context.py
@@ -1,0 +1,85 @@
+"""Replay seed propagation channel.
+
+Phase 11c of the runtime migration epic (issue #207). Borrows the
+Anthropic Managed Agents pattern for reproducible regression testing:
+when an ``EvalRecord`` carries a ``replay_seed``, the same seed is
+threaded through every LLM call in the turn so a replay produces the
+same sampling decisions the original turn made.
+
+Wire shape:
+- ``replay_eval.py`` sets the seed before each replay turn via
+  ``set_replay_seed(record.replay_seed)`` and clears it after.
+- LLM call sites (``UnifiedLLMClient``, raw provider adapters) read the
+  active value via ``get_replay_seed()`` and pass it through whatever
+  provider-native parameter exists (OpenAI ``seed=``, etc.).
+- Default is ``None`` — production traffic is non-deterministic.
+
+ContextVar (not threading.local) because the entire runtime is async.
+The token returned by ``set_replay_seed`` MUST be passed back to
+``clear_replay_seed`` to avoid leaking state across turns; the
+``replay_seed_scope`` context manager makes that pairing implicit.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from typing import Generator, Optional
+
+_seed_var: ContextVar[Optional[str]] = ContextVar(
+    "wiii_replay_seed", default=None
+)
+
+
+def get_replay_seed() -> Optional[str]:
+    """Return the currently active replay seed, or ``None`` for live traffic."""
+    return _seed_var.get()
+
+
+def get_replay_seed_int() -> Optional[int]:
+    """Coerce the active seed to ``int`` for providers that need numeric seeds.
+
+    Returns ``None`` when no seed is set or when the seed string is not
+    parseable. Callers that fail closed on coerce errors should check the
+    return value rather than wrapping ``int(get_replay_seed())`` themselves.
+    """
+    raw = _seed_var.get()
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def set_replay_seed(seed: Optional[str]) -> Token:
+    """Set the active seed and return the token for clearing it later."""
+    return _seed_var.set(seed)
+
+
+def clear_replay_seed(token: Token) -> None:
+    """Restore the seed to its prior value using the token from ``set_replay_seed``."""
+    _seed_var.reset(token)
+
+
+@contextmanager
+def replay_seed_scope(seed: Optional[str]) -> Generator[None, None, None]:
+    """Apply ``seed`` for the duration of the ``with`` block.
+
+    Pairs ``set_replay_seed`` + ``clear_replay_seed`` automatically so
+    callers cannot leak state by forgetting to reset.
+    """
+    token = set_replay_seed(seed)
+    try:
+        yield
+    finally:
+        clear_replay_seed(token)
+
+
+__all__ = [
+    "get_replay_seed",
+    "get_replay_seed_int",
+    "set_replay_seed",
+    "clear_replay_seed",
+    "replay_seed_scope",
+]

--- a/maritime-ai-service/app/engine/runtime/session_wake.py
+++ b/maritime-ai-service/app/engine/runtime/session_wake.py
@@ -1,0 +1,203 @@
+"""Session reconstruction — replay a SessionEventLog into chat state.
+
+Phase 11a of the runtime migration epic (issue #207). The Anthropic
+Managed Agents pattern leans on durable session state living *outside* the
+context window so a process restart, host failover, or a follow-up turn
+hours later can resume cleanly. Phases 5/10c shipped the durable log;
+this module is the readback half — given a ``session_id`` it returns a
+``WakeState`` ready to feed into the next turn.
+
+Design points:
+- **Event-type tolerant.** The log purposefully keeps types as opaque
+  strings; ``wake`` recognises the four shapes that carry conversation
+  semantics (``user_message``, ``assistant_message``, ``tool_result``,
+  ``system_message``) and skips everything else without raising.
+- **Pending tool calls surfaced separately.** If an assistant turn ends
+  with one or more ``tool_calls`` and the matching ``tool_result`` events
+  never arrive, the resumer can decide whether to re-dispatch the call,
+  retry the whole turn, or surface a user-facing error.
+- **Pure projection.** No side effects. ``wake`` reads, builds, returns —
+  callers own decisions about what to do with the state.
+- **Org-scoped.** Pass ``org_id`` to filter; the underlying log already
+  enforces the boundary so this is a defence-in-depth mirror.
+
+Payload contract (loose, validated defensively):
+- ``user_message`` ─ ``{"text": str}`` (legacy ``content`` accepted)
+- ``assistant_message`` ─ ``{"text": str, "tool_calls": [ToolCall.dict, ...]}``
+- ``tool_result`` ─ ``{"tool_call_id": str, "content": str, "is_error": bool}``
+- ``system_message`` ─ ``{"text": str}``
+
+Anything else falls through with a debug log.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from app.engine.messages import Message, ToolCall
+from app.engine.runtime.session_event_log import (
+    SessionEventLog,
+    get_session_event_log,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class WakeState(BaseModel):
+    """Conversation state rebuilt from a session's event log."""
+
+    session_id: str
+    org_id: Optional[str] = None
+    messages: list[Message] = Field(default_factory=list)
+    """Reconstructed conversation in append order."""
+
+    pending_tool_calls: list[ToolCall] = Field(default_factory=list)
+    """Tool calls from the most recent assistant turn that never received
+    a matching ``tool_result`` event. Empty when the session is in a
+    clean state ready for the next user turn."""
+
+    latest_seq: int = 0
+    """Highest ``seq`` observed during replay. Useful as a ``since_seq``
+    cursor for incremental wake calls."""
+
+    event_count: int = 0
+    """Number of events visited (including ones skipped as unknown).
+    Diagnostic only — not the same as ``len(messages)``."""
+
+
+def _coerce_text(payload: dict) -> str:
+    """Extract a text body, accepting legacy aliases."""
+    for key in ("text", "content", "message"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _coerce_tool_calls(raw: object) -> list[ToolCall]:
+    """Pull a list of ToolCall from a payload field, defensively."""
+    if not isinstance(raw, list):
+        return []
+    parsed: list[ToolCall] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            parsed.append(ToolCall.model_validate(entry))
+        except Exception as exc:  # noqa: BLE001 — diagnostic only
+            logger.debug("[wake] dropped malformed tool_call: %s", exc)
+    return parsed
+
+
+def _apply_user_message(state: WakeState, payload: dict) -> None:
+    text = _coerce_text(payload)
+    if not text:
+        return
+    state.messages.append(Message(role="user", content=text))
+
+
+def _apply_system_message(state: WakeState, payload: dict) -> None:
+    text = _coerce_text(payload)
+    if not text:
+        return
+    state.messages.append(Message(role="system", content=text))
+
+
+def _apply_assistant_message(
+    state: WakeState, payload: dict, pending: dict[str, ToolCall]
+) -> None:
+    text = _coerce_text(payload)
+    tool_calls = _coerce_tool_calls(payload.get("tool_calls"))
+    if not text and not tool_calls:
+        return
+    state.messages.append(
+        Message(
+            role="assistant",
+            content=text,
+            tool_calls=tool_calls or None,
+        )
+    )
+    # Each tool_call this assistant turn requested is "pending" until a
+    # matching tool_result arrives. Replace any earlier pending set —
+    # only the most recent assistant turn's calls matter for resumption.
+    pending.clear()
+    for call in tool_calls:
+        if call.id:
+            pending[call.id] = call
+
+
+def _apply_tool_result(
+    state: WakeState, payload: dict, pending: dict[str, ToolCall]
+) -> None:
+    tool_call_id = payload.get("tool_call_id")
+    if not isinstance(tool_call_id, str) or not tool_call_id:
+        return
+    content = payload.get("content")
+    text = content if isinstance(content, str) else ""
+    state.messages.append(
+        Message(
+            role="tool",
+            content=text,
+            tool_call_id=tool_call_id,
+        )
+    )
+    pending.pop(tool_call_id, None)
+
+
+_HANDLERS = {
+    "user_message": _apply_user_message,
+    "system_message": _apply_system_message,
+}
+
+
+async def wake(
+    *,
+    session_id: str,
+    org_id: Optional[str] = None,
+    since_seq: Optional[int] = None,
+    log: Optional[SessionEventLog] = None,
+) -> WakeState:
+    """Replay events for ``session_id`` into a ``WakeState``.
+
+    ``since_seq`` lets a caller resume from a known cursor (e.g. a worker
+    that has already replayed up to seq 42 and only wants newer events).
+    ``log`` is injectable for tests; defaults to the configured singleton.
+    """
+    backend = log or get_session_event_log()
+    events = await backend.get_events(
+        session_id=session_id, org_id=org_id, since_seq=since_seq
+    )
+
+    state = WakeState(session_id=session_id, org_id=org_id)
+    pending: dict[str, ToolCall] = {}
+
+    for event in events:
+        state.event_count += 1
+        if event.seq > state.latest_seq:
+            state.latest_seq = event.seq
+
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        handler = _HANDLERS.get(event.event_type)
+        if handler is not None:
+            handler(state, payload)
+            continue
+        if event.event_type == "assistant_message":
+            _apply_assistant_message(state, payload, pending)
+            continue
+        if event.event_type == "tool_result":
+            _apply_tool_result(state, payload, pending)
+            continue
+        # Unknown event type: telemetry, status pings, etc. Ignored on
+        # purpose so new event categories don't break wake().
+        logger.debug(
+            "[wake] skipped event_type=%r seq=%d", event.event_type, event.seq
+        )
+
+    state.pending_tool_calls = list(pending.values())
+    return state
+
+
+__all__ = ["WakeState", "wake"]

--- a/maritime-ai-service/scripts/replay_eval.py
+++ b/maritime-ai-service/scripts/replay_eval.py
@@ -49,6 +49,7 @@ from app.engine.runtime.eval_recorder import (  # noqa: E402
     EvalRecorder,
     diff_records,
 )
+from app.engine.runtime.replay_context import replay_seed_scope  # noqa: E402
 
 logger = logging.getLogger("eval_replay")
 
@@ -101,7 +102,10 @@ async def _replay_one(
     orchestrator = ChatOrchestrator()
     started = time.monotonic()
     try:
-        response = await orchestrator.process(request, record=False)
+        # Pin LLM sampling to the original turn's seed when present so
+        # replay reproduces the same response shape (Phase 11c).
+        with replay_seed_scope(record.replay_seed):
+            response = await orchestrator.process(request, record=False)
     except Exception as exc:  # noqa: BLE001
         return {
             "record_id": record.record_id,

--- a/maritime-ai-service/tests/unit/engine/runtime/test_replay_context.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_replay_context.py
@@ -1,0 +1,103 @@
+"""Phase 11c replay seed propagation — Runtime Migration #207.
+
+Locks the ContextVar contract: set on a turn, read at LLM call site,
+clear on turn boundary, never leaks across coroutines.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.engine.runtime.replay_context import (
+    clear_replay_seed,
+    get_replay_seed,
+    get_replay_seed_int,
+    replay_seed_scope,
+    set_replay_seed,
+)
+
+
+def test_default_is_none():
+    assert get_replay_seed() is None
+    assert get_replay_seed_int() is None
+
+
+def test_set_and_clear_roundtrip():
+    token = set_replay_seed("42")
+    try:
+        assert get_replay_seed() == "42"
+        assert get_replay_seed_int() == 42
+    finally:
+        clear_replay_seed(token)
+    assert get_replay_seed() is None
+
+
+def test_get_int_returns_none_for_unparseable():
+    token = set_replay_seed("not-a-number")
+    try:
+        assert get_replay_seed() == "not-a-number"
+        assert get_replay_seed_int() is None
+    finally:
+        clear_replay_seed(token)
+
+
+def test_scope_context_manager_pairs_set_and_clear():
+    assert get_replay_seed() is None
+    with replay_seed_scope("99"):
+        assert get_replay_seed() == "99"
+    assert get_replay_seed() is None  # automatically cleared
+
+
+def test_scope_clears_on_exception():
+    assert get_replay_seed() is None
+    with pytest.raises(RuntimeError):
+        with replay_seed_scope("11"):
+            assert get_replay_seed() == "11"
+            raise RuntimeError("boom")
+    assert get_replay_seed() is None
+
+
+def test_nested_scopes_restore_outer_value():
+    with replay_seed_scope("outer"):
+        assert get_replay_seed() == "outer"
+        with replay_seed_scope("inner"):
+            assert get_replay_seed() == "inner"
+        assert get_replay_seed() == "outer"
+    assert get_replay_seed() is None
+
+
+# ── async isolation ──
+
+@pytest.mark.asyncio
+async def test_seed_does_not_leak_across_concurrent_tasks():
+    """ContextVar copy semantics — each task gets its own snapshot."""
+
+    captured: dict[str, list[str | None]] = {"a": [], "b": []}
+
+    async def task(label: str, seed: str, others: dict):
+        with replay_seed_scope(seed):
+            await asyncio.sleep(0)
+            others[label].append(get_replay_seed())
+            await asyncio.sleep(0)
+            others[label].append(get_replay_seed())
+
+    await asyncio.gather(task("a", "A", captured), task("b", "B", captured))
+    # Each task only ever sees its own seed.
+    assert captured["a"] == ["A", "A"]
+    assert captured["b"] == ["B", "B"]
+
+
+@pytest.mark.asyncio
+async def test_unscoped_task_sees_none():
+    """A task started outside any scope does not inherit a seed from its caller."""
+
+    async def child() -> object:
+        return get_replay_seed()
+
+    with replay_seed_scope("parent-only"):
+        # Task created inside the scope DOES inherit (ContextVar copy).
+        assert await asyncio.create_task(child()) == "parent-only"
+    # After the scope: no leak.
+    assert await asyncio.create_task(child()) is None

--- a/maritime-ai-service/tests/unit/engine/runtime/test_replay_seed_wiring.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_replay_seed_wiring.py
@@ -1,0 +1,68 @@
+"""Phase 11c — verify replay seed flows from ContextVar into LLM api_kwargs.
+
+The propagation channel itself is covered by ``test_replay_context``;
+this file pins the integration: when a turn is wrapped in
+``replay_seed_scope``, ``WiiiChatModel._build_api_kwargs`` must include
+``seed`` for OpenAI-compat providers.
+"""
+
+from __future__ import annotations
+
+from app.engine.llm_providers.wiii_chat_model import WiiiChatModel
+from app.engine.runtime.replay_context import replay_seed_scope
+
+
+def _build_model(base_url: str = "https://api.openai.com/v1") -> WiiiChatModel:
+    return WiiiChatModel(
+        model="gpt-4o-mini",
+        api_key="test-key",
+        base_url=base_url,
+        temperature=0.0,
+    )
+
+
+def test_no_seed_when_not_in_scope():
+    model = _build_model()
+    api_kwargs = model._build_api_kwargs(
+        messages=[{"role": "user", "content": "hi"}], kwargs={}
+    )
+    assert "seed" not in api_kwargs
+
+
+def test_seed_injected_when_replay_scope_active():
+    model = _build_model()
+    with replay_seed_scope("12345"):
+        api_kwargs = model._build_api_kwargs(
+            messages=[{"role": "user", "content": "hi"}], kwargs={}
+        )
+    assert api_kwargs["seed"] == 12345
+
+
+def test_seed_skipped_when_value_is_unparseable():
+    model = _build_model()
+    with replay_seed_scope("not-a-number"):
+        api_kwargs = model._build_api_kwargs(
+            messages=[{"role": "user", "content": "hi"}], kwargs={}
+        )
+    assert "seed" not in api_kwargs
+
+
+def test_seed_dropped_for_zhipu_endpoint():
+    """Zhipu's allowed-params filter strips ``seed`` — provider compat."""
+    model = _build_model(base_url="https://open.bigmodel.cn/api/paas/v4")
+    with replay_seed_scope("99"):
+        api_kwargs = model._build_api_kwargs(
+            messages=[{"role": "user", "content": "hi"}], kwargs={}
+        )
+    assert "seed" not in api_kwargs
+
+
+def test_seed_passes_through_for_streaming_path():
+    """The streaming path uses the same _build_api_kwargs — verify."""
+    model = _build_model()
+    with replay_seed_scope("77"):
+        api_kwargs = model._build_api_kwargs(
+            messages=[{"role": "user", "content": "hi"}], kwargs={}, stream=True
+        )
+    assert api_kwargs["seed"] == 77
+    assert api_kwargs["stream"] is True

--- a/maritime-ai-service/tests/unit/engine/runtime/test_session_wake.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_session_wake.py
@@ -1,0 +1,248 @@
+"""Phase 11a session wake() — Runtime Migration #207.
+
+Locks the conversation-reconstruction contract: replay an InMemory or
+Postgres event log into a ``WakeState`` ready for the next turn. Same
+contract drives both backends — tests use the in-memory log for speed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.engine.runtime.session_event_log import InMemorySessionEventLog
+from app.engine.runtime.session_wake import WakeState, wake
+
+
+@pytest.fixture
+def log() -> InMemorySessionEventLog:
+    return InMemorySessionEventLog()
+
+
+# ── empty / unknown ──
+
+async def test_wake_empty_session_returns_blank_state(log):
+    state = await wake(session_id="unknown", log=log)
+    assert isinstance(state, WakeState)
+    assert state.messages == []
+    assert state.pending_tool_calls == []
+    assert state.latest_seq == 0
+    assert state.event_count == 0
+
+
+async def test_wake_skips_unknown_event_types(log):
+    await log.append(
+        session_id="s", event_type="status_ping", payload={"ok": True}
+    )
+    await log.append(
+        session_id="s", event_type="user_message", payload={"text": "hi"}
+    )
+    state = await wake(session_id="s", log=log)
+    assert [m.role for m in state.messages] == ["user"]
+    assert state.event_count == 2  # both visited
+    assert state.latest_seq == 2
+
+
+# ── basic message replay ──
+
+async def test_wake_user_then_assistant(log):
+    await log.append(
+        session_id="s", event_type="user_message", payload={"text": "hello"}
+    )
+    await log.append(
+        session_id="s",
+        event_type="assistant_message",
+        payload={"text": "world"},
+    )
+    state = await wake(session_id="s", log=log)
+    assert [m.role for m in state.messages] == ["user", "assistant"]
+    assert state.messages[0].content == "hello"
+    assert state.messages[1].content == "world"
+    assert state.latest_seq == 2
+    assert state.pending_tool_calls == []
+
+
+async def test_wake_system_message_round_trips(log):
+    await log.append(
+        session_id="s",
+        event_type="system_message",
+        payload={"text": "you are a maritime tutor"},
+    )
+    state = await wake(session_id="s", log=log)
+    assert state.messages[0].role == "system"
+    assert state.messages[0].content == "you are a maritime tutor"
+
+
+async def test_wake_accepts_legacy_content_alias(log):
+    """Older recorders may have written ``content`` instead of ``text``."""
+    await log.append(
+        session_id="s",
+        event_type="user_message",
+        payload={"content": "legacy form"},
+    )
+    state = await wake(session_id="s", log=log)
+    assert state.messages[0].content == "legacy form"
+
+
+async def test_wake_drops_messages_with_empty_text(log):
+    """Empty payload → not a real user/assistant turn; skip."""
+    await log.append(
+        session_id="s", event_type="user_message", payload={"text": ""}
+    )
+    await log.append(
+        session_id="s", event_type="user_message", payload={"text": "real"}
+    )
+    state = await wake(session_id="s", log=log)
+    assert [m.content for m in state.messages] == ["real"]
+
+
+# ── tool calls ──
+
+async def test_wake_assistant_with_tool_calls_marks_pending(log):
+    await log.append(
+        session_id="s",
+        event_type="assistant_message",
+        payload={
+            "text": "let me check",
+            "tool_calls": [
+                {"id": "call_1", "name": "search", "arguments": {"q": "x"}}
+            ],
+        },
+    )
+    state = await wake(session_id="s", log=log)
+    assert state.messages[0].role == "assistant"
+    assert state.messages[0].tool_calls is not None
+    assert state.messages[0].tool_calls[0].name == "search"
+    assert len(state.pending_tool_calls) == 1
+    assert state.pending_tool_calls[0].id == "call_1"
+
+
+async def test_wake_tool_result_clears_pending_call(log):
+    await log.append(
+        session_id="s",
+        event_type="assistant_message",
+        payload={
+            "text": "let me check",
+            "tool_calls": [
+                {"id": "call_1", "name": "search", "arguments": {"q": "x"}}
+            ],
+        },
+    )
+    await log.append(
+        session_id="s",
+        event_type="tool_result",
+        payload={"tool_call_id": "call_1", "content": "result-text"},
+    )
+    state = await wake(session_id="s", log=log)
+    assert [m.role for m in state.messages] == ["assistant", "tool"]
+    assert state.messages[1].tool_call_id == "call_1"
+    assert state.messages[1].content == "result-text"
+    assert state.pending_tool_calls == []
+
+
+async def test_wake_partial_tool_results_keeps_remaining_pending(log):
+    """Two tool_calls, only one resolves → the other stays pending."""
+    await log.append(
+        session_id="s",
+        event_type="assistant_message",
+        payload={
+            "text": "checking two things",
+            "tool_calls": [
+                {"id": "a", "name": "f", "arguments": {}},
+                {"id": "b", "name": "g", "arguments": {}},
+            ],
+        },
+    )
+    await log.append(
+        session_id="s",
+        event_type="tool_result",
+        payload={"tool_call_id": "a", "content": "ok"},
+    )
+    state = await wake(session_id="s", log=log)
+    pending_ids = {c.id for c in state.pending_tool_calls}
+    assert pending_ids == {"b"}
+
+
+async def test_wake_new_assistant_turn_replaces_pending(log):
+    """Only the *most recent* assistant turn's pending calls matter."""
+    await log.append(
+        session_id="s",
+        event_type="assistant_message",
+        payload={
+            "text": "first call",
+            "tool_calls": [{"id": "old", "name": "f", "arguments": {}}],
+        },
+    )
+    # second turn: different unresolved call.
+    await log.append(
+        session_id="s",
+        event_type="assistant_message",
+        payload={
+            "text": "second call",
+            "tool_calls": [{"id": "new", "name": "g", "arguments": {}}],
+        },
+    )
+    state = await wake(session_id="s", log=log)
+    pending_ids = {c.id for c in state.pending_tool_calls}
+    assert pending_ids == {"new"}
+
+
+# ── filters ──
+
+async def test_wake_since_seq_replays_window_only(log):
+    await log.append(
+        session_id="s", event_type="user_message", payload={"text": "old"}
+    )
+    await log.append(
+        session_id="s", event_type="user_message", payload={"text": "new"}
+    )
+    state = await wake(session_id="s", since_seq=1, log=log)
+    assert [m.content for m in state.messages] == ["new"]
+    assert state.latest_seq == 2
+
+
+async def test_wake_org_id_filter(log):
+    await log.append(
+        session_id="s", event_type="user_message", payload={"text": "A"}, org_id="A"
+    )
+    await log.append(
+        session_id="s", event_type="user_message", payload={"text": "B"}, org_id="B"
+    )
+    state = await wake(session_id="s", org_id="A", log=log)
+    assert [m.content for m in state.messages] == ["A"]
+
+
+# ── defensive parsing ──
+
+async def test_wake_ignores_malformed_tool_call_entries(log):
+    await log.append(
+        session_id="s",
+        event_type="assistant_message",
+        payload={
+            "text": "mixed list",
+            "tool_calls": [
+                "not-a-dict",
+                {"id": "ok", "name": "f", "arguments": {}},
+                {"missing": "id-and-name"},  # validation will fail
+            ],
+        },
+    )
+    state = await wake(session_id="s", log=log)
+    assert state.messages[0].tool_calls is not None
+    assert [c.id for c in state.messages[0].tool_calls] == ["ok"]
+
+
+async def test_wake_handles_non_dict_payload_gracefully(log):
+    """The log layer enforces dict payloads, but the parser should not
+    rely on that — guard against future event sources."""
+    import dataclasses
+
+    await log.append(
+        session_id="s", event_type="user_message", payload={"text": "ok"}
+    )
+    # Sneak in a non-dict payload directly via internal API.
+    state_obj = log._sessions["s"]
+    bad_event = dataclasses.replace(state_obj.events[0], payload="not-a-dict")
+    state_obj.events[0] = bad_event
+    state = await wake(session_id="s", log=log)
+    # Bad payload is treated as empty; no crash.
+    assert state.messages == []


### PR DESCRIPTION
## Summary

Phase 11 of the runtime migration epic (#207) — completes the durable-session-state half of the Anthropic Managed Agents pattern. Stacked on top of #222 (Phase 10).

- **11a — wake() session reconstruction** (\`bd9a480\`): \`app/engine/runtime/session_wake.py\` replays a SessionEventLog into a \`WakeState\` (messages + pending tool calls + latest_seq). Event-type tolerant, defensive payload parsing, only the most recent assistant turn's tool calls counted as pending. Closes the "Postgres event log durable but not used" gap.
- **11b — Nightly replay CI workflow** (\`79e120d\`): \`.github/workflows/nightly-replay-eval.yml\` cron 02:00 UTC + \`workflow_dispatch\`. Today operates in HARNESS-VALIDATION mode — generates 5 synthetic recordings and replays in \`--dry-run\` so the eval loop is exercised end-to-end without burning a real \`GOOGLE_API_KEY\`. When \`enable_eval_recording\` flips on in production, swap the synthesis step for an artifact pull and the regression net is live.
- **11c — Deterministic seeded replay** (\`c571743\`): ContextVar \`replay_context\` propagates \`record.replay_seed\` from the replay script through to \`WiiiChatModel._build_api_kwargs\`, which adds \`seed=<int>\` to OpenAI-compat Chat Completions calls. Provider-specific allowed-params filter drops it for Zhipu. Closes the "replay_seed field exists, never used" gap.

## Test plan

- [x] \`pytest tests/unit/engine/runtime/ tests/unit/api/test_edge_endpoints.py\` — **125 pass** (was 98 pre-Phase-11; +14 wake + +13 replay context/wiring)
- [x] Local nightly-replay smoke: 5 synthetic recordings → replay → HTML report → \`No regressions flagged\` → exit 0
- [x] WiiiChatModel api_kwargs validated: no seed outside scope, seed=12345 inside scope, unparseable string → not injected, Zhipu base_url → seed stripped, streaming path picks it up
- [x] ContextVar isolation: concurrent \`asyncio.gather\` tasks get separate seeds, exceptions still clear

## Out of scope (deferred to later phases)

- Anthropic / Gemini native (non-OpenAI-compat) seed plumbing — neither exposes a public seed param.
- Wiring \`enable_eval_recording=True\` in production — that's an operational toggle, not a code change.
- Subagent isolation (Phase 12 — biggest remaining architectural gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)