### PR TITLE
auth: fail closed when production login secrets are missing

### DIFF
--- a/maritime-ai-service/app/auth/email_service.py
+++ b/maritime-ai-service/app/auth/email_service.py
@@ -6,6 +6,7 @@ Sends magic link emails using Resend API.
 import logging
 
 from app.core.config import settings
+from app.core.secret_validation import is_missing_or_placeholder_secret
 
 logger = logging.getLogger(__name__)
 
@@ -45,20 +46,7 @@ def build_magic_link_html(verify_url: str) -> str:
 
 def _is_resend_configured() -> bool:
     key = getattr(settings, "resend_api_key", "") or ""
-    lowered = key.strip().lower()
-    if not lowered:
-        return False
-    placeholder_markers = (
-        "change_me",
-        "change-me",
-        "changeme",
-        "placeholder",
-        "your_",
-        "your-",
-        "example",
-        "dummy",
-    )
-    return not any(marker in lowered for marker in placeholder_markers)
+    return not is_missing_or_placeholder_secret(key)
 
 
 async def send_magic_link_email(to_email: str, verify_url: str) -> bool:
@@ -79,9 +67,8 @@ async def send_magic_link_email(to_email: str, verify_url: str) -> bool:
         return False
 
     if not resend_ready:
-        # Placeholder secret (CHANGE_ME_...) or missing package → dev fallback.
-        # A real production deployment would never ship a CHANGE_ME_ key, so
-        # this branch is only allowed outside production.
+        # Development-only fallback for missing package or common placeholder
+        # secrets such as "your-", "placeholder", "example", and "dummy".
         logger.warning(
             "[DEV MAGIC LINK] Resend not configured. Open this URL to finish login for %s:\n  %s",
             to_email, verify_url,

--- a/maritime-ai-service/app/auth/email_service.py
+++ b/maritime-ai-service/app/auth/email_service.py
@@ -45,7 +45,20 @@ def build_magic_link_html(verify_url: str) -> str:
 
 def _is_resend_configured() -> bool:
     key = getattr(settings, "resend_api_key", "") or ""
-    return bool(key) and not key.startswith("CHANGE_ME")
+    lowered = key.strip().lower()
+    if not lowered:
+        return False
+    placeholder_markers = (
+        "change_me",
+        "change-me",
+        "changeme",
+        "placeholder",
+        "your_",
+        "your-",
+        "example",
+        "dummy",
+    )
+    return not any(marker in lowered for marker in placeholder_markers)
 
 
 async def send_magic_link_email(to_email: str, verify_url: str) -> bool:
@@ -59,10 +72,16 @@ async def send_magic_link_email(to_email: str, verify_url: str) -> bool:
     """
     resend_ready = _is_resend_configured() and resend is not None
 
+    if not resend_ready and getattr(settings, "environment", "") == "production":
+        logger.error(
+            "Magic Link email blocked in production because Resend is not configured."
+        )
+        return False
+
     if not resend_ready:
         # Placeholder secret (CHANGE_ME_...) or missing package → dev fallback.
         # A real production deployment would never ship a CHANGE_ME_ key, so
-        # this branch is safe to leave on even when environment=production.
+        # this branch is only allowed outside production.
         logger.warning(
             "[DEV MAGIC LINK] Resend not configured. Open this URL to finish login for %s:\n  %s",
             to_email, verify_url,

--- a/maritime-ai-service/app/auth/magic_link_router.py
+++ b/maritime-ai-service/app/auth/magic_link_router.py
@@ -28,6 +28,7 @@ from app.auth.magic_link_service import (
     validate_email,
 )
 from app.core.config import settings
+from app.core.secret_validation import is_missing_or_placeholder_secret
 
 logger = logging.getLogger(__name__)
 
@@ -159,18 +160,10 @@ async def _create_magic_link(email: str, conn) -> dict:
         "expires_in": settings.magic_link_expires_seconds,
     }
 
-    # Dev convenience: when Resend is a placeholder, Wiii cannot actually send
-    # email. Surface the verify URL so the UI can auto-open it. Real prod
-    # deployments will ship a proper Resend key and never hit this branch.
-    resend_key = getattr(settings, "resend_api_key", "") or ""
-    resend_key_lower = resend_key.strip().lower()
-    resend_missing_or_placeholder = (
-        not resend_key_lower
-        or resend_key.startswith("CHANGE_ME")
-        or any(
-            marker in resend_key_lower
-            for marker in ("change-me", "changeme", "placeholder", "your-", "your_")
-        )
+    # Development-only convenience: surface the verify URL when Resend is not
+    # usable locally. Production never exposes raw verification URLs.
+    resend_missing_or_placeholder = is_missing_or_placeholder_secret(
+        getattr(settings, "resend_api_key", "")
     )
     if (
         settings.environment != "production"

--- a/maritime-ai-service/app/auth/magic_link_router.py
+++ b/maritime-ai-service/app/auth/magic_link_router.py
@@ -163,7 +163,19 @@ async def _create_magic_link(email: str, conn) -> dict:
     # email. Surface the verify URL so the UI can auto-open it. Real prod
     # deployments will ship a proper Resend key and never hit this branch.
     resend_key = getattr(settings, "resend_api_key", "") or ""
-    if not resend_key or resend_key.startswith("CHANGE_ME"):
+    resend_key_lower = resend_key.strip().lower()
+    resend_missing_or_placeholder = (
+        not resend_key_lower
+        or resend_key.startswith("CHANGE_ME")
+        or any(
+            marker in resend_key_lower
+            for marker in ("change-me", "changeme", "placeholder", "your-", "your_")
+        )
+    )
+    if (
+        settings.environment != "production"
+        and resend_missing_or_placeholder
+    ):
         response["dev_verify_url"] = verify_url
         response["message"] = (
             "Resend chưa cấu hình — Wiii sẽ tự mở tab xác minh giúp bạn."

--- a/maritime-ai-service/app/core/config/_settings_validation.py
+++ b/maritime-ai-service/app/core/config/_settings_validation.py
@@ -144,6 +144,25 @@ def validate_google_compat_url_value(v: str) -> str:
     return v
 
 
+def _is_missing_or_placeholder_secret(value) -> bool:
+    text = str(value or "").strip()
+    if not text:
+        return True
+    lowered = text.lower()
+    placeholder_markers = (
+        "change_me",
+        "change-me",
+        "changeme",
+        "placeholder",
+        "your_",
+        "your-",
+        "example",
+        "dummy",
+        "test-secret",
+    )
+    return any(marker in lowered for marker in placeholder_markers)
+
+
 def build_validate_production_security(config_logger):
     def _validate(self):
         if self.environment == "production":
@@ -162,10 +181,28 @@ def build_validate_production_security(config_logger):
                     "SECURITY: api_key must be at least 16 characters in production. "
                     "Generate with: python -c \"import secrets; print(secrets.token_urlsafe(32))\""
                 )
-            if self.enable_magic_link_auth and not self.resend_api_key:
-                config_logger.warning(
-                    "SECURITY: enable_magic_link_auth=True but RESEND_API_KEY is empty — "
-                    "magic link emails will fail silently"
+            if getattr(
+                self, "enable_magic_link_auth", False
+            ) and _is_missing_or_placeholder_secret(
+                getattr(self, "resend_api_key", None)
+            ):
+                raise ValueError(
+                    "SECURITY: enable_magic_link_auth=True requires a real "
+                    "RESEND_API_KEY in production. Magic Link must fail closed "
+                    "instead of exposing dev verification URLs."
+                )
+            if getattr(self, "enable_google_oauth", False) and (
+                _is_missing_or_placeholder_secret(
+                    getattr(self, "google_oauth_client_id", None)
+                )
+                or _is_missing_or_placeholder_secret(
+                    getattr(self, "google_oauth_client_secret", None)
+                )
+            ):
+                raise ValueError(
+                    "SECURITY: enable_google_oauth=True requires real "
+                    "GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET "
+                    "in production."
                 )
             if (
                 getattr(self, "enable_distributed_magic_link_sessions", False)

--- a/maritime-ai-service/app/core/config/_settings_validation.py
+++ b/maritime-ai-service/app/core/config/_settings_validation.py
@@ -14,6 +14,7 @@ from app.core.config.memory import MemoryConfig
 from app.core.config.product_search import ProductSearchConfig
 from app.core.config.rag import RAGConfig
 from app.core.config.thinking import ThinkingConfig
+from app.core.secret_validation import is_missing_or_placeholder_secret
 from app.engine.llm_provider_registry import get_supported_provider_names
 from app.engine.llm_timeout_policy import loads_timeout_provider_overrides
 
@@ -144,25 +145,6 @@ def validate_google_compat_url_value(v: str) -> str:
     return v
 
 
-def _is_missing_or_placeholder_secret(value) -> bool:
-    text = str(value or "").strip()
-    if not text:
-        return True
-    lowered = text.lower()
-    placeholder_markers = (
-        "change_me",
-        "change-me",
-        "changeme",
-        "placeholder",
-        "your_",
-        "your-",
-        "example",
-        "dummy",
-        "test-secret",
-    )
-    return any(marker in lowered for marker in placeholder_markers)
-
-
 def build_validate_production_security(config_logger):
     def _validate(self):
         if self.environment == "production":
@@ -183,7 +165,7 @@ def build_validate_production_security(config_logger):
                 )
             if getattr(
                 self, "enable_magic_link_auth", False
-            ) and _is_missing_or_placeholder_secret(
+            ) and is_missing_or_placeholder_secret(
                 getattr(self, "resend_api_key", None)
             ):
                 raise ValueError(
@@ -192,10 +174,10 @@ def build_validate_production_security(config_logger):
                     "instead of exposing dev verification URLs."
                 )
             if getattr(self, "enable_google_oauth", False) and (
-                _is_missing_or_placeholder_secret(
+                is_missing_or_placeholder_secret(
                     getattr(self, "google_oauth_client_id", None)
                 )
-                or _is_missing_or_placeholder_secret(
+                or is_missing_or_placeholder_secret(
                     getattr(self, "google_oauth_client_secret", None)
                 )
             ):

--- a/maritime-ai-service/app/core/secret_validation.py
+++ b/maritime-ai-service/app/core/secret_validation.py
@@ -1,0 +1,27 @@
+"""Shared secret validation helpers for fail-closed production config."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+PLACEHOLDER_SECRET_MARKERS: tuple[str, ...] = (
+    "change_me",
+    "change-me",
+    "changeme",
+    "placeholder",
+    "your_",
+    "your-",
+    "example",
+    "dummy",
+    "test-secret",
+)
+
+
+def is_missing_or_placeholder_secret(value: Any) -> bool:
+    """Return True when a secret is absent or still looks like a placeholder."""
+    text = str(value or "").strip()
+    if not text:
+        return True
+    lowered = text.lower()
+    return any(marker in lowered for marker in PLACEHOLDER_SECRET_MARKERS)

