### PR TITLE
phase-15: SubagentRunner ↔ ChatService default bridge

### DIFF
--- a/maritime-ai-service/app/engine/runtime/subagent_chatservice_bridge.py
+++ b/maritime-ai-service/app/engine/runtime/subagent_chatservice_bridge.py
@@ -1,0 +1,140 @@
+"""SubagentRunner ↔ ChatService bridge.
+
+Phase 15 of the runtime migration epic (issue #207). Phase 12 shipped
+the isolation harness (``SubagentRunner``) but left ``runner_callable``
+unbound — production parents that called ``run(task)`` got an
+``error / "no runner_callable"`` result. This module fills that gap by
+binding the existing battle-tested ``ChatService`` as the default runner.
+
+Wire shape (intentionally minimal):
+
+    SubagentTask(description="...", parent_session_id="p1") →
+        chatservice_runner(task, child_session_id) →
+            ChatRequest(message=task.description, session_id=child_session_id, ...) →
+            ChatService.process_message(...) → InternalChatResponse →
+        SubagentResult(status="success", summary=..., sources=..., tool_calls_made=...)
+
+The bridge does NOT replay the parent's history — by design. The whole
+point of subagent isolation is a clean child window scoped to the task
+description + any explicit ``context_hints``. A parent that wants the
+child to know more must encode it in ``description`` or ``context_hints``.
+
+Failure modes:
+- ChatService raises → SubagentRunner.run catches it and emits a
+  ``subagent_completed`` event with ``status="error"``. We do NOT swallow
+  exceptions here — let the runner's own error path own the protocol.
+- Returned response is missing fields → fall back to safe defaults (empty
+  summary, zero counts) rather than crashing.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from app.engine.runtime.subagent_runner import (
+    SubagentResult,
+    SubagentRunner,
+    SubagentTask,
+    get_subagent_runner,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _format_description(task: SubagentTask) -> str:
+    """Materialise the child's user-message body.
+
+    Description is the primary signal. ``context_hints`` ride as a
+    structured suffix so the LLM can see them without losing them in
+    free-form prose.
+    """
+    lines = [task.description.strip()]
+    if task.context_hints:
+        lines.append("")
+        lines.append("Context hints (do not echo verbatim):")
+        for key, value in task.context_hints.items():
+            lines.append(f"- {key}: {value}")
+    return "\n".join(lines)
+
+
+def _count_tool_calls(internal_response) -> int:
+    """Extract the tool-call count from whichever metadata shape is present."""
+    metadata = getattr(internal_response, "metadata", None) or {}
+    tools_used = metadata.get("tools_used")
+    if isinstance(tools_used, list):
+        return len(tools_used)
+    raw = metadata.get("tool_calls")
+    if isinstance(raw, list):
+        return len(raw)
+    return 0
+
+
+def _coerce_sources(internal_response) -> list[dict]:
+    """Return citation dicts; fall back to ``[]`` on any shape mismatch."""
+    raw_sources = getattr(internal_response, "sources", None) or []
+    sources: list[dict] = []
+    for src in raw_sources:
+        if hasattr(src, "model_dump"):
+            try:
+                sources.append(src.model_dump())
+                continue
+            except Exception:  # noqa: BLE001
+                pass
+        if isinstance(src, dict):
+            sources.append(src)
+    return sources
+
+
+async def chatservice_subagent_runner(
+    task: SubagentTask, child_session_id: str
+) -> SubagentResult:
+    """Default runner_callable: run a child agent through ChatService.
+
+    Imports happen inside the function so this module's import is free of
+    runtime side effects — call sites can register the bridge without
+    pulling ChatService into module-load.
+    """
+    from app.models.schemas import ChatRequest, UserRole
+    from app.services.chat_service import get_chat_service
+
+    request = ChatRequest(
+        user_id=f"subagent::{task.parent_session_id}",
+        message=_format_description(task),
+        role=UserRole.STUDENT,
+        session_id=child_session_id,
+        organization_id=task.parent_org_id,
+    )
+
+    response = await get_chat_service().process_message(request)
+    summary = getattr(response, "message", "") or ""
+    return SubagentResult(
+        status="success",
+        summary=summary,
+        sources=_coerce_sources(response),
+        tool_calls_made=_count_tool_calls(response),
+        child_session_id=child_session_id,
+        raw_output=summary,
+    )
+
+
+def wire_default_subagent_runner(
+    runner: Optional[SubagentRunner] = None,
+) -> SubagentRunner:
+    """Bind ``chatservice_subagent_runner`` as the default callable.
+
+    Idempotent: re-calling overwrites the binding. Tests should NOT call
+    this — they construct ``SubagentRunner(runner_callable=fake)``
+    directly. Production startup (or the first parent that calls
+    ``get_subagent_runner()``) is the right place to wire the default.
+    """
+    target = runner or get_subagent_runner()
+    if target._runner is None:  # noqa: SLF001 — explicit DI seam
+        target._runner = chatservice_subagent_runner
+    return target
+
+
+__all__ = [
+    "chatservice_subagent_runner",
+    "wire_default_subagent_runner",
+]

--- a/maritime-ai-service/app/engine/runtime/subagent_runner.py
+++ b/maritime-ai-service/app/engine/runtime/subagent_runner.py
@@ -223,16 +223,24 @@ _singleton: Optional[SubagentRunner] = None
 
 
 def get_subagent_runner() -> SubagentRunner:
-    """Default singleton — production binds the runner_callable lazily.
+    """Default singleton with the ChatService bridge auto-wired (Phase 15).
 
     Tests should construct ``SubagentRunner`` directly with a fake
-    ``runner_callable`` rather than rely on this; the singleton exists so
-    parent code paths can call ``get_subagent_runner().run(task)`` without
-    wiring DI everywhere.
+    ``runner_callable`` rather than rely on this. Production parents that
+    call ``get_subagent_runner().run(task)`` get a ChatService-backed
+    child without any DI ceremony. The bridge import is lazy so module
+    import stays free of side effects.
     """
     global _singleton
     if _singleton is None:
         _singleton = SubagentRunner()
