### PR TITLE
ops: polish production status and backups

### DIFF
--- a/maritime-ai-service/scripts/deploy/backup-db.sh
+++ b/maritime-ai-service/scripts/deploy/backup-db.sh
@@ -18,9 +18,9 @@
 set -euo pipefail
 
 # Configuration
-APP_DIR="/opt/wiii"
-SERVICE_DIR="${APP_DIR}/maritime-ai-service"
-BACKUP_DIR="${APP_DIR}/backups"
+APP_DIR="${APP_DIR:-/opt/wiii}"
+SERVICE_DIR="${SERVICE_DIR:-${APP_DIR}/maritime-ai-service}"
+BACKUP_DIR="${BACKUP_DIR:-${SERVICE_DIR}/backups}"
 COMPOSE_FILE="docker-compose.prod.yml"
 RETENTION_DAYS=7
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)

--- a/maritime-ai-service/scripts/deploy/setup-backup-cron.sh
+++ b/maritime-ai-service/scripts/deploy/setup-backup-cron.sh
@@ -3,13 +3,15 @@
 # One-time setup for automated PostgreSQL backups.
 #
 # Runs daily at 3 AM UTC+7 (8 PM UTC).
-# Logs to /opt/wiii/backups/backup.log
+# Logs to /opt/wiii/maritime-ai-service/backups/backup.log
 #
 # Usage: sudo bash setup-backup-cron.sh
 
 set -euo pipefail
 
-BACKUP_SCRIPT="/opt/wiii/maritime-ai-service/scripts/deploy/backup-db.sh"
+SERVICE_DIR="${SERVICE_DIR:-/opt/wiii/maritime-ai-service}"
+BACKUP_DIR="${BACKUP_DIR:-${SERVICE_DIR}/backups}"
+BACKUP_SCRIPT="${BACKUP_SCRIPT:-${SERVICE_DIR}/scripts/deploy/backup-db.sh}"
 CRON_SCHEDULE="0 20 * * *"  # 8 PM UTC = 3 AM UTC+7
 
 # Verify script exists
@@ -21,16 +23,16 @@ fi
 chmod +x "$BACKUP_SCRIPT"
 
 # Create backup directory
-mkdir -p /opt/wiii/backups
+mkdir -p "$BACKUP_DIR"
 
 # Add to crontab (idempotent — removes old entry first)
 (crontab -l 2>/dev/null | grep -v "backup-db.sh") | crontab -
-(crontab -l 2>/dev/null; echo "$CRON_SCHEDULE $BACKUP_SCRIPT >> /opt/wiii/backups/backup.log 2>&1") | crontab -
+(crontab -l 2>/dev/null; echo "$CRON_SCHEDULE BACKUP_DIR=$BACKUP_DIR $BACKUP_SCRIPT >> $BACKUP_DIR/backup.log 2>&1") | crontab -
 
 echo "Backup cron installed:"
 crontab -l | grep backup-db
 echo ""
 echo "Next steps:"
 echo "  1. Run a test backup: $BACKUP_SCRIPT"
-echo "  2. Check logs: tail -f /opt/wiii/backups/backup.log"
+echo "  2. Check logs: tail -f $BACKUP_DIR/backup.log"
 echo "  3. (Optional) Set GCS_BACKUP_BUCKET=gs://your-bucket for cloud upload"

--- a/maritime-ai-service/scripts/deploy/setup-server.sh
+++ b/maritime-ai-service/scripts/deploy/setup-server.sh
@@ -10,7 +10,7 @@
 #   1. Updates system packages
 #   2. Installs Docker + Docker Compose v2
 #   3. Installs Caddy (auto-SSL reverse proxy)
-#   4. Creates /opt/wiii app directory + backup directory
+#   4. Creates /opt/wiii app directory
 #   5. Configures swap (default 4G, override via SWAP_SIZE)
 #   6. Kernel tuning for high-connection server
 #   7. Installs fail2ban (brute-force protection)
@@ -91,15 +91,11 @@ else
 fi
 
 # ─────────────────────────────────────────────────
-# 5. Create app + backup directories
+# 5. Create app directory
 # ─────────────────────────────────────────────────
 info "Step 5/10: Setting up directories..."
 sudo mkdir -p /opt/wiii
 sudo chown "$USER":"$USER" /opt/wiii
