### PR TITLE
ops: align smoke test with SSE visual lifecycle

### DIFF
--- a/maritime-ai-service/scripts/deploy/smoke-test.sh
+++ b/maritime-ai-service/scripts/deploy/smoke-test.sh
@@ -82,9 +82,10 @@ if [ -n "$API_KEY" ]; then
         -H "X-API-Key: ${API_KEY}" \
         -H "X-Session-ID: smoke-test-visual" \
         -d '{"user_id":"api-client","message":"So sánh attention mềm và linear attention bằng visual inline","role":"student","session_id":"smoke-test-visual","domain_id":"maritime"}' \
-        --max-time 45 \
+        --max-time 90 \
         2>/dev/null || true)
-    check "Structured visual SSE contract emits event: visual" "$(echo "$STREAM_BODY" | grep -q 'event: visual' && echo true || echo false)"
+    check "Structured visual SSE opens visual lifecycle" "$(echo "$STREAM_BODY" | grep -q '^event: visual_open$' && echo true || echo false)"
+    check "Structured visual SSE commits visual lifecycle" "$(echo "$STREAM_BODY" | grep -q '^event: visual_commit$' && echo true || echo false)"
     check "Structured visual stream hides raw widget fences" "$([ -n "$STREAM_BODY" ] && ! echo "$STREAM_BODY" | grep -q '```widget' && echo true || echo false)"
 else
     echo "  [SKIP] Chat API — set API_KEY to test"

--- a/maritime-ai-service/tests/unit/test_production_validation.py
+++ b/maritime-ai-service/tests/unit/test_production_validation.py
@@ -144,6 +144,15 @@ class TestProductionSmokeTestDocs:
         assert '"user_id": "api-client"' in script
         assert '-H "X-User-ID:' not in script
 
+    def test_smoke_test_script_matches_sse_v3_visual_lifecycle(self):
+        """Production visual smoke test should assert current SSE V3 lifecycle events."""
+        import pathlib
+
+        script = pathlib.Path("scripts/deploy/smoke-test.sh").read_text(encoding="utf-8")
+        assert "event: visual_open" in script
+        assert "event: visual_commit" in script
+        assert "```widget" in script
+
     def test_launch_checklist_examples_match_api_key_contract(self):
         """Launch checklist should document service-client auth for API key examples."""
         import pathlib


### PR DESCRIPTION
## Summary\n- validate current SSE V3 visual lifecycle events (isual_open + isual_commit) instead of the historical isual event\n- raise the visual SSE smoke timeout to avoid false negatives near production visual latency\n- add unit coverage so the smoke script stays aligned with the runtime contract\n\n## Verification\n- ash -n scripts/deploy/smoke-test.sh\n- python -m pytest tests/unit/test_production_validation.py -q → 24 passed\n- git diff --check\n- copied patched smoke script to the rebuilt GCP VM and ran against https://wiii.holilihu.online with the production API key kept on the VM: 12 passed, 0 failed\n\n## Production note\nDuring cutover validation, the NVIDIA DeepSeek v4 Flash/Pro models timed out from the VM, while qwen/qwen3-next-80b-a3b-instruct was healthy and passed chat + visual smoke. Production was hotfixed to the healthy NVIDIA Qwen model; follow-up model-health/fallback work should make this automatic.\n\n## Risk and rollback\nLow risk: smoke-test and unit-test alignment only. Rollback by reverting this PR; no runtime behavior, database, or secret changes.\n\nCloses #251