### PR TITLE
fix: resolve Pointy tour targets by data id

### DIFF
--- a/docs/integration/WIII_POINTY_LMS_GUIDE.md
+++ b/docs/integration/WIII_POINTY_LMS_GUIDE.md
@@ -189,6 +189,34 @@ or off-screen after validation, Pointy returns a failure such as
 `unsafe_click_target`, `disabled_click_target`, or `target_not_visible` and does
 not call `element.click()`.
 
+### V1.1 Testing Strategy And Known Limitations
+
+Verify `ui.click` at three layers before treating an LMS page as product-ready:
+
+- Unit tests should cover shared selector resolution, including bare
+  `data-wiii-id` values and normal selectors, so `ui.click`, `ui.highlight`,
+  `ui.scroll_to`, and `ui.show_tour` resolve targets consistently.
+- Integration or E2E tests should exercise safe-click success paths with
+  `data-wiii-click-safe="true"` and `data-wiii-click-kind`, then verify
+  fail-closed behavior for unsafe, disabled, hidden, detached, or off-screen
+  targets.
+- Product smoke should use real LMS pages and confirm that safe-click is only
+  attached to navigation-like targets such as continue, open panel, help, or
+  back-to-dashboard.
+
+Current limits:
+
+- `ui.click` only clicks host-marked targets with
+  `data-wiii-click-safe="true"`; unmarked targets fail closed.
+- `data-wiii-click-kind` is observability metadata, not a permission override.
+- Pointy will not click quiz answers, submit, publish, enroll, payment,
+  grading, logout, delete, or other mutating controls in V1.1.
+- Pointy will not click elements that fail selector resolution or visibility
+  validation, including detached and off-screen targets.
+- Selector resolution prefers stable `data-wiii-id` values, then falls back to
+  CSS. LMS pages should avoid raw class names and fragile `nth-child`
+  selectors.
+
 ## Selector Discipline
 
 Wiii can only point reliably when the host gives it stable targets.

--- a/docs/integration/WIII_POINTY_LMS_GUIDE.md
+++ b/docs/integration/WIII_POINTY_LMS_GUIDE.md
@@ -1,6 +1,6 @@
 # Wiii Pointy - LMS Integration Guide
 
-Status: V1 production-supported contract
+Status: V1.1 production-supported contract
 
 Owner: Wiii Lab
 
@@ -15,9 +15,13 @@ elements, scroll to them, navigate safe LMS routes, and run guided tours. It is
 the web-native path toward a collaborative-cursor UX: the host app keeps control
 of the DOM, while Wiii requests actions through a typed bridge.
 
-V1 is intentionally read-only. It does not auto-click, auto-fill, submit forms,
-or mutate LMS state. Mutating actions belong to a future V2 contract and must be
-gated by explicit confirmation plus per-tool `mutates_state=true`.
+V1 is intentionally tutor-safe. The default actions highlight, scroll,
+navigate, and run guided tours without mutating LMS state. V1.1 also supports
+fail-closed safe-click for navigation-like elements, but only when the LMS host
+marks the target with `data-wiii-click-safe="true"`. It does not auto-fill,
+submit forms, delete, publish, grade, enroll, pay, or otherwise mutate LMS
+state. Mutating actions belong to a future V2 contract and must be gated by
+explicit confirmation plus per-tool `mutates_state=true`.
 
 ## Integration Contract
 
@@ -65,6 +69,7 @@ iframe frontend already speak this protocol.
 | `ui.scroll_to` | no | no | Scroll a target into view |
 | `ui.navigate` | no | no | Navigate to an internal route or safe absolute URL |
 | `ui.show_tour` | no | no | Run a 2-5 step guided walkthrough |
+| `ui.click` | no | no | Click only host-marked safe navigation targets |
 
 ### `ui.highlight`
 
@@ -138,6 +143,52 @@ Reject loopback, `.local`, `.internal`, and non-`http(s)` URLs fail closed.
 
 A new tour cancels any tour already running.
 
