### PR TITLE
test: align direct wait heartbeat cap

### DIFF
--- a/maritime-ai-service/tests/unit/test_direct_execution_streaming.py
+++ b/maritime-ai-service/tests/unit/test_direct_execution_streaming.py
@@ -67,7 +67,7 @@ def test_split_visible_answer_chunks_preserves_markdown_urls_exactly():
 
 
 @pytest.mark.asyncio
-async def test_direct_wait_heartbeat_is_visible_progress():
+async def test_direct_wait_heartbeat_is_visible_progress_until_safety_cap():
     events = []
 
     async def _push_event(event):
@@ -81,7 +81,7 @@ async def test_direct_wait_heartbeat_is_visible_progress():
         interval_sec=0.001,
     )
 
-    assert len(events) == 2
+    assert len(events) == 8
     assert all(event["type"] == "status" for event in events)
     assert all(event["details"]["subtype"] == "visible_wait" for event in events)
     assert all(event["details"]["visibility"] == "progress" for event in events)


### PR DESCRIPTION
## Summary

Updates the direct wait heartbeat test to match the new UX contract merged in #269. The runtime now emits up to 8 visible wait beats, not 2, so slow provider paths keep the user informed instead of feeling frozen.

## Linked Work

Refs #268
Related: #269

## Scope

- In scope: one backend unit test expectation/name update.
- Out of scope: changing heartbeat runtime behavior.

## Verification

```text
Command: cd maritime-ai-service && python -m pytest tests/unit/test_direct_execution_streaming.py::test_direct_wait_heartbeat_is_visible_progress_until_safety_cap -q --tb=short
Result: 1 passed

Command: git diff --check
Result: pass
```

## Risk and Rollback

Low risk test-only change. Rollback reverts the assertion to the old 2-beat contract, but that would no longer match the intended UX behavior.
