### PR TITLE
runtime: expose LLM model health telemetry

### DIFF
--- a/maritime-ai-service/app/api/v1/health.py
+++ b/maritime-ai-service/app/api/v1/health.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from app.core.config import settings
 from app.core.constants import HEALTH_CHECK_TIMEOUT
 from app.engine.agentic_rag.rag_agent import get_knowledge_repository
+from app.engine.llm_model_health import get_model_health_snapshot
 from app.models.schemas import ComponentHealth, ComponentStatus, HealthResponse
 from app.repositories.chat_history_repository import get_chat_history_repository
 from app.repositories.semantic_memory_repository import get_semantic_memory_repository
@@ -318,6 +319,70 @@ async def check_async_pool_health() -> ComponentHealth:
         )
 
 
+def _build_llm_model_health_report() -> dict:
+    """Return a redacted operator-facing model health snapshot."""
+    snapshot = get_model_health_snapshot()
+    models = []
+    for provider, provider_models in sorted(snapshot.items()):
+        for model, record in sorted(provider_models.items()):
+            models.append(
+                {
+                    "provider": provider,
+                    "model": model,
+                    "state": record.get("state"),
+                    "last_reason_code": record.get("last_reason_code"),
+                    "last_timeout_seconds": record.get("last_timeout_seconds"),
+                    "last_failure_at": record.get("last_failure_at"),
+                    "last_success_at": record.get("last_success_at"),
+                    "degraded_until": record.get("degraded_until"),
+                }
+            )
+
+    degraded_count = sum(1 for item in models if item.get("state") == "degraded")
+    return {
+        "status": "degraded" if degraded_count else "healthy",
+        "model_count": len(models),
+        "degraded_count": degraded_count,
+        "models": models,
+    }
+
+
+async def check_llm_model_health() -> ComponentHealth:
+    """Summarize process-local model health without exposing raw provider errors."""
+    start = time.time()
+    try:
+        report = _build_llm_model_health_report()
+        latency = (time.time() - start) * 1000
+        model_count = report["model_count"]
+        degraded_count = report["degraded_count"]
+
+        if model_count == 0:
+            status = ComponentStatus.HEALTHY
+            message = "No model health records yet"
+        elif degraded_count:
+            status = ComponentStatus.DEGRADED
+            message = f"{degraded_count}/{model_count} model(s) degraded"
+        else:
+            status = ComponentStatus.HEALTHY
+            message = f"{model_count} model health record(s), all healthy"
+
+        return ComponentHealth(
+            name="LLM Model Health",
+            status=status,
+            latency_ms=round(latency, 2),
+            message=message,
+        )
+    except Exception as e:
+        latency = (time.time() - start) * 1000
+        logger.warning("LLM model health check failed: %s", e)
+        return ComponentHealth(
+            name="LLM Model Health",
+            status=ComponentStatus.UNAVAILABLE,
+            latency_ms=round(latency, 2),
+            message="Model health snapshot unavailable",
+        )
+
+
 def determine_overall_status(components: dict[str, ComponentHealth]) -> str:
     """
     Determine overall system status based on component health.
@@ -434,6 +499,7 @@ async def health_check_deep() -> HealthResponse:
     kg_health = await check_with_timeout(check_knowledge_graph_health, "Neo4j Knowledge Graph")
     storage_health = await check_with_timeout(check_object_storage_health, "Object Storage")
     async_pool_health = await check_with_timeout(check_async_pool_health, "Async Pool")
+    llm_model_health = await check_with_timeout(check_llm_model_health, "LLM Model Health")
 
     components = {
         "api": api_health,
@@ -442,6 +508,7 @@ async def health_check_deep() -> HealthResponse:
         "knowledge_graph": kg_health,  # Optional for RAG, reserved for Learning Graph
         "object_storage": storage_health,  # MinIO / S3-compatible storage
         "async_pool": async_pool_health,  # SOTA 2026: Async connection pool
+        "llm_model_health": llm_model_health,
     }
     
     overall_status = determine_overall_status(components)
@@ -456,6 +523,16 @@ async def health_check_deep() -> HealthResponse:
     logger.info("Deep health check: %s", overall_status)
     
     return response
+
+
+@router.get(
+    "/llm-models",
+    summary="LLM Model Health Snapshot",
+    description="Return redacted per-provider/per-model health for runtime operators.",
+)
+async def llm_model_health_snapshot():
+    """Expose model health state without API keys or raw provider error bodies."""
+    return _build_llm_model_health_report()
 
 
 @router.get(

--- a/maritime-ai-service/scripts/deploy/smoke-test.sh
+++ b/maritime-ai-service/scripts/deploy/smoke-test.sh
@@ -39,6 +39,10 @@ check "Liveness probe (GET /health/live)" "$([ "$HTTP" = "200" ] && echo true ||
 HTTP=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/api/v1/health/db" 2>/dev/null || echo "000")
 check "Deep health — DB (GET /health/db)" "$([ "$HTTP" = "200" ] && echo true || echo false)"
 
+LLM_MODEL_HEALTH=$(curl -s "${BASE_URL}/api/v1/health/llm-models" 2>/dev/null || true)
+check "LLM model health visible" "$(echo "$LLM_MODEL_HEALTH" | grep -q '"model_count"' && echo true || echo false)"
+check "LLM model health redacts raw errors" "$([ -n "$LLM_MODEL_HEALTH" ] && ! echo "$LLM_MODEL_HEALTH" | grep -q 'last_error_detail' && echo true || echo false)"
+
 # 2. Security Headers
 echo ""
 echo "2. Security Headers"

--- a/maritime-ai-service/tests/unit/test_async_pool_health.py
+++ b/maritime-ai-service/tests/unit/test_async_pool_health.py
@@ -140,6 +140,14 @@ class TestAsyncPoolIntegration:
         assert "async_pool" in source
         assert "check_async_pool_health" in source
 
+    def test_deep_health_includes_llm_model_health(self):
+        """Deep health check source code references llm_model_health."""
+        import inspect
+        from app.api.v1.health import health_check_deep
+        source = inspect.getsource(health_check_deep)
+        assert "llm_model_health" in source
+        assert "check_llm_model_health" in source
+
 
 class TestAsyncPoolComponentHealth:
     """Test ComponentHealth response format."""

--- a/maritime-ai-service/tests/unit/test_llm_model_health_endpoint.py
+++ b/maritime-ai-service/tests/unit/test_llm_model_health_endpoint.py
@@ -1,0 +1,66 @@
+"""Tests for the operator-facing LLM model health endpoint helpers."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_model_health():
+    from app.engine.llm_model_health import reset_model_health_state
+
+    reset_model_health_state()
+    yield
+    reset_model_health_state()
+
+
+def test_llm_model_health_report_redacts_raw_error_detail():
+    from app.api.v1.health import _build_llm_model_health_report
+    from app.engine.llm_model_health import record_model_failure
+
+    record_model_failure(
+        "nvidia",
+        "deepseek-ai/deepseek-v4-flash",
+        reason_code="timeout",
+        error=RuntimeError("provider payload containing should-not-leak"),
+        timeout_seconds=8.0,
+    )
+
+    report = _build_llm_model_health_report()
+
+    assert report["status"] == "degraded"
+    assert report["model_count"] == 1
+    assert report["degraded_count"] == 1
+    assert report["models"][0]["provider"] == "nvidia"
+    assert report["models"][0]["model"] == "deepseek-ai/deepseek-v4-flash"
+    assert report["models"][0]["state"] == "degraded"
+    assert "last_error_detail" not in report["models"][0]
+    assert "should-not-leak" not in str(report)
+
+
+@pytest.mark.asyncio
+async def test_check_llm_model_health_reports_degraded_component():
+    from app.api.v1.health import check_llm_model_health
+    from app.engine.llm_model_health import record_model_failure
+    from app.models.schemas import ComponentStatus
+
+    record_model_failure(
+        "nvidia",
+        "deepseek-ai/deepseek-v4-pro",
+        reason_code="rate_limit",
+    )
+
+    component = await check_llm_model_health()
+
+    assert component.name == "LLM Model Health"
+    assert component.status is ComponentStatus.DEGRADED
+    assert component.message == "1/1 model(s) degraded"
+
+
+@pytest.mark.asyncio
+async def test_check_llm_model_health_is_healthy_before_probe_records():
+    from app.api.v1.health import check_llm_model_health
+    from app.models.schemas import ComponentStatus
+
+    component = await check_llm_model_health()
+
+    assert component.status is ComponentStatus.HEALTHY
+    assert component.message == "No model health records yet"

