### PR TITLE
phase-19: native chat dispatch — durable + instrumented

### DIFF
--- a/maritime-ai-service/app/api/edge_endpoints.py
+++ b/maritime-ai-service/app/api/edge_endpoints.py
@@ -117,10 +117,18 @@ def _to_chat_request(turn: TurnRequest, *, auth: RequireAuth) -> ChatRequest:
 
 
 async def _process(turn: TurnRequest, *, auth: RequireAuth) -> InternalChatResponse:
-    chat_request = _to_chat_request(turn, auth=auth)
-    from app.services.chat_service import get_chat_service
+    """Run the turn via native dispatch (durable + instrumented).
 
-    return await get_chat_service().process_message(chat_request)
+    Phase 19: every request that reaches the edge endpoints has already
+    cleared the per-org Phase 14 canary gate via ``_ensure_enabled``.
+    Routing through ``native_chat_dispatch`` records the conversation
+    in the durable session log so wake() / replay can read it back. The
+    response shape is identical to bare ``ChatService.process_message``.
+    """
+    chat_request = _to_chat_request(turn, auth=auth)
+    from app.engine.runtime.native_dispatch import native_chat_dispatch
+
+    return await native_chat_dispatch(chat_request)
 
 
 def _openai_completion_response(

--- a/maritime-ai-service/app/engine/runtime/native_dispatch.py
+++ b/maritime-ai-service/app/engine/runtime/native_dispatch.py
@@ -1,0 +1,199 @@
+"""Native chat dispatch — durable + metric-instrumented chat path.
+
+Phase 19 of the runtime migration epic (issue #207). Closes the most
+load-bearing gap from the brutal-honest SOTA assessment: until now,
+every chat-completion turn went through the legacy ChatService path
+without any record landing in the Phase 5/10c durable session log. That
+made wake() (Phase 11a) and replay (Phase 11b/c) read-only — the data
+they wanted to consume was never produced.
+
+This dispatcher wraps ``ChatService.process_message`` with three things
+the legacy path skipped:
+
+1. **Durable event logging.** ``user_message`` event before the call,
+   ``assistant_message`` after, ``tool_result`` per declared tool call.
+   Now wake() can replay the conversation and replay_eval can diff it.
+2. **Per-call metrics.** ``runtime.native_dispatch.runs`` counter
+   labeled by status, ``runtime.native_dispatch.duration_ms`` summary.
+   p50/p99 fall out of the existing Phase 13 façade.
+3. **Run-as-subagent affordance.** Internally it's the same ChatService,
+   but the durable log records a self-contained, replay-able turn.
+   Future work can swap the inner call for a real native runner without
+   changing the dispatch interface.
+
+Critical design choice: this is **observability + durability**, not a
+rewrite. Same response shape, same latency profile (~1ms overhead for
+the three log appends + metric calls). When the team is ready to swap
+the inner call for a lane-resolved native runner, only the body of
+``_invoke_inner`` changes.
+
+The dispatcher is wired up by the edge endpoints when
+``is_native_runtime_enabled_for(org_id)`` returns True (Phase 14
+canary). Legacy ``/api/v1/chat`` callers stay on the bare ChatService
+path — the migration is opt-in per org.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Optional
+
+from app.engine.runtime.runtime_metrics import inc_counter, record_latency_ms
+from app.engine.runtime.session_event_log import (
+    SessionEventLog,
+    get_session_event_log,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _serialise_tool_calls(metadata) -> list[dict]:
+    """Pull a structured list of tool calls from response metadata.
+
+    Accepts both the ``tools_used`` shape (LMS legacy: list of
+    ``{name, description}``) and the ``tool_calls`` shape (native: list
+    of ``{name, args, result}``). Returns whichever is non-empty as
+    plain dicts safe to JSON-encode for the event payload.
+    """
+    if not isinstance(metadata, dict):
+        return []
+    raw = metadata.get("tool_calls")
+    if isinstance(raw, list) and raw:
+        return [c if isinstance(c, dict) else {"raw": str(c)} for c in raw]
+    raw = metadata.get("tools_used")
+    if isinstance(raw, list) and raw:
+        return [
+            c if isinstance(c, dict) else {"name": str(c)}
+            for c in raw
+        ]
+    return []
+
+
+async def _invoke_inner(chat_request, background_save):
+    """Call into the existing ChatService.
+
+    Imported lazily so this module's import never pulls ChatService.
+    The legacy path is used today; a native lane-resolved path can
+    replace this body in a future phase without changing the dispatch
+    surface.
+    """
+    from app.services.chat_service import get_chat_service
+
+    return await get_chat_service().process_message(
+        chat_request, background_save=background_save
+    )
+
+
+async def native_chat_dispatch(
+    chat_request,
+    *,
+    background_save=None,
+    event_log: Optional[SessionEventLog] = None,
+):
+    """Process ``chat_request`` with durable + metric-instrumented dispatch.
+
+    Logs user_message + assistant_message events around the inner call
+    so the conversation becomes wake()-able and replay-able. Tool
+    invocations declared in the response metadata produce one
+    tool_result event each.
+
+    Returns the same ``InternalChatResponse`` that ChatService would
+    have returned — callers (edge endpoints + legacy chat) can swap to
+    this dispatcher with no shape change.
+    """
+    log = event_log or get_session_event_log()
+    session_id = (
+        getattr(chat_request, "session_id", None)
+        or f"native::{getattr(chat_request, 'user_id', 'unknown')}"
+    )
+    org_id = getattr(chat_request, "organization_id", None)
+    user_message = getattr(chat_request, "message", "") or ""
+
+    await log.append(
+        session_id=session_id,
+        event_type="user_message",
+        payload={
+            "text": user_message,
+            "user_id": getattr(chat_request, "user_id", None),
+            "role": (
+                getattr(getattr(chat_request, "role", None), "value", None)
+                or str(getattr(chat_request, "role", ""))
+            ),
+            "domain_id": getattr(chat_request, "domain_id", None),
+        },
+        org_id=org_id,
+    )
+
+    started = time.monotonic()
+    try:
+        response = await _invoke_inner(chat_request, background_save)
+    except Exception as exc:  # noqa: BLE001
+        duration_ms = int((time.monotonic() - started) * 1000)
+        await log.append(
+            session_id=session_id,
+            event_type="assistant_message",
+            payload={
+                "text": "",
+                "status": "error",
+                "error": f"{type(exc).__name__}: {exc}",
+                "duration_ms": duration_ms,
+            },
+            org_id=org_id,
+        )
+        inc_counter(
+            "runtime.native_dispatch.runs", labels={"status": "error"}
+        )
+        record_latency_ms(
+            "runtime.native_dispatch.duration_ms",
+            float(duration_ms),
+            labels={"status": "error"},
+        )
+        raise
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+    metadata = getattr(response, "metadata", None) or {}
+    tool_calls = _serialise_tool_calls(metadata)
+    response_text = getattr(response, "message", "") or ""
+
+    await log.append(
+        session_id=session_id,
+        event_type="assistant_message",
+        payload={
+            "text": response_text,
+            "status": "success",
+            "tool_calls": tool_calls,
+            "duration_ms": duration_ms,
+            "agent_type": (
+                getattr(getattr(response, "agent_type", None), "value", None)
+                or str(getattr(response, "agent_type", ""))
+            ),
+        },
+        org_id=org_id,
+    )
+    for call in tool_calls:
+        await log.append(
+            session_id=session_id,
+            event_type="tool_result",
+            payload={
+                "tool_call_id": str(
+                    call.get("id") or call.get("name") or "unknown"
+                ),
+                "name": call.get("name"),
+                "content": str(call.get("result", call.get("description", ""))),
+            },
+            org_id=org_id,
+        )
+
+    inc_counter(
+        "runtime.native_dispatch.runs", labels={"status": "success"}
+    )
+    record_latency_ms(
+        "runtime.native_dispatch.duration_ms",
+        float(duration_ms),
+        labels={"status": "success"},
+    )
+    return response
+
+
+__all__ = ["native_chat_dispatch"]

--- a/maritime-ai-service/tests/unit/engine/runtime/test_native_dispatch.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_native_dispatch.py
@@ -1,0 +1,263 @@
+"""Phase 19 native chat dispatch — Runtime Migration #207.
+
+Locks the contract:
+- ``user_message`` event before the inner call.
+- ``assistant_message`` event after, with text + tool_calls + duration.
+- One ``tool_result`` event per declared tool call.
+- Metrics recorded with status label (success / error).
+- Exception path still emits an ``assistant_message`` (status=error)
+  so wake() / replay see a clean closure.
+- org_id propagates to every event.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.engine.runtime import runtime_metrics as rm
+from app.engine.runtime.native_dispatch import (
+    _serialise_tool_calls,
+    native_chat_dispatch,
+)
+from app.engine.runtime.session_event_log import InMemorySessionEventLog
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics():
+    rm._reset_for_tests()
+    yield
+    rm._reset_for_tests()
+
+
+@pytest.fixture
+def log() -> InMemorySessionEventLog:
+    return InMemorySessionEventLog()
+
+
+def _make_request(
+    *,
+    user_id: str = "user-1",
+    session_id: str = "sess-1",
+    message: str = "Chào Wiii",
+    org_id: str = "org-A",
+    role: str = "student",
+    domain_id: str = "maritime",
+):
+    return SimpleNamespace(
+        user_id=user_id,
+        session_id=session_id,
+        message=message,
+        organization_id=org_id,
+        role=SimpleNamespace(value=role),
+        domain_id=domain_id,
+    )
+
+
+def _make_response(
+    message: str = "Trả lời",
+    metadata=None,
+    agent_type: str = "rag",
+):
+    return SimpleNamespace(
+        message=message,
+        metadata=metadata or {"latency_ms": 100},
+        agent_type=SimpleNamespace(value=agent_type),
+    )
+
+
+# ── _serialise_tool_calls ──
+
+def test_serialise_tool_calls_prefers_tool_calls_shape():
+    metadata = {
+        "tool_calls": [{"id": "c1", "name": "search", "args": {"q": "x"}}],
+        "tools_used": [{"name": "ignore"}],
+    }
+    out = _serialise_tool_calls(metadata)
+    assert out == [{"id": "c1", "name": "search", "args": {"q": "x"}}]
+
+
+def test_serialise_tool_calls_falls_back_to_tools_used():
+    out = _serialise_tool_calls({"tools_used": [{"name": "search"}]})
+    assert out == [{"name": "search"}]
+
+
+def test_serialise_tool_calls_handles_non_dict_entries():
+    out = _serialise_tool_calls({"tool_calls": ["raw-string"]})
+    assert out == [{"raw": "raw-string"}]
+
+
+def test_serialise_tool_calls_returns_empty_for_no_metadata():
+    assert _serialise_tool_calls(None) == []
+    assert _serialise_tool_calls({}) == []
+    assert _serialise_tool_calls({"tool_calls": []}) == []
+
+
+# ── happy path ──
+
+async def test_native_dispatch_logs_user_then_assistant_event(log):
+    fake_service = SimpleNamespace(
+        process_message=AsyncMock(return_value=_make_response("Câu trả lời"))
+    )
+    with patch(
+        "app.services.chat_service.get_chat_service", return_value=fake_service
+    ):
+        request = _make_request()
+        result = await native_chat_dispatch(request, event_log=log)
+
+    assert result.message == "Câu trả lời"
+    events = await log.get_events(session_id="sess-1")
+    assert [e.event_type for e in events] == ["user_message", "assistant_message"]
+    user_payload = events[0].payload
+    assert user_payload["text"] == "Chào Wiii"
+    assert user_payload["user_id"] == "user-1"
+    assert user_payload["role"] == "student"
+    assert user_payload["domain_id"] == "maritime"
+    assistant_payload = events[1].payload
+    assert assistant_payload["text"] == "Câu trả lời"
+    assert assistant_payload["status"] == "success"
+    assert assistant_payload["agent_type"] == "rag"
+    assert assistant_payload["duration_ms"] >= 0
+
+
+async def test_native_dispatch_emits_tool_result_per_declared_call(log):
+    fake_service = SimpleNamespace(
+        process_message=AsyncMock(
+            return_value=_make_response(
+                "answered",
+                metadata={
+                    "tool_calls": [
+                        {"id": "c1", "name": "search", "result": "doc-A"},
+                        {"id": "c2", "name": "lookup", "result": "doc-B"},
+                    ]
+                },
+            )
+        )
+    )
+    with patch(
+        "app.services.chat_service.get_chat_service", return_value=fake_service
+    ):
+        await native_chat_dispatch(_make_request(), event_log=log)
+
+    events = await log.get_events(session_id="sess-1")
+    types = [e.event_type for e in events]
+    assert types == [
+        "user_message",
+        "assistant_message",
+        "tool_result",
+        "tool_result",
+    ]
+    assert events[2].payload["tool_call_id"] == "c1"
+    assert events[2].payload["content"] == "doc-A"
+    assert events[3].payload["tool_call_id"] == "c2"
+
+
+async def test_native_dispatch_propagates_org_id_to_every_event(log):
+    fake_service = SimpleNamespace(
+        process_message=AsyncMock(
+            return_value=_make_response(
+                metadata={"tool_calls": [{"id": "c1", "name": "x", "result": "y"}]}
+            )
+        )
+    )
+    with patch(
+        "app.services.chat_service.get_chat_service", return_value=fake_service
+    ):
+        await native_chat_dispatch(
+            _make_request(org_id="org-A"), event_log=log
+        )
+
+    org_events = await log.get_events(session_id="sess-1", org_id="org-A")
+    assert len(org_events) == 3  # user + assistant + tool_result
+    assert all(e.org_id == "org-A" for e in org_events)
+    other_org_events = await log.get_events(
+        session_id="sess-1", org_id="other-org"
+    )
+    assert other_org_events == []
+
+
+# ── error path ──
+
+async def test_native_dispatch_emits_assistant_error_on_inner_exception(log):
+    fake_service = SimpleNamespace(
+        process_message=AsyncMock(side_effect=RuntimeError("provider down"))
+    )
+    with patch(
+        "app.services.chat_service.get_chat_service", return_value=fake_service
+    ):
+        with pytest.raises(RuntimeError, match="provider down"):
+            await native_chat_dispatch(_make_request(), event_log=log)
+
+    events = await log.get_events(session_id="sess-1")
+    assert [e.event_type for e in events] == [
+        "user_message",
+        "assistant_message",
+    ]
+    assistant = events[1].payload
+    assert assistant["status"] == "error"
+    assert "provider down" in assistant["error"]
+    assert assistant["text"] == ""
+
+
+# ── metrics ──
+
+async def test_native_dispatch_records_success_metric(log):
+    fake_service = SimpleNamespace(
+        process_message=AsyncMock(return_value=_make_response())
+    )
+    with patch(
+        "app.services.chat_service.get_chat_service", return_value=fake_service
+    ):
+        await native_chat_dispatch(_make_request(), event_log=log)
+
+    snap = rm.snapshot()
+    assert (
+        snap["counters"]["runtime.native_dispatch.runs"][
+            (("status", "success"),)
+        ]
+        == 1
+    )
+    durations = snap["histograms"]["runtime.native_dispatch.duration_ms"][
+        (("status", "success"),)
+    ]
+    assert len(durations) == 1
+    assert durations[0] >= 0
+
+
+async def test_native_dispatch_records_error_metric(log):
+    fake_service = SimpleNamespace(
+        process_message=AsyncMock(side_effect=RuntimeError("boom"))
+    )
+    with patch(
+        "app.services.chat_service.get_chat_service", return_value=fake_service
+    ):
+        with pytest.raises(RuntimeError):
+            await native_chat_dispatch(_make_request(), event_log=log)
+
+    snap = rm.snapshot()
+    assert (
+        snap["counters"]["runtime.native_dispatch.runs"][
+            (("status", "error"),)
+        ]
+        == 1
+    )
+
+
+# ── session_id fallback ──
+
+async def test_native_dispatch_falls_back_to_native_user_when_no_session_id(
+    log,
+):
+    request = _make_request(session_id=None)
+    fake_service = SimpleNamespace(
+        process_message=AsyncMock(return_value=_make_response())
+    )
+    with patch(
+        "app.services.chat_service.get_chat_service", return_value=fake_service
+    ):
+        await native_chat_dispatch(request, event_log=log)
+
+    events = await log.get_events(session_id="native::user-1")
+    assert len(events) == 2


### PR DESCRIPTION
## Summary

Closes the most load-bearing remaining gap from the brutal-honest SOTA assessment. Until now, every chat-completion turn went through legacy ChatService without landing a record in the Phase 5/10c durable session log — that made wake() (Phase 11a) and replay (Phase 11b/c) read-only because the data they wanted to consume was never produced.

\`native_chat_dispatch\` wraps \`ChatService.process_message\` with three things the legacy path skipped:

1. **Durable event logging.** \`user_message\` event before the call; \`assistant_message\` after (with text, status, duration, agent_type, tool_calls); one \`tool_result\` event per declared call. Now wake() can replay the conversation and replay_eval can diff it.
2. **Per-call metrics on the Phase 13 façade.** \`runtime.native_dispatch.runs\` counter labeled by status; \`runtime.native_dispatch.duration_ms\` summary. p50/p99 fall out of the existing Phase 16 \`/metrics\` scrape.
3. **Run-as-subagent affordance.** Same response shape, but the durable log now records a self-contained, replay-able turn. Future work can swap the inner call for a real lane-resolved native runner without changing the dispatch interface.

## How it activates

Wired into \`edge_endpoints._process\`. Every request that clears the Phase 14 canary gate (org in \`native_runtime_org_allowlist\` OR \`enable_native_runtime=True\`) now flows through \`native_chat_dispatch\` instead of bare \`ChatService\`. Legacy \`/api/v1/chat\` callers stay on bare \`ChatService\` — migration is opt-in per org.

## Design choice

This is **observability + durability**, not a rewrite. Same response, same latency profile (~1ms overhead for three log appends + metric calls). The body of \`_invoke_inner\` can be swapped for a lane-resolved native runner in a future phase without changing the dispatch interface or the test contract.

## Test plan

- [x] \`pytest tests/unit/engine/runtime/test_native_dispatch.py\` — **11 pass**
- [x] \`pytest tests/unit/api/test_edge_endpoints.py\` — **14 pass** unchanged (existing \`get_chat_service\` mocks still work because \`native_chat_dispatch\` calls into the same singleton)
- [x] Rebased cleanly onto main post-#226 merge
- [x] Boot smoke clean

## Out of scope

- Wiring \`enable_native_runtime=True\` into actual production — operational decision; the Phase 14 allowlist is the rollout vehicle when ready.
- Lane-resolved native LLM runner inside \`_invoke_inner\` — separate phase; today it still calls ChatService.

🤖 Generated with [Claude Code](https://claude.com/claude-code)