+`ui.show_tour`, `ui.highlight`, `ui.scroll_to`, and `ui.click` all use the same
+selector resolver. The LMS may pass either a normal CSS selector such as
+`[data-wiii-id="continue-lesson"]` or the bare stable id `continue-lesson`.
+Bare ids resolve to `[data-wiii-id="..."]` first, then fall back to CSS.
+
+### `ui.click`
+
+Safe-click is for low-risk navigation controls only. The host must explicitly
+mark each eligible target:
+
+```html
+<button
+  data-wiii-id="continue-lesson"
+  data-wiii-click-safe="true"
+  data-wiii-click-kind="navigation"
+>
+  Tiep tuc bai hoc
+</button>
+```
+
+Request:
+
+```json
+{
+  "selector": "continue-lesson",
+  "message": "Minh mo tiep bai hoc cho ban nhe."
+}
+```
+
+Expected reply:
+
+```json
+{
+  "success": true,
+  "data": {
+    "clicked": true,
+    "click_kind": "navigation"
+  }
+}
+```
+
+If the target lacks `data-wiii-click-safe="true"`, is disabled, hidden, detached,
+or off-screen after validation, Pointy returns a failure such as
+`unsafe_click_target`, `disabled_click_target`, or `target_not_visible` and does
+not call `element.click()`.
+
 ## Selector Discipline
 
 Wiii can only point reliably when the host gives it stable targets.
@@ -145,6 +196,12 @@ Wiii can only point reliably when the host gives it stable targets.
 - Prefer `data-wiii-id` for every interactive element Wiii may reference.
 - Keep IDs semantic and durable, for example `continue-lesson`, `browse-courses`,
   `submit-quiz`, `profile-link`.
+- Add `data-wiii-click-safe="true"` only to low-risk navigation helpers such as
+  `continue-lesson`, `browse-courses`, `open-help`, or `back-to-dashboard`.
+  Do not mark destructive, payment, quiz-answer, grading, publish, enrollment,
+  logout, or final-submit actions as safe-click.
+- Add `data-wiii-click-kind` for observability, for example `navigation`,
+  `open_panel`, `help`, or `preview`.
 - Use `id` only when uniqueness is guaranteed.
 - Avoid raw class names and `nth-child` selectors.
 - Add visible interactive elements to `HostContext.content.structured` as
@@ -163,7 +220,8 @@ filters can enforce the rule.
   throwing into the host page.
 - URL hardening: `ui.navigate` rejects loopback and internal targets to prevent
   SSRF-style behavior.
-- State safety: V1 actions are visual/navigation assistance only; any future
+- State safety: V1/V1.1 actions are visual/navigation assistance only. Safe-click
+  is fail-closed and limited to explicit navigation-like targets. Any future
   mutating action must require confirmation.
 - CSP: the bundle is plain JS plus DOM. No `eval`, workers, or fetch are
   required. `script-src 'self' https://wiii.holilihu.online` is sufficient for
@@ -210,8 +268,9 @@ wiii-desktop/dev-demo/pointy/index.html
 ## Roadmap
 
 - V1: read-only tutor primitives.
-- V2: `ui.click` and `ui.fill_field`, gated by `mutates_state=true` and
-  `requires_confirmation=true`.
+- V1.1: fail-closed `ui.click` for host-marked safe navigation targets.
+- V2: `ui.fill_field` and any mutating click/apply path, gated by
+  `mutates_state=true` and `requires_confirmation=true`.
 - V3: voice-assisted guidance and an operator dashboard surface.
 - Long-term: map `HostCapabilities.tools[]` to WebMCP once that surface is
   stable enough for production.

--- a/wiii-desktop/src/pointy-host/__tests__/bridge.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/bridge.test.ts
@@ -238,6 +238,8 @@ describe("handleShowTour", () => {
 
     expect(result.success).toBe(true);
     expect(result.data?.completed_steps).toBe(2);
+    expect(result.data?.total_steps).toBe(2);
+    expect(result.data?.cancelled).toBe(false);
     expect(result.data?.missing_selectors).toEqual([]);
   });
 });