--- a/maritime-ai-service/tests/unit/test_dev_login_router.py
+++ b/maritime-ai-service/tests/unit/test_dev_login_router.py
@@ -221,6 +221,9 @@ def test_production_validator_rejects_dev_login_enabled():
     settings_mock.api_key = "a-real-prod-key-with-enough-bytes"
     settings_mock.enable_magic_link_auth = False
     settings_mock.resend_api_key = ""
+    settings_mock.enable_google_oauth = False
+    settings_mock.google_oauth_client_id = ""
+    settings_mock.google_oauth_client_secret = ""
     settings_mock.enable_dev_login = True
 
     with pytest.raises(ValueError, match="enable_dev_login=True is forbidden"):
@@ -241,6 +244,9 @@ def test_production_validator_passes_when_dev_login_off():
     settings_mock.api_key = "a-real-prod-key-with-enough-bytes"
     settings_mock.enable_magic_link_auth = False
     settings_mock.resend_api_key = ""
+    settings_mock.enable_google_oauth = False
+    settings_mock.google_oauth_client_id = ""
+    settings_mock.google_oauth_client_secret = ""
     settings_mock.enable_dev_login = False
 
     # No raise = pass

--- a/maritime-ai-service/tests/unit/test_production_validation.py
+++ b/maritime-ai-service/tests/unit/test_production_validation.py
@@ -1,6 +1,19 @@
 """Tests for production config validation."""
 import pytest
 