-
-# Backup directory (PostgreSQL dumps)
-sudo mkdir -p /opt/wiii/backups
-sudo chown "$USER":"$USER" /opt/wiii/backups
 
 # Caddy log directory. Install with explicit ownership so Caddy can create and
 # rotate access logs after config reloads.

--- a/maritime-ai-service/scripts/deploy/status.sh
+++ b/maritime-ai-service/scripts/deploy/status.sh
@@ -94,9 +94,9 @@ docker stats --no-stream --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\
 echo ""
 echo -e "${GREEN}--- System ---${NC}"
 echo "  Uptime:  $(uptime -p 2>/dev/null || uptime)"
-echo "  RAM:     $(free -h | awk 'NR==2 {printf \"%s used / %s total (%s free)\", $3, $2, $7}')"
-echo "  Swap:    $(free -h | awk 'NR==3 {printf \"%s used / %s total\", $3, $2}')"
-echo "  Disk:    $(df -h / | awk 'NR==2 {printf \"%s used / %s total (%s free, %s)\", $3, $2, $4, $5}')"
+echo "  RAM:     $(free -h | awk 'NR==2 {printf "%s used / %s total (%s free)", $3, $2, $7}')"
+echo "  Swap:    $(free -h | awk 'NR==3 {printf "%s used / %s total", $3, $2}')"
+echo "  Disk:    $(df -h / | awk 'NR==2 {printf "%s used / %s total (%s free, %s)", $3, $2, $4, $5}')"
 
 echo ""
 echo -e "${GREEN}--- PostgreSQL ---${NC}"
@@ -107,8 +107,9 @@ compose exec -T postgres psql -U "$POSTGRES_USER_VALUE" -d "$POSTGRES_DB_VALUE" 
 
 echo ""
 echo -e "${GREEN}--- Backups ---${NC}"
-BACKUP_COUNT=$(find "${SERVICE_DIR}/backups" -name "wiii_ai_*.dump" -o -name "predeploy_*.dump" 2>/dev/null | wc -l)
-LATEST_BACKUP=$(find "${SERVICE_DIR}/backups" \( -name "wiii_ai_*.dump" -o -name "predeploy_*.dump" \) -type f -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -1 | cut -d' ' -f2- || echo "")
+BACKUP_DIR="${BACKUP_DIR:-${SERVICE_DIR}/backups}"
+BACKUP_COUNT=$(find "$BACKUP_DIR" -type f \( -name "wiii_ai_*.dump" -o -name "predeploy_*.dump" \) 2>/dev/null | wc -l)
+LATEST_BACKUP=$(find "$BACKUP_DIR" -type f \( -name "wiii_ai_*.dump" -o -name "predeploy_*.dump" \) -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -1 | cut -d' ' -f2- || echo "")
 echo "  Total backups: ${BACKUP_COUNT}"
 if [ -n "$LATEST_BACKUP" ]; then
     BACKUP_AGE=$(( ($(date +%s) - $(stat -c %Y "$LATEST_BACKUP")) / 3600 ))


### PR DESCRIPTION
## Summary\n- fix production status dashboard resource output so awk warnings do not pollute ops checks\n- align manual backup/cron defaults with the compose-backed maritime-ai-service/backups directory\n- avoid creating /opt/wiii/backups during bootstrap so git clone ... /opt/wiii remains safe on fresh VMs\n\n## Verification\n- git diff --check\n- ash -n maritime-ai-service/scripts/deploy/status.sh\n- ash -n maritime-ai-service/scripts/deploy/setup-server.sh\n- ash -n maritime-ai-service/scripts/deploy/backup-db.sh\n- ash -n maritime-ai-service/scripts/deploy/setup-backup-cron.sh\n- copied patched status.sh to new GCP VM and ran SERVICE_DIR=/opt/wiii/maritime-ai-service bash /tmp/wiii-status-codex.sh: containers healthy, API/nginx/embed OK, no awk warnings\n\n## Risk and rollback\nLow risk: shell-script-only ops polish. Rollback by reverting this PR; no database, runtime image, or environment changes.\n\nCloses #249