### PR TITLE
ops: use internal origin TLS for Caddy

### DIFF
--- a/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
+++ b/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
@@ -87,6 +87,8 @@ ZONE=asia-southeast1-c \
 
 After provisioning, update DNS or Cloudflare so `wiii.holilihu.online` points to the new static IP. Do not route Wiii traffic to the LMS VM IP.
 
+For the current Caddy origin configuration, set Cloudflare SSL/TLS mode to `Full` while the record is proxied. Caddy uses an internal origin certificate (`tls internal`), so `Full (strict)` should wait until a Cloudflare Origin Certificate or a public certificate is installed on the VM.
+
 Verify DNS and edge routing before deploying:
 
 ```bash

--- a/maritime-ai-service/scripts/deploy/Caddyfile
+++ b/maritime-ai-service/scripts/deploy/Caddyfile
@@ -38,6 +38,11 @@
 # Either way, Cloudflare "Full" SSL mode works.
 # ─────────────────────────────────────────────────
 wiii.holilihu.online {
+    # Cloudflare should use SSL/TLS mode "Full" for this origin. Caddy uses
+    # an internal origin cert so rebuilds do not depend on public ACME while
+    # the DNS record is proxied through Cloudflare.
+    tls internal
+
     reverse_proxy localhost:8080 {
         # Flush immediately for SSE streaming (critical!)
         flush_interval -1

--- a/maritime-ai-service/scripts/deploy/setup-server.sh
+++ b/maritime-ai-service/scripts/deploy/setup-server.sh
@@ -101,9 +101,11 @@ sudo chown "$USER":"$USER" /opt/wiii
 sudo mkdir -p /opt/wiii/backups
 sudo chown "$USER":"$USER" /opt/wiii/backups
 
-# Caddy log directory
-sudo mkdir -p /var/log/caddy
-sudo chown caddy:caddy /var/log/caddy
+# Caddy log directory. Install with explicit ownership so Caddy can create and
+# rotate access logs after config reloads.
+sudo install -d -o caddy -g caddy -m 0755 /var/log/caddy
+sudo touch /var/log/caddy/wiii-access.log
+sudo chown caddy:caddy /var/log/caddy/wiii-access.log
 
 # ─────────────────────────────────────────────────
 # 6. Configure swap (critical for single-node Docker production)


### PR DESCRIPTION
## Summary\n\n- closes #247\n- configures the Caddy origin with 	ls internal so Cloudflare-proxied DNS no longer depends on public ACME during the GCP rebuild\n- documents Cloudflare SSL/TLS mode Full for the current origin setup\n- hardens Caddy log directory setup so reloads can open /var/log/caddy/wiii-access.log\n\n## Verification\n\n- ash -n maritime-ai-service/scripts/deploy/setup-server.sh maritime-ai-service/scripts/deploy/deploy.sh\n- git diff --check\n- production VM hotfix validation will run after PR creation: Caddy validate/restart and origin health probe\n\n## Risk / Rollback\n\nRisk is limited to host Caddy routing. Rollback by reverting this PR or removing 	ls internal from /etc/caddy/Caddyfile and restarting Caddy. App/nginx containers are unchanged.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the operations release runbook with detailed SSL/TLS configuration recommendations for Cloudflare proxied DNS records and origin certificate installation requirements.

* **Chores**
  * Enhanced server deployment scripts to improve logging capabilities through better directory permission management and log file initialization for the reverse proxy service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->