+PLACEHOLDER_SECRET_VALUES = (
+    "",
+    "change_me",
+    "change-me",
+    "changeme",
+    "placeholder",
+    "your_secret",
+    "your-secret",
+    "example",
+    "dummy",
+    "test-secret",
+)
+
 
 class TestProductionValidation:
     """Validate that production config blocks insecure defaults."""
@@ -37,7 +50,10 @@ class TestProductionValidation:
         assert "resend_api_key" in fields
         assert "enable_magic_link_auth" in fields
 
-    def test_magic_link_requires_real_resend_key_when_enabled_in_production(self):
+    @pytest.mark.parametrize("placeholder_secret", PLACEHOLDER_SECRET_VALUES)
+    def test_magic_link_requires_real_resend_key_when_enabled_in_production(
+        self, placeholder_secret
+    ):
         """Production Magic Link must fail closed without a real email provider."""
         from app.core.config import Settings
 
@@ -49,10 +65,13 @@ class TestProductionValidation:
                 session_secret_key="session]secret]with]enough]entropy]for]prod",
                 google_api_key="test",
                 enable_magic_link_auth=True,
-                resend_api_key="",
+                resend_api_key=placeholder_secret,
             )
 
-    def test_google_oauth_requires_real_client_secret_when_enabled_in_production(self):
+    @pytest.mark.parametrize("placeholder_secret", PLACEHOLDER_SECRET_VALUES)
+    def test_google_oauth_requires_real_client_secret_when_enabled_in_production(
+        self, placeholder_secret
+    ):
         """Production Google OAuth must fail closed without real OAuth credentials."""
         from app.core.config import Settings
 
