### PR TITLE
chore: add Wiii LMS agent coordination watcher

### DIFF
--- a/.github/ISSUE_TEMPLATE/lms_wiii_integration.yml
+++ b/.github/ISSUE_TEMPLATE/lms_wiii_integration.yml
@@ -1,0 +1,68 @@
+name: Wiii x LMS integration
+description: Coordinate cross-repository Wiii and Maritime LMS product work.
+title: "[Wiii x LMS]: "
+labels:
+  - coord:watch
+  - integration:wiii-lms
+  - needs-triage
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What product outcome should work end-to-end?
+      placeholder: "Teacher uploads a PDF/DOCX and Wiii creates a previewable lesson plan."
+    validations:
+      required: true
+  - type: textarea
+    id: repos
+    attributes:
+      label: Repository responsibilities
+      description: Split ownership between Wiii and LMS.
+      value: |
+        Wiii owns:
+        - Embed/iframe contract
+        - Pointy/voice/document parsing/course-generation API
+        - Preview/apply contract and source-grounded output
+
+        LMS owns:
+        - Angular host UI and route placement
+        - Stable data-wiii-id and safe-click metadata
+        - Teacher upload/review/apply UX
+        - LMS persistence and auth/token exchange
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      value: |
+        - [ ] Wiii issue/PR linked
+        - [ ] LMS issue/PR linked
+        - [ ] Product smoke prompt documented
+        - [ ] Screenshot or recording attached
+        - [ ] Preview -> confirm -> apply path verified
+        - [ ] Rollback notes included
+    validations:
+      required: true
+  - type: textarea
+    id: agent-sync
+    attributes:
+      label: Agent sync comment template
+      value: |
+        <!-- wiii-lms-sync:v1 -->
+        ROLE: observer-agent
+        STATUS: in_progress
+        BLOCKER: none
+        NEEDS_OTHER_REPO: none
+        EVIDENCE: issue created
+        NEXT_PATCH: assign first repo owner
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risk notes
+      description: Call out auth, tenant, LMS data mutation, document privacy, or deployment risk.
+    validations:
+      required: true

