### PR TITLE
docs: document production auth enablement

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -14,6 +14,7 @@ Operational docs are different from exploratory reports:
 - `WIII_GITHUB_GOVERNANCE.md`: GitHub issue, PR, branch, review, label, and merge standards.
 - `WIII_CODEX_REVIEW_SETUP.md`: Codex GitHub Review setup, rollout, operating policy, and rollback controls.
 - `WIII_LOCAL_DEMO_RUNBOOK.md`: local demo login contract, smoke gate, browser state recovery, and OpenAI Agents SDK-inspired runtime lessons.
+- `WIII_PRODUCTION_AUTH_RUNBOOK.md`: production Magic Link and Google OAuth enablement, fail-closed behavior, smoke tests, and rollback.
 - `WIII_GITHUB_HARDENING_2026-04-26.md`: current GitHub hardening checkpoint, applied settings, CI gate rollout, and security follow-up.
 - `WIII_MULTI_AGENT_MAINTAINER_PROTOCOL.md`: multi-agent ownership, maintainer review, CodeRabbit, conflict, and merge protocol.
 - `WIII_SYSTEM_CLEANUP_CHECKPOINT_2026-04-24.md`: current cleanup checkpoint consolidated from runtime and pipeline research.

--- a/docs/operations/WIII_PRODUCTION_AUTH_RUNBOOK.md
+++ b/docs/operations/WIII_PRODUCTION_AUTH_RUNBOOK.md
@@ -1,0 +1,218 @@
+# Wiii Production Auth Runbook
+
+Status: Active
+
+Owner: Project leadership
+
+Last updated: 2026-05-10
+
+Related issue: [#264](https://github.com/meiiie/wiii/issues/264)
+
+## Purpose
+
+This runbook defines the production-safe setup for Wiii login methods after the
+fail-closed auth guard shipped in [#263](https://github.com/meiiie/wiii/pull/263).
+
+Production auth must be boring, explicit, and reversible:
+
+- never commit auth secrets, API keys, OAuth client secrets, or `.env.production`
+- keep login methods disabled until the matching provider secret is present
+- validate Google redirect URIs in Google Cloud Console before enabling OAuth
+- smoke test from the public domain after each auth change
+- rollback by disabling the feature flag and restarting the app
+
+## Current Production State
+
+As of 2026-05-10, Magic Link is provisioned on production with a verified
+Resend domain. Google OAuth remains disabled until the Wiii callback is added to
+Google Cloud Console.
+
+```env
+ENABLE_MAGIC_LINK_AUTH=true
+ENABLE_GOOGLE_OAUTH=false
+MAGIC_LINK_BASE_URL=https://wiii.holilihu.online
+MAGIC_LINK_FROM_EMAIL=Wiii <noreply@holilihu.online>
+ENABLE_DISTRIBUTED_MAGIC_LINK_SESSIONS=true
+VALKEY_URL=redis://valkey:6379/0
+OAUTH_REDIRECT_BASE_URL=https://wiii.holilihu.online
+OAUTH_ALLOWED_REDIRECT_ORIGINS=https://wiii.holilihu.online
+```
+
+The Resend API key lives only in the VM runtime `.env.production`. It must not
+appear in Git, GitHub, docs, PR comments, or shell output. Rotate any key that
+was pasted into chat before using it for a higher-stakes production launch.
+
+## Fail-Closed Contract
+
+In production, Wiii refuses unsafe optional auth configuration:
+
+- `ENABLE_MAGIC_LINK_AUTH=true` requires a non-placeholder `RESEND_API_KEY`
+- `ENABLE_GOOGLE_OAUTH=true` requires non-placeholder Google OAuth client ID and secret
+- Magic Link never returns `dev_verify_url` in production
+- `ENABLE_DEV_LOGIN=true` is forbidden in production
+
+If one of these checks fails, treat startup failure as the correct outcome.
+Fix the environment, do not loosen validation.
+
+## Magic Link With Resend
+
+### Provisioning Checklist
+
+1. Verify the sender domain in Resend.
+2. Prefer a domain sender such as `noreply@holilihu.online`.
+3. Store the Resend API key only in the production runtime environment.
+4. Use Valkey-backed Magic Link sessions in production so WebSocket handoff
+   survives multiple workers or app restarts.
+
+Required runtime variables:
+
+```env
+ENABLE_MAGIC_LINK_AUTH=true
+RESEND_API_KEY=<real-resend-api-key>
+MAGIC_LINK_BASE_URL=https://wiii.holilihu.online
+MAGIC_LINK_FROM_EMAIL=Wiii <noreply@holilihu.online>
+ENABLE_DISTRIBUTED_MAGIC_LINK_SESSIONS=true
+VALKEY_URL=redis://valkey:6379/0
+```
+
+### Smoke Test
+
+From a trusted operator machine, request a link for a real test inbox:
+
+```bash
+curl -fsS https://wiii.holilihu.online/api/v1/auth/magic-link/request \
+  -H 'content-type: application/json' \
+  --data '{"email":"<operator-test-email>"}'
+```
+
+Expected result:
+
+- response contains `session_id`, `message`, and `expires_in`
+- response does not contain `dev_verify_url`
+- the test inbox receives a link under `https://wiii.holilihu.online`
+- opening the link verifies the session and issues Wiii tokens
+
+If the request returns `500`, check the app logs for Resend rejection, sender
+domain status, or rate limits before changing application code.
+
+### Rollback
+
+```env
+ENABLE_MAGIC_LINK_AUTH=false
+```
+
+Restart the app container, then confirm the request endpoint no longer exposes a
+working login path.
+
+## Google OAuth
+
+Wiii uses Google OAuth authorization code flow through the Wiii backend. This is
+different from the current LMS GIS browser-token flow documented in
+`E:/Sach/Sua/LMS_hohulili/docs/runbooks/GOOGLE_LOGIN_GIS_SETUP_RUNBOOK.md`.
+
+Wiii's Google Cloud Console redirect URI is:
+
+```text
+https://wiii.holilihu.online/api/v1/auth/google/callback
+```
+
+The public login endpoint is:
+
+```text
+https://wiii.holilihu.online/api/v1/auth/google/login
+```
+
+Required runtime variables:
+
+```env
+ENABLE_GOOGLE_OAUTH=true
+GOOGLE_OAUTH_CLIENT_ID=<google-web-client-id>
+GOOGLE_OAUTH_CLIENT_SECRET=<google-web-client-secret>
+OAUTH_REDIRECT_BASE_URL=https://wiii.holilihu.online
+OAUTH_ALLOWED_REDIRECT_ORIGINS=https://wiii.holilihu.online
+SESSION_SECRET_KEY=<real-32-byte-or-longer-secret>
+```
+
+### Can Wiii Reuse The LMS Google OAuth Client?
+
+Yes, but only if the same Google Cloud OAuth web client is intentionally shared
+inside the same project/trust boundary and has every required origin or redirect
+URI configured.
+
+For the current LMS repo, local `.env` contains a valid-shaped Google client and
+secret, but the redirect URI is local:
+
+```text
+http://localhost:8088/api/v3/auth/google/callback
+```
+
+That local value is not enough for Wiii production. Before enabling Wiii Google
+OAuth, Google Cloud Console must include:
+
+```text
+https://wiii.holilihu.online/api/v1/auth/google/callback
+```
+
+If Wiii is pointed at a client that lacks this exact redirect URI, Google will
+fail with `redirect_uri_mismatch`. Fix Google Cloud Console, not Wiii code.
+
+Recommended production setup:
+
+- use a dedicated Wiii production OAuth web client when possible
+- use a shared LMS/Wiii client only when project ownership, consent screen,
+  authorized domains, and rollback ownership are shared
+- keep local, staging, and production OAuth clients separate if the team can
+  manage the extra secrets
+
+### Smoke Test
+
+After enabling OAuth and restarting the app:
+
+```bash
+curl -fsSI https://wiii.holilihu.online/api/v1/auth/google/login
+```
+
+Expected result:
+
+- endpoint returns a redirect toward Google Accounts
+- browser login returns to Wiii without `redirect_uri_mismatch`
+- callback delivers tokens to the expected Wiii web or desktop redirect flow
+
+### Rollback
+
+```env
+ENABLE_GOOGLE_OAUTH=false
+```
+
+Restart the app container. Keep client secrets in the runtime store if rotation
+is not required; remove or rotate them if there is any exposure concern.
+
+## Production Change Procedure
+
+1. Edit `/opt/wiii/maritime-ai-service/.env.production` on the Wiii VM.
+2. Never paste secrets into GitHub issues, pull requests, docs, chat logs, or
+   shell output.
+3. Restart through the pinned deploy path when possible:
+
+```bash
+cd /opt/wiii
+SHA=<current-production-sha>
+DEPLOY_SHA=${SHA} \
+WIII_APP_IMAGE=ghcr.io/meiiie/wiii-app:sha-${SHA} \
+WIII_NGINX_IMAGE=ghcr.io/meiiie/wiii-nginx:sha-${SHA} \
+REQUIRE_PINNED_IMAGES=true \
+RUN_EXTERNAL_SMOKE=true \
+BASE_URL=https://wiii.holilihu.online \
+  bash ./maritime-ai-service/scripts/deploy/deploy.sh
+```
+
+4. Run auth-specific smoke tests.
+5. Record outcome and rollback notes in the release issue or PR.
+
+## Operator Notes
+
+- If a test key was pasted in an AI chat, rotate it before real production use.
+- A Resend key alone is not enough; sender/domain verification still matters.
+- A Google client ID and secret alone are not enough; exact redirect URIs matter.
+- Do not enable both optional login methods at once unless the rollback owner is
+  online and the release smoke window is clear.

--- a/docs/operations/WIII_PRODUCTION_AUTH_RUNBOOK.md
+++ b/docs/operations/WIII_PRODUCTION_AUTH_RUNBOOK.md
@@ -189,10 +189,10 @@ is not required; remove or rotate them if there is any exposure concern.
 
 ## Production Change Procedure
 
-1. Edit `/opt/wiii/maritime-ai-service/.env.production` on the Wiii VM.
-2. Never paste secrets into GitHub issues, pull requests, docs, chat logs, or
-   shell output.
-3. Restart through the pinned deploy path when possible:
+- Edit `/opt/wiii/maritime-ai-service/.env.production` on the Wiii VM.
+- Never paste secrets into GitHub issues, pull requests, docs, chat logs, or
+  shell output.
+- Restart through the pinned deploy path when possible:
 
 ```bash
 cd /opt/wiii
@@ -206,8 +206,10 @@ BASE_URL=https://wiii.holilihu.online \
   bash ./maritime-ai-service/scripts/deploy/deploy.sh
 ```
 
-4. Run auth-specific smoke tests.
-5. Record outcome and rollback notes in the release issue or PR.
+After deploy:
+
+- Run auth-specific smoke tests.
+- Record outcome and rollback notes in the release issue or PR.
 
 ## Operator Notes
 

--- a/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
+++ b/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
@@ -69,6 +69,9 @@ LLM_MODEL_HEALTH_PROBE_TIMEOUT_SECONDS=45
 AGENT_PROVIDER_CONFIGS={"code_studio_agent":{"tier":"deep","provider":"nvidia","model":"deepseek-ai/deepseek-v4-pro"}}
 
 # Required while production embeddings use models/gemini-embedding-001.
+# Use only the minimum Gemini/API permissions needed for embeddings, track its
+# rotation independently from NVIDIA_API_KEY, and document any provider-specific
+# rotation procedure in the release or auth runbook.
 GOOGLE_API_KEY=<google-gemini-api-key>
 
 APP_REPLICAS=1

--- a/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
+++ b/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
@@ -30,13 +30,21 @@ Cloudflare/DNS -> Caddy on host -> local nginx on :8080 -> app on Docker network
 
 Important implication: the app container is private. Health probes on the VM must use nginx-local URLs such as `http://localhost:8080/api/v1/health/live`, not `http://localhost:8000`.
 
-On 2026-05-09, a public probe showed:
+On 2026-05-10, production was verified on `wiii-production` in project
+`the-wiii-lab`:
 
-- `https://holilihu.online/embed/` returned `200`
-- `https://wiii.holilihu.online/api/v1/health/live` timed out
-- `https://wiii.holilihu.online/api/v1/health` timed out
+- `https://wiii.holilihu.online/api/v1/health/llm-models` was reachable
+- the active model pool contained primary `qwen/qwen3-next-80b-a3b-instruct`
+  and advanced fallback `deepseek-ai/deepseek-v4-pro`
+- model-level health may temporarily mark the advanced model degraded after a
+  timeout; routing should keep normal chat on the healthy primary model
+- `ENABLE_MAGIC_LINK_AUTH=true` was enabled after Resend API validation and
+  verified `holilihu.online` sender domain smoke
+- `ENABLE_GOOGLE_OAUTH=false` remained the safe default until the Wiii callback
+  is registered in Google Cloud Console
 
-Treat public API health timeout as a release blocker until the deploy script, Caddy routing, nginx health, and app health all agree.
+Treat any future public API health timeout as a release blocker until the deploy
+script, Caddy routing, nginx health, and app health all agree.
 
 ## Current GCP Rebuild Target
 
@@ -54,9 +62,14 @@ Production `.env.production` is secret-bearing and must stay on the VM. For the 
 ```bash
 LLM_PROVIDER=nvidia
 NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
-NVIDIA_MODEL=deepseek-ai/deepseek-v4-flash
+NVIDIA_MODEL=qwen/qwen3-next-80b-a3b-instruct
 NVIDIA_MODEL_ADVANCED=deepseek-ai/deepseek-v4-pro
+ENABLE_LLM_MODEL_HEALTH_PROBES=true
+LLM_MODEL_HEALTH_PROBE_TIMEOUT_SECONDS=45
 AGENT_PROVIDER_CONFIGS={"code_studio_agent":{"tier":"deep","provider":"nvidia","model":"deepseek-ai/deepseek-v4-pro"}}
+
+# Required while production embeddings use models/gemini-embedding-001.
+GOOGLE_API_KEY=<google-gemini-api-key>
 
 APP_REPLICAS=1
 GUNICORN_WORKERS=2
@@ -76,6 +89,12 @@ BACKUP_MEM_LIMIT=192M
 ```
 
 `NVIDIA_API_KEY` and all database/auth/object-storage secrets must be copied through the operator's secure channel only; never paste them into issues, PR comments, docs, or shell logs.
+
+Optional production login methods are governed by
+[`WIII_PRODUCTION_AUTH_RUNBOOK.md`](./WIII_PRODUCTION_AUTH_RUNBOOK.md). Keep
+Magic Link enabled only while Resend smoke stays healthy. Keep
+`ENABLE_GOOGLE_OAUTH=false` unless the matching Google OAuth callback setup has
+been completed and smoke tested.
 
 Provision the new VM:
 
@@ -124,6 +143,8 @@ Required release evidence:
 - app and nginx images exist in GHCR
 - no unresolved P0/P1 issue blocks the release
 - production secrets are present on the VM and contain no `CHANGE_ME` placeholders
+- optional auth flags are either disabled or backed by real provider secrets and
+  exact callback/origin configuration
 
 Image existence check:
 
@@ -155,7 +176,7 @@ WIII_NGINX_IMAGE=ghcr.io/meiiie/wiii-nginx:sha-${SHA} \
 REQUIRE_PINNED_IMAGES=true \
 RUN_EXTERNAL_SMOKE=true \
 BASE_URL=https://wiii.holilihu.online \
-  ./maritime-ai-service/scripts/deploy/deploy.sh
+  bash ./maritime-ai-service/scripts/deploy/deploy.sh
 ```
 
 The deploy script will:
@@ -194,6 +215,8 @@ Minimum product smoke criteria:
 - SSE V3 smoke reaches metadata and done events
 - a normal short chat returns without a long silent period
 - LMS iframe loads Wiii without cross-origin console errors beyond known sandbox limitations
+- optional Magic Link or Google OAuth smoke passes if that login method was
+  changed during the release
 
 ## Rollback
 
@@ -209,7 +232,7 @@ WIII_NGINX_IMAGE=ghcr.io/meiiie/wiii-nginx:sha-${PREV_SHA} \
 REQUIRE_PINNED_IMAGES=true \
 RUN_EXTERNAL_SMOKE=true \
 BASE_URL=https://wiii.holilihu.online \
-  ./maritime-ai-service/scripts/deploy/deploy.sh
+  bash ./maritime-ai-service/scripts/deploy/deploy.sh
 ```
 
 If rollback follows a migration, check whether the migration is backward-compatible before restarting the previous app image. If not, restore the predeploy dump created in `maritime-ai-service/backups/` and document the recovery in the release issue.

--- a/maritime-ai-service/scripts/deploy/.env.production.template
+++ b/maritime-ai-service/scripts/deploy/.env.production.template
@@ -55,26 +55,20 @@ SENTRY_TRACES_SAMPLE_RATE=0.2
 
 # ─────────────────────────────────────────────────
 # MAGIC LINK AUTH (Sprint 224)
-# Sign up at resend.com, verify sender/domain, then get an API key.
-# Keep disabled until RESEND_API_KEY is real. Production fails closed if this
-# is enabled with a missing or placeholder key.
+# Sign up at resend.com → verify domain → get API key
+# Free tier: 3,000 emails/month
 # ─────────────────────────────────────────────────
-ENABLE_MAGIC_LINK_AUTH=false
+ENABLE_MAGIC_LINK_AUTH=true
 RESEND_API_KEY=CHANGE_ME_your_resend_api_key
 MAGIC_LINK_BASE_URL=https://wiii.holilihu.online
 MAGIC_LINK_FROM_EMAIL=Wiii <noreply@holilihu.online>
-ENABLE_DISTRIBUTED_MAGIC_LINK_SESSIONS=true
 
 # ─────────────────────────────────────────────────
-# LLM - NVIDIA NIM (current production lane)
+# LLM — Google Gemini (primary)
 # ─────────────────────────────────────────────────
-LLM_PROVIDER=nvidia
-NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
-NVIDIA_API_KEY=CHANGE_ME_your_nvidia_api_key
-NVIDIA_MODEL=qwen/qwen3-next-80b-a3b-instruct
-NVIDIA_MODEL_ADVANCED=deepseek-ai/deepseek-v4-pro
-ENABLE_LLM_MODEL_HEALTH_PROBES=true
-LLM_MODEL_HEALTH_PROBE_TIMEOUT_SECONDS=45
+LLM_PROVIDER=google
+GOOGLE_API_KEY=CHANGE_ME_your_gemini_api_key
+GOOGLE_MODEL=gemini-3.1-flash-lite-preview
 
 # Optional: OpenAI failover
 # OPENAI_API_KEY=sk-...
@@ -127,17 +121,14 @@ DEFAULT_DOMAIN=maritime
 
 # ─────────────────────────────────────────────────
 # GOOGLE OAUTH (Sprint 157)
-# Keep disabled until the Google Cloud OAuth web client has this exact
-# Authorized redirect URI:
-#   https://wiii.holilihu.online/api/v1/auth/google/callback
-# Production fails closed if this is enabled with missing placeholder secrets.
 # ─────────────────────────────────────────────────
-ENABLE_GOOGLE_OAUTH=false
+ENABLE_GOOGLE_OAUTH=true
 GOOGLE_OAUTH_CLIENT_ID=CHANGE_ME_your_client_id.apps.googleusercontent.com
 GOOGLE_OAUTH_CLIENT_SECRET=CHANGE_ME_your_client_secret
-OAUTH_REDIRECT_BASE_URL=https://wiii.holilihu.online
+GOOGLE_OAUTH_REDIRECT_URI=https://holilihu.online/api/v1/auth/google/callback
 # Sprint 228: Web OAuth redirect origins (comma-separated whitelist)
-OAUTH_ALLOWED_REDIRECT_ORIGINS=https://wiii.holilihu.online
+OAUTH_ALLOWED_REDIRECT_ORIGINS=http://localhost:1420,http://localhost:1421,https://wiii.holilihu.online
+OAUTH_REDIRECT_BASE_URL=https://wiii.holilihu.online
 
 # ─────────────────────────────────────────────────
 # CROSS-PLATFORM IDENTITY (Sprint 174)
@@ -218,8 +209,6 @@ RATE_LIMIT_WINDOW_SECONDS=60
 # ─────────────────────────────────────────────────
 # SEMANTIC MEMORY
 # ─────────────────────────────────────────────────
-# Required while EMBEDDING_MODEL uses Gemini embeddings.
-GOOGLE_API_KEY=CHANGE_ME_your_gemini_api_key
 EMBEDDING_MODEL=models/gemini-embedding-001
 EMBEDDING_DIMENSIONS=768
 SEMANTIC_MEMORY_ENABLED=true
@@ -229,8 +218,8 @@ SEMANTIC_MEMORY_ENABLED=true
 # ─────────────────────────────────────────────────
 USE_MULTI_AGENT=true
 ENABLE_CORRECTIVE_RAG=true
-# Code Studio agent uses the advanced NVIDIA model for higher-quality React/visual generation
-AGENT_PROVIDER_CONFIGS={"code_studio_agent":{"tier":"deep","provider":"nvidia","model":"deepseek-ai/deepseek-v4-pro"}}
+# Code Studio agent uses Gemini Pro for higher-quality React/visual generation
+AGENT_PROVIDER_CONFIGS={"code_studio_agent":{"tier":"deep","provider":"google","model":"gemini-3.1-pro-preview"}}
 
 # ─────────────────────────────────────────────────
 # VALKEY — Cache/Rate Limiter (Docker internal)

--- a/maritime-ai-service/scripts/deploy/.env.production.template
+++ b/maritime-ai-service/scripts/deploy/.env.production.template
@@ -55,20 +55,26 @@ SENTRY_TRACES_SAMPLE_RATE=0.2
 
 # ─────────────────────────────────────────────────
 # MAGIC LINK AUTH (Sprint 224)
-# Sign up at resend.com → verify domain → get API key
-# Free tier: 3,000 emails/month
+# Sign up at resend.com, verify sender/domain, then get an API key.
+# Keep disabled until RESEND_API_KEY is real. Production fails closed if this
+# is enabled with a missing or placeholder key.
 # ─────────────────────────────────────────────────
-ENABLE_MAGIC_LINK_AUTH=true
+ENABLE_MAGIC_LINK_AUTH=false
 RESEND_API_KEY=CHANGE_ME_your_resend_api_key
 MAGIC_LINK_BASE_URL=https://wiii.holilihu.online
 MAGIC_LINK_FROM_EMAIL=Wiii <noreply@holilihu.online>
+ENABLE_DISTRIBUTED_MAGIC_LINK_SESSIONS=true
 
 # ─────────────────────────────────────────────────
-# LLM — Google Gemini (primary)
+# LLM - NVIDIA NIM (current production lane)
 # ─────────────────────────────────────────────────
-LLM_PROVIDER=google
-GOOGLE_API_KEY=CHANGE_ME_your_gemini_api_key
-GOOGLE_MODEL=gemini-3.1-flash-lite-preview
+LLM_PROVIDER=nvidia
+NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
+NVIDIA_API_KEY=CHANGE_ME_your_nvidia_api_key
+NVIDIA_MODEL=qwen/qwen3-next-80b-a3b-instruct
+NVIDIA_MODEL_ADVANCED=deepseek-ai/deepseek-v4-pro
+ENABLE_LLM_MODEL_HEALTH_PROBES=true
+LLM_MODEL_HEALTH_PROBE_TIMEOUT_SECONDS=45
 
 # Optional: OpenAI failover
 # OPENAI_API_KEY=sk-...
@@ -121,14 +127,17 @@ DEFAULT_DOMAIN=maritime
 
 # ─────────────────────────────────────────────────
 # GOOGLE OAUTH (Sprint 157)
+# Keep disabled until the Google Cloud OAuth web client has this exact
+# Authorized redirect URI:
+#   https://wiii.holilihu.online/api/v1/auth/google/callback
+# Production fails closed if this is enabled with missing placeholder secrets.
 # ─────────────────────────────────────────────────
-ENABLE_GOOGLE_OAUTH=true
+ENABLE_GOOGLE_OAUTH=false
 GOOGLE_OAUTH_CLIENT_ID=CHANGE_ME_your_client_id.apps.googleusercontent.com
 GOOGLE_OAUTH_CLIENT_SECRET=CHANGE_ME_your_client_secret
-GOOGLE_OAUTH_REDIRECT_URI=https://holilihu.online/api/v1/auth/google/callback
-# Sprint 228: Web OAuth redirect origins (comma-separated whitelist)
-OAUTH_ALLOWED_REDIRECT_ORIGINS=http://localhost:1420,http://localhost:1421,https://wiii.holilihu.online
 OAUTH_REDIRECT_BASE_URL=https://wiii.holilihu.online
+# Sprint 228: Web OAuth redirect origins (comma-separated whitelist)
+OAUTH_ALLOWED_REDIRECT_ORIGINS=https://wiii.holilihu.online
 
 # ─────────────────────────────────────────────────
 # CROSS-PLATFORM IDENTITY (Sprint 174)
@@ -209,6 +218,8 @@ RATE_LIMIT_WINDOW_SECONDS=60
 # ─────────────────────────────────────────────────
 # SEMANTIC MEMORY
 # ─────────────────────────────────────────────────
+# Required while EMBEDDING_MODEL uses Gemini embeddings.
+GOOGLE_API_KEY=CHANGE_ME_your_gemini_api_key
 EMBEDDING_MODEL=models/gemini-embedding-001
 EMBEDDING_DIMENSIONS=768
 SEMANTIC_MEMORY_ENABLED=true
@@ -218,8 +229,8 @@ SEMANTIC_MEMORY_ENABLED=true
 # ─────────────────────────────────────────────────
 USE_MULTI_AGENT=true
 ENABLE_CORRECTIVE_RAG=true
-# Code Studio agent uses Gemini Pro for higher-quality React/visual generation
-AGENT_PROVIDER_CONFIGS={"code_studio_agent":{"tier":"deep","provider":"google","model":"gemini-3.1-pro-preview"}}
+# Code Studio agent uses the advanced NVIDIA model for higher-quality React/visual generation
+AGENT_PROVIDER_CONFIGS={"code_studio_agent":{"tier":"deep","provider":"nvidia","model":"deepseek-ai/deepseek-v4-pro"}}
 
 # ─────────────────────────────────────────────────
 # VALKEY — Cache/Rate Limiter (Docker internal)


### PR DESCRIPTION
﻿## Summary

Closes #264.

- Add a production auth runbook for Magic Link and Google OAuth fail-closed operations.
- Update the product release runbook with the current Wiii production model/auth state and `bash deploy.sh` invocation.
- Harden `.env.production.template` so optional Magic Link/Google OAuth defaults stay disabled until provider setup is complete.

## Production ops evidence

- Resend API key validated without printing the key.
- Resend domain `holilihu.online` verified.
- Production runtime updated on `wiii-production`; Magic Link is enabled, Google OAuth remains disabled.
- Pinned deploy completed for `59a0b35aa48935b0668312f13e501282f55f8123`.
- External smoke passed: `14 passed, 0 failed`.
- Magic Link smoke returned `session_id`, `message`, `expires_in`, and no `dev_verify_url`.
- Google OAuth smoke returned `404`, expected while `ENABLE_GOOGLE_OAUTH=false`.

## Risk and rollback

- Risk: auth docs and template drift could confuse operators. Mitigation: runbook now separates safe template defaults from current runtime state.
- Rollback: set `ENABLE_MAGIC_LINK_AUTH=false` in production `.env.production`, run the pinned deploy command from the runbook, and keep Google OAuth disabled until Google Cloud Console has the exact Wiii callback.

## Verification

- `git diff --check` passed.
- Secret scan over changed docs/template found no real Resend, NVIDIA, Google OAuth, or Google API key values.
- `API_KEY=<production-api-key> bash scripts/deploy/smoke-test.sh https://wiii.holilihu.online` passed via deploy script with `14 passed, 0 failed`.
- `Invoke-RestMethod https://wiii.holilihu.online/api/v1/auth/magic-link/request` with a Resend test recipient passed and did not expose `dev_verify_url`.
- `curl https://wiii.holilihu.online/api/v1/auth/google/login` returned `404`, expected while Google OAuth is disabled.

## Notes

- Local `pytest` was not available on PATH. `uv run pytest tests/unit/test_production_validation.py tests/unit/test_sprint224_magic_link.py -q` created an ephemeral environment but failed before tests because `pytest` is not in the project dependency set; the generated `.venv` and `uv.lock` were removed. No runtime code changed in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added production authentication operations runbook with configuration guidance, smoke testing procedures, and rollback instructions for Magic Link and OAuth methods.
  * Updated product release runbook with production verification procedures and deployment guidance.

* **Chores**
  * Updated production environment configuration template to reflect authentication and LLM model provider settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/265)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->