@@ -64,8 +83,20 @@ class TestProductionValidation:
                 session_secret_key="session]secret]with]enough]entropy]for]prod",
                 google_api_key="test",
                 enable_google_oauth=True,
-                google_oauth_client_id="",
-                google_oauth_client_secret="",
+                google_oauth_client_id=placeholder_secret,
+                google_oauth_client_secret="real-google-oauth-client-secret",
+            )
+
+        with pytest.raises(ValueError, match="GOOGLE_OAUTH_CLIENT_ID"):
+            Settings(
+                environment="production",
+                api_key="a-real-prod-api-key-with-enough-bytes",
+                jwt_secret_key="jwt]secret]with]enough]entropy]for]prod",
+                session_secret_key="session]secret]with]enough]entropy]for]prod",
+                google_api_key="test",
+                enable_google_oauth=True,
+                google_oauth_client_id="real-google-oauth-client-id",
+                google_oauth_client_secret=placeholder_secret,
             )
 
     def test_api_key_too_short_in_production(self):

--- a/maritime-ai-service/tests/unit/test_production_validation.py
+++ b/maritime-ai-service/tests/unit/test_production_validation.py
@@ -37,6 +37,37 @@ class TestProductionValidation:
         assert "resend_api_key" in fields
         assert "enable_magic_link_auth" in fields
 