--- a/docs/operations/WIII_LMS_AGENT_COORDINATION.md
+++ b/docs/operations/WIII_LMS_AGENT_COORDINATION.md
@@ -1,0 +1,163 @@
+# Wiii x LMS Agent Coordination Protocol
+
+Status: Draft operational protocol
+
+Owner: Project leadership
+
+Last updated: 2026-05-10
+
+Applies to: Wiii repository, LMS repository, Codex workers, GitHub watchers,
+cross-repository PR review, and product integration work.
+
+## Purpose
+
+This protocol lets two implementation agents work in parallel while a third
+observer agent coordinates through GitHub. The goal is to integrate Wiii into
+the Maritime LMS product safely, then support the flagship teacher flow:
+
+```text
+Teacher uploads Word/PDF
+-> Wiii parses and normalizes source material
+-> Wiii drafts course/lesson outline
+-> Teacher reviews preview
+-> LMS applies confirmed lesson patches
+-> Sources remain traceable for RAG/citations
+```
+
+GitHub is the coordination bus. The agents do not need private chat with each
+other; they exchange structured issue and PR comments that humans can review.
+
+## Agent Roles
+
+| Role | Workspace | Owns | Must not do |
+|---|---|---|---|
+| `wiii-agent` | `E:\Sach\Sua\AI_v1` | Wiii embed, Pointy, voice, document parsing, course-generation API, preview/apply contracts, RAG/memory | Edit LMS source directly, merge own PRs, deploy production |
+| `lms-agent` | `E:\Sach\Sua\LMS_hohulili` | Angular LMS host UI, `data-wiii-id`, safe-click attributes, teacher upload UX, course editor, LMS auth/API integration | Edit Wiii source directly, merge own PRs, deploy production |
+| `observer-agent` | Either workspace | Watch GitHub, detect blockers, summarize evidence, create coordination issues, request focused next steps | Auto-merge, auto-deploy, edit secrets, make unrelated code changes |
+
+## Safety Rules
+
+- Agents only edit their own repository.
+- Agents never commit `.env*`, screenshots, local caches, generated build output,
+  or secrets.
+- Watchers are report-only unless run with explicit `--apply`.
+- No agent merges its own PR.
+- No agent deploys production without a human release owner.
+- Product-changing actions must follow preview -> confirm -> apply.
+- Cross-repo blockers must be represented as GitHub comments or issues, not lost
+  in local chat.
+- Every claim of "done" needs evidence: command output, CI link, screenshot, or
+  product smoke summary.
+
+## Labels
+
+Use the same label vocabulary in both repositories where possible.
+
+| Label | Meaning |
+|---|---|
+| `coord:watch` | The observer watcher should include this issue/PR in digests. |
+| `integration:wiii-lms` | Cross-repository Wiii/LMS integration work. |
+| `needs-wiii` | LMS work is blocked on Wiii contract/API/behavior. |
+| `needs-lms` | Wiii work is blocked on LMS host/API/UI behavior. |
+| `blocked:other-repo` | Cannot move without a partner-repo change. |
+| `agent:wiii` | Wiii agent owns the next implementation step. |
+| `agent:lms` | LMS agent owns the next implementation step. |
+| `agent:observer` | Observer/reporting issue or PR. |
+
+## Structured Comment Contract
+
+Agents should post comments with this marker so watcher tooling can parse them.
+
+```markdown
+<!-- wiii-lms-sync:v1 -->
+ROLE: wiii-agent
+STATUS: blocked
+BLOCKER: LMS course editor does not expose data-wiii-id on lesson toolbar.
+NEEDS_OTHER_REPO: linhlinhlin/LMS_hohulili
+EVIDENCE: Product smoke screenshot attached; selector inventory returned 0 toolbar targets.
+NEXT_PATCH: Add stable data-wiii-id and data-wiii-click-safe to low-risk navigation controls.
+```
+
+Recommended `STATUS` values:
+
+- `ready`
+- `in_progress`
+- `blocked`
+- `needs_review`
+- `verified`
+- `not_applicable`
+
+## Product Flow Gates
+
+The Word/PDF-to-lesson goal is not complete until these gates pass:
+
+1. LMS teacher can open Wiii inside the course editor.
+2. LMS host sends page-aware context and stable target inventory.
+3. Pointy can highlight, tour, and safe-click low-risk navigation controls.
+4. Teacher uploads Word/PDF from LMS or Wiii embed.
+5. Wiii parses source content into markdown with source metadata.
+6. Wiii generates an outline with source-grounded lesson objectives.
+7. LMS displays a preview/diff before any course mutation.
+8. Teacher confirms apply.
+9. LMS stores generated lesson blocks.
+10. Wiii can answer follow-up questions with citations to the uploaded source.
+
+## Observer Workflow
+
+1. Bootstrap labels in both repos.
+2. Create a central coordination issue in Wiii and a mirrored issue in LMS.
+3. Ask each worker agent to comment with the structured contract above.
+4. Run the watcher digest periodically.
+5. When a blocker is detected, the observer posts one focused request to the
+   owning repo.
+6. When both repos report `verified`, the observer asks humans for merge/deploy
+   review rather than merging directly.
+
+## Active Coordination Threads
+
+- Wiii central thread: `meiiie/wiii#283`
+- LMS mirror thread: `linhlinhlin/LMS_hohulili#400`
+- Current Wiii Pointy product fix under watch: `meiiie/wiii#282`
+
+Use the Wiii central thread for observer digests. Use the LMS mirror thread when
+the next step belongs to the LMS repository.
+
+## Watcher Commands
+
+From the Wiii workspace:
+
+```bash
+python scripts/agent_coordination/watcher.py bootstrap-labels --apply
+python scripts/agent_coordination/watcher.py create-thread --apply --title "Wiii x LMS teacher doc-to-course integration"
+python scripts/agent_coordination/watcher.py digest
+python scripts/agent_coordination/watcher.py digest --post-to meiiie/wiii#123 --apply
+```
+
+The watcher depends on the GitHub CLI (`gh`) and the currently authenticated
+GitHub user. It does not require project secrets.
+
+## Product Smoke Prompts
+
+Use these prompts as realistic end-to-end checks:
+
+```text
+Teacher: Toi vua upload file Word/PDF bai giang an toan hang hai. Hay tao outline 4 phan, moi phan co muc tieu hoc tap, noi dung chinh, cau hoi kiem tra nhanh, va trich nguon tu tai lieu.
+```
+
+```text
+Teacher: Hay dua noi dung nay vao lesson hien tai, nhung truoc tien cho toi xem preview diff. Neu toi dong y moi apply.
+```
+
+```text
+Teacher: Chi cho toi nut tiep tuc bai hoc va mo panel quiz mau, nhung dung bam vao nut nop bai hay xoa khoa hoc.
+```
+
+## Failure Modes
+
+- Infinite comment loop: watcher only posts to a central issue by default.
+- False "done": require evidence in every `verified` status.
+- Unsafe LMS mutation: preview/apply contract and human confirmation are
+  mandatory.
+- Selector drift: LMS must prefer semantic `data-wiii-id`, not CSS class names.
+- Large PR drift: split by Wiii contract, LMS host UI, document/course pipeline,
+  and product smoke harness.