--- a/maritime-ai-service/tests/unit/test_production_validation.py
+++ b/maritime-ai-service/tests/unit/test_production_validation.py
@@ -153,6 +153,15 @@ class TestProductionSmokeTestDocs:
         assert "event: visual_commit" in script
         assert "```widget" in script
 
+    def test_smoke_test_script_checks_llm_model_health_visibility(self):
+        """Production smoke should expose redacted model health telemetry."""
+        import pathlib
+
+        script = pathlib.Path("scripts/deploy/smoke-test.sh").read_text(encoding="utf-8")
+        assert "/api/v1/health/llm-models" in script
+        assert "LLM model health visible" in script
+        assert "last_error_detail" in script
+
     def test_launch_checklist_examples_match_api_key_contract(self):
         """Launch checklist should document service-client auth for API key examples."""
         import pathlib


### PR DESCRIPTION
Refs #253\n\n## Summary\n- Add redacted \/api/v1/health/llm-models\ endpoint for operator-visible per-provider/per-model health.\n- Include \llm_model_health\ in deep health so degraded model state is visible without log grep.\n- Extend deploy smoke to assert model health visibility and absence of raw provider error detail.\n\n## Verification\n- \python -m pytest tests/unit/test_llm_model_health_endpoint.py tests/unit/test_async_pool_health.py tests/unit/test_production_validation.py -q\ -> 38 passed\n- \python -m pytest tests/unit/test_llm_model_health_probe_service.py tests/unit/test_llm_pool_multi.py -q\ -> 29 passed\n- \python -m ruff check app/api/v1/health.py tests/unit/test_llm_model_health_endpoint.py tests/unit/test_async_pool_health.py tests/unit/test_production_validation.py --select=E9,F63,F7\ -> passed\n- \ash -n scripts/deploy/smoke-test.sh\ -> passed (local WSL emitted a path translation warning only)\n- \git diff --check\ -> passed\n\n## Risk / Rollback\n- Low-to-medium runtime ops surface: public health endpoint exposes provider/model names and coarse health state, but intentionally omits raw provider error bodies and API keys.\n- Rollback: revert this PR; model probes and fallback from PR #258 remain unaffected.