### PR TITLE
phase-33: UX cadence + casual fast-path + episodic + memory ops + Living Agent + Unsloth plan

### DIFF
--- a/maritime-ai-service/app/engine/runtime/casual_intent.py
+++ b/maritime-ai-service/app/engine/runtime/casual_intent.py
@@ -1,0 +1,164 @@
+"""Heuristic casual-intent classifier — no LLM call needed.
+
+Phase 33b of the runtime migration epic (issue #207). Today every chat
+turn pays the multi-agent tax (guardian → supervisor → direct →
+synthesizer). For long educational queries that's appropriate.
+For casual greetings ("alo", "hihi", "ok"), each LLM call adds 2-5s of
+latency that the user can FEEL. Big orgs avoid this by routing casual
+turns through a fast lane.
+
+The detector here is **deliberately conservative** — when unsure it
+returns ``None``, and the caller falls back to the full multi-agent
+flow. The cost of a false-positive (treating a real question as
+casual) is high (Wiii answers wrong). The cost of a false-negative
+(running the full pipeline on "alo") is low (just slower than ideal).
+
+**No LLM call.** Pure-Python pattern match + length heuristics. Sub-ms.
+
+Confidence is a 0-1 float so callers can pick their own threshold.
+Recommended:
+- ``>= 0.85`` — strong casual signal, fast-path is safe.
+- ``>= 0.70`` — soft signal; consider fast-path only if no tools needed.
+- ``< 0.70`` — let the full multi-agent decide.
+
+Out of scope:
+- Multilingual signals beyond Vietnamese + a few English greetings.
+- Sentiment analysis (Sprint 210d already runs that).
+- Tool-call intent detection (different problem).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+# Vietnamese + English greeting / acknowledgment / filler markers.
+# All lowercase; matched against word-boundary or full-message regex.
+_GREETING_TOKENS = frozenset(
+    {
+        # Vietnamese
+        "chào", "chao", "hí", "hi", "hello", "hey", "alo", "yo",
+        "xin chào", "xin chao",
+        # Address-only ("Wiii ơi", "Wiii à") — checked separately
+    }
+)
+_ACK_TOKENS = frozenset(
+    {
+        # Yes / acknowledgment
+        "ok", "oke", "okay", "uhm", "ừm", "ừ", "ờ", "à", "vâng", "dạ",
+        "yes", "ya", "yep", "đúng", "đúng rồi", "ừ ha", "à ừ",
+        # No / rejection
+        "không", "khong", "no", "nope", "không đâu", "khong dau",
+        "thôi", "thoi",
+        # Mild surprise / filler
+        "hmm", "huhu", "hihi", "haha", "hehe", "kk", "lol", "wow",
+        "uầy", "ơ", "ồ",
+        "tốt", "tot", "ngon", "ổn", "on",
+    }
+)
+# Pure address (user calls Wiii's name without follow-up).
+_ADDRESS_TOKENS = frozenset({"wiii", "wiii ơi", "wiii à", "wiii oi", "wiii a"})
+
+# Markers that BLOCK the fast-path even when the rest of the heuristic
+# would say "casual". Anything that smells like a real question, a
+# tool intent, or a knowledge query routes through the full pipeline.
+_HARD_QUESTION_MARKERS = (
+    re.compile(r"\?$"),
+    re.compile(r"\b(làm sao|làm thế nào|how do|how to|why|tại sao|sao lại)\b", re.IGNORECASE),
+    re.compile(r"\b(giải thích|explain|tóm tắt|summary|so sánh|compare)\b", re.IGNORECASE),
+    re.compile(r"\b(rule|quy tắc|colregs|solas|marpol|điều)\b", re.IGNORECASE),
+    re.compile(r"\b(tìm|search|tra cứu|lookup|fetch)\b", re.IGNORECASE),
+    re.compile(r"\b(code|lập trình|python|javascript|sql)\b", re.IGNORECASE),
+)
+
+
+@dataclass(slots=True, frozen=True)
+class CasualIntent:
+    """Verdict + reason from the heuristic classifier."""
+
+    confidence: float
+    reason: str
+    matched_token: Optional[str] = None
+
+
+def _normalize(message: str) -> str:
+    return (message or "").strip().lower()
+
+
+def classify(message: str) -> CasualIntent:
+    """Return a confidence score that ``message`` is casual social chat.
+
+    ``confidence == 0.0`` means "definitely not casual — treat as a
+    knowledge / tool request". Higher values mean the message looks
+    like a greeting, acknowledgment, or short filler. The caller
+    decides the threshold.
+    """
+    if not message or not message.strip():
+        return CasualIntent(confidence=0.0, reason="empty")
+
+    norm = _normalize(message)
+
+    # Hard blockers — anything that smells like a real question or
+    # knowledge / tool request kills the fast-path immediately.
+    for pattern in _HARD_QUESTION_MARKERS:
+        if pattern.search(message):
+            return CasualIntent(
+                confidence=0.0,
+                reason=f"blocked by question/knowledge marker: {pattern.pattern}",
+            )
+
+    # Length-based prior — very short messages are more likely casual.
+    length = len(norm)
+    if length > 80:
+        return CasualIntent(
+            confidence=0.0, reason=f"too long ({length} chars > 80)"
+        )
+
+    # Pure address: "Wiii ơi", "Wiii à" — strong casual signal.
+    if norm in _ADDRESS_TOKENS:
+        return CasualIntent(
+            confidence=0.95,
+            reason="pure address",
+            matched_token=norm,
+        )
+
+    # Greeting-only (with optional address).
+    for token in _GREETING_TOKENS:
+        if norm == token or norm.startswith(token + " ") or norm == f"{token} wiii":
+            return CasualIntent(
+                confidence=0.92,
+                reason="greeting-only",
+                matched_token=token,
+            )
+
+    # Acknowledgment / single-word filler.
+    if norm in _ACK_TOKENS:
+        return CasualIntent(
+            confidence=0.90,
+            reason="single-word acknowledgment",
+            matched_token=norm,
+        )
+
+    # Multi-word but short and contains a casual marker.
+    if length <= 30:
+        words = set(norm.split())
+        ack_overlap = words & _ACK_TOKENS
+        greet_overlap = words & _GREETING_TOKENS
+        if ack_overlap or greet_overlap:
+            matched = next(iter(ack_overlap | greet_overlap))
+            return CasualIntent(
+                confidence=0.78,
+                reason="short utterance contains casual token",
+                matched_token=matched,
+            )
+
+    # Length 30-80 with NO casual markers and NO question markers —
+    # ambiguous, let the full pipeline handle it.
+    return CasualIntent(
+        confidence=0.0,
+        reason="no casual markers found",
+    )
+
+
+__all__ = ["CasualIntent", "classify"]

--- a/maritime-ai-service/app/engine/runtime/episodic_retrieval.py
+++ b/maritime-ai-service/app/engine/runtime/episodic_retrieval.py
@@ -1,0 +1,173 @@
+"""Cross-session episodic retrieval over the durable session log.
+
+Phase 33c of the runtime migration epic (issue #207). Wiii's existing
+memory layers cover within-session context (recent window + summary)
+and slow-changing facts (core_memory_block). This module fills the
+gap for "I mentioned this 3 days ago in another chat" — semantic /
+keyword recall across the user's PRIOR sessions.
+
+Primitive only. The wiring step (calling this from the multi-agent
+context builder so retrieved snippets show up in the prompt) lives in
+a follow-up commit so the primitive can land + be reviewed on its own.
+
+Design points:
+- **Scope to user_id + org_id** — never leak prior turns across users
+  or across orgs. The session_events table is already org-aware
+  (Phase 14), so the SQL filter is straightforward.
+- **Exclude current session** — we don't want to dilute the recent
+  window with content the conversation_window manager already shows.
+  Caller passes ``exclude_session_id`` for the active turn.
+- **Text-similarity for now**, embedding-based later. The
+  ``session_events.payload`` jsonb has a ``text`` field for both
+  user_message and assistant_message events — Postgres ``ILIKE`` +
+  trigram or full-text search picks up keyword overlap fast. When the
+  team adopts pgvector for session_events (separate phase) we can
+  swap the SELECT for a vector-distance query without changing the
+  caller.
+- **Defensive on missing data**. If the durable log isn't enabled
+  (``enable_session_event_log=False``, in-memory backend), this
+  module returns an empty list instead of raising — the caller's
+  prompt builder treats no-results as "no episodic context" and
+  proceeds normally.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class EpisodicMatch:
+    """One matching prior turn with enough context to render a citation.
+
+    ``score`` is implementation-defined (today: substring overlap
+    proxy). Callers should treat it as "higher is more relevant"
+    without leaning on the exact number.
+    """
+
+    session_id: str
+    seq: int
+    event_type: str
+    text: str
+    created_at: str
+    score: float
+
+
+async def search_prior_user_turns(
+    *,
+    user_id: str,
+    query: str,
+    limit: int = 5,
+    exclude_session_id: Optional[str] = None,
+    org_id: Optional[str] = None,
+    min_query_length: int = 3,
+) -> list[EpisodicMatch]:
+    """Return up to ``limit`` prior turns from this user that look related.
+
+    Returns ``[]`` when:
+    - ``query`` is too short / empty (avoids matching everything).
+    - The asyncpg pool isn't available (e.g. in-memory event log).
+    - The user has no prior session_events.
+    - The DB query raises (logged at warning, never re-raised — episodic
+      retrieval is a best-effort enhancement, not a hard dependency).
+    """
+    cleaned = (query or "").strip()
+    if len(cleaned) < min_query_length:
+        return []
+    if limit <= 0:
+        return []
+
+    try:
+        from app.core.database import get_asyncpg_pool
+
+        pool = await get_asyncpg_pool()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "[episodic] asyncpg pool unavailable; returning []: %s", exc
+        )
+        return []
+
+    # Build the WHERE clause defensively. The user_id filter is on the
+    # payload jsonb (we don't have a dedicated user_id column on
+    # session_events). org_id is a top-level column from Alembic 047.
+    params: list = [user_id, f"%{cleaned.lower()}%"]
+    where_parts = [
+        "(payload->>'user_id') = $1",
+        "lower(payload->>'text') LIKE $2",
+    ]
+    if exclude_session_id:
+        params.append(exclude_session_id)
+        where_parts.append(f"session_id <> ${len(params)}")
+    if org_id:
+        params.append(org_id)
+        where_parts.append(f"org_id = ${len(params)}")
+
+    sql = (
+        "SELECT session_id, seq, event_type, "
+        "       payload->>'text' AS text, "
+        "       created_at "
+        "FROM session_events "
+        f"WHERE {' AND '.join(where_parts)} "
+        "ORDER BY created_at DESC "
+        f"LIMIT {int(limit)}"
+    )
+
+    try:
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(sql, *params)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[episodic] retrieval query raised; returning []: %s", exc
+        )
+        return []
+
+    needle_lower = cleaned.lower()
+    matches: list[EpisodicMatch] = []
+    for row in rows:
+        text = row["text"] or ""
+        # Score proxy: more occurrences = higher score, with a cap.
+        # When we move to pgvector, replace this with the cosine
+        # distance from the embedding query.
+        text_lower = text.lower()
+        occurrences = text_lower.count(needle_lower) if needle_lower else 0
+        score = min(1.0, 0.4 + 0.2 * occurrences)
+        matches.append(
+            EpisodicMatch(
+                session_id=row["session_id"],
+                seq=int(row["seq"]),
+                event_type=row["event_type"],
+                text=text,
+                created_at=str(row["created_at"]),
+                score=score,
+            )
+        )
+
+    return matches
+
+
+def render_for_prompt(
+    matches: list[EpisodicMatch], *, max_chars_per_match: int = 200
+) -> str:
+    """Render a compact prompt-ready block from a list of matches.
+
+    Returns "" when ``matches`` is empty so callers can ``+`` it into
+    the system prompt unconditionally without worrying about extra
+    blank lines.
+    """
+    if not matches:
+        return ""
+
+    lines = ["Trí nhớ từ các phiên trước (chỉ tham khảo, đừng nhắc lại nguyên văn):"]
+    for m in matches:
+        snippet = m.text.strip()
+        if len(snippet) > max_chars_per_match:
+            snippet = snippet[: max_chars_per_match - 1].rstrip() + "…"
+        lines.append(f"- ({m.event_type}, seq {m.seq}) {snippet}")
+    return "\n".join(lines) + "\n"
+
+
+__all__ = ["EpisodicMatch", "search_prior_user_turns", "render_for_prompt"]

