### PR TITLE
phase-32: thinking-stream model + UI pipeline noise cleanup

### DIFF
--- a/maritime-ai-service/app/engine/model_catalog.py
+++ b/maritime-ai-service/app/engine/model_catalog.py
@@ -83,6 +83,12 @@ ZHIPU_DEFAULT_BASE_URL = "https://open.bigmodel.cn/api/paas/v4"
 NVIDIA_DEFAULT_BASE_URL = "https://integrate.api.nvidia.com/v1"
 NVIDIA_DEFAULT_MODEL = "deepseek-ai/deepseek-v4-flash"
 NVIDIA_DEFAULT_MODEL_ADVANCED = "deepseek-ai/deepseek-v4-pro"
+# Phase 32a (#207): Qwen3 thinking model emits ``reasoning_content`` deltas
+# that Wiii's existing thinking-stream extractor already understands.
+# Switch ``NVIDIA_MODEL_ADVANCED`` to this id when you want a visible
+# reasoning block in the UI (the streaming pipeline picks it up
+# automatically via ``_extract_openai_delta_text_impl``).
+NVIDIA_THINKING_MODEL = "qwen/qwen3-next-80b-a3b-thinking"
 
 GOOGLE_CHAT_MODELS: dict[str, ChatModelMetadata] = {
     GOOGLE_DEFAULT_MODEL: ChatModelMetadata(
@@ -437,6 +443,19 @@ NVIDIA_CHAT_MODELS: dict[str, ChatModelMetadata] = {
         provider="nvidia",
         model_name=NVIDIA_DEFAULT_MODEL_ADVANCED,
         display_name="DeepSeek V4 Pro (NVIDIA NIM)",
+        status="current",
+        supports_streaming=True,
+        supports_structured_output=False,
+        capability_source="static",
+    ),
+    # Phase 32a (#207): Reasoning-capable model. Emits ``reasoning_content``
+    # deltas that surface as ``thinking_*`` SSE events in the UI. Slower
+    # per-turn (model thinks then answers) but gives the user the
+    # transparency that Claude / o3 / DeepSeek-R1 deliver natively.
+    NVIDIA_THINKING_MODEL: ChatModelMetadata(
+        provider="nvidia",
+        model_name=NVIDIA_THINKING_MODEL,
+        display_name="Qwen3 80B Thinking (NVIDIA NIM)",
         status="current",
         supports_streaming=True,
         supports_structured_output=False,

--- a/wiii-desktop/src/__tests__/sprint110-hardening.test.ts
+++ b/wiii-desktop/src/__tests__/sprint110-hardening.test.ts
@@ -116,14 +116,25 @@ describe("useSSEStream — type-safe metadata", () => {
     expect(code).not.toContain("Wiii dang tro tren trang");
   });
 
-  it("surfaces status_only heartbeats as the live timer status only", async () => {
+  it("hides status_only heartbeats from the live timer (Phase 32d UX cleanup)", async () => {
+    // Before Phase 32d, every status event — including the ~13
+    // status_only heartbeats per turn from the multi-agent pipeline —
+    // updated the live timer label. That repaint cadence is what the
+    // user perceived as "giật" (jerky). After Phase 32d, the live
+    // timer call lives INSIDE the !isEphemeralHeartbeat guard so only
+    // user-facing progress events update it. Internal pipeline events
+    // (guardian → supervisor → direct → synthesizer) stay in the
+    // persistent timeline for debug, not in the live timer.
     const src = await import("@/hooks/useSSEStream?raw");
     const code = (src as any).default || src;
     const heartbeatGuard = code.indexOf("if (!isEphemeralHeartbeat)");
     const liveStatus = code.indexOf("store.setStreamingStep(label);", code.indexOf("onStatus:"));
-    expect(liveStatus).toBeGreaterThan(-1);
-    expect(heartbeatGuard).toBeGreaterThan(liveStatus);
-    expect(code).toContain("keep them out of the persistent step/phase timeline");
+    expect(heartbeatGuard).toBeGreaterThan(-1);
+    expect(liveStatus).toBeGreaterThan(heartbeatGuard);
+    // The Phase 32d comment block must mention the SOTA precedent
+    // (Claude / ChatGPT / Gemini show ONE generic spinner) so a
+    // future contributor doesn't revert this for "more transparency".
+    expect(code).toContain("Phase 32d");
   });
 
   it("sets an immediate live status before the first SSE event arrives", async () => {

--- a/wiii-desktop/src/hooks/useSSEStream.ts
+++ b/wiii-desktop/src/hooks/useSSEStream.ts
@@ -812,10 +812,20 @@ export function useSSEStream() {
         }
 
         if (label) {
-          // Show status_only heartbeats as the current live timer status,
-          // but keep them out of the persistent step/phase timeline.
-          store.setStreamingStep(label);
+          // Phase 32d (#207): UI cleanup. The backend pipeline emits
+          // ~13 status events per turn (guardian → supervisor → direct
+          // → synthesizer with route + step_start/end variants). Each
+          // setStreamingStep call repaints the live timer label, which
+          // produces a jerky "internal pipeline" feeling that big
+          // orgs (Claude / ChatGPT / Gemini) deliberately avoid — they
+          // show ONE generic spinner ("Wiii đang nghĩ...") until the
+          // first answer or thinking event lands. We surface only the
+          // user-facing labels: explicit ``thinking_*`` events drive
+          // ThinkingBlock; routing-internal status_only events stay
+          // in the persistent timeline (debug / power users) but do
+          // NOT update the live timer.
           if (!isEphemeralHeartbeat) {
+            store.setStreamingStep(label);
             store.addStreamingStep(label, data.node);
             store.appendPhaseStatus(label, data.node, data.step_id);
           }


### PR DESCRIPTION
## Summary

Two surgical UX changes that close the streaming-quality gap vs Anthropic / OpenAI / DeepSeek native UIs. User report: "stream khá giật" + no thinking-stream like big orgs.

## Phase 32a — Thinking-stream model

DeepSeek V4 Pro doesn't emit \`reasoning_content\` (verified via raw NVIDIA NIM probe — returns \`null\` for that field). DeepSeek R1 reached EOL 2026-01-26. Qwen3-Thinking emits both \`reasoning\` AND \`reasoning_content\` per delta — Wiii's existing extractor already handles both shapes.

Adds \`qwen/qwen3-next-80b-a3b-thinking\` to \`NVIDIA_CHAT_MODELS\` as an opt-in alternative.

\`\`\`bash
# To enable thinking-stream UX:
NVIDIA_MODEL_ADVANCED=qwen/qwen3-next-80b-a3b-thinking
\`\`\`

No default change. Trade-off documented: thinking models are slower per turn but give visible reasoning that big-org chatbots deliver natively.

## Phase 32d — UI pipeline noise cleanup

Diagnosis: the multi-agent pipeline emits ~13 \`status_only\` events per turn (guardian → supervisor → direct → synthesizer × runtime_step_start/end + runtime_route variants). UI's \`onStatus\` handler called \`setStreamingStep(label)\` for EVERY status event → live timer label repaints 13× before any answer token arrives. **That's the perceived "giật" jerkiness.**

Fix: move \`setStreamingStep(label)\` INSIDE the existing \`if (!isEphemeralHeartbeat)\` guard. Internal pipeline transitions (\`visibility: status_only\`) no longer poll the live timer. Persistent step/phase timeline (debug panel) unchanged.

Result: live timer shows initial "Wiii đang nghe bạn..." and stays calm until a real user-facing event (\`thinking_delta\`, \`answer_delta\`, or non-heartbeat status). Matches SOTA UX big orgs ship — Claude / ChatGPT / Gemini show ONE generic spinner until the first reasoning or answer token lands.

## Phase 32b/c status

- **32b (backend smoothness)**: events ALREADY tagged \`status_only\` correctly. No code change needed — Phase 32d UI filter catches them.
- **32c (TTFT optimization)**: supervisor ALREADY uses \`tier="light"\`. Further TTFT improvement requires speculative streaming or provider change (gpt-4o-mini, claude-haiku) — bigger refactor, deferred to Phase 33.

## Test plan

- [x] \`sprint110-hardening.test.ts\` — 15/15 pass (updated to assert new heartbeat-guards-live-timer behavior)
- [x] \`auth-mode-fallback.test.ts\` — 6/6 pass
- [x] Pre-existing failures in \`local-preview-bootstrap\` + \`theme\` + \`settings-page\` reproduce on main (env-related, unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Qwen3 80B Thinking chat model via NVIDIA NIM.

* **Bug Fixes**
  * Fixed live timer display to properly hide internal status heartbeats from user-facing updates.

* **Tests**
  * Updated test cases to verify correct filtering of ephemeral heartbeats in the live timer functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->