### PR TITLE
docs: record production Google OAuth enablement

### DIFF
--- a/docs/operations/WIII_PRODUCTION_AUTH_RUNBOOK.md
+++ b/docs/operations/WIII_PRODUCTION_AUTH_RUNBOOK.md
@@ -24,12 +24,12 @@ Production auth must be boring, explicit, and reversible:
 ## Current Production State
 
 As of 2026-05-10, Magic Link is provisioned on production with a verified
-Resend domain. Google OAuth remains disabled until the Wiii callback is added to
-Google Cloud Console.
+Resend domain, and Google OAuth is enabled through the shared `LMS Maritime`
+web client in project `the-wiii-lab`.
 
 ```env
 ENABLE_MAGIC_LINK_AUTH=true
-ENABLE_GOOGLE_OAUTH=false
+ENABLE_GOOGLE_OAUTH=true
 MAGIC_LINK_BASE_URL=https://wiii.holilihu.online
 MAGIC_LINK_FROM_EMAIL=Wiii <noreply@holilihu.online>
 ENABLE_DISTRIBUTED_MAGIC_LINK_SESSIONS=true
@@ -41,6 +41,10 @@ OAUTH_ALLOWED_REDIRECT_ORIGINS=https://wiii.holilihu.online
 The Resend API key lives only in the VM runtime `.env.production`. It must not
 appear in Git, GitHub, docs, PR comments, or shell output. Rotate any key that
 was pasted into chat before using it for a higher-stakes production launch.
+
+The Google OAuth client secret also lives only in the VM runtime
+`.env.production`. The downloaded OAuth JSON must not be committed or left on
+the production host after enablement.
 
 ## Fail-Closed Contract
 
@@ -139,22 +143,17 @@ Yes, but only if the same Google Cloud OAuth web client is intentionally shared
 inside the same project/trust boundary and has every required origin or redirect
 URI configured.
 
-For the current LMS repo, local `.env` contains a valid-shaped Google client and
-secret, but the redirect URI is local:
+The current production setup reuses the existing `LMS Maritime` web client. That
+client must keep all LMS redirect URIs and the Wiii callback URI:
 
 ```text
 http://localhost:8088/api/v3/auth/google/callback
-```
-
-That local value is not enough for Wiii production. Before enabling Wiii Google
-OAuth, Google Cloud Console must include:
-
-```text
+https://holilihu.online/api/v3/auth/google/callback
 https://wiii.holilihu.online/api/v1/auth/google/callback
 ```
 
-If Wiii is pointed at a client that lacks this exact redirect URI, Google will
-fail with `redirect_uri_mismatch`. Fix Google Cloud Console, not Wiii code.
+If Wiii is pointed at a client that lacks the exact Wiii redirect URI, Google
+will fail with `redirect_uri_mismatch`. Fix Google Cloud Console, not Wiii code.
 
 Recommended production setup:
 
@@ -177,6 +176,13 @@ Expected result:
 - endpoint returns a redirect toward Google Accounts
 - browser login returns to Wiii without `redirect_uri_mismatch`
 - callback delivers tokens to the expected Wiii web or desktop redirect flow
+
+Production smoke evidence from 2026-05-10:
+
+- `GET /api/v1/auth/google/login` returned `302`
+- `Location` pointed to `https://accounts.google.com/o/oauth2/v2/auth`
+- the redirect URI in the Google URL was
+  `https://wiii.holilihu.online/api/v1/auth/google/callback`
 
 ### Rollback
 

--- a/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
+++ b/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
@@ -40,8 +40,8 @@ On 2026-05-10, production was verified on `wiii-production` in project
   timeout; routing should keep normal chat on the healthy primary model
 - `ENABLE_MAGIC_LINK_AUTH=true` was enabled after Resend API validation and
   verified `holilihu.online` sender domain smoke
-- `ENABLE_GOOGLE_OAUTH=false` remained the safe default until the Wiii callback
-  is registered in Google Cloud Console
+- `ENABLE_GOOGLE_OAUTH=true` was enabled after the shared `LMS Maritime` Google
+  OAuth web client included the Wiii callback URI
 
 Treat any future public API health timeout as a release blocker until the deploy
 script, Caddy routing, nginx health, and app health all agree.
@@ -95,9 +95,9 @@ BACKUP_MEM_LIMIT=192M
 
 Optional production login methods are governed by
 [`WIII_PRODUCTION_AUTH_RUNBOOK.md`](./WIII_PRODUCTION_AUTH_RUNBOOK.md). Keep
-Magic Link enabled only while Resend smoke stays healthy. Keep
-`ENABLE_GOOGLE_OAUTH=false` unless the matching Google OAuth callback setup has
-been completed and smoke tested.
+Magic Link enabled only while Resend smoke stays healthy. Keep Google OAuth
+enabled only while the Google Cloud Console client keeps the exact Wiii callback
+URI and login smoke returns a redirect to Google Accounts.
 
 Provision the new VM:
 


### PR DESCRIPTION
## Summary
- Documents that production Google OAuth is now enabled through the shared `LMS Maritime` OAuth web client in project `the-wiii-lab`.
- Records the exact Wiii callback URI required in Google Cloud Console.
- Adds production smoke evidence for `/api/v1/auth/google/login` redirecting to Google Accounts without storing secrets in docs.

Closes #266

## Verification
- `git diff --check`
- `rg -n client_secret|GOOGLE_OAUTH_CLIENT_SECRET=|765038377883|re_gzi|AIza docs -S` only reports the placeholder `GOOGLE_OAUTH_CLIENT_SECRET=<google-web-client-secret>`.
- `curl -D - -o NUL https://wiii.holilihu.online/api/v1/auth/google/login` returns `302 Found` with a Google Accounts `Location` using callback `https://wiii.holilihu.online/api/v1/auth/google/callback`.

## Risk / Rollback
- Docs-only change; no runtime behavior changes.
- If Google OAuth must be disabled operationally, set `ENABLE_GOOGLE_OAUTH=false` in production env and redeploy the pinned image.