--- a/scripts/agent_coordination/README.md
+++ b/scripts/agent_coordination/README.md
@@ -1,0 +1,42 @@
+# Agent Coordination Watcher
+
+This folder contains the local watcher used by the observer agent for Wiii x LMS
+coordination. It is intentionally small and depends only on Python 3 plus the
+GitHub CLI.
+
+Default mode is read-only. Add `--apply` only when you intentionally want to
+write labels, issues, or comments through `gh`.
+
+## Quick Start
+
+```bash
+python scripts/agent_coordination/watcher.py --help
+python scripts/agent_coordination/watcher.py bootstrap-labels
+python scripts/agent_coordination/watcher.py bootstrap-labels --apply
+python scripts/agent_coordination/watcher.py create-thread --title "Wiii x LMS teacher doc-to-course integration"
+python scripts/agent_coordination/watcher.py digest
+```
+
+## Comment Marker
+
+The watcher parses comments that contain:
+
+```markdown
+<!-- wiii-lms-sync:v1 -->
+ROLE: wiii-agent
+STATUS: blocked
+BLOCKER: What is blocked.
+NEEDS_OTHER_REPO: owner/repo
+EVIDENCE: Link, command, screenshot, or smoke result.
+NEXT_PATCH: One concrete next patch.
+```
+
+## Supported Repos
+
+The default config watches:
+
+- `meiiie/wiii`
+- `linhlinhlin/LMS_hohulili`
+
+Copy `coordination_config.example.json` if you need a custom fork or a different
+central issue.

--- a/scripts/agent_coordination/coordination_config.example.json
+++ b/scripts/agent_coordination/coordination_config.example.json
@@ -1,0 +1,74 @@
+{
+  "observer": {
+    "name": "observer-agent",
+    "mode": "report-only"
+  },
+  "labels": [
+    {
+      "name": "coord:watch",
+      "color": "6f42c1",
+      "description": "Include this item in Wiii/LMS coordination watcher digests."
+    },
+    {
+      "name": "integration:wiii-lms",
+      "color": "0e8a16",
+      "description": "Cross-repository Wiii and Maritime LMS integration."
+    },
+    {
+      "name": "needs-wiii",
+      "color": "fbca04",
+      "description": "Blocked until Wiii repo changes or clarifies a contract."
+    },
+    {
+      "name": "needs-lms",
+      "color": "fbca04",
+      "description": "Blocked until LMS repo changes or clarifies host behavior."
+    },
+    {
+      "name": "blocked:other-repo",
+      "color": "d73a4a",
+      "description": "Blocked by the partner repository."
+    },
+    {
+      "name": "agent:wiii",
+      "color": "1d76db",
+      "description": "Next implementation step belongs to the Wiii agent."
+    },
+    {
+      "name": "agent:lms",
+      "color": "1d76db",
+      "description": "Next implementation step belongs to the LMS agent."
+    },
+    {
+      "name": "agent:observer",
+      "color": "5319e7",
+      "description": "Observer/coordinator issue or PR."
+    }
+  ],
+  "repos": [
+    {
+      "key": "wiii",
+      "full_name": "meiiie/wiii",
+      "role": "wiii-agent",
+      "partner_repo": "linhlinhlin/LMS_hohulili",
+      "watch_labels": [
+        "coord:watch",
+        "integration:wiii-lms",
+        "needs-lms",
+        "blocked:other-repo"
+      ]
+    },
+    {
+      "key": "lms",
+      "full_name": "linhlinhlin/LMS_hohulili",
+      "role": "lms-agent",
+      "partner_repo": "meiiie/wiii",
+      "watch_labels": [
+        "coord:watch",
+        "integration:wiii-lms",
+        "needs-wiii",
+        "blocked:other-repo"
+      ]
+    }
+  ]
+}

