### PR TITLE
ops: harden product release lane

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Use this folder for repository-level documentation that explains the product, th
 - `operations/WIII_GITHUB_GOVERNANCE.md`: GitHub issue, PR, branch, review, label, and merge standards
 - `operations/WIII_CODEX_REVIEW_SETUP.md`: Codex GitHub Review setup, rollout, operating policy, and rollback controls
 - `operations/WIII_MULTI_AGENT_MAINTAINER_PROTOCOL.md`: multi-agent ownership, maintainer review, CodeRabbit, conflict, and merge protocol
+- `operations/WIII_PRODUCT_RELEASE_RUNBOOK.md`: product release lane, pinned deploys, smoke gates, rollback, and parallel-team safety
 - `operations/WIII_SYSTEM_CLEANUP_CHECKPOINT_2026-04-24.md`: current operational cleanup checkpoint and runtime truth snapshot
 - `operations/WIII_REPOSITORY_HYGIENE_AUDIT_2026-04-24.md`: final cleanup verification, retained local artifacts, and rebuild runbook
 - `../maritime-ai-service/docs/architecture/SYSTEM_ARCHITECTURE.md`: authoritative system architecture

--- a/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
+++ b/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
@@ -1,0 +1,188 @@
+# Wiii Product Release Runbook
+
+Status: Active
+
+Owner: Project leadership
+
+Last updated: 2026-05-09
+
+Related issue: [#243](https://github.com/meiiie/wiii/issues/243)
+
+## Purpose
+
+This runbook defines the safe path for moving Wiii to production while multiple agents and teammates continue active development in parallel.
+
+The release lane is intentionally narrow:
+
+- deploy only merged `main` commits or an explicitly reviewed release SHA
+- never deploy from a dirty local checkout or a parallel-agent WIP branch
+- use prebuilt GHCR images instead of building on the production host
+- verify API, web, embed, and SSE smoke signals after rollout
+- keep rollback tied to a previous Git SHA and matching image tags
+
+## Current Production Topology
+
+Production traffic is expected to flow through:
+
+```text
+Cloudflare/DNS -> Caddy on host -> local nginx on :8080 -> app on Docker network :8000
+```
+
+Important implication: the app container is private. Health probes on the VM must use nginx-local URLs such as `http://localhost:8080/api/v1/health/live`, not `http://localhost:8000`.
+
+On 2026-05-09, a public probe showed:
+
+- `https://holilihu.online/embed/` returned `200`
+- `https://wiii.holilihu.online/api/v1/health/live` timed out
+- `https://wiii.holilihu.online/api/v1/health` timed out
+
+Treat public API health timeout as a release blocker until the deploy script, Caddy routing, nginx health, and app health all agree.
+
+## Preflight Gate
+
+Before deploying, confirm the target commit is suitable for product:
+
+```bash
+cd /path/to/wiii
+git fetch origin main
+git status --short
+git log --oneline -5 origin/main
+```
+
+GitHub gates:
+
+```bash
+gh pr list --repo meiiie/wiii --state open --limit 20
+gh run list --repo meiiie/wiii --branch main --limit 10
+gh run list --repo meiiie/wiii --workflow "Build Production Images" --branch main --limit 5
+```
+
+Required release evidence:
+
+- `Gate Summary` is green on the PR that reached `main`
+- the latest `Build Production Images` run for the target SHA succeeded
+- app and nginx images exist in GHCR
+- no unresolved P0/P1 issue blocks the release
+- production secrets are present on the VM and contain no `CHANGE_ME` placeholders
+
+Image existence check:
+
+```bash
+SHA=<target-full-sha>
+docker manifest inspect ghcr.io/meiiie/wiii-app:sha-${SHA}
+docker manifest inspect ghcr.io/meiiie/wiii-nginx:sha-${SHA}
+```
+
+Use the same SHA tag for app and nginx. Floating `:main` is acceptable only for emergency recovery or a low-risk internal deploy. Product releases should use `sha-...` tags.
+
+## Deploy
+
+SSH to the production VM:
+
+```bash
+gcloud compute ssh wiii-production --zone=asia-southeast1-b --project=valued-range-443614-j4
+```
+
+Run a pinned deploy:
+
+```bash
+cd /opt/wiii
+
+SHA=<target-full-sha>
+DEPLOY_SHA=${SHA} \
+WIII_APP_IMAGE=ghcr.io/meiiie/wiii-app:sha-${SHA} \
+WIII_NGINX_IMAGE=ghcr.io/meiiie/wiii-nginx:sha-${SHA} \
+REQUIRE_PINNED_IMAGES=true \
+RUN_EXTERNAL_SMOKE=true \
+BASE_URL=https://wiii.holilihu.online \
+  ./maritime-ai-service/scripts/deploy/deploy.sh
+```
+
+The deploy script will:
+
+- refuse dirty server checkouts
+- fail on active placeholder secrets unless explicitly overridden
+- validate the target image manifests
+- validate `docker compose` configuration with `.env.production`
+- create a pre-migration database backup when Postgres is already running
+- run migrations
+- start app and nginx
+- probe `http://localhost:8080/api/v1/health/live`, `/health`, and `/embed/`
+- optionally run external smoke through `scripts/deploy/smoke-test.sh`
+
+## Post-Deploy Smoke
+
+Run these from the VM:
+
+```bash
+cd /opt/wiii/maritime-ai-service
+bash scripts/deploy/status.sh
+API_KEY=<production-api-key> bash scripts/deploy/smoke-test.sh https://wiii.holilihu.online
+```
+
+Run these from a local machine:
+
+```bash
+curl -fsS https://wiii.holilihu.online/api/v1/health/live
+curl -fsSI https://wiii.holilihu.online/embed/
+```
+
+Minimum product smoke criteria:
+
+- public health returns `200`
+- `/embed/` returns `200` and has the expected frame policy
+- SSE V3 smoke reaches metadata and done events
+- a normal short chat returns without a long silent period
+- LMS iframe loads Wiii without cross-origin console errors beyond known sandbox limitations
+
+## Rollback
+
+Rollback uses the last known-good Git SHA and matching image tags.
+
+```bash
+cd /opt/wiii
+
+PREV_SHA=<previous-good-full-sha>
+DEPLOY_SHA=${PREV_SHA} \
+WIII_APP_IMAGE=ghcr.io/meiiie/wiii-app:sha-${PREV_SHA} \
+WIII_NGINX_IMAGE=ghcr.io/meiiie/wiii-nginx:sha-${PREV_SHA} \
+REQUIRE_PINNED_IMAGES=true \
+RUN_EXTERNAL_SMOKE=true \
+BASE_URL=https://wiii.holilihu.online \
+  ./maritime-ai-service/scripts/deploy/deploy.sh
+```
+
+If rollback follows a migration, check whether the migration is backward-compatible before restarting the previous app image. If not, restore the predeploy dump created in `maritime-ai-service/backups/` and document the recovery in the release issue.
+
+## Parallel-Team Rule
+
+Product deploys must not use:
+
+- the dirty Codex desktop workspace
+- an unmerged feature branch
+- local generated assets
+- manually edited container state
+- a PR that has required review/checks pending
+
+When multiple agents are working, create a clean worktree for release operations and keep runtime work on separate branches. The release owner should merge only narrow, reviewed PRs into `main`, then deploy from that resulting SHA.
+
+## If Public Health Still Times Out
+
+Investigate in this order:
+
+```bash
+cd /opt/wiii/maritime-ai-service
+bash scripts/deploy/status.sh
+docker compose --env-file .env.production -f docker-compose.prod.yml logs --tail 120 nginx
+docker compose --env-file .env.production -f docker-compose.prod.yml logs --tail 120 app
+sudo journalctl -u caddy --since "15 minutes ago"
+curl -v http://localhost:8080/api/v1/health/live
+curl -v http://localhost:8080/health
+curl -v https://wiii.holilihu.online/api/v1/health/live
+```
+
+Interpretation:
+
+- local nginx health fails: inspect app/nginx compose health and container logs
+- local nginx health passes but public health fails: inspect Caddy, DNS, Cloudflare, and firewall
+- health passes but chat is slow: use the runtime latency timeline and provider health probes before changing orchestration code

--- a/maritime-ai-service/scripts/deploy/README.md
+++ b/maritime-ai-service/scripts/deploy/README.md
@@ -8,6 +8,18 @@
 
 ---
 
+## Product Release Lane
+
+For product launches and release-candidate deploys, use the repository-level runbook:
+
+```text
+docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
+```
+
+That runbook is the canonical checklist for pinned-SHA deploys, GHCR image verification, smoke tests, rollback, and parallel-team safety. The short version is: deploy from a clean `main` checkout, use matching `sha-...` tags for app and nginx, and probe the app through local nginx (`http://localhost:8080`) because the app container is not exposed on the host.
+
+---
+
 ## Architecture
 
 ```

--- a/maritime-ai-service/scripts/deploy/deploy.sh
+++ b/maritime-ai-service/scripts/deploy/deploy.sh
@@ -1,34 +1,32 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # =============================================================================
-# Wiii Production Deployment Script
-# by The Wiii Lab (Hong Linh Linh Hung)
+# Wiii production deployment script
 #
-# Domain: holilihu.online
+# Safe release lane:
+#   - deploy only from a clean server checkout
+#   - optionally pin the repository with DEPLOY_SHA
+#   - pull prebuilt GHCR images
+#   - validate compose topology before rollout
+#   - create a pre-migration database backup when Postgres is already running
+#   - probe the app through local nginx, matching production topology
 #
 # Usage:
-#   cd /opt/wiii && ./maritime-ai-service/scripts/deploy/deploy.sh
+#   cd /opt/wiii
+#   DEPLOY_SHA=<full-or-short-sha> \
+#   WIII_APP_IMAGE=ghcr.io/meiiie/wiii-app:sha-<full-sha> \
+#   WIII_NGINX_IMAGE=ghcr.io/meiiie/wiii-nginx:sha-<full-sha> \
+#     ./maritime-ai-service/scripts/deploy/deploy.sh
 #
-# What this does:
-#   1. Pulls latest code from git
-#   2. Pulls production images by tag
-#   3. Starts databases, waits for health
-#   4. Runs Alembic migrations
-#   5. Starts App, waits for health
-#   6. Starts Nginx reverse proxy
-#   7. Reloads Caddy (SSL) + final health check
-#
-# First-time setup:
-#   1. Run setup-server.sh first
-#   2. Clone repo: git clone <repo-url> /opt/wiii
-#   3. Create .env.production: cp scripts/deploy/.env.production.template maritime-ai-service/.env.production
-#   4. Edit .env.production with real secrets
-#   5. Copy Caddyfile: sudo cp scripts/deploy/Caddyfile /etc/caddy/Caddyfile
-#   6. Run this script
+# Useful overrides:
+#   APP_DIR=/opt/wiii
+#   BRANCH=main
+#   ENV_FILE=.env.production
+#   REQUIRE_PINNED_IMAGES=true
+#   RUN_EXTERNAL_SMOKE=true
 # =============================================================================
 
 set -euo pipefail
 
-# Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -38,166 +36,356 @@ info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
 error() { echo -e "${RED}[ERROR]${NC} $*"; }
 
-# Configuration
-APP_DIR="/opt/wiii"
-SERVICE_DIR="${APP_DIR}/maritime-ai-service"
-COMPOSE_FILE="docker-compose.prod.yml"
-DOMAIN="${DOMAIN:-wiii.holilihu.online}"
+APP_DIR="${APP_DIR:-/opt/wiii}"
+SERVICE_DIR="${SERVICE_DIR:-${APP_DIR}/maritime-ai-service}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+ENV_FILE="${ENV_FILE:-.env.production}"
+BRANCH="${BRANCH:-main}"
+DEPLOY_SHA="${DEPLOY_SHA:-}"
+ALLOW_PLACEHOLDERS="${ALLOW_PLACEHOLDERS:-false}"
+REQUIRE_PINNED_IMAGES="${REQUIRE_PINNED_IMAGES:-false}"
+SKIP_IMAGE_MANIFEST_CHECK="${SKIP_IMAGE_MANIFEST_CHECK:-false}"
+SKIP_PREDEPLOY_BACKUP="${SKIP_PREDEPLOY_BACKUP:-false}"
+RUN_EXTERNAL_SMOKE="${RUN_EXTERNAL_SMOKE:-false}"
 
-echo ""
-echo "============================================="
-echo "   Wiii Production Deploy"
-echo "   $(date '+%Y-%m-%d %H:%M:%S')"
-echo "============================================="
-echo ""
+case "$ENV_FILE" in
+    /*)
+        ENV_PATH="$ENV_FILE"
+        ENV_ARG="$ENV_FILE"
+        ;;
+    *)
+        ENV_PATH="${SERVICE_DIR}/${ENV_FILE}"
+        ENV_ARG="$ENV_FILE"
+        ;;
+esac
 
-# ─────────────────────────────────────────────────
-# Pre-checks
-# ─────────────────────────────────────────────────
-if [ ! -d "$SERVICE_DIR" ]; then
-    error "Service directory not found: $SERVICE_DIR"
-    error "Clone the repo first: git clone <repo-url> $APP_DIR"
-    exit 1
-fi
+env_value() {
+    local key="$1"
+    awk -v key="$key" '
+        BEGIN { FS = "="; found = 0 }
+        $0 !~ /^[[:space:]]*#/ && $1 == key {
+            sub(/^[^=]*=/, "")
+            print
+            found = 1
+        }
+        END { exit found ? 0 : 1 }
+    ' "$ENV_PATH" | tail -n 1
+}
 
-if [ ! -f "$SERVICE_DIR/.env.production" ]; then
-    error "Missing .env.production!"
-    error "Copy and edit the template:"
-    error "  cp $SERVICE_DIR/scripts/deploy/.env.production.template $SERVICE_DIR/.env.production"
-    exit 1
-fi
+clean_value() {
+    local value="${1:-}"
+    value="${value%$'\r'}"
+    value="${value#\"}"
+    value="${value%\"}"
+    value="${value#\'}"
+    value="${value%\'}"
+    printf '%s' "$value"
+}
 
-if ! grep -q "^WIII_APP_IMAGE=" "$SERVICE_DIR/.env.production"; then
-    error "Missing WIII_APP_IMAGE in .env.production"
-    exit 1
-fi
+compose() {
+    (cd "$SERVICE_DIR" && docker compose --env-file "$ENV_ARG" -f "$COMPOSE_FILE" "$@")
+}
 
-if ! grep -q "^WIII_NGINX_IMAGE=" "$SERVICE_DIR/.env.production"; then
-    error "Missing WIII_NGINX_IMAGE in .env.production"
-    exit 1
-fi
-
-# Check for CHANGE_ME placeholder values
-if grep -q "CHANGE_ME" "$SERVICE_DIR/.env.production"; then
-    warn "Found CHANGE_ME placeholders in .env.production!"
-    warn "Update ALL secrets before deploying to production."
-    echo ""
-    grep "CHANGE_ME" "$SERVICE_DIR/.env.production" | head -5
-    echo ""
-    read -p "Continue anyway? (y/N) " -n 1 -r
-    echo ""
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+require_command() {
+    local name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        error "Required command not found: $name"
         exit 1
     fi
-fi
+}
 
-# ─────────────────────────────────────────────────
-# Step 1: Pull latest code
-# ─────────────────────────────────────────────────
-info "Step 1/7: Pulling latest code..."
-cd "$APP_DIR"
-git pull origin main
-
-# ─────────────────────────────────────────────────
-# Step 2: Pull Docker images
-# ─────────────────────────────────────────────────
-info "Step 2/7: Pulling Docker images..."
-cd "$SERVICE_DIR"
-docker compose -f "$COMPOSE_FILE" pull app nginx
-
-# ─────────────────────────────────────────────────
-# Step 3: Start database services first
-# ─────────────────────────────────────────────────
-info "Step 3/7: Starting database services..."
-docker compose -f "$COMPOSE_FILE" up -d postgres minio minio-init valkey
-
-# Wait for databases to be healthy
-info "Waiting for databases to be ready..."
-TIMEOUT=60
-ELAPSED=0
-while ! docker compose -f "$COMPOSE_FILE" ps postgres | grep -q "healthy"; do
-    sleep 2
-    ELAPSED=$((ELAPSED + 2))
-    if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
-        error "PostgreSQL did not become healthy within ${TIMEOUT}s"
-        docker compose -f "$COMPOSE_FILE" logs postgres --tail 20
+require_clean_checkout() {
+    cd "$APP_DIR"
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        error "$APP_DIR is not a git checkout."
         exit 1
     fi
-done
-info "PostgreSQL is healthy."
 
-# ─────────────────────────────────────────────────
-# Step 4: Run database migrations
-# ─────────────────────────────────────────────────
-info "Step 4/7: Running Alembic migrations..."
-docker compose -f "$COMPOSE_FILE" run --rm app alembic upgrade head
-info "Migrations complete."
-
-# ─────────────────────────────────────────────────
-# Step 5: Start/restart app
-# ─────────────────────────────────────────────────
-info "Step 5/7: Starting application..."
-docker compose -f "$COMPOSE_FILE" up -d app
-
-# Wait for app to be healthy before starting Nginx
-info "Waiting for app health check..."
-TIMEOUT=90
-ELAPSED=0
-while ! docker compose -f "$COMPOSE_FILE" ps app | grep -q "healthy"; do
-    sleep 3
-    ELAPSED=$((ELAPSED + 3))
-    if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
-        error "App did not become healthy within ${TIMEOUT}s"
-        docker compose -f "$COMPOSE_FILE" logs app --tail 50
+    local dirty
+    dirty="$(git status --porcelain=v1)"
+    if [ -n "$dirty" ]; then
+        error "Server checkout has local changes. Refusing to deploy from a dirty tree."
+        echo "$dirty"
+        echo ""
+        error "Commit, stash, or move local work before deploying. Do not deploy parallel-agent WIP."
         exit 1
     fi
-    echo -n "."
-done
-echo ""
-info "App is healthy."
+}
 
-# ─────────────────────────────────────────────────
-# Step 6: Start/restart Nginx
-# ─────────────────────────────────────────────────
-info "Step 6/7: Starting Nginx reverse proxy..."
-docker compose -f "$COMPOSE_FILE" up -d nginx
+validate_environment() {
+    if [ ! -d "$SERVICE_DIR" ]; then
+        error "Service directory not found: $SERVICE_DIR"
+        exit 1
+    fi
 
-# ─────────────────────────────────────────────────
-# Step 7: Reload Caddy + final health check
-# ─────────────────────────────────────────────────
-info "Step 7/7: Reloading Caddy (SSL)..."
-sudo systemctl reload caddy 2>/dev/null || warn "Caddy reload failed (may not be configured yet)"
+    if [ ! -f "$ENV_PATH" ]; then
+        error "Missing production env file: $ENV_PATH"
+        error "Create it from scripts/deploy/.env.production.template and replace all secrets."
+        exit 1
+    fi
 
-# Final health check via localhost
-sleep 3
-if curl -sf "http://localhost:8000/api/v1/health/live" > /dev/null 2>&1; then
-    info "Health check passed! (localhost:8000)"
-else
-    warn "Direct health check failed — app may still be starting"
-fi
+    local required_keys=(
+        WIII_APP_IMAGE
+        WIII_NGINX_IMAGE
+        POSTGRES_PASSWORD
+        MINIO_SECRET_KEY
+        API_KEY
+        JWT_SECRET_KEY
+        SESSION_SECRET_KEY
+    )
 
-if curl -sf "http://localhost:${NGINX_HTTP_PORT:-8080}/embed/" > /dev/null 2>&1; then
-    info "Embed health check passed! (/embed/)"
-else
-    warn "Embed health check failed — check nginx logs if this was an embed-related deploy"
-fi
+    local key
+    for key in "${required_keys[@]}"; do
+        if ! grep -Eq "^${key}=.+" "$ENV_PATH"; then
+            error "Missing required production env value: $key"
+            exit 1
+        fi
+    done
 
-# ─────────────────────────────────────────────────
-# Summary
-# ─────────────────────────────────────────────────
-echo ""
-echo "============================================="
-info "Deployment successful!"
-echo "============================================="
-echo ""
-echo "  URL:      https://${DOMAIN}"
-echo "  API:      https://${DOMAIN}/api/v1/health/live"
-echo "  API Docs: https://${DOMAIN}/docs"
-echo ""
-echo "Useful commands:"
-echo "  docker compose -f $COMPOSE_FILE ps              # Service status"
-echo "  docker compose -f $COMPOSE_FILE logs -f app     # App logs"
-echo "  docker compose -f $COMPOSE_FILE logs -f nginx   # Nginx logs"
-echo "  docker compose -f $COMPOSE_FILE restart app     # Restart app"
-echo "  sudo journalctl -u caddy -f                     # Caddy SSL logs"
-echo ""
+    local placeholders
+    placeholders="$(grep -nE '^[A-Za-z0-9_]+=.*(CHANGE_ME|your_)' "$ENV_PATH" || true)"
+    if [ -n "$placeholders" ] && [ "$ALLOW_PLACEHOLDERS" != "true" ]; then
+        error "Production env still contains placeholder values."
+        echo "$placeholders" | head -20
+        echo ""
+        error "Set ALLOW_PLACEHOLDERS=true only for a non-production dry run."
+        exit 1
+    fi
+}
+
+sync_release_code() {
+    info "Step 1/9: Syncing release code..."
+    require_clean_checkout
+
+    cd "$APP_DIR"
+    git fetch --tags --prune origin "$BRANCH"
+
+    if [ -n "$DEPLOY_SHA" ]; then
+        git cat-file -e "${DEPLOY_SHA}^{commit}" 2>/dev/null || {
+            error "DEPLOY_SHA is not present after fetch: $DEPLOY_SHA"
+            exit 1
+        }
+        git checkout --detach "$DEPLOY_SHA"
+    else
+        if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+            git checkout "$BRANCH"
+        else
+            git checkout -b "$BRANCH" "origin/${BRANCH}"
+        fi
+        git pull --ff-only origin "$BRANCH"
+    fi
+
+    require_clean_checkout
+    DEPLOYED_SHA="$(git rev-parse --short=12 HEAD)"
+    info "Release checkout: ${DEPLOYED_SHA}"
+}
+
+validate_images() {
+    info "Step 2/9: Validating image tags..."
+
+    APP_IMAGE="$(clean_value "${WIII_APP_IMAGE:-$(env_value WIII_APP_IMAGE || true)}")"
+    NGINX_IMAGE="$(clean_value "${WIII_NGINX_IMAGE:-$(env_value WIII_NGINX_IMAGE || true)}")"
+
+    if [ -z "$APP_IMAGE" ] || [ -z "$NGINX_IMAGE" ]; then
+        error "WIII_APP_IMAGE and WIII_NGINX_IMAGE must be set."
+        exit 1
+    fi
+
+    if [[ "$APP_IMAGE" == *":main" || "$NGINX_IMAGE" == *":main" ]]; then
+        if [ "$REQUIRE_PINNED_IMAGES" = "true" ]; then
+            error "Floating :main image tags are blocked by REQUIRE_PINNED_IMAGES=true."
+            error "Use matching sha-<commit> tags for app and nginx."
+            exit 1
+        fi
+        warn "Using floating :main image tags. Prefer sha-<commit> tags for product releases."
+    fi
+
+    if [ "$SKIP_IMAGE_MANIFEST_CHECK" != "true" ]; then
+        docker manifest inspect "$APP_IMAGE" >/dev/null
+        docker manifest inspect "$NGINX_IMAGE" >/dev/null
+    else
+        warn "Skipping docker manifest validation."
+    fi
+
+    info "App image:   ${APP_IMAGE}"
+    info "Nginx image: ${NGINX_IMAGE}"
+}
+
+validate_compose_config() {
+    info "Step 3/9: Validating docker compose configuration..."
+    compose config --quiet
+}
+
+pull_images() {
+    info "Step 4/9: Pulling production images..."
+    compose pull app nginx
+}
+
+wait_for_health() {
+    local service="$1"
+    local timeout="$2"
+    local interval="${3:-3}"
+    local elapsed=0
+    local statuses=""
+
+    while true; do
+        statuses="$(compose ps --format '{{.Status}}' "$service" 2>/dev/null || true)"
+        if [ -n "$statuses" ] &&
+            printf '%s\n' "$statuses" | grep -qi "healthy" &&
+            ! printf '%s\n' "$statuses" | grep -Eiq "unhealthy|starting"; then
+            info "${service} is healthy."
+            return 0
+        fi
+
+        if [ "$elapsed" -ge "$timeout" ]; then
+            error "${service} did not become healthy within ${timeout}s"
+            compose logs "$service" --tail 80 || true
+            exit 1
+        fi
+
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+        echo -n "."
+    done
+}
+
+start_data_services() {
+    info "Step 5/9: Starting data services..."
+    compose up -d postgres minio minio-init valkey
+    info "Waiting for PostgreSQL..."
+    wait_for_health postgres 90 3
+}
+
+create_predeploy_backup() {
+    info "Step 6/9: Creating pre-deploy database backup..."
+
+    if [ "$SKIP_PREDEPLOY_BACKUP" = "true" ]; then
+        warn "Skipping pre-deploy backup because SKIP_PREDEPLOY_BACKUP=true."
+        return 0
+    fi
+
+    if ! compose ps --services --status running | grep -qx "postgres"; then
+        warn "PostgreSQL is not running yet; assuming first deploy and skipping backup."
+        return 0
+    fi
+
+    mkdir -p "${SERVICE_DIR}/backups"
+    local backup_name="predeploy_${DEPLOYED_SHA:-unknown}_$(date -u +%Y%m%d_%H%M%S).dump"
+    local backup_path="${SERVICE_DIR}/backups/${backup_name}"
+
+    compose exec -T postgres sh -c \
+        'PGPASSWORD="$POSTGRES_PASSWORD" pg_dump -U "${POSTGRES_USER:-wiii}" -d "${POSTGRES_DB:-wiii_ai}" --format=custom --compress=6 --no-owner' \
+        > "$backup_path"
+
+    if [ ! -s "$backup_path" ]; then
+        error "Pre-deploy backup was not created: $backup_path"
+        exit 1
+    fi
+
+    info "Backup created: ${backup_path}"
+}
+
+run_migrations() {
+    info "Step 7/9: Running Alembic migrations..."
+    compose run --rm app alembic upgrade head
+    info "Migrations complete."
+}
+
+start_runtime() {
+    info "Step 8/9: Starting application and nginx..."
+    compose up -d app
+    wait_for_health app 150 3
+
+    compose up -d nginx pg-backup
+    wait_for_health nginx 60 3
+}
+
+reload_caddy() {
+    if command -v systemctl >/dev/null 2>&1; then
+        sudo systemctl reload caddy 2>/dev/null || warn "Caddy reload failed or Caddy is not configured yet."
+    else
+        warn "systemctl is unavailable; skipping Caddy reload."
+    fi
+}
+
+run_final_smoke() {
+    info "Step 9/9: Running local release smoke checks..."
+
+    local nginx_port
+    nginx_port="$(clean_value "${NGINX_HTTP_PORT:-$(env_value NGINX_HTTP_PORT || true)}")"
+    nginx_port="${nginx_port:-8080}"
+    NGINX_LOCAL_URL="${NGINX_LOCAL_URL:-http://localhost:${nginx_port}}"
+
+    curl -fsS --max-time 15 "${NGINX_LOCAL_URL}/api/v1/health/live" >/dev/null
+    curl -fsS --max-time 15 "${NGINX_LOCAL_URL}/health" >/dev/null
+    curl -fsS --max-time 15 "${NGINX_LOCAL_URL}/embed/" >/dev/null
+
+    info "Local nginx smoke passed: ${NGINX_LOCAL_URL}"
+
+    if [ "$RUN_EXTERNAL_SMOKE" = "true" ]; then
+        local domain
+        local base_url
+        local smoke_api_key
+        domain="$(clean_value "${DOMAIN:-$(env_value DOMAIN || true)}")"
+        domain="${domain:-wiii.holilihu.online}"
+        base_url="${BASE_URL:-https://${domain}}"
+        smoke_api_key="${EXTERNAL_SMOKE_API_KEY:-$(clean_value "$(env_value API_KEY || true)")}"
+
+        info "Running external smoke against ${base_url}"
+        API_KEY="$smoke_api_key" bash "${SERVICE_DIR}/scripts/deploy/smoke-test.sh" "$base_url"
+    else
+        info "External smoke skipped. Run with RUN_EXTERNAL_SMOKE=true after DNS/CDN is ready."
+    fi
+}
+
+print_summary() {
+    local domain
+    domain="$(clean_value "${DOMAIN:-$(env_value DOMAIN || true)}")"
+    domain="${domain:-wiii.holilihu.online}"
+
+    echo ""
+    echo "============================================="
+    info "Deployment completed"
+    echo "============================================="
+    echo ""
+    echo "  Commit:      ${DEPLOYED_SHA:-unknown}"
+    echo "  App image:   ${APP_IMAGE:-unknown}"
+    echo "  Nginx image: ${NGINX_IMAGE:-unknown}"
+    echo "  URL:         https://${domain}"
+    echo "  Health:      https://${domain}/api/v1/health/live"
+    echo ""
+    echo "Useful commands:"
+    echo "  cd ${SERVICE_DIR}"
+    echo "  docker compose --env-file ${ENV_ARG} -f ${COMPOSE_FILE} ps"
+    echo "  docker compose --env-file ${ENV_ARG} -f ${COMPOSE_FILE} logs -f app"
+    echo "  bash scripts/deploy/status.sh"
+    echo ""
+}
+
+main() {
+    echo ""
+    echo "============================================="
+    echo "   Wiii Production Deploy"
+    echo "   $(date '+%Y-%m-%d %H:%M:%S %Z')"
+    echo "============================================="
+    echo ""
+
+    require_command git
+    require_command docker
+    require_command curl
+
+    validate_environment
+    sync_release_code
+    validate_images
+    validate_compose_config
+    pull_images
+    start_data_services
+    create_predeploy_backup
+    run_migrations
+    start_runtime
+    reload_caddy
+    run_final_smoke
+    print_summary
+}
+
+main "$@"

--- a/maritime-ai-service/scripts/deploy/health-check.sh
+++ b/maritime-ai-service/scripts/deploy/health-check.sh
@@ -1,50 +1,78 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # =============================================================================
-# Wiii Production Health Check — External Monitoring
-# by The Wiii Lab (Hong Linh Linh Hung)
+# Wiii production health check
 #
-# Usage:
-#   ./health-check.sh                  # Manual check
-#   crontab: */2 * * * * /opt/wiii/maritime-ai-service/scripts/deploy/health-check.sh
-#   (Every 2 minutes)
-#
-# What this does:
-#   1. Checks API health endpoint
-#   2. Checks required Docker services are running and no containers are unhealthy
-#   3. Checks disk usage (alert if >85%)
-#   4. Checks available memory (alert if <256MB)
-#   5. Sends Discord/Telegram alert on failure (with deduplication)
-#   6. Sends recovery notification when issues resolve
+# This script is meant for cron/systemd monitoring on the production VM.
+# It probes the public-facing app through local nginx, not localhost:8000,
+# because the app container is intentionally private on the Docker network.
 # =============================================================================
 
 set -euo pipefail
 
-# Configuration
-DOMAIN="${WIII_DOMAIN:-holilihu.online}"
-COMPOSE_FILE="/opt/wiii/maritime-ai-service/docker-compose.prod.yml"
-ALERT_FILE="/tmp/wiii_alert_sent"
-LOG_FILE="/var/log/wiii-health.log"
+SERVICE_DIR="${SERVICE_DIR:-/opt/wiii/maritime-ai-service}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+ENV_FILE="${ENV_FILE:-.env.production}"
+ALERT_FILE="${ALERT_FILE:-/tmp/wiii_alert_sent}"
+LOG_FILE="${LOG_FILE:-/var/log/wiii-health.log}"
 REQUIRED_SERVICES=(postgres minio valkey app nginx pg-backup)
 
-# Alert webhook (set in environment or .env)
-# Discord: DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
-# Telegram: TELEGRAM_BOT_TOKEN=... TELEGRAM_CHAT_ID=...
+case "$ENV_FILE" in
+    /*)
+        ENV_PATH="$ENV_FILE"
+        ENV_ARG="$ENV_FILE"
+        ;;
+    *)
+        ENV_PATH="${SERVICE_DIR}/${ENV_FILE}"
+        ENV_ARG="$ENV_FILE"
+        ;;
+esac
+
+env_value() {
+    local key="$1"
+    [ -f "$ENV_PATH" ] || return 1
+    awk -v key="$key" '
+        BEGIN { FS = "="; found = 0 }
+        $0 !~ /^[[:space:]]*#/ && $1 == key {
+            sub(/^[^=]*=/, "")
+            print
+            found = 1
+        }
+        END { exit found ? 0 : 1 }
+    ' "$ENV_PATH" | tail -n 1
+}
+
+clean_value() {
+    local value="${1:-}"
+    value="${value%$'\r'}"
+    value="${value#\"}"
+    value="${value%\"}"
+    value="${value#\'}"
+    value="${value%\'}"
+    printf '%s' "$value"
+}
+
+compose() {
+    (cd "$SERVICE_DIR" && docker compose --env-file "$ENV_ARG" -f "$COMPOSE_FILE" "$@")
+}
+
+NGINX_HTTP_PORT="$(clean_value "${NGINX_HTTP_PORT:-$(env_value NGINX_HTTP_PORT || true)}")"
+NGINX_HTTP_PORT="${NGINX_HTTP_PORT:-8080}"
+NGINX_LOCAL_URL="${NGINX_LOCAL_URL:-http://localhost:${NGINX_HTTP_PORT}}"
+DOMAIN="$(clean_value "${WIII_DOMAIN:-${DOMAIN:-$(env_value DOMAIN || true)}}")"
+DOMAIN="${DOMAIN:-wiii.holilihu.online}"
+
 DISCORD_WEBHOOK_URL="${DISCORD_WEBHOOK_URL:-}"
 TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
 TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:-}"
-
-# ─────────────────────────────────────────────────
-# Check functions
-# ─────────────────────────────────────────────────
 
 check_api() {
     local response_code
     response_code=$(curl -s -o /dev/null -w "%{http_code}" \
         --max-time 10 --connect-timeout 5 \
-        "http://localhost:8000/api/v1/health/live") || response_code=0
+        "${NGINX_LOCAL_URL}/api/v1/health/live") || response_code=0
 
     if [ "$response_code" != "200" ]; then
-        echo "API health returned ${response_code} (expected 200)"
+        echo "API health via nginx returned ${response_code} (expected 200)"
         return 1
     fi
     return 0
@@ -54,7 +82,7 @@ check_nginx() {
     local response_code
     response_code=$(curl -s -o /dev/null -w "%{http_code}" \
         --max-time 5 --connect-timeout 3 \
-        "http://localhost:80/health") || response_code=0
+        "${NGINX_LOCAL_URL}/health") || response_code=0
 
     if [ "$response_code" != "200" ]; then
         echo "Nginx health returned ${response_code}"
@@ -69,7 +97,7 @@ check_containers() {
     local missing_services=""
     local service
 
-    running_services=$(docker compose -f "$COMPOSE_FILE" ps --services --status running 2>/dev/null || echo "")
+    running_services=$(compose ps --services --status running 2>/dev/null || echo "")
     for service in "${REQUIRED_SERVICES[@]}"; do
         if ! printf '%s\n' "$running_services" | grep -qx "$service"; then
             missing_services="${missing_services}${service} "
@@ -116,40 +144,31 @@ check_memory() {
     return 0
 }
 
-# ─────────────────────────────────────────────────
-# Alert functions
-# ─────────────────────────────────────────────────
-
 send_alert() {
-    local message=$1
-    local is_recovery=${2:-false}
-    local emoji="🚨"
+    local message="$1"
+    local is_recovery="${2:-false}"
+    local marker="[ALERT]"
     local title="Wiii Production Alert"
 
     if [ "$is_recovery" = "true" ]; then
-        emoji="✅"
+        marker="[RECOVERED]"
         title="Wiii Production Recovered"
     fi
 
-    # Discord webhook
     if [ -n "$DISCORD_WEBHOOK_URL" ]; then
         curl -s -H "Content-Type: application/json" \
-            -d "{\"content\":\"${emoji} **${title}**\n${message}\nTime: $(date -Iseconds)\nDomain: ${DOMAIN}\"}" \
-            "$DISCORD_WEBHOOK_URL" > /dev/null 2>&1 || true
+            -d "{\"content\":\"${marker} **${title}**\n${message}\nTime: $(date -Iseconds)\nDomain: ${DOMAIN}\"}" \
+            "$DISCORD_WEBHOOK_URL" >/dev/null 2>&1 || true
     fi
 
-    # Telegram bot
     if [ -n "$TELEGRAM_BOT_TOKEN" ] && [ -n "$TELEGRAM_CHAT_ID" ]; then
         curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -d "chat_id=${TELEGRAM_CHAT_ID}" \
-            -d "text=${emoji} ${title}%0A${message}%0ATime: $(date -Iseconds)" \
-            -d "parse_mode=HTML" > /dev/null 2>&1 || true
+            -d "text=${marker} ${title}%0A${message}%0ATime: $(date -Iseconds)" \
+            -d "parse_mode=HTML" >/dev/null 2>&1 || true
     fi
 }
 
-# ─────────────────────────────────────────────────
-# Run all checks
-# ─────────────────────────────────────────────────
 ERRORS=""
 
 api_err=$(check_api 2>&1) || ERRORS+="${api_err}. "
@@ -158,20 +177,19 @@ container_err=$(check_containers 2>&1) || ERRORS+="${container_err}. "
 disk_err=$(check_disk 2>&1) || ERRORS+="${disk_err}. "
 memory_err=$(check_memory 2>&1) || ERRORS+="${memory_err}. "
 
-# ─────────────────────────────────────────────────
-# Handle results
-# ─────────────────────────────────────────────────
 if [ -n "$ERRORS" ]; then
-    # Alert (with 30-minute deduplication)
     if [ ! -f "$ALERT_FILE" ] || [ $(( $(date +%s) - $(stat -c %Y "$ALERT_FILE" 2>/dev/null || echo 0) )) -gt 1800 ]; then
         send_alert "$ERRORS"
         touch "$ALERT_FILE"
     fi
     echo "[$(date)] ALERT: ${ERRORS}" >> "$LOG_FILE" 2>/dev/null || true
-else
-    # Recovery notification
-    if [ -f "$ALERT_FILE" ]; then
-        send_alert "All checks passing." "true"
-        rm -f "$ALERT_FILE"
-    fi
+    echo "$ERRORS"
+    exit 1
 fi
+
+if [ -f "$ALERT_FILE" ]; then
+    send_alert "All checks passing." "true"
+    rm -f "$ALERT_FILE"
+fi
+
+echo "Wiii production health OK via ${NGINX_LOCAL_URL}"

--- a/maritime-ai-service/scripts/deploy/status.sh
+++ b/maritime-ai-service/scripts/deploy/status.sh
@@ -1,23 +1,69 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # =============================================================================
-# Wiii Production Status Dashboard
-# by The Wiii Lab (Hong Linh Linh Hung)
-#
-# Usage: ./status.sh
-# Shows: container status, resource usage, disk, DB stats, uptime
+# Wiii production status dashboard
 # =============================================================================
 
 set -euo pipefail
 
-SERVICE_DIR="/opt/wiii/maritime-ai-service"
-COMPOSE_FILE="docker-compose.prod.yml"
+SERVICE_DIR="${SERVICE_DIR:-/opt/wiii/maritime-ai-service}"
+APP_DIR="${APP_DIR:-$(dirname "$SERVICE_DIR")}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
+ENV_FILE="${ENV_FILE:-.env.production}"
 
-# Colors
+case "$ENV_FILE" in
+    /*)
+        ENV_PATH="$ENV_FILE"
+        ENV_ARG="$ENV_FILE"
+        ;;
+    *)
+        ENV_PATH="${SERVICE_DIR}/${ENV_FILE}"
+        ENV_ARG="$ENV_FILE"
+        ;;
+esac
+
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
 BLUE='\033[0;34m'
 NC='\033[0m'
+
+env_value() {
+    local key="$1"
+    [ -f "$ENV_PATH" ] || return 1
+    awk -v key="$key" '
+        BEGIN { FS = "="; found = 0 }
+        $0 !~ /^[[:space:]]*#/ && $1 == key {
+            sub(/^[^=]*=/, "")
+            print
+            found = 1
+        }
+        END { exit found ? 0 : 1 }
+    ' "$ENV_PATH" | tail -n 1
+}
+
+clean_value() {
+    local value="${1:-}"
+    value="${value%$'\r'}"
+    value="${value#\"}"
+    value="${value%\"}"
+    value="${value#\'}"
+    value="${value%\'}"
+    printf '%s' "$value"
+}
+
+compose() {
+    (cd "$SERVICE_DIR" && docker compose --env-file "$ENV_ARG" -f "$COMPOSE_FILE" "$@")
+}
+
+NGINX_HTTP_PORT="$(clean_value "${NGINX_HTTP_PORT:-$(env_value NGINX_HTTP_PORT || true)}")"
+NGINX_HTTP_PORT="${NGINX_HTTP_PORT:-8080}"
+NGINX_LOCAL_URL="${NGINX_LOCAL_URL:-http://localhost:${NGINX_HTTP_PORT}}"
+POSTGRES_USER_VALUE="$(clean_value "${POSTGRES_USER:-$(env_value POSTGRES_USER || true)}")"
+POSTGRES_USER_VALUE="${POSTGRES_USER_VALUE:-wiii}"
+POSTGRES_DB_VALUE="$(clean_value "${POSTGRES_DB:-$(env_value POSTGRES_DB || true)}")"
+POSTGRES_DB_VALUE="${POSTGRES_DB_VALUE:-wiii_ai}"
+APP_IMAGE="$(clean_value "${WIII_APP_IMAGE:-$(env_value WIII_APP_IMAGE || true)}")"
+NGINX_IMAGE="$(clean_value "${WIII_NGINX_IMAGE:-$(env_value WIII_NGINX_IMAGE || true)}")"
 
 echo ""
 echo -e "${BLUE}============================================="
@@ -25,82 +71,82 @@ echo "   Wiii Production Dashboard"
 echo "   $(date '+%Y-%m-%d %H:%M:%S %Z')"
 echo -e "=============================================${NC}"
 
-# ─────────────────────────────────────────────────
-# Container Status
-# ─────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}--- Release ---${NC}"
+if git -C "$APP_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "  Git commit:  $(git -C "$APP_DIR" rev-parse --short=12 HEAD)"
+    echo "  Git branch:  $(git -C "$APP_DIR" branch --show-current 2>/dev/null || echo detached)"
+else
+    echo -e "  Git:         ${YELLOW}not available${NC}"
+fi
+echo "  App image:   ${APP_IMAGE:-unknown}"
+echo "  Nginx image: ${NGINX_IMAGE:-unknown}"
+echo "  Local URL:   ${NGINX_LOCAL_URL}"
+
 echo ""
 echo -e "${GREEN}--- Container Status ---${NC}"
-cd "$SERVICE_DIR"
-docker compose -f "$COMPOSE_FILE" ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || echo "Docker compose not running"
+compose ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || echo "Docker compose not running"
 
-# ─────────────────────────────────────────────────
-# Resource Usage
-# ─────────────────────────────────────────────────
 echo ""
 echo -e "${GREEN}--- Resource Usage ---${NC}"
 docker stats --no-stream --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.NetIO}}" 2>/dev/null || echo "No running containers"
 
-# ─────────────────────────────────────────────────
-# System Resources
-# ─────────────────────────────────────────────────
 echo ""
 echo -e "${GREEN}--- System ---${NC}"
 echo "  Uptime:  $(uptime -p 2>/dev/null || uptime)"
-echo "  RAM:     $(free -h | awk 'NR==2 {printf "%s used / %s total (%s free)", $3, $2, $7}')"
-echo "  Swap:    $(free -h | awk 'NR==3 {printf "%s used / %s total", $3, $2}')"
-echo "  Disk:    $(df -h / | awk 'NR==2 {printf "%s used / %s total (%s free, %s)", $3, $2, $4, $5}')"
+echo "  RAM:     $(free -h | awk 'NR==2 {printf \"%s used / %s total (%s free)\", $3, $2, $7}')"
+echo "  Swap:    $(free -h | awk 'NR==3 {printf \"%s used / %s total\", $3, $2}')"
+echo "  Disk:    $(df -h / | awk 'NR==2 {printf \"%s used / %s total (%s free, %s)\", $3, $2, $4, $5}')"
 
-# ─────────────────────────────────────────────────
-# PostgreSQL
-# ─────────────────────────────────────────────────
 echo ""
 echo -e "${GREEN}--- PostgreSQL ---${NC}"
-docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U wiii -d wiii_ai -t -c \
+compose exec -T postgres psql -U "$POSTGRES_USER_VALUE" -d "$POSTGRES_DB_VALUE" -t -c \
     "SELECT 'Active connections: ' || count(*) FROM pg_stat_activity WHERE state = 'active';" 2>/dev/null || echo "  PostgreSQL not reachable"
-docker compose -f "$COMPOSE_FILE" exec -T postgres psql -U wiii -d wiii_ai -t -c \
-    "SELECT 'Database size: ' || pg_size_pretty(pg_database_size('wiii_ai'));" 2>/dev/null || true
+compose exec -T postgres psql -U "$POSTGRES_USER_VALUE" -d "$POSTGRES_DB_VALUE" -t -c \
+    "SELECT 'Database size: ' || pg_size_pretty(pg_database_size('${POSTGRES_DB_VALUE}'));" 2>/dev/null || true
 
-# ─────────────────────────────────────────────────
-# Backups
-# ─────────────────────────────────────────────────
 echo ""
 echo -e "${GREEN}--- Backups ---${NC}"
-BACKUP_COUNT=$(find /opt/wiii/backups -name "wiii_ai_*.dump" 2>/dev/null | wc -l)
-LATEST_BACKUP=$(ls -t /opt/wiii/backups/wiii_ai_*.dump 2>/dev/null | head -1 || echo "none")
+BACKUP_COUNT=$(find "${SERVICE_DIR}/backups" -name "wiii_ai_*.dump" -o -name "predeploy_*.dump" 2>/dev/null | wc -l)
+LATEST_BACKUP=$(find "${SERVICE_DIR}/backups" \( -name "wiii_ai_*.dump" -o -name "predeploy_*.dump" \) -type f -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -1 | cut -d' ' -f2- || echo "")
 echo "  Total backups: ${BACKUP_COUNT}"
-if [ "$LATEST_BACKUP" != "none" ]; then
+if [ -n "$LATEST_BACKUP" ]; then
     BACKUP_AGE=$(( ($(date +%s) - $(stat -c %Y "$LATEST_BACKUP")) / 3600 ))
     BACKUP_SIZE=$(du -h "$LATEST_BACKUP" | awk '{print $1}')
     echo "  Latest: $(basename "$LATEST_BACKUP") (${BACKUP_SIZE}, ${BACKUP_AGE}h ago)"
 else
-    echo -e "  Latest: ${RED}No backups found!${NC}"
+    echo -e "  Latest: ${RED}No backups found${NC}"
 fi
 
-# ─────────────────────────────────────────────────
-# Health Check
-# ─────────────────────────────────────────────────
 echo ""
 echo -e "${GREEN}--- Health ---${NC}"
-API_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:8000/api/v1/health/live 2>/dev/null || echo "unreachable")
-NGINX_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:80/health 2>/dev/null || echo "unreachable")
+API_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "${NGINX_LOCAL_URL}/api/v1/health/live" 2>/dev/null || echo "unreachable")
+NGINX_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "${NGINX_LOCAL_URL}/health" 2>/dev/null || echo "unreachable")
+EMBED_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "${NGINX_LOCAL_URL}/embed/" 2>/dev/null || echo "unreachable")
 
 if [ "$API_STATUS" = "200" ]; then
-    echo -e "  API:   ${GREEN}OK${NC} (200)"
+    echo -e "  API via nginx: ${GREEN}OK${NC} (200)"
 else
-    echo -e "  API:   ${RED}FAIL${NC} (${API_STATUS})"
+    echo -e "  API via nginx: ${RED}FAIL${NC} (${API_STATUS})"
 fi
 
 if [ "$NGINX_STATUS" = "200" ]; then
-    echo -e "  Nginx: ${GREEN}OK${NC} (200)"
+    echo -e "  Nginx:         ${GREEN}OK${NC} (200)"
 else
-    echo -e "  Nginx: ${RED}FAIL${NC} (${NGINX_STATUS})"
+    echo -e "  Nginx:         ${RED}FAIL${NC} (${NGINX_STATUS})"
+fi
+
+if [ "$EMBED_STATUS" = "200" ]; then
+    echo -e "  Embed:         ${GREEN}OK${NC} (200)"
+else
+    echo -e "  Embed:         ${RED}FAIL${NC} (${EMBED_STATUS})"
 fi
 
 CADDY_STATUS=$(sudo systemctl is-active caddy 2>/dev/null || echo "inactive")
 if [ "$CADDY_STATUS" = "active" ]; then
-    echo -e "  Caddy: ${GREEN}active${NC}"
+    echo -e "  Caddy:         ${GREEN}active${NC}"
 else
-    echo -e "  Caddy: ${RED}${CADDY_STATUS}${NC}"
+    echo -e "  Caddy:         ${YELLOW}${CADDY_STATUS}${NC}"
 fi
 
 echo ""

--- a/maritime-ai-service/tests/unit/test_production_validation.py
+++ b/maritime-ai-service/tests/unit/test_production_validation.py
@@ -194,9 +194,15 @@ class TestProductionOperationalScripts:
             in script
         )
         assert (
-            'docker compose -f "$COMPOSE_FILE" ps --services --status running'
+            'docker compose --env-file "$ENV_ARG" -f "$COMPOSE_FILE" "$@"'
             in script
         )
+        assert (
+            'compose ps --services --status running'
+            in script
+        )
+        assert '${NGINX_LOCAL_URL}/api/v1/health/live' in script
+        assert 'http://localhost:8000/api/v1/health/live' not in script
         assert 'Missing required services:' in script
 
     def test_ingest_script_uses_explicit_live_health_endpoint(self):


### PR DESCRIPTION
## Summary
- Harden the production release lane so product deploys use clean checkouts, optional `DEPLOY_SHA`, GHCR image validation, compose config validation, pre-migration backup, and nginx-local smoke checks.
- Fix production health/status scripts to probe the app through local nginx (`http://localhost:${NGINX_HTTP_PORT:-8080}`) instead of the now-private app port.
- Add `docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md` with pinned-SHA deploy, smoke, rollback, and parallel-team safety rules.

Closes #243.

## Release findings
- Public `https://holilihu.online/embed/` returned 200 during preflight.
- Public `https://wiii.holilihu.online/api/v1/health/live` and `/api/v1/health` timed out during preflight, so public API health remains a deploy blocker until the hardened path verifies local nginx, Caddy, and external smoke together.

## Risk
- Low runtime risk: this PR changes ops scripts/docs only.
- Deploy behavior is stricter: dirty server checkouts and active placeholder secrets now fail closed unless explicitly overridden.
- `:main` image tags still work by default but product releases can enforce pinned tags with `REQUIRE_PINNED_IMAGES=true`.

## Rollback
- Revert this PR to restore the previous script behavior.
- Runtime rollback remains image/SHA based: redeploy the previous known-good `sha-...` app and nginx images with `DEPLOY_SHA=<previous-good-full-sha>`.

## Verification
- `bash -n maritime-ai-service/scripts/deploy/deploy.sh maritime-ai-service/scripts/deploy/health-check.sh maritime-ai-service/scripts/deploy/status.sh maritime-ai-service/scripts/deploy/smoke-test.sh` passed. WSL printed a non-fatal Cursor PATH translation warning.
- `git diff --check` passed.
- `git diff --cached --check` passed.
- `docker compose --env-file .env.production -f docker-compose.prod.yml config --quiet` passed using a temporary copy of `.env.production.template`; Docker warned that optional `CF_TUNNEL_TOKEN` was unset.