### PR TITLE
ci: enforce reviewability only on PRs

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -129,6 +129,10 @@ jobs:
     name: Reviewability Gate
     runs-on: ubuntu-latest
     needs: detect-changes
+    # Reviewability is a pre-merge control. On push to main, the change has
+    # already landed and this gate would only make the baseline red after an
+    # intentional admin merge or emergency repair.
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Keeps the reviewability gate focused on PR review, where it belongs. On `push` to `main`, oversized history has already landed, so this job should skip and let `Gate Summary` report the remaining runtime/build gates instead of making the protected baseline red after an intentional admin merge.

## Linked Work

Refs #271
Related: #269, #272

## Scope

- In scope: limit `Reviewability Gate` to `pull_request` events.
- Out of scope: changing file/line thresholds or the rest of merge gate behavior.

## Verification

```text
Command: git diff --check
Result: pass

Command: python YAML parse for .github/workflows/merge-gate.yml
Result: pass
```

## Risk and Rollback

Risk is low: PRs are still blocked by reviewability, while `push` events no longer fail solely because an already-merged baseline was large. Rollback is reverting this one-line workflow condition.