--- a/scripts/agent_coordination/watcher.py
+++ b/scripts/agent_coordination/watcher.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""GitHub coordination watcher for Wiii x Maritime LMS.
+
+The watcher is deliberately conservative:
+
+- read-only by default
+- requires --apply for GitHub writes
+- posts digests to a chosen central issue, not to every watched item
+- parses only explicit structured comments
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8")
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = Path(__file__).with_name("coordination_config.example.json")
+SYNC_MARKER = "<!-- wiii-lms-sync:v1 -->"
+SYNC_FIELDS = ("ROLE", "STATUS", "BLOCKER", "NEEDS_OTHER_REPO", "EVIDENCE", "NEXT_PATCH")
+
+
+@dataclass(frozen=True)
+class RepoConfig:
+    key: str
+    full_name: str
+    role: str
+    partner_repo: str
+    watch_labels: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class WatchedItem:
+    repo: str
+    kind: str
+    number: int
+    title: str
+    url: str
+    labels: tuple[str, ...]
+    updated_at: str
+    state: str = "OPEN"
+    is_draft: bool = False
+    head_ref: str = ""
+    base_ref: str = ""
+    latest_sync: dict[str, str] | None = None
+
+
+def run_gh(args: list[str], *, check: bool = True) -> str:
+    proc = subprocess.run(
+        ["gh", *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if check and proc.returncode != 0:
+        details = proc.stderr.strip() or proc.stdout.strip()
+        raise RuntimeError(f"gh {' '.join(args)} failed: {details}")
+    return proc.stdout
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def repo_configs(config: dict[str, Any]) -> list[RepoConfig]:
+    repos: list[RepoConfig] = []
+    for item in config.get("repos", []):
+        repos.append(
+            RepoConfig(
+                key=str(item["key"]),
+                full_name=str(item["full_name"]),
+                role=str(item["role"]),
+                partner_repo=str(item["partner_repo"]),
+                watch_labels=tuple(str(x) for x in item.get("watch_labels", [])),
+            )
+        )
+    return repos
+
+
+def label_names(raw_labels: list[dict[str, Any]]) -> tuple[str, ...]:
+    return tuple(str(label.get("name", "")).strip() for label in raw_labels if label.get("name"))
+
+
+def should_watch(labels: tuple[str, ...], repo: RepoConfig, include_all: bool) -> bool:
+    if include_all:
+        return True
+    label_set = set(labels)
+    return bool(label_set.intersection(repo.watch_labels))
+
+
+def list_repo_items(repo: RepoConfig, *, limit: int, include_all: bool) -> list[WatchedItem]:
+    items: list[WatchedItem] = []
+    issue_json = run_gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo.full_name,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,url,labels,updatedAt",
+        ]
+    )
+    for issue in json.loads(issue_json or "[]"):
+        labels = label_names(issue.get("labels", []))
+        if not should_watch(labels, repo, include_all):
+            continue
+        items.append(
+            WatchedItem(
+                repo=repo.full_name,
+                kind="issue",
+                number=int(issue["number"]),
+                title=str(issue["title"]),
+                url=str(issue["url"]),
+                labels=labels,
+                updated_at=str(issue.get("updatedAt", "")),
+            )
+        )
+
+    pr_json = run_gh(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo.full_name,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,url,labels,updatedAt,isDraft,headRefName,baseRefName",
+        ]
+    )
+    for pr in json.loads(pr_json or "[]"):
+        labels = label_names(pr.get("labels", []))
+        if not should_watch(labels, repo, include_all):
+            continue
+        items.append(
+            WatchedItem(
+                repo=repo.full_name,
+                kind="pr",
+                number=int(pr["number"]),
+                title=str(pr["title"]),
+                url=str(pr["url"]),
+                labels=labels,
+                updated_at=str(pr.get("updatedAt", "")),
+                is_draft=bool(pr.get("isDraft")),
+                head_ref=str(pr.get("headRefName") or ""),
+                base_ref=str(pr.get("baseRefName") or ""),
+            )
+        )
+    return items
+
+
+def parse_sync_comment(body: str) -> dict[str, str] | None:
+    if SYNC_MARKER not in body:
+        return None
+    parsed: dict[str, str] = {}
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        for field in SYNC_FIELDS:
+            prefix = f"{field}:"
+            if line.startswith(prefix):
+                parsed[field] = line[len(prefix) :].strip()
+    return parsed or None
+
+
+def latest_sync_for(item: WatchedItem) -> dict[str, str] | None:
+    command = "pr" if item.kind == "pr" else "issue"
+    try:
+        raw = run_gh(
+            [
+                command,
+                "view",
+                str(item.number),
+                "--repo",
+                item.repo,
+                "--comments",
+                "--json",
+                "comments",
+            ]
+        )
+    except RuntimeError:
+        return None
+    comments = json.loads(raw or "{}").get("comments", [])
+    latest: dict[str, str] | None = None
+    for comment in comments:
+        parsed = parse_sync_comment(str(comment.get("body") or ""))
+        if parsed:
+            parsed["COMMENT_AUTHOR"] = str(comment.get("author", {}).get("login") or "")
+            parsed["COMMENT_CREATED_AT"] = str(comment.get("createdAt") or "")
+            latest = parsed
+    return latest
+
+
+def collect_items(config: dict[str, Any], *, limit: int, include_all: bool, enrich: bool) -> list[WatchedItem]:
+    items: list[WatchedItem] = []
+    for repo in repo_configs(config):
+        for item in list_repo_items(repo, limit=limit, include_all=include_all):
+            if enrich:
+                item = WatchedItem(**{**item.__dict__, "latest_sync": latest_sync_for(item)})
+            items.append(item)
+    return sorted(items, key=lambda x: x.updated_at, reverse=True)
+
+
+def render_digest(items: list[WatchedItem], config: dict[str, Any]) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+    observer = config.get("observer", {})
+    lines = [
+        "<!-- wiii-lms-observer-digest:v1 -->",
+        f"## Wiii x LMS Coordination Digest - {now}",
+        "",
+        f"Observer: `{observer.get('name', 'observer-agent')}`",
+        f"Mode: `{observer.get('mode', 'report-only')}`",
+        "",
+    ]
+    if not items:
+        lines.append("No watched open issues or PRs found.")
+        return "\n".join(lines)
+
+    blockers: list[WatchedItem] = []
+    needs_review: list[WatchedItem] = []
+    for item in items:
+        status = (item.latest_sync or {}).get("STATUS", "").lower()
+        if status == "blocked" or "blocked:other-repo" in item.labels:
+            blockers.append(item)
+        if status in {"needs_review", "verified"}:
+            needs_review.append(item)
+
+    lines.extend(["### Blockers", ""])
+    if blockers:
+        for item in blockers:
+            sync = item.latest_sync or {}
+            lines.append(
+                f"- `{item.repo}#{item.number}` {item.title} - "
+                f"{sync.get('BLOCKER') or 'blocked; see labels/comments'}"
+            )
+            if sync.get("NEXT_PATCH"):
+                lines.append(f"  Next: {sync['NEXT_PATCH']}")
+    else:
+        lines.append("- No structured blockers found.")
+
+    lines.extend(["", "### Watched Items", ""])
+    for item in items:
+        sync = item.latest_sync or {}
+        status = sync.get("STATUS", "no-sync-comment")
+        role = sync.get("ROLE", "unknown")
+        labels = ", ".join(item.labels) if item.labels else "no labels"
+        draft = " draft" if item.is_draft else ""
+        lines.append(f"- `{item.repo}#{item.number}` [{item.kind}{draft}] {item.title}")
+        lines.append(f"  URL: {item.url}")
+        lines.append(f"  Labels: {labels}")
+        lines.append(f"  Latest sync: `{status}` by `{role}`")
+        if sync.get("EVIDENCE"):
+            lines.append(f"  Evidence: {sync['EVIDENCE']}")
+        if sync.get("NEEDS_OTHER_REPO"):
+            lines.append(f"  Needs: `{sync['NEEDS_OTHER_REPO']}`")
+
+    if needs_review:
+        lines.extend(["", "### Human Review Queue", ""])
+        for item in needs_review:
+            lines.append(f"- `{item.repo}#{item.number}` {item.title} - {item.url}")
+
+    lines.extend(
+        [
+            "",
+            "### Observer Rule",
+            "",
+            "This digest is advisory. It does not merge, deploy, or approve PRs.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def parse_issue_ref(value: str) -> tuple[str, str]:
+    if "#" not in value:
+        raise ValueError("--post-to must look like owner/repo#123")
+    repo, number = value.rsplit("#", 1)
+    if not repo or not number.isdigit():
+        raise ValueError("--post-to must look like owner/repo#123")
+    return repo, number
+
+
+def bootstrap_labels(config: dict[str, Any], *, apply: bool) -> None:
+    labels = config.get("labels", [])
+    repos = repo_configs(config)
+    for repo in repos:
+        for label in labels:
+            name = str(label["name"])
+            color = str(label.get("color", "ededed")).lstrip("#")
+            description = str(label.get("description", ""))
+            if not apply:
+                print(
+                    "DRY-RUN gh label create",
+                    name,
+                    "--repo",
+                    repo.full_name,
+                    "--color",
+                    color,
+                )
+                continue
+            create_args = [
+                "label",
+                "create",
+                name,
+                "--repo",
+                repo.full_name,
+                "--color",
+                color,
+                "--description",
+                description,
+            ]
+            proc = subprocess.run(
+                ["gh", *create_args],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+            )
+            if proc.returncode == 0:
+                print(f"created {repo.full_name}:{name}")
+                continue
+            edit_args = [
+                "label",
+                "edit",
+                name,
+                "--repo",
+                repo.full_name,
+                "--color",
+                color,
+                "--description",
+                description,
+            ]
+            run_gh(edit_args)
+            print(f"updated {repo.full_name}:{name}")
+
+
+def create_thread(config: dict[str, Any], *, title: str, body: str, apply: bool) -> None:
+    repos = repo_configs(config)
+    created: list[tuple[str, str]] = []
+    base_body = body.strip() or (
+        "Cross-repository coordination issue for Wiii x Maritime LMS integration.\n\n"
+        "Agents should use the structured sync comment contract from "
+        "`docs/operations/WIII_LMS_AGENT_COORDINATION.md`."
+    )
+    for repo in repos:
+        labels = "coord:watch,integration:wiii-lms,agent:observer"
+        partner_links = "\n".join(f"- {r}#{n}" for r, n in created)
+        full_body = base_body
+        if partner_links:
+            full_body += f"\n\nPartner coordination issue(s):\n{partner_links}\n"
+        if not apply:
+            print(f"DRY-RUN create issue in {repo.full_name}: {title}")
+            continue
+        out = run_gh(
+            [
+                "issue",
+                "create",
+                "--repo",
+                repo.full_name,
+                "--title",
+                title,
+                "--body",
+                full_body,
+                "--label",
+                labels,
+            ]
+        ).strip()
+        match = re.search(r"/issues/(\d+)", out)
+        number = match.group(1) if match else "unknown"
+        created.append((repo.full_name, number))
+        print(out)
+    if apply and len(created) > 1:
+        summary = "\n".join(f"- {repo}#{number}" for repo, number in created)
+        print("created coordination thread:\n" + summary)
+
+
+def cmd_snapshot(args: argparse.Namespace) -> int:
+    config = load_config(args.config)
+    items = collect_items(config, limit=args.limit, include_all=args.all, enrich=args.enrich)
+    if args.json:
+        print(json.dumps([item.__dict__ for item in items], indent=2, ensure_ascii=False))
+    else:
+        print(render_digest(items, config))
+    return 0
+
+
+def cmd_digest(args: argparse.Namespace) -> int:
+    config = load_config(args.config)
+    items = collect_items(config, limit=args.limit, include_all=args.all, enrich=True)
+    digest = render_digest(items, config)
+    if not args.post_to:
+        print(digest)
+        return 0
+    repo, number = parse_issue_ref(args.post_to)
+    if not args.apply:
+        print("DRY-RUN would post digest to", args.post_to)
+        print(digest)
+        return 0
+    run_gh(["issue", "comment", number, "--repo", repo, "--body", digest])
+    print(f"posted digest to {args.post_to}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    labels = sub.add_parser("bootstrap-labels", help="Create/update coordination labels.")
+    labels.add_argument("--apply", action="store_true", help="Write labels through gh.")
+    labels.set_defaults(func=lambda args: (bootstrap_labels(load_config(args.config), apply=args.apply), 0)[1])
+
+    thread = sub.add_parser("create-thread", help="Create paired coordination issues.")
+    thread.add_argument("--title", required=True)
+    thread.add_argument("--body", default="")
+    thread.add_argument("--apply", action="store_true", help="Create issues through gh.")
+    thread.set_defaults(
+        func=lambda args: (create_thread(load_config(args.config), title=args.title, body=args.body, apply=args.apply), 0)[1]
+    )
+
+    snapshot = sub.add_parser("snapshot", help="Print watched issues/PRs.")
+    snapshot.add_argument("--limit", type=int, default=20)
+    snapshot.add_argument("--all", action="store_true", help="Include open items even without watch labels.")
+    snapshot.add_argument("--enrich", action="store_true", help="Fetch and parse latest sync comments.")
+    snapshot.add_argument("--json", action="store_true")
+    snapshot.set_defaults(func=cmd_snapshot)
+
+    digest = sub.add_parser("digest", help="Render or post an observer digest.")
+    digest.add_argument("--limit", type=int, default=20)
+    digest.add_argument("--all", action="store_true", help="Include open items even without watch labels.")
+    digest.add_argument("--post-to", help="Central issue ref, e.g. meiiie/wiii#123.")
+    digest.add_argument("--apply", action="store_true", help="Post digest through gh.")
+    digest.set_defaults(func=cmd_digest)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args) or 0)
+    except Exception as exc:  # pragma: no cover - CLI safety net
+        print(f"watcher error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #283

## Summary
Adds the first safe coordination layer for running two Codex workers in parallel across Wiii and Maritime LMS, with this thread/session acting as the observer lane.

## What changed
- Added `docs/operations/WIII_LMS_AGENT_COORDINATION.md` with the three-agent protocol, safety rules, labels, structured comment contract, and product gates for teacher doc-to-course.
- Added `scripts/agent_coordination/watcher.py`, a report-only-by-default GitHub watcher using `gh` for label bootstrap, paired issue creation, snapshots, and central digest posting.
- Added `scripts/agent_coordination/coordination_config.example.json` for `meiiie/wiii` and `linhlinhlin/LMS_hohulili`.
- Added a Wiii x LMS issue template so future integration tasks start with repo ownership, acceptance criteria, and sync comment format.

## Already bootstrapped on GitHub
- Created coordination labels on both repos.
- Created Wiii central issue: https://github.com/meiiie/wiii/issues/283
- Created LMS mirror issue: https://github.com/linhlinhlin/LMS_hohulili/issues/400
- Added watcher labels to Wiii Pointy product bug issue/PR: #281 and #282.
- Posted initial observer digests to both coordination issues.

## Verification
- `python scripts/agent_coordination/watcher.py --help` -> passed.
- `python scripts/agent_coordination/watcher.py bootstrap-labels` -> dry-run passed.
- `python scripts/agent_coordination/watcher.py snapshot --limit 20 --enrich` -> passed; detected Wiii #283, LMS #400, Wiii #281/#282.
- `python scripts/agent_coordination/watcher.py digest --limit 20` -> passed.
- Python AST syntax check for `scripts/agent_coordination/watcher.py` -> passed.
- `git diff --check` -> passed.

## Risk / Rollback
Low runtime risk: this is docs, issue template, and local watcher tooling only. The watcher does not merge, deploy, approve, or write anything unless invoked with explicit `--apply`. Rollback by reverting this PR and deleting the coordination labels/issues if the team decides not to use the protocol.