+    def test_magic_link_requires_real_resend_key_when_enabled_in_production(self):
+        """Production Magic Link must fail closed without a real email provider."""
+        from app.core.config import Settings
+
+        with pytest.raises(ValueError, match="RESEND_API_KEY"):
+            Settings(
+                environment="production",
+                api_key="a-real-prod-api-key-with-enough-bytes",
+                jwt_secret_key="jwt]secret]with]enough]entropy]for]prod",
+                session_secret_key="session]secret]with]enough]entropy]for]prod",
+                google_api_key="test",
+                enable_magic_link_auth=True,
+                resend_api_key="",
+            )
+
+    def test_google_oauth_requires_real_client_secret_when_enabled_in_production(self):
+        """Production Google OAuth must fail closed without real OAuth credentials."""
+        from app.core.config import Settings
+
+        with pytest.raises(ValueError, match="GOOGLE_OAUTH_CLIENT_ID"):
+            Settings(
+                environment="production",
+                api_key="a-real-prod-api-key-with-enough-bytes",
+                jwt_secret_key="jwt]secret]with]enough]entropy]for]prod",
+                session_secret_key="session]secret]with]enough]entropy]for]prod",
+                google_api_key="test",
+                enable_google_oauth=True,
+                google_oauth_client_id="",
+                google_oauth_client_secret="",
+            )
+
     def test_api_key_too_short_in_production(self):
         """API key under 16 chars should fail in production."""
         from app.core.config import Settings

--- a/maritime-ai-service/tests/unit/test_sprint160b_hardening.py
+++ b/maritime-ai-service/tests/unit/test_sprint160b_hardening.py
@@ -575,7 +575,7 @@ class TestConfigSecurity:
                 environment="production",
                 enable_google_oauth=True,
                 google_oauth_client_id="test-id",
-                google_oauth_client_secret="test-secret",
+                google_oauth_client_secret="real-google-client-secret-for-session-test",
                 session_secret_key="change-session-secret-in-production",
                 jwt_secret_key="real-secret-key-with-32-chars",
                 api_key="real-api-key-with-32-chars",

--- a/maritime-ai-service/tests/unit/test_sprint224_magic_link.py
+++ b/maritime-ai-service/tests/unit/test_sprint224_magic_link.py
@@ -83,6 +83,38 @@ class TestEmailService:
             result = await send_magic_link_email("test@example.com", "https://wiii.app/verify/abc")
             assert result is False
 
+    @pytest.mark.asyncio
+    async def test_send_magic_link_email_fails_closed_in_production_without_resend(self):
+        from app.auth.email_service import send_magic_link_email
+
+        mock_settings = MagicMock()
+        mock_settings.environment = "production"
+        mock_settings.resend_api_key = ""
+
+        with patch("app.auth.email_service.settings", mock_settings):
+            result = await send_magic_link_email(
+                "test@example.com",
+                "https://wiii.app/verify/abc",
+            )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_send_magic_link_email_keeps_dev_fallback_outside_production(self):
+        from app.auth.email_service import send_magic_link_email
+
+        mock_settings = MagicMock()
+        mock_settings.environment = "development"
+        mock_settings.resend_api_key = ""
+
+        with patch("app.auth.email_service.settings", mock_settings):
+            result = await send_magic_link_email(
+                "test@example.com",
+                "https://wiii.app/verify/abc",
+            )
+
+        assert result is True
+
 
 class TestMagicLinkTokenGeneration:
     """Token generation and hashing."""
@@ -264,6 +296,52 @@ class TestMagicLinkRequest:
             # token_hash is the first positional param ($1)
             stored_hash = call_args[0][1]
             assert len(stored_hash) == 64  # SHA256 hex digest
