### PR TITLE
runtime: tune model health partial degradation status

### DIFF
--- a/maritime-ai-service/app/api/v1/health.py
+++ b/maritime-ai-service/app/api/v1/health.py
@@ -339,9 +339,12 @@ def _build_llm_model_health_report() -> dict:
             )
 
     degraded_count = sum(1 for item in models if item.get("state") == "degraded")
+    healthy_count = sum(1 for item in models if item.get("state") == "healthy")
+    all_known_models_degraded = bool(models) and degraded_count >= len(models)
     return {
-        "status": "degraded" if degraded_count else "healthy",
+        "status": "degraded" if all_known_models_degraded else "healthy",
         "model_count": len(models),
+        "healthy_count": healthy_count,
         "degraded_count": degraded_count,
         "models": models,
     }
@@ -354,14 +357,21 @@ async def check_llm_model_health() -> ComponentHealth:
         report = _build_llm_model_health_report()
         latency = (time.time() - start) * 1000
         model_count = report["model_count"]
+        healthy_count = report["healthy_count"]
         degraded_count = report["degraded_count"]
 
         if model_count == 0:
             status = ComponentStatus.HEALTHY
             message = "No model health records yet"
-        elif degraded_count:
+        elif degraded_count >= model_count:
             status = ComponentStatus.DEGRADED
-            message = f"{degraded_count}/{model_count} model(s) degraded"
+            message = f"All {model_count} model(s) degraded"
+        elif degraded_count:
+            status = ComponentStatus.HEALTHY
+            message = (
+                f"{degraded_count}/{model_count} model(s) degraded; "
+                f"{healthy_count} model(s) healthy for routing"
+            )
         else:
             status = ComponentStatus.HEALTHY
             message = f"{model_count} model health record(s), all healthy"

--- a/maritime-ai-service/tests/unit/test_llm_model_health_endpoint.py
+++ b/maritime-ai-service/tests/unit/test_llm_model_health_endpoint.py
@@ -28,6 +28,7 @@ def test_llm_model_health_report_redacts_raw_error_detail():
 
     assert report["status"] == "degraded"
     assert report["model_count"] == 1
+    assert report["healthy_count"] == 0
     assert report["degraded_count"] == 1
     assert report["models"][0]["provider"] == "nvidia"
     assert report["models"][0]["model"] == "deepseek-ai/deepseek-v4-flash"
@@ -37,7 +38,7 @@ def test_llm_model_health_report_redacts_raw_error_detail():
 
 
 @pytest.mark.asyncio
-async def test_check_llm_model_health_reports_degraded_component():
+async def test_check_llm_model_health_reports_degraded_component_when_all_known_models_degraded():
     from app.api.v1.health import check_llm_model_health
     from app.engine.llm_model_health import record_model_failure
     from app.models.schemas import ComponentStatus
@@ -52,7 +53,34 @@ async def test_check_llm_model_health_reports_degraded_component():
 
     assert component.name == "LLM Model Health"
     assert component.status is ComponentStatus.DEGRADED
-    assert component.message == "1/1 model(s) degraded"
+    assert component.message == "All 1 model(s) degraded"
+
+
+@pytest.mark.asyncio
+async def test_check_llm_model_health_keeps_component_healthy_for_partial_degradation():
+    from app.api.v1.health import _build_llm_model_health_report, check_llm_model_health
+    from app.engine.llm_model_health import record_model_failure, record_model_success
+    from app.models.schemas import ComponentStatus
+
+    record_model_failure(
+        "nvidia",
+        "deepseek-ai/deepseek-v4-flash",
+        reason_code="timeout",
+        timeout_seconds=8.0,
+    )
+    record_model_success("nvidia", "deepseek-ai/deepseek-v4-pro")
+
+    report = _build_llm_model_health_report()
+    component = await check_llm_model_health()
+
+    assert report["status"] == "healthy"
+    assert report["model_count"] == 2
+    assert report["healthy_count"] == 1
+    assert report["degraded_count"] == 1
+    assert component.status is ComponentStatus.HEALTHY
+    assert component.message == (
+        "1/2 model(s) degraded; 1 model(s) healthy for routing"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep the LLM model-health component healthy when at least one known model is still healthy for routing
- continue marking the component degraded when all known models are degraded
- expose `healthy_count` alongside `degraded_count` for operator clarity
- add regression coverage for full vs partial NVIDIA model degradation

## Production context
After PR #259, production telemetry showed the endpoint correctly detecting NVIDIA/Qwen timeout flapping. A direct production probe also showed the current env has identical `NVIDIA_MODEL` and `NVIDIA_MODEL_ADVANCED`, which means there is no same-provider model fallback path. This PR fixes the aggregate health semantics so a partial degraded model set does not falsely mark the traffic path red when a healthy model remains available.

## Verification
- `python -m pytest tests/unit/test_llm_model_health_endpoint.py tests/unit/test_async_pool_health.py tests/unit/test_production_validation.py -q` -> 39 passed
- `python -m ruff check app/api/v1/health.py tests/unit/test_llm_model_health_endpoint.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk / rollback
Risk is limited to operator health semantics. Raw provider errors remain redacted. If dashboards need the previous stricter behavior, revert this PR and `/health/llm-models` will return degraded whenever any configured model is degraded again.

Refs #253
Refs #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced LLM model health status reporting to distinguish between partial and complete model degradation
  * Partial degradation now provides more detailed metrics while maintaining accurate overall system health status

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/261)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->