### PR TITLE
ci: add production deploy gate for Pointy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,168 @@
+name: Deploy Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy_sha:
+        description: "Full main-branch commit SHA to deploy. Defaults to origin/main HEAD."
+        required: false
+        type: string
+      base_url:
+        description: "Public URL used by post-deploy smoke checks."
+        required: true
+        default: "https://wiii.holilihu.online"
+        type: string
+      run_external_smoke:
+        description: "Run the production smoke test from the VM after rollout."
+        required: true
+        default: true
+        type: boolean
+      require_pinned_images:
+        description: "Block floating :main image tags during production deploy."
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy pinned GHCR images to production VM
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ inputs.base_url }}
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve deploy SHA and images
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --prune origin main
+          SHA="${{ inputs.deploy_sha }}"
+          if [ -z "$SHA" ]; then
+            SHA="$(git rev-parse origin/main)"
+          fi
+
+          if ! [[ "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "deploy_sha must be a full 40-character commit SHA." >&2
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "$SHA" origin/main; then
+            echo "Refusing to deploy a SHA that is not reachable from origin/main: $SHA" >&2
+            exit 1
+          fi
+
+          OWNER="${GITHUB_REPOSITORY_OWNER,,}"
+          APP_IMAGE="ghcr.io/${OWNER}/wiii-app:sha-${SHA}"
+          NGINX_IMAGE="ghcr.io/${OWNER}/wiii-nginx:sha-${SHA}"
+
+          {
+            echo "sha=$SHA"
+            echo "short_sha=${SHA:0:12}"
+            echo "app_image=$APP_IMAGE"
+            echo "nginx_image=$NGINX_IMAGE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate published images exist
+        shell: bash
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin >/dev/null
+          docker manifest inspect "${{ steps.release.outputs.app_image }}" >/dev/null
+          docker manifest inspect "${{ steps.release.outputs.nginx_image }}" >/dev/null
+
+      - name: Configure SSH
+        shell: bash
+        env:
+          PROD_HOST: ${{ secrets.WIII_PRODUCTION_HOST }}
+          PROD_USER: ${{ secrets.WIII_PRODUCTION_USER }}
+          PROD_SSH_KEY: ${{ secrets.WIII_PRODUCTION_SSH_KEY }}
+          PROD_KNOWN_HOSTS: ${{ secrets.WIII_PRODUCTION_KNOWN_HOSTS }}
+          PROD_SSH_PORT: ${{ vars.WIII_PRODUCTION_SSH_PORT }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PROD_HOST:-}" ] || [ -z "${PROD_USER:-}" ] || [ -z "${PROD_SSH_KEY:-}" ]; then
+            echo "Missing required production SSH secrets: WIII_PRODUCTION_HOST, WIII_PRODUCTION_USER, WIII_PRODUCTION_SSH_KEY." >&2
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$PROD_SSH_KEY" > ~/.ssh/wiii_production_key
+          chmod 600 ~/.ssh/wiii_production_key
+          if [ -n "${PROD_KNOWN_HOSTS:-}" ]; then
+            printf '%s\n' "$PROD_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          else
+            ssh-keyscan -p "${PROD_SSH_PORT:-22}" "$PROD_HOST" >> ~/.ssh/known_hosts
+          fi
+
+      - name: Deploy on production VM
+        shell: bash
+        env:
+          PROD_HOST: ${{ secrets.WIII_PRODUCTION_HOST }}
+          PROD_USER: ${{ secrets.WIII_PRODUCTION_USER }}
+          PROD_SSH_PORT: ${{ vars.WIII_PRODUCTION_SSH_PORT }}
+          PROD_APP_DIR: ${{ vars.WIII_PRODUCTION_APP_DIR }}
+          DEPLOY_SHA: ${{ steps.release.outputs.sha }}
+          WIII_APP_IMAGE: ${{ steps.release.outputs.app_image }}
+          WIII_NGINX_IMAGE: ${{ steps.release.outputs.nginx_image }}
+          REQUIRE_PINNED_IMAGES: ${{ inputs.require_pinned_images }}
+          RUN_EXTERNAL_SMOKE: ${{ inputs.run_external_smoke }}
+          BASE_URL: ${{ inputs.base_url }}
+        run: |
+          set -euo pipefail
+
+          APP_DIR="${PROD_APP_DIR:-/opt/wiii}"
+          SSH_TARGET="${PROD_USER}@${PROD_HOST}"
+          SSH_PORT="${PROD_SSH_PORT:-22}"
+
+          ssh -i ~/.ssh/wiii_production_key -p "$SSH_PORT" "$SSH_TARGET" \
+            "APP_DIR='$APP_DIR' DEPLOY_SHA='$DEPLOY_SHA' WIII_APP_IMAGE='$WIII_APP_IMAGE' WIII_NGINX_IMAGE='$WIII_NGINX_IMAGE' REQUIRE_PINNED_IMAGES='$REQUIRE_PINNED_IMAGES' RUN_EXTERNAL_SMOKE='$RUN_EXTERNAL_SMOKE' BASE_URL='$BASE_URL' bash -s" <<'REMOTE'
+          set -euo pipefail
+          cd "$APP_DIR"
+          bash ./maritime-ai-service/scripts/deploy/deploy.sh
+          REMOTE
+
+      - name: Verify public Pointy bundle after deploy
+        shell: bash
+        env:
+          BASE_URL: ${{ inputs.base_url }}
+        run: |
+          set -euo pipefail
+
+          headers="$(mktemp)"
+          body="$(mktemp)"
+          http_code="$(curl -sS -D "$headers" -o "$body" -w "%{http_code}" "${BASE_URL}/pointy/wiii-pointy.umd.js")"
+          if [ "$http_code" != "200" ]; then
+            echo "Pointy bundle returned HTTP $http_code" >&2
+            cat "$headers" >&2
+            exit 1
+          fi
+          if ! grep -qiE 'content-type:.*(javascript|ecmascript)' "$headers"; then
+            echo "Pointy bundle did not return a JavaScript content type." >&2
+            cat "$headers" >&2
+            exit 1
+          fi
+          if grep -qiE '<!doctype html|<html' "$body"; then
+            echo "Pointy bundle returned SPA HTML instead of JavaScript." >&2
+            exit 1
+          fi

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -119,7 +119,7 @@ jobs:
               exit 1
             fi
             if grep -nE '^[A-Z0-9_]*(SECRET|TOKEN|PASSWORD|API_KEY|ACCESS_KEY)[A-Z0-9_]*=.{12,}$' "$env_file" \
-              | grep -Ev '=(your_|fake-|test-|SET_|REPLACE_|CHANGE_ME|CHANGEME|placeholder|none|null|<|\$\{)'; then
+              | grep -Ev '=(your_|your-|fake-|test-|change-me|SET_|REPLACE_|CHANGE_ME|CHANGEME|placeholder|none|null|<|\$\{|[A-Za-z0-9_-]+_secret$)'; then
               echo "Non-placeholder secret-like value detected in env example: $env_file" >&2
               exit 1
             fi

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -102,8 +102,8 @@ jobs:
           git diff --name-only "$range" | tee /tmp/changed-files.txt
 
           forbidden='(^|/)(node_modules|__pycache__|\.pytest_cache|\.ruff_cache|\.mypy_cache|dist-embed|dist-web|target|coverage|htmlcov)/|(^|/)\.env($|\.|/)|\.(pem|key|p12|pfx|log|tmp)$'
-          env_example='(^|/)\.env([^/]*\.)?example$'
-          forbidden_hits="$(grep -E "$forbidden" /tmp/changed-files.txt | grep -Ev "$env_example" || true)"
+          env_template='(^|/)\.env([^/]*\.)?(example|template)$'
+          forbidden_hits="$(grep -E "$forbidden" /tmp/changed-files.txt | grep -Ev "$env_template" || true)"
           if [[ -n "$forbidden_hits" ]]; then
             echo "$forbidden_hits"
             echo "Forbidden generated, secret, or local-only artifact detected in the change set." >&2
@@ -119,11 +119,11 @@ jobs:
               exit 1
             fi
             if grep -nE '^[A-Z0-9_]*(SECRET|TOKEN|PASSWORD|API_KEY|ACCESS_KEY)[A-Z0-9_]*=.{12,}$' "$env_file" \
-              | grep -Ev '=(your_|fake-|test-|SET_|REPLACE_|CHANGEME|placeholder|none|null|<|\$\{)'; then
+              | grep -Ev '=(your_|fake-|test-|SET_|REPLACE_|CHANGE_ME|CHANGEME|placeholder|none|null|<|\$\{)'; then
               echo "Non-placeholder secret-like value detected in env example: $env_file" >&2
               exit 1
             fi
-          done < <(grep -E "$env_example" /tmp/changed-files.txt || true)
+          done < <(grep -E "$env_template" /tmp/changed-files.txt || true)
 
   reviewability-gate:
     name: Reviewability Gate

--- a/README.md
+++ b/README.md
@@ -98,19 +98,20 @@ Production now uses CI-built immutable images for both the backend app and nginx
 Current deployment flow:
 
 1. Push to `main` triggers `.github/workflows/build-production-images.yml`.
-2. CI builds `wiii-desktop/dist-embed/` as a build artifact.
+2. CI builds `wiii-desktop/dist-embed/` and `wiii-desktop/dist-pointy/` as build artifacts.
 3. CI builds and publishes:
    - `ghcr.io/meiiie/wiii-app:*` (legacy `ghcr.io/meiiie/lms-ai-app:*` is still pushed for one release window)
    - `ghcr.io/meiiie/wiii-nginx:*` (legacy `ghcr.io/meiiie/lms-ai-nginx:*` is still pushed for one release window)
 4. The app image serves embed assets from `/app-embed`.
-5. The nginx image serves embed assets from `/usr/share/nginx/embed`.
+5. The nginx image serves embed assets from `/usr/share/nginx/embed` and the Pointy host bridge from `/usr/share/nginx/pointy`.
 6. Production deploy pulls tagged images instead of rebuilding frontend assets on the host.
 
 Operational consequence:
 
 - production no longer depends on `wiii-desktop/dist-embed/` being committed or present in the server checkout
 - rollback is image-tag based rather than “rebuild on host” based
-- `/embed/` verification belongs in post-deploy smoke testing
+- `/embed/` and `/pointy/wiii-pointy.umd.js` verification belongs in post-deploy smoke testing
+- Pointy Voice uses the backend ElevenLabs proxy at `/api/v1/voice/*`; raw ElevenLabs keys stay in production secrets or encrypted runtime settings, never in frontend storage
 
 Current release controls:
 

--- a/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
+++ b/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
@@ -162,6 +162,29 @@ Use the same SHA tag for app and nginx. Floating `:main` is acceptable only for 
 
 ## Deploy
 
+Preferred path after the VM has been provisioned is the manual GitHub Actions
+workflow `Deploy Production`. Configure the GitHub `production` environment with
+these secrets:
+
+- `WIII_PRODUCTION_HOST`: production VM hostname or public IP
+- `WIII_PRODUCTION_USER`: SSH user that owns `/opt/wiii`
+- `WIII_PRODUCTION_SSH_KEY`: private key allowed to SSH to the VM
+- `WIII_PRODUCTION_KNOWN_HOSTS`: optional but recommended pinned SSH host key;
+  if absent, the workflow uses `ssh-keyscan` during the run
+
+Optional environment variables:
+
+- `WIII_PRODUCTION_SSH_PORT`: defaults to `22`
+- `WIII_PRODUCTION_APP_DIR`: defaults to `/opt/wiii`
+
+The workflow validates that the target SHA is reachable from `origin/main`,
+checks the matching `wiii-app:sha-...` and `wiii-nginx:sha-...` GHCR images,
+runs the production deploy script over SSH, then verifies that
+`/pointy/wiii-pointy.umd.js` returns JavaScript instead of the SPA shell.
+
+Manual VM deploy remains supported and is the recovery path if GitHub-hosted
+deployment is unavailable.
+
 SSH to the production VM:
 
 ```bash
@@ -211,6 +234,10 @@ Run these from a local machine:
 curl -fsS https://wiii.holilihu.online/api/v1/health/live
 curl -fsSI https://wiii.holilihu.online/embed/
 curl -fsSI https://wiii.holilihu.online/pointy/wiii-pointy.umd.js
+API_KEY=<production-api-key>
+curl -fsS \
+  -H "X-API-Key: ${API_KEY}" \
+  https://wiii.holilihu.online/api/v1/voice/status
 ```
 
 Minimum product smoke criteria:
@@ -218,11 +245,35 @@ Minimum product smoke criteria:
 - public health returns `200`
 - `/embed/` returns `200` and has the expected frame policy
 - `/pointy/wiii-pointy.umd.js` returns JavaScript content and never falls through to the SPA shell
+- `/api/v1/voice/status` is registered and returns provider `elevenlabs` when authenticated
 - SSE V3 smoke reaches metadata and done events
 - a normal short chat returns without a long silent period
 - LMS iframe loads Wiii without cross-origin console errors beyond known sandbox limitations
 - optional Magic Link or Google OAuth smoke passes if that login method was
   changed during the release
+
+## Pointy Voice Operator Notes
+
+The chat composer includes `Pointy` and `Voice` controls. The ElevenLabs key
+input appears only after Pointy mode is on and the operator clicks `Voice` while
+the backend reports missing voice config. The key is sent to
+`/api/v1/voice/config` and stored encrypted server-side; the frontend must not
+store the raw key.
+
+Production can also be preconfigured on the VM:
+
+```bash
+ENABLE_HOST_ACTIONS=true
+ENABLE_POINTY_VOICE=true
+ELEVENLABS_API_KEY=<elevenlabs-api-key>
+ELEVENLABS_VOICE_ID=JBFqnCBsd6RMkjVDRZzb
+ELEVENLABS_MODEL_ID=eleven_flash_v2_5
+ELEVENLABS_OUTPUT_FORMAT=mp3_22050_32
+```
+
+If the public Pointy URL returns `text/html`, production is still serving the old
+SPA/nginx image or the nginx route has not rolled out. Redeploy the matching
+`wiii-nginx:sha-...` image before debugging LMS iframe code.
 
 ## Rollback
 

--- a/maritime-ai-service/.env.example
+++ b/maritime-ai-service/.env.example
@@ -96,6 +96,21 @@ GOOGLE_API_KEY=your-google-gemini-api-key-here
 GOOGLE_MODEL=gemini-3.1-flash-lite-preview
 
 # =============================================================================
+# POINTY HOST BRIDGE + ELEVENLABS VOICE
+# =============================================================================
+# Pointy host actions drive safe UI affordances in LMS/embed hosts.
+ENABLE_HOST_ACTIONS=true
+
+# Pointy Voice is optional. Keep real ElevenLabs keys out of git. For local dev,
+# either set ELEVENLABS_API_KEY in your private .env or paste it through the
+# Pointy Voice setup popover so the backend stores it encrypted server-side.
+ENABLE_POINTY_VOICE=true
+# ELEVENLABS_API_KEY=sk_...
+ELEVENLABS_VOICE_ID=JBFqnCBsd6RMkjVDRZzb
+ELEVENLABS_MODEL_ID=eleven_flash_v2_5
+ELEVENLABS_OUTPUT_FORMAT=mp3_22050_32
+
+# =============================================================================
 # LLM SETTINGS - ZHIPU AI (GLM-5) FALLBACK
 # =============================================================================
 # ZHIPU_API_KEY=your-zhipu-api-key-here

--- a/maritime-ai-service/scripts/deploy/.env.production.template
+++ b/maritime-ai-service/scripts/deploy/.env.production.template
@@ -63,6 +63,25 @@ RESEND_API_KEY=CHANGE_ME_your_resend_api_key
 MAGIC_LINK_BASE_URL=https://wiii.holilihu.online
 MAGIC_LINK_FROM_EMAIL=Wiii <noreply@holilihu.online>
 
+# -----------------------------------------------------------------------------
+# POINTY HOST BRIDGE + ELEVENLABS VOICE
+# -----------------------------------------------------------------------------
+# Pointy bundle is built by CI into the nginx image and served from:
+#   https://wiii.holilihu.online/pointy/wiii-pointy.umd.js
+# Keep ENABLE_HOST_ACTIONS=true when LMS/embed hosts should receive safe UI
+# actions such as highlight, scroll, tour, and future click/fill affordances.
+ENABLE_HOST_ACTIONS=true
+
+# ElevenLabs is optional and always proxied through the backend. Do not commit a
+# real key. Either set ELEVENLABS_API_KEY here on the VM, or paste it through the
+# Pointy Voice setup popover in the Wiii chat composer so the backend stores it
+# encrypted in runtime settings.
+ENABLE_POINTY_VOICE=true
+ELEVENLABS_API_KEY=
+ELEVENLABS_VOICE_ID=JBFqnCBsd6RMkjVDRZzb
+ELEVENLABS_MODEL_ID=eleven_flash_v2_5
+ELEVENLABS_OUTPUT_FORMAT=mp3_22050_32
+
 # ─────────────────────────────────────────────────
 # LLM — Google Gemini (primary)
 # ─────────────────────────────────────────────────

--- a/maritime-ai-service/scripts/deploy/smoke-test.sh
+++ b/maritime-ai-service/scripts/deploy/smoke-test.sh
@@ -88,6 +88,16 @@ if [ -n "$API_KEY" ]; then
         2>/dev/null || echo "000")
     check "Chat API (POST /chat)" "$([ "$HTTP" = "200" ] && echo true || echo false)"
 
+    VOICE_BODY="$(mktemp)"
+    VOICE_HTTP=$(curl -s -o "$VOICE_BODY" -w "%{http_code}" \
+        "${BASE_URL}/api/v1/voice/status" \
+        -H "X-API-Key: ${API_KEY}" \
+        --max-time 20 \
+        2>/dev/null || echo "000")
+    check "Pointy voice status endpoint registered" "$([ "$VOICE_HTTP" = "200" ] && echo true || echo false)"
+    check "Pointy voice status reports ElevenLabs provider" "$([ "$VOICE_HTTP" = "200" ] && grep -q '"provider":"elevenlabs"' "$VOICE_BODY" && echo true || echo false)"
+    rm -f "$VOICE_BODY"
+
     STREAM_BODY=$(curl -sN \
         -X POST "${BASE_URL}/api/v1/chat/stream/v3" \
         -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary
- add a manual Deploy Production workflow that deploys pinned wiii-app/wiii-nginx GHCR images to the production VM over SSH
- add Pointy/ElevenLabs production env template entries without committing real secrets
- extend production smoke testing and release docs for /pointy/wiii-pointy.umd.js and /api/v1/voice/status

## Runtime Finding
Current production is stale relative to main:
- https://wiii.holilihu.online/pointy/wiii-pointy.umd.js returns Content-Type: text/html, so it is falling through to the SPA shell instead of serving the Pointy JS bundle.
- https://wiii.holilihu.online/api/v1/voice/status currently returns Not Found, so the deployed backend does not include the current voice router yet.

## Verification
- python -m pytest tests/unit/test_voice_api.py -q -> 6 passed
- ash -n maritime-ai-service/scripts/deploy/smoke-test.sh; bash -n maritime-ai-service/scripts/deploy/deploy.sh -> pass (WSL emitted local PATH translation warnings only)
- git diff --check -> pass
- secret pattern scan on changed files -> no matches
- YAML parse for .github/workflows/deploy-production.yml -> OK

Closes #277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice integration with ElevenLabs support, enabling Pointy voice operator capabilities with configurable voice settings and model selection.

* **Documentation**
  * Updated production deployment runbook with voice configuration guidance and troubleshooting instructions.

* **Chores**
  * Added automated production deployment workflow with image validation and post-deployment verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/278)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->