--- a/maritime-ai-service/app/engine/runtime/memory_ops.py
+++ b/maritime-ai-service/app/engine/runtime/memory_ops.py
@@ -1,0 +1,266 @@
+"""Hierarchical memory operations — Letta / MemGPT self-edit pattern.
+
+Phase 33e of the runtime migration epic (issue #207). Wiii's existing
+``core_memory_block`` (Sprint 168) holds ~800 tokens of slow-changing
+sticky facts about the user (name, preferences, role, recent goals).
+Today that block is read-only from the LLM's perspective — Wiii sees
+it but cannot edit it. The Letta / MemGPT paradigm exposes
+``core_memory.replace`` and ``core_memory.append`` as tool calls so
+the agent itself decides when a fact is stable enough to promote.
+
+This module ships the primitive — pure functions over a memory
+store interface. Wiring as actual tool definitions (so the LLM can
+call them) lives in a follow-up commit so the primitive lands first
+and the contract is reviewable on its own.
+
+Out of scope:
+- Tool registration in ToolRegistry (separate commit).
+- LLM training so it knows when to call these (prompt engineering).
+- Concurrency for multi-process writes (an asyncpg row-lock would
+  cover it; the in-memory backend uses asyncio.Lock).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+# ── data ──
+
+
+@dataclass(slots=True)
+class MemoryEditResult:
+    """Outcome of a self-edit op. Always returned, never raised — the
+    LLM needs structured feedback to decide what to do next."""
+
+    success: bool
+    block_name: str
+    new_content: str
+    operation: str  # "replace" | "append" | "no_op"
+    reason: Optional[str] = None
+
+
+# ── store interface ──
+
+
+class CoreMemoryStore(Protocol):
+    """Backend that owns the actual core_memory_block bytes for a user.
+
+    The Wiii production backend (Sprint 168) lives in a Postgres row
+    keyed by user_id + block_name. Tests use ``InMemoryCoreMemoryStore``.
+    """
+
+    async def get_block(
+        self, *, user_id: str, block_name: str
+    ) -> Optional[str]: ...
+
+    async def put_block(
+        self, *, user_id: str, block_name: str, content: str
+    ) -> None: ...
+
+
+class InMemoryCoreMemoryStore:
+    """Process-local store for tests + dev. Loses state on restart."""
+
+    def __init__(self) -> None:
+        self._blocks: dict[tuple[str, str], str] = {}
+        self._lock = asyncio.Lock()
+
+    async def get_block(
+        self, *, user_id: str, block_name: str
+    ) -> Optional[str]:
+        async with self._lock:
+            return self._blocks.get((user_id, block_name))
+
+    async def put_block(
+        self, *, user_id: str, block_name: str, content: str
+    ) -> None:
+        async with self._lock:
+            self._blocks[(user_id, block_name)] = content
+
+
+# ── ops ──
+
+DEFAULT_MAX_BLOCK_CHARS = 3200  # ~800 tokens at chars_per_token=4
+
+
+async def replace_block(
+    store: CoreMemoryStore,
+    *,
+    user_id: str,
+    block_name: str,
+    new_content: str,
+    max_chars: int = DEFAULT_MAX_BLOCK_CHARS,
+) -> MemoryEditResult:
+    """Overwrite the named block with ``new_content``.
+
+    Caps at ``max_chars`` to keep token budget predictable. When the
+    new content already matches the existing block, returns a no_op
+    result — saves a Postgres write under the typical "LLM re-states
+    the same fact" flow.
+    """
+    if not user_id or not block_name:
+        return MemoryEditResult(
+            success=False,
+            block_name=block_name,
+            new_content="",
+            operation="replace",
+            reason="user_id and block_name are required",
+        )
+
+    cleaned = (new_content or "").strip()
+    if len(cleaned) > max_chars:
+        # Reserve 1 char for the ellipsis so total stays <= max_chars.
+        cleaned = cleaned[: max_chars - 1].rstrip() + "…"
+
+    existing = await store.get_block(user_id=user_id, block_name=block_name)
+    if existing == cleaned:
+        return MemoryEditResult(
+            success=True,
+            block_name=block_name,
+            new_content=cleaned,
+            operation="no_op",
+            reason="content unchanged",
+        )
+
+    try:
+        await store.put_block(
+            user_id=user_id, block_name=block_name, content=cleaned
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[memory_ops.replace] put_block raised for %s/%s: %s",
+            user_id,
+            block_name,
+            exc,
+        )
+        return MemoryEditResult(
+            success=False,
+            block_name=block_name,
+            new_content=cleaned,
+            operation="replace",
+            reason=f"put_block failed: {type(exc).__name__}",
+        )
+
+    return MemoryEditResult(
+        success=True,
+        block_name=block_name,
+        new_content=cleaned,
+        operation="replace",
+    )
+
+
+async def append_to_block(
+    store: CoreMemoryStore,
+    *,
+    user_id: str,
+    block_name: str,
+    addition: str,
+    separator: str = "\n",
+    max_chars: int = DEFAULT_MAX_BLOCK_CHARS,
+) -> MemoryEditResult:
+    """Append ``addition`` to the named block.
+
+    When the new total would exceed ``max_chars``, trims FROM THE
+    FRONT (oldest content) so the most recent addition stays visible
+    — matches the SOTA "memory pressure" behavior in MemGPT / Letta.
+    Concretely: fact-amnesia is preferable to silently dropping the
+    user's just-stated preference.
+    """
+    if not user_id or not block_name:
+        return MemoryEditResult(
+            success=False,
+            block_name=block_name,
+            new_content="",
+            operation="append",
+            reason="user_id and block_name are required",
+        )
+
+    addition_clean = (addition or "").strip()
+    if not addition_clean:
+        return MemoryEditResult(
+            success=False,
+            block_name=block_name,
+            new_content="",
+            operation="append",
+            reason="empty addition",
+        )
+
+    existing = await store.get_block(
+        user_id=user_id, block_name=block_name
+    ) or ""
+
+    if existing:
+        combined = f"{existing}{separator}{addition_clean}"
+    else:
+        combined = addition_clean
+
+    if len(combined) > max_chars:
+        # Drop the oldest bytes (head) to make room. This is the
+        # MemGPT "memory pressure" trade-off: prefer keeping recent
+        # facts even if it means losing older ones.
+        combined = "…" + combined[-(max_chars - 1):]
+
+    try:
+        await store.put_block(
+            user_id=user_id, block_name=block_name, content=combined
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[memory_ops.append] put_block raised for %s/%s: %s",
+            user_id,
+            block_name,
+            exc,
+        )
+        return MemoryEditResult(
+            success=False,
+            block_name=block_name,
+            new_content=combined,
+            operation="append",
+            reason=f"put_block failed: {type(exc).__name__}",
+        )
+
+    return MemoryEditResult(
+        success=True,
+        block_name=block_name,
+        new_content=combined,
+        operation="append",
+    )
+
+
+async def read_block(
+    store: CoreMemoryStore, *, user_id: str, block_name: str
+) -> str:
+    """Return the named block's content, or empty string when missing.
+
+    Wraps ``store.get_block`` so callers (and tool definitions) get a
+    consistent string-typed return without juggling Optional[str].
+    """
+    if not user_id or not block_name:
+        return ""
+    try:
+        result = await store.get_block(
+            user_id=user_id, block_name=block_name
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[memory_ops.read] get_block raised: %s", exc
+        )
+        return ""
+    return result or ""
+
+
+__all__ = [
+    "CoreMemoryStore",
+    "InMemoryCoreMemoryStore",
+    "MemoryEditResult",
+    "replace_block",
+    "append_to_block",
+    "read_block",
+    "DEFAULT_MAX_BLOCK_CHARS",
+]

--- a/maritime-ai-service/app/engine/runtime/stream_smoother.py
+++ b/maritime-ai-service/app/engine/runtime/stream_smoother.py
@@ -1,0 +1,133 @@
+"""Punctuation-aware token batching for the SSE answer stream.
+
+Phase 33a of the runtime migration epic (issue #207). Phase 32d cleared
+status-event noise from the live timer; this module attacks the
+answer-event cadence problem.
+
+Today's stream emits each provider chunk as one ``answer_delta`` SSE
+event. Some providers burst 30-50 tokens into one chunk, others trickle
+single tokens. The UI repaints the message bubble on every chunk, so a
+bursty provider creates the same jerky feeling as the status spam did
+before Phase 32d.
+
+The fix is a simple **boundary-aware buffer**:
+
+- Accumulate tokens until we see a "natural" boundary (sentence-ending
+  punctuation, paragraph break, comma after >= K chars, or a length
+  threshold).
+- Flush on boundary OR after a short time-since-last-flush watchdog so
+  long-running tokens don't stall the UI.
+
+This matches what Anthropic, OpenAI, and DeepSeek do in their first-
+party UIs — token cadence at the UI layer is normalized, NOT the raw
+provider stream.
+
+Out of scope:
+- Cross-language smarter tokenization (the Vietnamese flush rules
+  here just look at ASCII punctuation, which is enough — VN text uses
+  the same . , ! ? boundaries).
+- Streaming TTFT optimization (Phase 33b).
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+# Sentence-ending punctuation that always flushes.
+_HARD_FLUSH_CHARS = frozenset(".!?\n")
+# Soft boundaries — flush only if we've already buffered MIN_SOFT_FLUSH_CHARS.
+_SOFT_FLUSH_CHARS = frozenset(",;:")
+# Floor / ceiling for the buffer. Below FLOOR we never flush on a soft
+# boundary (avoids stuttering on "I, " openings). Above CEILING we
+# force-flush regardless of punctuation (stops a mid-paragraph token
+# burst from stalling the UI for >100ms).
+MIN_SOFT_FLUSH_CHARS = 18
+MAX_BUFFER_CHARS = 60
+# Time-since-last-flush watchdog. If the LLM stalls mid-sentence, flush
+# whatever we have so the UI keeps moving.
+MAX_FLUSH_INTERVAL_MS = 200
+
+
+@dataclass
+class StreamSmoother:
+    """Boundary-aware accumulator that turns raw provider chunks into a
+    cadence the UI can repaint smoothly.
+
+    The pattern is deliberately stateful — Python instance state — so a
+    caller can drive it from inside the existing async generator without
+    plumbing channels around. Call ``feed()`` for each provider chunk;
+    it returns 0+ flushed strings to yield as ``answer_delta`` events.
+    Call ``flush_remaining()`` once at end-of-stream so the tail token
+    doesn't get dropped.
+    """
+
+    buffer: str = ""
+    last_flush_at_ms: float = 0.0
+
+    def _now_ms(self) -> float:
+        return time.monotonic() * 1000.0
+
+    def feed(self, chunk: str) -> list[str]:
+        """Accept a provider chunk. Return the strings to flush right now.
+
+        Multiple flushes per chunk are possible — e.g. if the provider
+        bursts ``"Hello. World!"`` in one shot, we emit two flushes
+        ``"Hello. "`` and ``"World!"`` so the UI sees two clean
+        sentence-ending repaints.
+        """
+        if not chunk:
+            return []
+        now_ms = self._now_ms()
+        if self.last_flush_at_ms == 0.0:
+            self.last_flush_at_ms = now_ms
+
+        flushes: list[str] = []
+        for ch in chunk:
+            self.buffer += ch
+            if self._should_flush_after_char(ch):
+                flushes.append(self.buffer)
+                self.buffer = ""
+                self.last_flush_at_ms = now_ms
+
+        # Watchdog: if we have unflushed bytes AND the last flush was >
+        # MAX_FLUSH_INTERVAL_MS ago, ship what we have so the UI keeps
+        # moving even when the provider stalls mid-sentence.
+        if (
+            self.buffer
+            and now_ms - self.last_flush_at_ms >= MAX_FLUSH_INTERVAL_MS
+        ):
+            flushes.append(self.buffer)
+            self.buffer = ""
+            self.last_flush_at_ms = now_ms
+
+        return flushes
+
+    def _should_flush_after_char(self, ch: str) -> bool:
+        if ch in _HARD_FLUSH_CHARS:
+            return True
+        if len(self.buffer) >= MAX_BUFFER_CHARS:
+            return True
+        if (
+            ch in _SOFT_FLUSH_CHARS
+            and len(self.buffer) >= MIN_SOFT_FLUSH_CHARS
+        ):
+            return True
+        return False
+
+    def flush_remaining(self) -> str:
+        """Drain whatever is left in the buffer at end-of-stream.
+
+        Call once when the inner generator finishes so the tail token
+        ("ạ", "!", or a final "...") doesn't get silently dropped.
+        Returns "" when the buffer is already empty.
+        """
+        if not self.buffer:
+            return ""
+        out = self.buffer
+        self.buffer = ""
+        self.last_flush_at_ms = self._now_ms()
+        return out
+
+
+__all__ = ["StreamSmoother"]

--- a/maritime-ai-service/docs/runtime/LIVING_AGENT_ENABLEMENT.md
+++ b/maritime-ai-service/docs/runtime/LIVING_AGENT_ENABLEMENT.md
@@ -1,0 +1,172 @@
+# Living Agent — Enablement Guide
+
+Phase 33d of the runtime migration epic ([#207](https://github.com/meiiie/wiii/issues/207)).
+Step-by-step procedure for enabling Wiii's autonomous "alive" layer
+(Soul AGI). The CODE has been complete since Sprint 170-210d; the
+remaining work is OPERATIONAL — install Ollama, pull the model, flip
+the flags. This doc captures that exact path.
+
+## What Living Agent gives you
+
+| Feature | Sprint | What user sees |
+|---------|--------|----------------|
+| 30-min heartbeat | 170 | Wiii's mood drifts naturally between sessions |
+| 4D emotion state (mood/energy/social/engagement) | 170 | Avatar emotes reflect time-of-day + recent interactions |
+| Skill DISCOVER → LEARN → PRACTICE → EVALUATE → MASTER | 191 | Wiii learns topics from conversations + retains them via SM-2 spaced repetition |
+| Journal entries | 170 | Wiii writes a per-tick journal that surfaces in proactive replies |
+| Routine tracking | 210 | Wiii notices when you usually appear + says hello differently |
+| Proactive messaging | 210 | After silence, Wiii sends a check-in (max 3/day) |
+| Living continuity | 210 | Chat conversations feed into emotion / memory / episodes |
+| Relationship psychology (CREATOR / KNOWN / OTHER) | 210c | Wiii treats you differently based on long-term relationship tier |
+| LLM sentiment analysis (Sprint 210d) | 210d | Sentiment shapes the next reply's emotional valence |
+
+What it does NOT give you:
+- Smarter chat answers — that comes from V4 Pro + multi-agent + RAG. Living Agent runs in the background, not on the chat hot path.
+- Faster TTFT — Living Agent doesn't touch streaming.
+
+## What Living Agent is NOT
+
+- Not a separate user-facing chat. The chat surface is unchanged.
+- Not required for production — Wiii ships with Living Agent OFF by default.
+- Not a replacement for memory layers — those (recent window + summary + core memory + episodic) work whether Living Agent is on or off.
+
+## Pre-flight checklist
+
+- [ ] **Ollama installed.** macOS / Windows: download from <https://ollama.com>. Linux: `curl -fsSL https://ollama.com/install.sh | sh`.
+- [ ] **Model pulled.** Run `ollama pull qwen3:8b` once. ~5 GB disk.
+- [ ] **Ollama daemon running** (auto-starts on macOS / Windows; `systemctl --user start ollama` on Linux).
+- [ ] **Verify Ollama reachable** from Wiii: `curl http://localhost:11434/api/tags` should return JSON listing `qwen3:8b`.
+- [ ] **Phase 9c+ on main** (already shipped — check `git log origin/main --grep='phase-9'`).
+
+## Procedure
+
+### 1. Enable the core flag
+
+Edit `maritime-ai-service/.env.production`:
+
+```bash
+# Living Agent core
+ENABLE_LIVING_AGENT=true
+LIVING_AGENT_HEARTBEAT_INTERVAL=1800        # seconds (30 min default)
+LIVING_AGENT_ACTIVE_HOURS_START=5           # UTC hour Wiii "wakes"
+LIVING_AGENT_ACTIVE_HOURS_END=23            # UTC hour Wiii "sleeps"
+
+# Local model (Ollama)
+LIVING_AGENT_LOCAL_MODEL=qwen3:8b
+OLLAMA_BASE_URL=http://localhost:11434
+```
+
+### 2. Pick the sub-features (each can be toggled independently)
+
+```bash
+# Background autonomy
+LIVING_AGENT_ENABLE_SOCIAL_BROWSE=true       # Wiii browses social feeds when idle
+LIVING_AGENT_ENABLE_SKILL_BUILDING=true      # SM-2 spaced repetition of learned topics
+LIVING_AGENT_ENABLE_JOURNAL=true             # per-tick journal entries
+LIVING_AGENT_ENABLE_WEATHER=true             # weather-aware mood drift
+LIVING_AGENT_ENABLE_BRIEFING=true            # morning briefing prep
+LIVING_AGENT_ENABLE_ROUTINE_TRACKING=true    # learns when you usually appear
+
+# Goal autonomy
+LIVING_AGENT_ENABLE_DYNAMIC_GOALS=true       # Wiii sets her own short-term goals
+LIVING_AGENT_AUTONOMY_LEVEL=1                # 0=just react, 3=full autonomy
+LIVING_AGENT_ENABLE_AUTONOMY_GRADUATION=true # auto-promote level over time
+
+# Proactive messaging (use with care — Wiii will message users)
+LIVING_AGENT_ENABLE_PROACTIVE_MESSAGING=true
+LIVING_AGENT_MAX_PROACTIVE_PER_DAY=3
+LIVING_AGENT_REQUIRE_HUMAN_APPROVAL=false    # set true for first canary
+
+# Optional: weather data
+OPENWEATHERMAP_API_KEY=your_key_here
+
+# Continuity — let Living Agent state shape the chat path
+ENABLE_LIVING_CONTINUITY=true                # chat → emotion + memory + episodes
+```
+
+### 3. Restart Wiii backend
+
+```bash
+# Stop current uvicorn (Phase 31 doc covers this)
+# Re-start with the new env:
+python -c "
+from dotenv import load_dotenv
+load_dotenv('.env.production', override=True)
+import uvicorn
+uvicorn.run('app.main:app', host='0.0.0.0', port=8000)
+"
+```
+
+### 4. Verify
+
+Boot logs should show:
+
+```
+[living_agent] Soul loaded: wiii_soul.yaml
+[living_agent] Heartbeat scheduled every 1800s (30 min)
+[living_agent] Skill engine ready (qwen3:8b via Ollama)
+[living_agent] Sentiment analyzer wired (Sprint 210d)
+```
+
+Check the API:
+
+```bash
+curl -H "X-API-Key: $WIII_API_KEY" \
+     -H "X-User-ID: smoke-test" \
+     http://localhost:8000/api/v1/living-agent/state
+# Returns JSON with mood / energy / social / engagement
+```
+
+Open the desktop UI's Living Agent panel — 5 tabs (overview / skills / goals / journal / reflections) should populate within 30 minutes.
+
+### 5. Soak
+
+- First heartbeat fires after `LIVING_AGENT_HEARTBEAT_INTERVAL` seconds.
+- First journal entry: same.
+- First skill spaced-repetition pass: depends on existing user history; new accounts wait until Wiii has discovered topics from conversations.
+- First proactive message (if enabled): `LIVING_AGENT_ACTIVE_HOURS_START` after the user has been silent for ≥ 4 hours.
+
+## Resource cost
+
+| Resource | Cost |
+|----------|------|
+| Disk | ~5 GB for qwen3:8b model weights |
+| RAM | ~6 GB held by Ollama when active (q4 quant) |
+| CPU/GPU | Heartbeat does 1-3 LLM calls per tick. ~1-3 minutes of compute every 30 min on consumer hardware |
+| Postgres | +~2 KB per tick (journal + emotion + skills records) |
+| Network | Optional: weather API (1 call per heartbeat if enabled), social_browse (varies) |
+
+For a 24-hour day at 30-min heartbeat: 48 ticks × ~2 KB = ~96 KB Postgres growth/day. Tiny.
+
+## Rollback
+
+```bash
+ENABLE_LIVING_AGENT=false
+```
+
+Restart. The autonomous loop stops on next heartbeat. Postgres records stay (no data loss; you can re-enable any time and pick up where you left off).
+
+## Acceptance bar before keeping it on for real users
+
+- [ ] One full week of heartbeat ticks with 0 errors in `app/engine/living_agent/` log namespace.
+- [ ] Mood drift looks plausible to a human reviewer (not stuck at one extreme).
+- [ ] No proactive message has been sent without `REQUIRE_HUMAN_APPROVAL=true` clearing in advance.
+- [ ] No measurable impact on chat-path TTFT (Living Agent runs in a separate worker, not the chat hot path).
+- [ ] If Ollama dies / restarts, Wiii degrades gracefully back to "no Living Agent updates" without 5xx-ing chat.
+
+## Why this is OPERATIONAL, not engineering
+
+The Living Agent code path has been stable since Sprint 210d. What's missing is:
+
+- Picking when to flip the flag (depends on real users existing).
+- Picking which sub-features to enable first (depends on product taste).
+- Validating the resource budget (depends on the host).
+- Watching the first week of ticks (operational).
+
+None of those are code work. Hence Phase 33d is a doc, not a code change.
+
+## Review log
+
+| Date | Reviewer | Change |
+|------|----------|--------|
+| 2026-05-04 | runtime | v1 — initial enablement guide, Phase 33d of #207 |

--- a/maritime-ai-service/docs/runtime/UNSLOTH_FINETUNE_PLAN.md
+++ b/maritime-ai-service/docs/runtime/UNSLOTH_FINETUNE_PLAN.md
@@ -1,0 +1,231 @@
+# Wiii Personality Fine-Tune via Unsloth — Research + Plan
+
+Phase 33f of the runtime migration epic ([#207](https://github.com/meiiie/wiii/issues/207)).
+Research output. **Implementation deferred** — fine-tuning needs GPU
+access, a curated dataset, and 1-2 weeks of focused work that doesn't
+fit a runtime-migration session. This doc captures the plan so the
+team can execute without re-deriving the design.
+
+## Why fine-tune at all
+
+Wiii's content quality at SOTA today (V4 Pro, ChatGPT, Claude all
+viable) — what's NOT at SOTA is **Vietnamese-first personality
+alignment**. Specifically:
+
+| Pain point | Today's mitigation | What fine-tuning unlocks |
+|------------|--------------------|--------------------------|
+| Thinking models think in English | Reverted to V4 Pro (no visible thinking) | A model that thinks in VN end-to-end → visible reasoning users can read |
+| V4 Pro persona drifts mid-conversation | Heavy system prompt + persona overlay | Persona BAKED IN — no prompt-engineering tax per turn |
+| Diacritic correction inconsistent | Model guesses (Hung → Hưng usually) | Model trained on VN diacritic-aware corpus → consistent every turn |
+| Soul / kawaii style imperfect on edge cases | Heavy prompt | Style baked in — saves ~500 prompt tokens per turn |
+| Token cost on every Wiii turn | Pay-per-call NVIDIA NIM | Self-hosted model = $0 marginal cost after training amortized |
+
+Concrete win: a fine-tuned 8B model running on a single RTX 4090 can
+serve Wiii's full traffic at ~$0/turn after the one-time training
+cost. Today every NVIDIA NIM call is metered.
+
+## Why Unsloth specifically
+
+Three open-source frameworks are mature for this in 2026-05:
+
+1. **Unsloth** (this repo: `_research/unsloth`) — Triton kernels +
+   2-5× faster QLoRA training than vanilla HF, ships notebooks for
+   Llama / Mistral / Gemma / Qwen / DeepSeek-R1 fine-tunes.
+2. **Axolotl** — config-driven, less kernel optimization, broader
+   model coverage.
+3. **TRL + PEFT** (HF native) — most flexible, slowest.
+
+Pick Unsloth because it lives in `_research/` already AND the team
+mentioned it specifically. Cost-wise: Unsloth's 4-bit QLoRA for an
+8B model fits on a single 24 GB GPU in ~6-12 hours.
+
+## Recommended base model
+
+**Qwen 2.5 7B** or **DeepSeek V4 Flash** (open-weight variant when
+DeepSeek ships it; today only the API version is hosted on NVIDIA NIM).
+
+Selection criteria:
+- Multilingual training corpus (VN + EN + ZH).
+- Compatible with Unsloth's trainer (Qwen 2.5 ✅, Llama 3.2 ✅,
+  Mistral 7B ✅).
+- Open-weight (no API gating).
+- Comparable raw capability to V4 Pro on Vietnamese benchmarks.
+
+DON'T pick:
+- Vietnamese-specific bases like PhoGPT — older base, weaker
+  reasoning than current 7B-class general models.
+- 3B-class models — too small for nuanced personality.
+- 70B-class models — 24 GB GPU can't fit even with QLoRA.
+
+## Dataset preparation
+
+Three sources, in this order:
+
+### Source 1 — synthetic Wiii-personality dialogues
+
+Generate ~5K turns using V4 Pro + Wiii's existing system prompt as
+the teacher. Each example:
+
+```
+{
+  "messages": [
+    {"role": "system", "content": "<wiii_soul.yaml prompt>"},
+    {"role": "user", "content": "alo Wiii"},
+    {"role": "assistant", "content": "Alo cậu! Mình đây rồi~ (˶˃ ᵕ ˂˶)"}
+  ]
+}
+```
+
+Filter: drop any example where V4 Pro broke persona (used "tôi" instead
+of "mình", switched to English mid-sentence, etc.). Manual review of
+~200 of them before training.
+
+### Source 2 — domain knowledge dialogues (COLREGs / SOLAS / MARPOL)
+
+~1K turns covering the maritime domain Wiii's primary users care about.
+Same shape as Source 1 but with anchored RAG context as the system prompt.
+
+### Source 3 — refusal / safety examples
+
+~500 turns where Wiii politely declines off-topic / harmful requests.
+Critical to prevent fine-tune from regressing safety.
+
+**Total**: ~6.5K turns. At 4-bit QLoRA, a 7B base trains in 6-8 hours
+on a 4090.
+
+## Training pipeline
+
+```bash
+# In _research/unsloth (clone if not present)
+cd _research/unsloth
+python -m venv .venv
+.venv/bin/pip install -e .
+
+# Prepare dataset as JSONL
+python scripts/prep_wiii_dataset.py \
+    --teacher-base-url https://integrate.api.nvidia.com/v1 \
+    --teacher-model deepseek-ai/deepseek-v4-pro \
+    --soul-prompt /path/to/wiii_soul.yaml \
+    --out wiii-train-v1.jsonl \
+    --num-turns 5000
+
+# Train
+python -m unsloth.cli train \
+    --base-model Qwen/Qwen2.5-7B-Instruct \
+    --dataset wiii-train-v1.jsonl \
+    --output-dir ./wiii-personality-v1 \
+    --num-train-epochs 3 \
+    --learning-rate 2e-4 \
+    --lora-rank 32 \
+    --quantization 4bit \
+    --max-seq-length 4096
+
+# Export to GGUF for Ollama serving
+python -m unsloth.cli export \
+    --adapter-path ./wiii-personality-v1 \
+    --format gguf \
+    --quantization q4_k_m \
+    --output wiii-personality-v1.gguf
+
+# Serve locally
+ollama create wiii-personality -f Modelfile
+# Where Modelfile points to the GGUF
+```
+
+## Integration with Wiii runtime
+
+Once `wiii-personality-v1.gguf` is in Ollama:
+
+1. Add a new provider config in `app/engine/llm_providers/`:
+
+   ```python
+   # app/engine/llm_providers/wiii_personality_provider.py
+   # Thin OpenAI-compat wrapper around Ollama's /v1/chat/completions
+   # endpoint. Same shape as the existing Ollama provider, just
+   # pinned to model="wiii-personality".
+   ```
+
+2. Add to `model_catalog.py`:
+
+   ```python
+   WIII_PERSONALITY_MODEL = "wiii-personality"
+   WIII_PERSONALITY_MODELS = {
+       WIII_PERSONALITY_MODEL: ChatModelMetadata(
+           provider="wiii-local",
+           model_name=WIII_PERSONALITY_MODEL,
+           display_name="Wiii Personality v1 (self-hosted)",
+           status="current",
+           supports_streaming=True,
+       ),
+   }
+   ```
+
+3. Set in `.env.production`:
+
+   ```bash
+   LLM_PROVIDER=wiii-local
+   LLM_FAILOVER_CHAIN=["wiii-local", "nvidia"]
+   WIII_LOCAL_BASE_URL=http://localhost:11434/v1
+   WIII_LOCAL_MODEL=wiii-personality
+   ```
+
+4. Failover to NVIDIA stays — if local model dies, traffic seamlessly
+   shifts to V4 Pro.
+
+## Acceptance bar before swapping the default
+
+- [ ] **Persona consistency** ≥ 95% — manual eval of 50 turns: how often
+      does the model use "mình" / "cậu" correctly + maintain kawaii
+      tone? Regression vs V4 Pro must be < 5%.
+- [ ] **Maritime knowledge accuracy** ≥ 90% — quiz on 50 COLREGs /
+      SOLAS / MARPOL questions. Regression vs V4 Pro must be < 10%.
+- [ ] **Refusal correctness** ≥ 99% on the 50-prompt safety eval set.
+      No regression vs V4 Pro acceptable.
+- [ ] **Latency** ≤ V4 Pro p99 on a 4090. (Should be much faster —
+      local model = no network round-trip.)
+- [ ] **Diacritic accuracy** ≥ 99% on a 30-prompt test where user
+      types diacritic-free Vietnamese.
+- [ ] **Replay regression** (Phase 11b nightly) shows token_jaccard
+      ≥ 0.85 vs the prior model on existing recordings.
+
+## Cost + time
+
+| Resource | Estimate |
+|----------|----------|
+| GPU rental (one-shot, RunPod / Lambda) | ~$30-50 (RTX 4090 × 8 hours) |
+| Teacher API cost (5K turns × ~500 tokens) | ~$5-10 (V4 Pro on NVIDIA NIM) |
+| Engineer time | 1-2 weeks (dataset prep + training + eval + integration) |
+| Storage (model weights + adapter) | ~10 GB total |
+| Marginal serving cost | $0/turn (self-hosted via Ollama) |
+
+## Risk register
+
+| Risk | Mitigation |
+|------|------------|
+| Fine-tune regresses on out-of-distribution queries | Keep NVIDIA NIM as failover (seamless via LLM_FAILOVER_CHAIN) |
+| Training data captures V4 Pro's edge-case bugs | Manual review of dataset; refusal/safety examples explicitly curated |
+| Personality over-fits to teacher's style quirks | Multiple teacher passes with different decoding seeds; sample diversity |
+| Model grows too confident on niche maritime topics | Regular refresh from RAG ground truth; eval set covers the hardest 10% |
+| 4090 is unavailable / too slow | Falls back to A100 rental on RunPod (~$60-80 for 8 hours) |
+
+## Why this is research output, not a code PR today
+
+Fine-tuning is a 1-2 week focused effort with hardware dependency.
+Squeezing it into a runtime-migration session would either rush the
+dataset (bad) or block the session on hardware availability (worse).
+Document the plan so the team executes when the window opens.
+
+## Related work
+
+- `_research/unsloth/` — the cloned framework with all kernels.
+- `_research/openai-agents-python/` — reference SDK comparison.
+- `docs/runtime/PROVIDER_SEED_SUPPORT.md` (Phase 22) — provider matrix
+  including upstream-blocked items.
+- `docs/runtime/CANARY_ONBOARDING.md` (Phase 28) — when ready to
+  cut over to the fine-tuned model.
+
+## Review log
+
+| Date | Reviewer | Change |
+|------|----------|--------|
+| 2026-05-04 | runtime | v1 — initial research + plan, Phase 33f of #207 |

--- a/maritime-ai-service/tests/unit/engine/runtime/test_casual_intent.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_casual_intent.py
@@ -1,0 +1,154 @@
+"""Phase 33b casual-intent classifier — Runtime Migration #207.
+
+Locks the conservative-bias contract:
+- Greetings, acknowledgments, address-only → high confidence.
+- Questions, knowledge markers, tool intents → confidence 0 (blocked).
+- Long messages (> 80 chars) → confidence 0.
+- Empty / whitespace → confidence 0.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.engine.runtime.casual_intent import classify
+
+
+# ── empty + whitespace ──
+
+@pytest.mark.parametrize("msg", ["", "   ", "\n\t"])
+def test_empty_or_whitespace_returns_zero(msg):
+    out = classify(msg)
+    assert out.confidence == 0.0
+
+
+# ── pure address ──
+
+@pytest.mark.parametrize("msg", ["wiii", "Wiii", "WIII", "wiii ơi", "wiii à"])
+def test_pure_address_high_confidence(msg):
+    out = classify(msg)
+    assert out.confidence >= 0.90
+    assert "address" in out.reason
+
+
+# ── greetings ──
+
+@pytest.mark.parametrize("msg", [
+    "alo", "alo Wiii", "chào", "Chào Wiii", "hi", "hello", "hey",
+])
+def test_greeting_high_confidence(msg):
+    out = classify(msg)
+    assert out.confidence >= 0.85, f"{msg!r} should be high-confidence casual"
+
+
+# ── acknowledgments ──
+
+@pytest.mark.parametrize("msg", [
+    "ok", "oke", "vâng", "dạ", "ừ", "không", "không đâu", "thôi",
+    "huhu", "hihi", "haha", "wow", "tốt",
+])
+def test_acknowledgment_high_confidence(msg):
+    out = classify(msg)
+    assert out.confidence >= 0.85, f"{msg!r} should be high-confidence casual"
+
+
+# ── short multi-word with casual token ──
+
+@pytest.mark.parametrize("msg", [
+    "ok cảm ơn",
+    "không đâu nha",
+])
+def test_short_with_casual_token_medium_confidence(msg):
+    """Short multi-word with a casual marker but NOT a greeting prefix
+    — these get the medium-confidence fast-path (≥ 0.7) but stay below
+    the 0.9 hard-fast-path threshold so a borderline case can still
+    fall back to the full pipeline."""
+    out = classify(msg)
+    assert 0.7 <= out.confidence < 0.9
+
+
+def test_greeting_with_address_gets_high_confidence():
+    """'hi cậu' starts with the greeting token + space, so it's
+    treated as a full greeting (>= 0.9), not a 'short multi-word'
+    soft signal."""
+    out = classify("hi cậu")
+    assert out.confidence >= 0.9
+
+
+# ── questions BLOCK fast-path ──
+
+@pytest.mark.parametrize("msg", [
+    "Tên mình là gì?",
+    "How do I use this?",
+    "Làm sao để học COLREGs?",
+    "Giải thích Quy tắc 13",
+    "tóm tắt MARPOL",
+    "tại sao lại vậy",
+    "search Vietnamese maritime law",
+])
+def test_questions_blocked(msg):
+    out = classify(msg)
+    assert out.confidence == 0.0
+    assert "blocked" in out.reason or "no casual markers" in out.reason
+
+
+def test_question_mark_alone_blocks():
+    """Even a short message ending in '?' shouldn't fast-path —
+    user might be asking a real question with terse phrasing."""
+    out = classify("ok?")
+    assert out.confidence == 0.0
+
+
+# ── knowledge / tool markers BLOCK ──
+
+@pytest.mark.parametrize("msg", [
+    "rule 13",
+    "tìm thông tin về COLREGs",
+    "code Python để xử lý",
+    "Điều 15 SOLAS",
+])
+def test_knowledge_markers_blocked(msg):
+    out = classify(msg)
+    assert out.confidence == 0.0
+
+
+# ── long messages ──
+
+def test_long_message_blocked_even_with_casual_words():
+    """A long message with a casual prefix is NOT casual — fast-path
+    is for short utterances only."""
+    msg = "alo Wiii, " + ("nhân tiện hôm nay cậu thế nào " * 5)
+    assert len(msg) > 80
+    out = classify(msg)
+    assert out.confidence == 0.0
+    assert "too long" in out.reason
+
+
+# ── unicode / diacritic robustness ──
+
+def test_diacritics_handled_correctly():
+    out = classify("không đâu")
+    assert out.confidence >= 0.85
+    out2 = classify("khong dau")
+    assert out2.confidence >= 0.85
+
+
+# ── matched_token field ──
+
+def test_matched_token_populated_for_greetings():
+    out = classify("hi")
+    assert out.matched_token == "hi"
+
+
+def test_matched_token_none_for_blocked_messages():
+    out = classify("Giải thích cho tôi")
+    assert out.matched_token is None
+
+
+# ── reason field is informative ──
+
+def test_reason_field_present_for_every_verdict():
+    cases = ["", "alo", "wiii", "ok", "What is x?", "tìm", "x" * 100]
+    for msg in cases:
+        out = classify(msg)
+        assert out.reason  # non-empty string for every case

--- a/maritime-ai-service/tests/unit/engine/runtime/test_episodic_retrieval.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_episodic_retrieval.py
@@ -1,0 +1,248 @@
+"""Phase 33c episodic retrieval — Runtime Migration #207.
+
+Locks the contract:
+- Empty / too-short query → [] (no DB call).
+- Pool unavailable → [] (logged at debug, no raise).
+- Query SQL composition matches expected params.
+- render_for_prompt empty when no matches.
+- render_for_prompt truncates each snippet at the configured cap.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.engine.runtime.episodic_retrieval import (
+    EpisodicMatch,
+    render_for_prompt,
+    search_prior_user_turns,
+)
+
+
+# ── input-validation short-circuits ──
+
+@pytest.mark.parametrize("query", ["", "  ", "ab"])
+async def test_too_short_query_returns_empty_list_without_db(query):
+    """Tiny / blank queries must not hit the DB — they would match
+    too much and produce noise."""
+    with patch(
+        "app.core.database.get_asyncpg_pool",
+        new_callable=AsyncMock,
+    ) as pool_mock:
+        out = await search_prior_user_turns(user_id="u", query=query)
+    assert out == []
+    pool_mock.assert_not_called()
+
+
+async def test_zero_limit_returns_empty():
+    out = await search_prior_user_turns(
+        user_id="u", query="some text", limit=0
+    )
+    assert out == []
+
+
+# ── pool unavailable ──
+
+async def test_pool_unavailable_returns_empty(monkeypatch):
+    async def boom():
+        raise RuntimeError("no pool here")
+
+    monkeypatch.setattr(
+        "app.core.database.get_asyncpg_pool", boom, raising=False
+    )
+    out = await search_prior_user_turns(user_id="u", query="some text")
+    assert out == []
+
+
+# ── happy path with mocked pool ──
+
+@pytest.fixture
+def mock_pool_with_rows():
+    """Fixture: returns a pool whose .acquire() yields a connection
+    with .fetch returning canned rows. Lets us inspect the SQL + args
+    without a live Postgres."""
+    rows = [
+        {
+            "session_id": "s-1",
+            "seq": 5,
+            "event_type": "user_message",
+            "text": "Tên mình là Hùng và mình thích COLREGs",
+            "created_at": "2026-05-01T10:00:00Z",
+        },
+        {
+            "session_id": "s-2",
+            "seq": 12,
+            "event_type": "assistant_message",
+            "text": "Wiii nhớ rồi nha Hùng~",
+            "created_at": "2026-05-02T11:00:00Z",
+        },
+    ]
+
+    captured_calls: list[tuple] = []
+
+    class FakeConn:
+        async def fetch(self, sql, *args):
+            captured_calls.append((sql, args))
+            return rows
+
+    class FakePool:
+        def acquire(self):
+            outer = self
+
+            class _CtxManager:
+                async def __aenter__(self):
+                    return FakeConn()
+
+                async def __aexit__(self, *exc):
+                    return None
+
+            return _CtxManager()
+
+    return FakePool(), captured_calls
+
+
+async def test_returns_episodic_matches_with_score(monkeypatch, mock_pool_with_rows):
+    pool, _ = mock_pool_with_rows
+
+    async def get_pool():
+        return pool
+
+    monkeypatch.setattr(
+        "app.core.database.get_asyncpg_pool", get_pool, raising=False
+    )
+    out = await search_prior_user_turns(user_id="user-1", query="Hùng")
+    assert len(out) == 2
+    assert isinstance(out[0], EpisodicMatch)
+    assert out[0].session_id == "s-1"
+    assert out[0].seq == 5
+    assert out[0].event_type == "user_message"
+    # Score is bounded.
+    for m in out:
+        assert 0.0 <= m.score <= 1.0
+
+
+async def test_query_composition_includes_user_filter(
+    monkeypatch, mock_pool_with_rows
+):
+    pool, captured = mock_pool_with_rows
+
+    async def get_pool():
+        return pool
+
+    monkeypatch.setattr(
+        "app.core.database.get_asyncpg_pool", get_pool, raising=False
+    )
+    await search_prior_user_turns(user_id="user-A", query="search me")
+    sql, args = captured[0]
+    assert "session_events" in sql
+    assert "(payload->>'user_id') = $1" in sql
+    assert args[0] == "user-A"
+    assert args[1] == "%search me%"
+
+
+async def test_query_composition_excludes_current_session(
+    monkeypatch, mock_pool_with_rows
+):
+    pool, captured = mock_pool_with_rows
+
+    async def get_pool():
+        return pool
+
+    monkeypatch.setattr(
+        "app.core.database.get_asyncpg_pool", get_pool, raising=False
+    )
+    await search_prior_user_turns(
+        user_id="u", query="hello world", exclude_session_id="current-sess"
+    )
+    sql, args = captured[0]
+    assert "session_id <> $3" in sql
+    assert args[2] == "current-sess"
+
+
+async def test_query_composition_filters_by_org(
+    monkeypatch, mock_pool_with_rows
+):
+    pool, captured = mock_pool_with_rows
+
+    async def get_pool():
+        return pool
+
+    monkeypatch.setattr(
+        "app.core.database.get_asyncpg_pool", get_pool, raising=False
+    )
+    await search_prior_user_turns(
+        user_id="u", query="hello world", org_id="org-A"
+    )
+    sql, args = captured[0]
+    assert "org_id = $3" in sql
+    assert args[2] == "org-A"
+
+
+async def test_db_error_returns_empty_no_raise(monkeypatch):
+    """A DB error must NOT bubble up — episodic is best-effort."""
+
+    class FailingConn:
+        async def fetch(self, sql, *args):
+            raise RuntimeError("simulated DB outage")
+
+    class FailingPool:
+        def acquire(self):
+            class _CtxManager:
+                async def __aenter__(self):
+                    return FailingConn()
+
+                async def __aexit__(self, *exc):
+                    return None
+
+            return _CtxManager()
+
+    async def get_pool():
+        return FailingPool()
+
+    monkeypatch.setattr(
+        "app.core.database.get_asyncpg_pool", get_pool, raising=False
+    )
+    out = await search_prior_user_turns(user_id="u", query="hello")
+    assert out == []
+
+
+# ── render_for_prompt ──
+
+def test_render_for_prompt_empty_when_no_matches():
+    assert render_for_prompt([]) == ""
+
+
+def test_render_for_prompt_includes_each_match():
+    matches = [
+        EpisodicMatch(
+            session_id="s1", seq=1, event_type="user_message",
+            text="Tên mình là Hùng", created_at="t1", score=0.6,
+        ),
+        EpisodicMatch(
+            session_id="s2", seq=4, event_type="assistant_message",
+            text="Wiii nhớ rồi", created_at="t2", score=0.5,
+        ),
+    ]
+    out = render_for_prompt(matches)
+    assert "Trí nhớ từ các phiên trước" in out
+    assert "user_message" in out
+    assert "Tên mình là Hùng" in out
+    assert "assistant_message" in out
+    assert out.endswith("\n")
+
+
+def test_render_for_prompt_truncates_long_snippets():
+    long_text = "A" * 500
+    matches = [
+        EpisodicMatch(
+            session_id="s1", seq=1, event_type="user_message",
+            text=long_text, created_at="t", score=0.5,
+        )
+    ]
+    out = render_for_prompt(matches, max_chars_per_match=50)
+    # Each match line stays at or under the cap (plus the prefix).
+    snippet_line = [l for l in out.splitlines() if l.startswith("- ")][0]
+    assert len(snippet_line) < 100  # well under the cap + prefix overhead
+    assert "…" in snippet_line  # truncation marker preserved

--- a/maritime-ai-service/tests/unit/engine/runtime/test_memory_ops.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_memory_ops.py
@@ -1,0 +1,265 @@
+"""Phase 33e hierarchical memory ops — Runtime Migration #207.
+
+Locks the Letta / MemGPT self-edit contract:
+- replace overwrites + caps at max_chars
+- replace returns no_op when content unchanged
+- append concatenates with separator
+- append trims FROM THE FRONT under pressure (recent wins)
+- read returns empty string for missing blocks
+- All ops never raise — return MemoryEditResult with success=False
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.engine.runtime.memory_ops import (
+    DEFAULT_MAX_BLOCK_CHARS,
+    InMemoryCoreMemoryStore,
+    MemoryEditResult,
+    append_to_block,
+    read_block,
+    replace_block,
+)
+
+
+@pytest.fixture
+def store():
+    return InMemoryCoreMemoryStore()
+
+
+# ── replace_block ──
+
+async def test_replace_writes_new_content(store):
+    out = await replace_block(
+        store, user_id="u1", block_name="profile",
+        new_content="Tên: Hùng. Sở thích: COLREGs.",
+    )
+    assert out.success is True
+    assert out.operation == "replace"
+    assert out.new_content == "Tên: Hùng. Sở thích: COLREGs."
+
+    # Persisted.
+    assert (
+        await store.get_block(user_id="u1", block_name="profile")
+        == "Tên: Hùng. Sở thích: COLREGs."
+    )
+
+
+async def test_replace_trims_to_max_chars(store):
+    long_content = "A" * (DEFAULT_MAX_BLOCK_CHARS + 200)
+    out = await replace_block(
+        store, user_id="u1", block_name="x", new_content=long_content
+    )
+    assert out.success
+    assert len(out.new_content) <= DEFAULT_MAX_BLOCK_CHARS
+    assert out.new_content.endswith("…")
+
+
+async def test_replace_with_unchanged_content_returns_no_op(store):
+    await replace_block(
+        store, user_id="u1", block_name="b", new_content="same"
+    )
+    out = await replace_block(
+        store, user_id="u1", block_name="b", new_content="same"
+    )
+    assert out.operation == "no_op"
+    assert out.success is True
+    assert "unchanged" in (out.reason or "")
+
+
+async def test_replace_strips_whitespace(store):
+    out = await replace_block(
+        store, user_id="u1", block_name="b",
+        new_content="   trimmed   \n",
+    )
+    assert out.new_content == "trimmed"
+
+
+@pytest.mark.parametrize("user_id,block_name", [
+    ("", "block"),
+    ("user", ""),
+    ("", ""),
+])
+async def test_replace_rejects_empty_user_or_block(
+    store, user_id, block_name
+):
+    out = await replace_block(
+        store, user_id=user_id, block_name=block_name,
+        new_content="anything",
+    )
+    assert out.success is False
+    assert "required" in (out.reason or "")
+
+
+async def test_replace_returns_failure_on_store_exception():
+    class BoomStore:
+        async def get_block(self, **kw):
+            return None
+
+        async def put_block(self, **kw):
+            raise RuntimeError("disk full")
+
+    out = await replace_block(
+        BoomStore(), user_id="u", block_name="b", new_content="x"
+    )
+    assert out.success is False
+    assert out.operation == "replace"
+    assert "RuntimeError" in (out.reason or "")
+
+
+# ── append_to_block ──
+
+async def test_append_to_empty_block_writes_addition(store):
+    out = await append_to_block(
+        store, user_id="u", block_name="b", addition="first fact"
+    )
+    assert out.success
+    assert out.operation == "append"
+    assert out.new_content == "first fact"
+
+
+async def test_append_concatenates_with_separator(store):
+    await append_to_block(
+        store, user_id="u", block_name="b", addition="first"
+    )
+    out = await append_to_block(
+        store, user_id="u", block_name="b", addition="second"
+    )
+    assert out.new_content == "first\nsecond"
+
+
+async def test_append_custom_separator(store):
+    await append_to_block(
+        store, user_id="u", block_name="b", addition="a"
+    )
+    out = await append_to_block(
+        store, user_id="u", block_name="b", addition="b", separator=" | "
+    )
+    assert out.new_content == "a | b"
+
+
+async def test_append_empty_addition_no_op(store):
+    out = await append_to_block(
+        store, user_id="u", block_name="b", addition="   "
+    )
+    assert out.success is False
+    assert "empty addition" in (out.reason or "")
+
+
+async def test_append_under_pressure_trims_front(store):
+    """Recent additions must survive when the block hits the cap —
+    older content gets trimmed from the front (MemGPT pressure)."""
+    cap = 100
+    # Pre-fill with old content near the cap.
+    await replace_block(
+        store, user_id="u", block_name="b",
+        new_content="OLD_" + "x" * 90, max_chars=cap,
+    )
+    out = await append_to_block(
+        store, user_id="u", block_name="b",
+        addition="NEW_FACT_KEEP_ME", max_chars=cap,
+    )
+    assert out.success
+    assert len(out.new_content) <= cap
+    # The recent addition is in the trimmed result.
+    assert "NEW_FACT_KEEP_ME" in out.new_content
+    # Old content trimmed.
+    assert out.new_content.startswith("…")
+
+
+@pytest.mark.parametrize("user_id,block_name", [
+    ("", "b"),
+    ("u", ""),
+])
+async def test_append_rejects_empty_user_or_block(store, user_id, block_name):
+    out = await append_to_block(
+        store, user_id=user_id, block_name=block_name, addition="x"
+    )
+    assert out.success is False
+    assert "required" in (out.reason or "")
+
+
+async def test_append_returns_failure_on_store_exception():
+    class BoomStore:
+        async def get_block(self, **kw):
+            return "existing"
+
+        async def put_block(self, **kw):
+            raise RuntimeError("disk full")
+
+    out = await append_to_block(
+        BoomStore(), user_id="u", block_name="b", addition="more"
+    )
+    assert out.success is False
+    assert out.operation == "append"
+
+
+# ── read_block ──
+
+async def test_read_returns_empty_string_for_missing(store):
+    assert await read_block(store, user_id="u", block_name="missing") == ""
+
+
+async def test_read_returns_existing_content(store):
+    await replace_block(
+        store, user_id="u", block_name="b", new_content="hello"
+    )
+    assert await read_block(store, user_id="u", block_name="b") == "hello"
+
+
+@pytest.mark.parametrize("user_id,block_name", [
+    ("", "b"),
+    ("u", ""),
+])
+async def test_read_rejects_empty_user_or_block(user_id, block_name):
+    """read_block must NOT raise — returns "" instead."""
+    store = InMemoryCoreMemoryStore()
+    assert (
+        await read_block(store, user_id=user_id, block_name=block_name) == ""
+    )
+
+
+async def test_read_returns_empty_when_store_raises():
+    class BoomStore:
+        async def get_block(self, **kw):
+            raise RuntimeError("DB down")
+
+        async def put_block(self, **kw):
+            pass
+
+    assert await read_block(BoomStore(), user_id="u", block_name="b") == ""
+
+
+# ── multi-user isolation ──
+
+async def test_users_have_independent_blocks(store):
+    await replace_block(
+        store, user_id="alice", block_name="profile",
+        new_content="Alice loves COLREGs",
+    )
+    await replace_block(
+        store, user_id="bob", block_name="profile",
+        new_content="Bob loves SOLAS",
+    )
+    assert (
+        await read_block(store, user_id="alice", block_name="profile")
+        == "Alice loves COLREGs"
+    )
+    assert (
+        await read_block(store, user_id="bob", block_name="profile")
+        == "Bob loves SOLAS"
+    )
+
+
+async def test_blocks_have_independent_namespaces(store):
+    await replace_block(
+        store, user_id="u", block_name="profile", new_content="A"
+    )
+    await replace_block(
+        store, user_id="u", block_name="goals", new_content="B"
+    )
+    assert (
+        await read_block(store, user_id="u", block_name="profile") == "A"
+    )
+    assert await read_block(store, user_id="u", block_name="goals") == "B"

--- a/maritime-ai-service/tests/unit/engine/runtime/test_stream_smoother.py
+++ b/maritime-ai-service/tests/unit/engine/runtime/test_stream_smoother.py
@@ -1,0 +1,153 @@
+"""Phase 33a stream smoother — Runtime Migration #207.
+
+Locks the boundary-aware flushing contract:
+- Hard flush on .!?\\n
+- Soft flush on ,;: AFTER MIN_SOFT_FLUSH_CHARS chars buffered
+- Force flush at MAX_BUFFER_CHARS
+- Time watchdog after MAX_FLUSH_INTERVAL_MS
+- flush_remaining drains the tail at end-of-stream
+"""
+
+from __future__ import annotations
+
+import time
+
+from app.engine.runtime.stream_smoother import (
+    MAX_BUFFER_CHARS,
+    MAX_FLUSH_INTERVAL_MS,
+    MIN_SOFT_FLUSH_CHARS,
+    StreamSmoother,
+)
+
+
+def test_empty_chunk_yields_nothing():
+    s = StreamSmoother()
+    assert s.feed("") == []
+
+
+def test_period_triggers_hard_flush():
+    s = StreamSmoother()
+    out = s.feed("Hello world.")
+    assert out == ["Hello world."]
+    assert s.buffer == ""
+
+
+def test_question_mark_triggers_hard_flush():
+    s = StreamSmoother()
+    out = s.feed("How are you?")
+    assert out == ["How are you?"]
+
+
+def test_newline_triggers_hard_flush():
+    s = StreamSmoother()
+    out = s.feed("First line\nSecond line.")
+    assert out == ["First line\n", "Second line."]
+
+
+def test_comma_alone_does_not_flush_under_min_chars():
+    """A leading ", " in a short utterance must not flush — flushing
+    "I," then " think" would produce stuttering UI repaints."""
+    s = StreamSmoother()
+    out = s.feed("I,")
+    assert out == []
+    # Buffered, not flushed.
+    assert s.buffer == "I,"
+
+
+def test_comma_flushes_after_min_chars():
+    s = StreamSmoother()
+    primer = "x" * MIN_SOFT_FLUSH_CHARS  # at threshold
+    out = s.feed(primer + ",")
+    assert out == [primer + ","]
+
+
+def test_max_buffer_force_flushes_without_punctuation():
+    s = StreamSmoother()
+    long_run = "a" * (MAX_BUFFER_CHARS + 5)
+    out = s.feed(long_run)
+    # First flush at exactly MAX_BUFFER_CHARS, remainder buffered.
+    assert len(out) == 1
+    assert len(out[0]) == MAX_BUFFER_CHARS
+    assert s.buffer == "a" * 5
+
+
+def test_multiple_sentences_in_one_chunk_emit_separate_flushes():
+    s = StreamSmoother()
+    out = s.feed("Hello. World! Done?")
+    assert out == ["Hello.", " World!", " Done?"]
+    assert s.buffer == ""
+
+
+def test_flush_remaining_drains_tail():
+    s = StreamSmoother()
+    s.feed("trailing text without punctuation")
+    # Flush whatever is left.
+    tail = s.flush_remaining()
+    assert tail == "trailing text without punctuation"
+    assert s.buffer == ""
+    # Calling again is a no-op.
+    assert s.flush_remaining() == ""
+
+
+def test_watchdog_flushes_when_provider_stalls(monkeypatch):
+    """If the buffer hasn't been flushed for MAX_FLUSH_INTERVAL_MS,
+    feed() should flush even without a punctuation boundary."""
+    s = StreamSmoother()
+    # First chunk lays down some content but no flush boundary.
+    out1 = s.feed("hello")
+    assert out1 == []
+    # Fast-forward time by manipulating monkeypatch on time.monotonic.
+    real_monotonic = time.monotonic
+    fake_now = real_monotonic() + (MAX_FLUSH_INTERVAL_MS + 50) / 1000.0
+    monkeypatch.setattr(
+        "app.engine.runtime.stream_smoother.time.monotonic",
+        lambda: fake_now,
+    )
+    # Second chunk arrives long after — watchdog flushes the combined buffer.
+    out2 = s.feed(" world")
+    # The watchdog flushes everything accumulated so far.
+    assert out2 == ["hello world"]
+
+
+def test_vietnamese_punctuation_boundaries():
+    """Sanity check VN content hits the same boundaries as English."""
+    s = StreamSmoother()
+    out = s.feed("Chào cậu! Có gì để học không? Mình giúp nha.")
+    assert out == [
+        "Chào cậu!",
+        " Có gì để học không?",
+        " Mình giúp nha.",
+    ]
+
+
+def test_streaming_chunk_by_chunk_simulates_provider_burst():
+    """A realistic provider that emits 1-2 chars per chunk should
+    accumulate into clean sentence-level flushes."""
+    s = StreamSmoother()
+    chunks = ["He", "ll", "o", " w", "or", "ld", "."]
+    output: list[str] = []
+    for c in chunks:
+        output.extend(s.feed(c))
+    output.append(s.flush_remaining())
+    output = [o for o in output if o]
+    assert output == ["Hello world."]
+
+
+def test_streaming_long_paragraph_with_commas():
+    """A multi-clause Vietnamese sentence should flush on the period,
+    not on the early commas (because we're under MIN_SOFT_FLUSH_CHARS
+    when the first comma arrives)."""
+    s = StreamSmoother()
+    # First chunk: "Bạn ơi," is 8 chars before the comma — under min.
+    out = s.feed("Bạn ơi, ")
+    assert out == []
+    # Build past the soft threshold so the next comma flushes.
+    # Total buffer "Bạn ơi, mình muốn nói rằng," — comma at end after >18 chars.
+    out = s.feed("mình muốn nói rằng, hôm nay vui lắm.")
+    # Expect a soft flush at "rằng," (>= 18 chars at boundary), then a
+    # hard flush at "lắm." for the period.
+    joined = "".join(out) + s.flush_remaining()
+    assert "Bạn ơi, mình muốn nói rằng, hôm nay vui lắm." == joined
+    # And expect at least 2 flush events (we don't pin the exact split,
+    # only that boundary-driven flushing happened).
+    assert len(out) >= 2


### PR DESCRIPTION
## Summary

Six sub-phases closing the streaming UX + memory hierarchy gaps. All low-risk (primitives + docs). Commit-by-commit reviewable.

| Phase | Commit | What lands |
|-------|--------|------------|
| **33a** | \`a8cb548\` | Punctuation-aware token batching primitive (\`StreamSmoother\`) |
| **33b** | \`71cb1bb\` | Heuristic casual-intent classifier (no LLM call) |
| **33c** | \`b989c9e\` | Cross-session episodic retrieval primitive |
| **33d** | \`8e7aa44\` | Living Agent enablement guide (operational doc) |
| **33e** | \`616da58\` | Hierarchical memory ops — Letta / MemGPT self-edit primitive |
| **33f** | \`f7bbeb0\` | Unsloth fine-tune research + execution plan |

## What this enables

### Phase 33a — Stream cadence
\`StreamSmoother\` is a stateful boundary-aware accumulator. Hard flush on \`.!?\n\`, soft flush on \`,;:\` after 18 chars buffered, ceiling at 60 chars, watchdog at 200ms since last flush. Vietnamese diacritic-aware (uses ASCII boundaries which VN reuses). Wiring lands in a follow-up commit so the primitive can be reviewed on its own.

### Phase 33b — Casual fast-path
Sub-millisecond Vietnamese + English greeting / acknowledgment / filler classifier. Conservative bias — when unsure returns 0.0 so caller falls back to full pipeline. Hard blockers (\`?\`, \`giải thích\`, \`rule\`, \`tìm\`, \`code\`) prevent fast-path on real questions. Length cap at 80 chars. Integration TBD — primitive ships first.

### Phase 33c — Cross-session episodic
\`search_prior_user_turns\` queries \`session_events\` (Phase 5/10c durable log) for prior turns matching keywords, scoped to user_id + org_id, excluding current session. Best-effort — pool unavailable / DB error returns \`[]\` instead of bubbling. Today: ILIKE-based; tomorrow: pgvector embedding query (caller signature unchanged). \`render_for_prompt\` produces a Vietnamese prompt-ready block.

### Phase 33d — Living Agent enablement
Operational guide. Pre-flight checklist (Ollama install + qwen3:8b pull + reachability probe), step-by-step procedure, resource cost (~5 GB disk, ~6 GB RAM, ~96 KB/day Postgres), rollback (one flag flip), acceptance bar (1 week 0-error ticks, plausible mood drift, no proactive without human-approval gate, no TTFT impact). Pure doc; zero code change.

### Phase 33e — MemGPT self-edit
\`replace_block\` / \`append_to_block\` / \`read_block\` over a \`CoreMemoryStore\` Protocol. \`InMemoryCoreMemoryStore\` for tests. Caps at 3200 chars (= 800 tokens at chars_per_token=4). Replace returns no_op when content unchanged (saves Postgres write). Append's pressure trim drops the OLDEST bytes — recent facts win. Every op returns \`MemoryEditResult\`; never raises. Tool-definition wiring + Postgres backend deferred to focused PRs.

### Phase 33f — Unsloth plan
1-2 week plan to fine-tune a Wiii-personality 7B on Unsloth (already in \`_research/\`). Base: Qwen 2.5 7B. Dataset: ~6.5K turns from 3 sources (synthetic + domain + safety). Training: 6-8 hours on a 4090 via QLoRA. Integration: new \`wiii-local\` provider in Wiii's existing failover chain (NVIDIA NIM stays as fallback). Acceptance bar with concrete numbers. Risk register. Cost: ~$30-50 GPU + $5-10 API. Pure research doc — execution deferred to when hardware window opens.

## Test plan

- [x] \`pytest tests/unit/engine/runtime/test_stream_smoother.py\` — **13 pass**
- [x] \`pytest tests/unit/engine/runtime/test_casual_intent.py\` — **48 pass**
- [x] \`pytest tests/unit/engine/runtime/test_episodic_retrieval.py\` — **13 pass**
- [x] \`pytest tests/unit/engine/runtime/test_memory_ops.py\` — **23 pass**
- [x] **Cross-cut all 4 primitive suites: 97 tests pass**
- [x] No requirements.txt changes — pure-Python primitives
- [x] No backend regression — primitives are unwired (callers opt in via follow-up PR)

## Why primitives-first vs full integration

Each primitive is small + reviewable on its own. Wiring (chat coordinator using StreamSmoother + CasualIntent + episodic_retrieval + memory_ops + Living Agent + Unsloth model) is a separate concern that benefits from a stable underlying contract. This PR locks the contract; integration PRs follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)