+    if _singleton._runner is None:
+        # Lazy bind so importing this module never pulls ChatService.
+        from app.engine.runtime.subagent_chatservice_bridge import (
+            chatservice_subagent_runner,
+        )
+
+        _singleton._runner = chatservice_subagent_runner
     return _singleton
 
 

--- a/maritime-ai-service/tests/unit/engine/runtime/test_subagent_chatservice_bridge.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_subagent_chatservice_bridge.py
@@ -1,0 +1,196 @@
+"""Phase 15 SubagentRunner ↔ ChatService bridge — Runtime Migration #207.
+
+Locks the production wire shape:
+- description + context_hints become the child's user-message body.
+- ChatService.process_message returns InternalChatResponse → coerced into
+  SubagentResult with sources, tool counts, and the child session id.
+- Source coercion is defensive (model_dump or dict; anything else dropped).
+- get_subagent_runner() auto-wires the default callable on first call.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _enable_isolation(monkeypatch):
+    from app.core import config as config_module
+
+    monkeypatch.setattr(
+        config_module.settings, "enable_subagent_isolation", True, raising=False
+    )
+
+
+@pytest.fixture
+def fake_internal_response():
+    src = SimpleNamespace(
+        model_dump=lambda: {"id": "doc-1", "page": 5}
+    )
+    return SimpleNamespace(
+        message="Trả lời từ child agent.",
+        sources=[src],
+        metadata={
+            "tools_used": [{"name": "search"}, {"name": "lookup"}],
+            "latency_ms": 320,
+        },
+    )
+
+
+# ── description formatting ──
+
+def test_format_description_plain():
+    from app.engine.runtime.subagent_chatservice_bridge import _format_description
+    from app.engine.runtime.subagent_runner import SubagentTask
+
+    out = _format_description(
+        SubagentTask(description="Tìm Rule 13 COLREGs", parent_session_id="p1")
+    )
+    assert out == "Tìm Rule 13 COLREGs"
+
+
+def test_format_description_with_context_hints():
+    from app.engine.runtime.subagent_chatservice_bridge import _format_description
+    from app.engine.runtime.subagent_runner import SubagentTask
+
+    out = _format_description(
+        SubagentTask(
+            description="Tóm tắt phần 1",
+            parent_session_id="p1",
+            context_hints={"chapter": "Phần 1: Tổng quan", "level": "beginner"},
+        )
+    )
+    assert "Tóm tắt phần 1" in out
+    assert "chapter: Phần 1: Tổng quan" in out
+    assert "level: beginner" in out
+
+
+# ── source / tool-call coercion ──
+
+def test_coerce_sources_handles_pydantic_and_dict():
+    from app.engine.runtime.subagent_chatservice_bridge import _coerce_sources
+
+    pydantic_like = SimpleNamespace(model_dump=lambda: {"id": "p1"})
+    plain_dict = {"id": "p2"}
+    bad_value = "not-a-source"
+    response = SimpleNamespace(sources=[pydantic_like, plain_dict, bad_value])
+    out = _coerce_sources(response)
+    assert out == [{"id": "p1"}, {"id": "p2"}]
+
+
+def test_coerce_sources_no_sources_attribute():
+    from app.engine.runtime.subagent_chatservice_bridge import _coerce_sources
+
+    assert _coerce_sources(SimpleNamespace()) == []
+
+
+def test_count_tool_calls_prefers_tools_used():
+    from app.engine.runtime.subagent_chatservice_bridge import _count_tool_calls
+
+    response = SimpleNamespace(metadata={"tools_used": [1, 2, 3]})
+    assert _count_tool_calls(response) == 3
+
+
+def test_count_tool_calls_falls_back_to_tool_calls():
+    from app.engine.runtime.subagent_chatservice_bridge import _count_tool_calls
+
+    response = SimpleNamespace(metadata={"tool_calls": [1, 2]})
+    assert _count_tool_calls(response) == 2
+
+
+def test_count_tool_calls_returns_zero_for_unknown_shape():
+    from app.engine.runtime.subagent_chatservice_bridge import _count_tool_calls
+
+    assert _count_tool_calls(SimpleNamespace(metadata={})) == 0
+    assert _count_tool_calls(SimpleNamespace()) == 0
+
+
+# ── end-to-end run via the bridge ──
+
+async def test_bridge_runs_chatservice_and_builds_subagent_result(
+    monkeypatch, fake_internal_response
+):
+    _enable_isolation(monkeypatch)
+
+    from app.engine.runtime.subagent_chatservice_bridge import (
+        chatservice_subagent_runner,
+    )
+    from app.engine.runtime.subagent_runner import SubagentTask
+
+    fake_service = SimpleNamespace(
+        process_message=AsyncMock(return_value=fake_internal_response)
+    )
+    with patch(
+        "app.services.chat_service.get_chat_service", return_value=fake_service
+    ):
+        task = SubagentTask(
+            description="Giải thích Rule 13",
+            parent_session_id="p1",
+            parent_org_id="org-A",
+            context_hints={"focus": "navigation"},
+        )
+        result = await chatservice_subagent_runner(task, "child-xyz")
+
+    assert result.status == "success"
+    assert result.summary == "Trả lời từ child agent."
+    assert result.child_session_id == "child-xyz"
+    assert result.tool_calls_made == 2
+    assert result.sources == [{"id": "doc-1", "page": 5}]
+    # ChatService received exactly one ChatRequest with the expected fields.
+    fake_service.process_message.assert_awaited_once()
+    chat_request = fake_service.process_message.await_args.args[0]
+    assert "Giải thích Rule 13" in chat_request.message
+    assert "focus: navigation" in chat_request.message
+    assert chat_request.session_id == "child-xyz"
+    assert chat_request.organization_id == "org-A"
+
+
+async def test_bridge_propagates_chatservice_exception(monkeypatch):
+    _enable_isolation(monkeypatch)
+
+    from app.engine.runtime.subagent_chatservice_bridge import (
+        chatservice_subagent_runner,
+    )
+    from app.engine.runtime.subagent_runner import SubagentTask
+
+    fake_service = SimpleNamespace(
+        process_message=AsyncMock(side_effect=RuntimeError("provider down"))
+    )
+    with patch(
+        "app.services.chat_service.get_chat_service", return_value=fake_service
+    ):
+        with pytest.raises(RuntimeError, match="provider down"):
+            await chatservice_subagent_runner(
+                SubagentTask(description="x", parent_session_id="p1"),
+                "child-xyz",
+            )
+
+
+# ── singleton auto-wiring ──
+
+async def test_get_subagent_runner_auto_wires_default(
+    monkeypatch, fake_internal_response
+):
+    _enable_isolation(monkeypatch)
+    from app.engine.runtime import subagent_runner as runner_module
+
+    runner_module._reset_for_tests()
+    fake_service = SimpleNamespace(
+        process_message=AsyncMock(return_value=fake_internal_response)
+    )
+    with patch(
+        "app.services.chat_service.get_chat_service", return_value=fake_service
+    ):
+        runner = runner_module.get_subagent_runner()
+        # _runner is bound on first access — no manual wire required.
+        assert runner._runner is not None
+        from app.engine.runtime.subagent_runner import SubagentTask
+
+        result = await runner.run(
+            SubagentTask(description="hi", parent_session_id="p1")
+        )
+    assert result.status == "success"
+    assert result.summary == "Trả lời từ child agent."
+    runner_module._reset_for_tests()


### PR DESCRIPTION
## Summary

Phase 12 shipped the isolation harness but left ``runner_callable`` unbound — production parents calling ``get_subagent_runner().run(task)`` got an error result. This PR wires the existing battle-tested ``ChatService`` as the default runner, completing the Anthropic Task pattern from harness through to dispatch.

### Wire shape

\`\`\`
SubagentTask → chatservice_subagent_runner →
  ChatRequest(message=description+context_hints, session_id=child) →
  ChatService.process_message → InternalChatResponse →
SubagentResult(summary, sources, tool_calls_made)
\`\`\`

### Design choices

- **No history replay.** Subagent isolation exists to keep the child's window scoped to the task; parents that need extra context must encode it in ``description`` or ``context_hints``.
- **Defensive coercion.** Sources accept Pydantic ``model_dump`` or plain dict; bad shapes silently dropped. Tool counting prefers ``metadata.tools_used``, falls back to ``metadata.tool_calls``, defaults to 0.
- **Bridge does NOT swallow exceptions.** ``SubagentRunner.run`` owns the error protocol (catches → emits ``subagent_completed`` event with error). Re-raising from the bridge keeps that path clean.
- **Lazy auto-wiring.** ``get_subagent_runner()`` binds the bridge on first access so production parents need zero DI ceremony. Tests still construct ``SubagentRunner(runner_callable=fake)`` directly (no auto-wire).

## Test plan

- [x] \`pytest tests/unit/engine/runtime/test_subagent_chatservice_bridge.py\` — **10 pass** (description formatting, source coercion edge cases, tool count from various shapes, end-to-end ChatService bridge call, exception propagation, singleton auto-wire on first access)
- [x] \`pytest tests/unit/engine/runtime/test_subagent_runner.py\` — **9 pass** unchanged (Phase 12 contract preserved)
- [x] Rebased cleanly onto main post-#224 merge

## Out of scope

- Wiring \`enable_native_runtime=True\` into actual production dispatch (still legacy ChatService path globally; Phase 14 canary is the rollout vehicle when ready)
- Production load testing / chaos testing / SLO doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)