### PR TITLE
ops: fix production async pool health URL

### DIFF
--- a/maritime-ai-service/app/api/v1/health.py
+++ b/maritime-ai-service/app/api/v1/health.py
@@ -257,12 +257,17 @@ async def check_knowledge_graph_health() -> ComponentHealth:
 _shared_async_engine = None
 
 
+def _get_sqlalchemy_async_engine_url() -> str:
+    """Return a SQLAlchemy async URL without asyncpg-incompatible options."""
+    return settings._remove_connect_timeout(settings.postgres_url)
+
+
 async def _get_shared_async_engine():
     """Get or create a module-level singleton async engine for health checks."""
     global _shared_async_engine
     if _shared_async_engine is None:
         _shared_async_engine = create_async_engine(
-            settings.postgres_url,
+            _get_sqlalchemy_async_engine_url(),
             pool_pre_ping=True,
             pool_size=1,
             max_overflow=0,

--- a/maritime-ai-service/tests/unit/test_async_pool_health.py
+++ b/maritime-ai-service/tests/unit/test_async_pool_health.py
@@ -105,6 +105,33 @@ class TestAsyncPoolIntegration:
         assert hasattr(health, "check_async_pool_health")
         assert callable(health.check_async_pool_health)
 
+    @pytest.mark.asyncio
+    async def test_shared_engine_strips_connect_timeout_from_sqlalchemy_url(self):
+        """Health checks should keep asyncpg driver but drop invalid timeout query."""
+        import app.api.v1.health as health_mod
+
+        health_mod._shared_async_engine = None
+        mock_settings = MagicMock()
+        mock_settings.postgres_url = (
+            "postgresql+asyncpg://wiii:secret@postgres:5432/wiii"
+            "?connect_timeout=5&ssl=require"
+        )
+        mock_settings._remove_connect_timeout.side_effect = (
+            lambda url: url.replace("?connect_timeout=5&ssl=require", "?ssl=require")
+        )
+
+        with patch("app.api.v1.health.settings", mock_settings), \
+             patch("app.api.v1.health.create_async_engine") as mock_create:
+            mock_engine = MagicMock()
+            mock_create.return_value = mock_engine
+
+            engine = await health_mod._get_shared_async_engine()
+
+        assert engine is mock_engine
+        created_url = mock_create.call_args.args[0]
+        assert created_url.startswith("postgresql+asyncpg://")
+        assert "connect_timeout" not in created_url
+
     def test_deep_health_includes_async_pool(self):
         """Deep health check source code references async_pool."""
         import inspect


### PR DESCRIPTION
﻿## Summary
- Add a small health helper that keeps the SQLAlchemy async driver URL but strips asyncpg-incompatible `connect_timeout`.
- Reuse that sanitized URL when creating the shared async health-check engine.
- Add a unit regression test for the exact production failure mode.

## Root Cause
Production health logs showed:

```text
Async pool health check failed: connect() got an unexpected keyword argument 'connect_timeout'
```

`settings.postgres_url` intentionally appends `connect_timeout` for PostgreSQL clients, but asyncpg does not accept that parameter in the SQLAlchemy async engine path.

## Risk / Rollback
Low risk: this only affects the health-check engine URL and does not change repository pools, migrations, user data, or provider runtime. Rollback is reverting the helper, but that would restore degraded production health logs.

## Verification
- `python -m pytest tests/unit/test_async_pool_health.py -q` → 8 passed
- `python -m pytest tests/unit/test_sprint171_pg_minio_hardening.py -q` → 29 passed
- `python -m ruff check app/api/v1/health.py tests/unit/test_async_pool_health.py --select=E9,F63,F7` → passed
- `git diff --check` → passed

Closes #256