--- a/wiii-desktop/src/pointy-host/__tests__/bridge.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/bridge.test.ts
@@ -12,6 +12,7 @@ import {
   handleHighlight,
   handleNavigate,
   handleScrollTo,
+  handleShowTour,
   resolveSelector,
   type BridgeHandle,
 } from "../bridge";
@@ -218,6 +219,26 @@ describe("handleScrollTo", () => {
     document.body.innerHTML = `<section id="ch1">Chapter 1</section>`;
     const result = await handleScrollTo({ selector: "#ch1" });
     expect(result.success).toBe(true);
+  });
+});
+
+describe("handleShowTour", () => {
+  it("uses the same data-wiii-id resolver as highlight and click", async () => {
+    document.body.innerHTML = `
+      <button data-wiii-id="continue-lesson">Continue</button>
+      <button data-wiii-id="quiz-card">Quiz</button>
+    `;
+
+    const result = await handleShowTour({
+      steps: [
+        { selector: "continue-lesson", message: "Step 1", duration_ms: 1 },
+        { selector: "quiz-card", message: "Step 2", duration_ms: 1 },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.completed_steps).toBe(2);
+    expect(result.data?.missing_selectors).toEqual([]);
   });
 });
 

--- a/wiii-desktop/src/pointy-host/bridge.ts
+++ b/wiii-desktop/src/pointy-host/bridge.ts
@@ -269,7 +269,10 @@ export async function handleShowTour(params: ShowTourParams): Promise<PointyResu
     (s): s is TourStep => !!s && typeof s.selector === "string" && typeof s.message === "string",
   );
   if (steps.length === 0) return fail("invalid_tour_steps");
-  const result = await runTour(steps, { startAt: params.start_at });
+  const result = await runTour(steps, {
+    startAt: params.start_at,
+    resolveSelector: (selector) => resolveSelector(selector),
+  });
   return ok({
     summary: `Tour ${result.completed_steps}/${result.total_steps} bước.`,
     completed_steps: result.completed_steps,


### PR DESCRIPTION
Closes #281

## Context
Product-origin Pointy contract testing found a real multi-step guidance bug: `ui.click` and `ui.highlight` could resolve bare `data-wiii-id` selectors, but `ui.show_tour` used raw `document.querySelector`, so tour steps like `continue-lesson` missed host elements and returned `Tour 0/2`.

## Product Evidence
- Public bundle smoke on `https://holilihu.online` host origin + `https://wiii.holilihu.online/embed/` iframe:
  - `ui.click` safe target -> success
  - unsafe target -> `unsafe_click_target`
  - `ui.show_tour` with bare `data-wiii-id` targets -> `Tour 0/2`, missing `continue-lesson`, `quiz-card`
- Local fixed bundle with the same product-origin harness:
  - safe-click success
  - unsafe-click blocked
  - `ui.show_tour` -> `Tour 2/2`, no missing selectors

## Changes
- Make `handleShowTour` pass Pointy's shared `resolveSelector` into `runTour`.
- Add regression coverage for multi-step tours using bare `data-wiii-id` selectors.
- Update the LMS integration guide to document V1.1 safe-click, selector discipline, and fail-closed rules.

## Verification
- `cd wiii-desktop && npx vitest run src/pointy-host/__tests__/bridge.test.ts src/pointy-host/__tests__/tour.test.ts` -> 2 files passed, 47 tests passed. Vitest still prints the existing jsdom navigation warning from an unrelated navigate fallback test, but exits 0.
- `cd wiii-desktop && npm run build:pointy` -> passed.
- `cd wiii-desktop && npx tsc --noEmit` -> passed.
- `git diff --check` -> passed.

## Risk / Rollback
Low-risk targeted fix. Rollback reverts this PR. The behavior only broadens tour selector resolution to match existing highlight/click behavior; safe-click remains fail-closed and still requires `data-wiii-click-safe=true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `ui.click` action with safe-click support for navigation elements marked with `data-wiii-click-safe="true"`
  * V1.1 production-supported contract now available

* **Documentation**
  * Updated integration guide with V1.1 contract specifications and safe-click eligibility requirements
  * Clarified selector handling and resolution behavior across action types

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/282)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->