### PR TITLE
ops: seed primary Wiii production organization

### DIFF
--- a/maritime-ai-service/alembic/versions/048_seed_primary_wiii_organization.py
+++ b/maritime-ai-service/alembic/versions/048_seed_primary_wiii_organization.py
@@ -3,6 +3,10 @@
 Production traffic for wiii.holilihu.online resolves to organization id
 ``wiii``. Seed it in Alembic so rebuilt environments do not fail thread and
 memory writes against the thread_views organization foreign key.
+
+If a production operator has already customized or disabled the organization,
+the conflict path preserves those existing choices and only fills missing
+metadata.
 """
 
 from alembic import op
@@ -19,7 +23,8 @@ def _table_exists(conn, table_name: str) -> bool:
     result = conn.execute(
         sa.text(
             "SELECT table_name FROM information_schema.tables "
-            "WHERE table_name = :table_name"
+            "WHERE table_schema = current_schema() "
+            "AND table_name = :table_name"
         ),
         {"table_name": table_name},
     )
@@ -55,13 +60,26 @@ def upgrade():
                 true
             )
             ON CONFLICT (id) DO UPDATE SET
-                name = EXCLUDED.name,
-                display_name = EXCLUDED.display_name,
-                description = EXCLUDED.description,
-                allowed_domains = EXCLUDED.allowed_domains,
-                default_domain = EXCLUDED.default_domain,
-                settings = organizations.settings || EXCLUDED.settings,
-                is_active = true,
+                name = COALESCE(organizations.name, EXCLUDED.name),
+                display_name = COALESCE(
+                    organizations.display_name,
+                    EXCLUDED.display_name
+                ),
+                description = COALESCE(
+                    organizations.description,
+                    EXCLUDED.description
+                ),
+                allowed_domains = COALESCE(
+                    organizations.allowed_domains,
+                    EXCLUDED.allowed_domains
+                ),
+                default_domain = COALESCE(
+                    organizations.default_domain,
+                    EXCLUDED.default_domain
+                ),
+                settings = COALESCE(EXCLUDED.settings, '{}'::jsonb)
+                    || COALESCE(organizations.settings, '{}'::jsonb),
+                is_active = COALESCE(organizations.is_active, EXCLUDED.is_active),
                 updated_at = NOW()
             """
         )

--- a/maritime-ai-service/alembic/versions/048_seed_primary_wiii_organization.py
+++ b/maritime-ai-service/alembic/versions/048_seed_primary_wiii_organization.py
@@ -1,0 +1,74 @@
+"""048: seed primary wiii organization.
+
+Production traffic for wiii.holilihu.online resolves to organization id
+``wiii``. Seed it in Alembic so rebuilt environments do not fail thread and
+memory writes against the thread_views organization foreign key.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "048"
+down_revision = "047"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(conn, table_name: str) -> bool:
+    result = conn.execute(
+        sa.text(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_name = :table_name"
+        ),
+        {"table_name": table_name},
+    )
+    return result.fetchone() is not None
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not _table_exists(conn, "organizations"):
+        return
+
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO organizations (
+                id,
+                name,
+                display_name,
+                description,
+                allowed_domains,
+                default_domain,
+                settings,
+                is_active
+            )
+            VALUES (
+                'wiii',
+                'Wiii',
+                'Wiii Production',
+                'Primary Wiii production organization for wiii.holilihu.online',
+                ARRAY['maritime', 'traffic_law'],
+                'maritime',
+                '{"source": "alembic-048", "domain": "wiii.holilihu.online"}'::jsonb,
+                true
+            )
+            ON CONFLICT (id) DO UPDATE SET
+                name = EXCLUDED.name,
+                display_name = EXCLUDED.display_name,
+                description = EXCLUDED.description,
+                allowed_domains = EXCLUDED.allowed_domains,
+                default_domain = EXCLUDED.default_domain,
+                settings = organizations.settings || EXCLUDED.settings,
+                is_active = true,
+                updated_at = NOW()
+            """
+        )
+    )
+
+
+def downgrade():
+    # Do not delete `wiii`: production thread/history rows may already
+    # reference it. Operators can remove or remap data explicitly if needed.
+    return

--- a/maritime-ai-service/tests/unit/test_production_validation.py
+++ b/maritime-ai-service/tests/unit/test_production_validation.py
@@ -233,3 +233,21 @@ class TestProductionOperationalScripts:
             "docs/deploy/KNOWLEDGE_INGESTION.md"
         ).read_text(encoding="utf-8")
         assert 'curl localhost:8000/api/v1/health/live' in doc
+
+
+class TestProductionOrganizationSeed:
+    """Verify production org bootstrap stays compatible with subdomain routing."""
+
+    def test_wiii_org_seed_is_idempotent_and_non_destructive(self):
+        """The primary production org seed should upsert and preserve data."""
+        import pathlib
+
+        migration = pathlib.Path(
+            "alembic/versions/048_seed_primary_wiii_organization.py"
+        ).read_text(encoding="utf-8")
+
+        assert "INSERT INTO organizations" in migration
+        assert "'wiii'" in migration
+        assert "ON CONFLICT (id) DO UPDATE" in migration
+        assert "wiii.holilihu.online" in migration
+        assert "DELETE FROM organizations" not in migration

--- a/maritime-ai-service/tests/unit/test_production_validation.py
+++ b/maritime-ai-service/tests/unit/test_production_validation.py
@@ -250,4 +250,8 @@ class TestProductionOrganizationSeed:
         assert "'wiii'" in migration
         assert "ON CONFLICT (id) DO UPDATE" in migration
         assert "wiii.holilihu.online" in migration
+        assert "table_schema = current_schema()" in migration
+        assert "COALESCE(EXCLUDED.settings" in migration
+        assert "COALESCE(organizations.settings" in migration
+        assert "is_active = COALESCE(organizations.is_active" in migration
         assert "DELETE FROM organizations" not in migration


### PR DESCRIPTION
﻿## Summary
- Add Alembic revision `048` to seed the primary `wiii` organization used by `wiii.holilihu.online` routing.
- Use an idempotent `ON CONFLICT` upsert so existing production metadata is preserved and refreshed safely.
- Keep downgrade non-destructive because thread/history rows may already reference `wiii`.
- Add a production validation regression test for the seed contract.

## Root Cause
The rebuilt production VM routed requests under organization id `wiii`, while migration history only guaranteed `default` and `maritime-lms`. Thread persistence then failed on `thread_views.organization_id` FK checks until a manual DB hotfix inserted `wiii`.

## Risk / Rollback
Risk is low: this only seeds organization metadata and does not touch user rows, threads, memory, or provider/runtime code. Rollback should not auto-delete `wiii`; if operators truly need to remove it, dependent rows must be remapped or deleted explicitly first.

## Verification
- `python -m pytest tests/unit/test_production_validation.py -q` → 25 passed
- `python -m ruff check alembic/versions/048_seed_primary_wiii_organization.py tests/unit/test_production_validation.py --select=E9,F63,F7` → passed
- `git diff --check` → passed

Closes #254


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added database migration to initialize a primary organization in the system with idempotent upsert logic that safely handles duplicate entries and preserves existing data.
  * Added validation tests to ensure the migration operates safely and can be executed multiple times without side effects.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/255)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->