+
+    @pytest.mark.asyncio
+    async def test_create_magic_link_does_not_surface_dev_verify_url_in_production(self):
+        """Production responses must not expose raw verification URLs."""
+        from app.auth.magic_link_router import _create_magic_link
+
+        mock_conn = AsyncMock()
+        mock_conn.fetchval = AsyncMock(return_value=0)
+        mock_conn.execute = AsyncMock()
+
+        with patch("app.auth.magic_link_router.send_magic_link_email", new_callable=AsyncMock, return_value=True), \
+             patch("app.auth.magic_link_router.settings") as mock_settings:
+            mock_settings.environment = "production"
+            mock_settings.resend_api_key = ""
+            mock_settings.magic_link_expires_seconds = 600
+            mock_settings.magic_link_base_url = "https://wiii.holilihu.online"
+            mock_settings.magic_link_max_per_hour = 5
+            mock_settings.api_v1_prefix = "/api/v1"
+
+            result = await _create_magic_link("test@example.com", mock_conn)
+
+        assert "dev_verify_url" not in result
+
+    @pytest.mark.asyncio
+    async def test_create_magic_link_surfaces_dev_verify_url_outside_production(self):
+        """Local/dev keeps the convenience URL for manual login testing."""
+        from app.auth.magic_link_router import _create_magic_link
+
+        mock_conn = AsyncMock()
+        mock_conn.fetchval = AsyncMock(return_value=0)
+        mock_conn.execute = AsyncMock()
+
+        with patch("app.auth.magic_link_router.send_magic_link_email", new_callable=AsyncMock, return_value=True), \
+             patch("app.auth.magic_link_router.settings") as mock_settings:
+            mock_settings.environment = "development"
+            mock_settings.resend_api_key = ""
+            mock_settings.magic_link_expires_seconds = 600
+            mock_settings.magic_link_base_url = "http://localhost:8000"
+            mock_settings.magic_link_max_per_hour = 5
+            mock_settings.api_v1_prefix = "/api/v1"
+
+            result = await _create_magic_link("test@example.com", mock_conn)
+
+        assert result["dev_verify_url"].startswith(
+            "http://localhost:8000/api/v1/auth/magic-link/verify/"
+        )
 
     @pytest.mark.asyncio
     async def test_create_magic_link_at_rate_limit_boundary(self):


### PR DESCRIPTION
﻿## Summary
- Fail closed when production Magic Link is enabled without a real `RESEND_API_KEY`.
- Fail closed when production Google OAuth is enabled without real `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET`.
- Keep Magic Link `dev_verify_url` convenience responses outside production only.
- Add focused regression coverage for production auth secret guards and dev fallback behavior.

Fixes #262

## Verification
- `cd maritime-ai-service && python -m pytest tests/unit/test_production_validation.py tests/unit/test_sprint224_magic_link.py tests/unit/test_dev_login_router.py tests/unit/test_magic_link_session_store.py -q` → 116 passed, 6 skipped
- `cd maritime-ai-service && python -m ruff check app/auth/email_service.py app/auth/magic_link_router.py app/core/config/_settings_validation.py tests/unit/test_production_validation.py tests/unit/test_sprint224_magic_link.py tests/unit/test_dev_login_router.py --select=E9,F63,F7` → passed
- `cd maritime-ai-service && python -m ruff check app/ --select=E9,F63,F7` → passed
- `git diff --check` → passed
- `cd maritime-ai-service && set PYTHONIOENCODING=utf-8; python -m pytest tests/unit/ -p no:capture --tb=short -q` → timed out after 15 minutes before completion; no focused failures were observed before timeout output was returned.

## Risk
- Production deployments that turn on Magic Link or Google OAuth without real secrets will now refuse startup instead of running in a broken or unsafe state.
- Local/dev Magic Link manual-login convenience remains available outside production.

## Rollback
- Revert this PR to restore previous warning-only behavior, or provide real production secrets before enabling `ENABLE_MAGIC_LINK_AUTH` / `ENABLE_GOOGLE_OAUTH`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened production validation to fail deployments when magic-link or OAuth credentials are missing or use placeholder values.
  * Broadened detection of placeholder/missing secrets to avoid unsafe fallbacks.

* **New Features**
  * In production, magic-link email sending is blocked when the email provider key is not properly configured.

* **Tests**
  * Added and updated tests covering production validation and magic-link/email behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/263)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
