### PR TITLE
Guard legacy LMS doc-to-course expansion

### DIFF
--- a/docs/integration/WIII_LMS_DOC_TO_COURSE_CONTRACT.md
+++ b/docs/integration/WIII_LMS_DOC_TO_COURSE_CONTRACT.md
@@ -1,0 +1,101 @@
+# Wiii LMS Doc-To-Course Contract
+
+Status: Draft for product integration
+
+Owner: Wiii/LMS integration agents
+
+Last updated: 2026-05-10
+
+## Product Safety Rule
+
+The LMS doc-to-course product flow is:
+
+1. Teacher uploads a Word/PDF/DOCX document to Wiii.
+2. Wiii parses the document and returns an outline plus source references.
+3. Wiii/LMS produces a lesson or course patch preview.
+4. Teacher explicitly confirms the preview.
+5. LMS applies the confirmed patch.
+
+Wiii must not publish, mutate, or push LMS content from a product doc-to-course
+flow before the teacher has reviewed a preview.
+
+## Safe Contract
+
+Use the host action preview/apply lane for LMS authoring:
+
+- Preview action: `authoring.preview_lesson_patch`
+- Apply action: `authoring.apply_lesson_patch`
+- Preview kind: `lesson_patch`
+- Apply input must include the preview token returned by the preview action.
+- The preview payload must carry source references from the uploaded document.
+- The apply action must fail closed when the preview token is missing, expired, or
+  does not match the patch being applied.
+
+Expected preview metadata:
+
+```json
+{
+  "preview_kind": "lesson_patch",
+  "apply_action": "authoring.apply_lesson_patch",
+  "preview_token": "opaque-host-token",
+  "source_references": [
+    {
+      "kind": "chapter",
+      "chapter_index": 0,
+      "title": "Chapter title",
+      "source_pages": [1, 2]
+    }
+  ]
+}
+```
+
+## Legacy Direct Expansion
+
+`POST /course-generation/{generation_id}/expand` is a legacy direct LMS mutation
+path. It can create a course shell and push generated chapters to LMS without a
+preview/apply host action.
+
+New calls to this endpoint must set:
+
+```json
+{
+  "legacy_lms_mutation_confirmed": true
+}
+```
+
+Without that explicit opt-in, Wiii returns HTTP 409 with:
+
+- `code`: `legacy_lms_mutation_confirmation_required`
+- `required_field`: `legacy_lms_mutation_confirmed`
+- `safe_contract`: `host_action_preview_apply`
+
+This guard is for accidental product calls. Existing recovery/resume behavior for
+already-persisted legacy jobs remains runtime-owned and should not be presented
+as the safe LMS product flow.
+
+## Source References
+
+`GET /course-generation/{generation_id}` returns `source_references` derived from
+outline `sourcePages`. LMS previews should surface these references so teachers
+can verify generated material against the uploaded document before applying it.
+
+The current Wiii status response emits references for:
+
+- chapter-level `sourcePages`
+- lesson-level `sourcePages`
+
+LMS may display these references as page chips, source rows, or citation links,
+but should preserve the page values verbatim.
+
+## LMS-Side Requirements
+
+The LMS host must implement the apply side in its own repository:
+
+- expose `authoring.preview_lesson_patch`
+- expose `authoring.apply_lesson_patch`
+- bind each apply call to a valid preview token
+- keep apply idempotent where practical
+- reject publish/enroll/delete/grading/quiz-submit mutations from Wiii safe-click
+  or preview/apply lanes unless a separate reviewed contract exists
+
+Do not implement LMS mutations in the Wiii repository.

--- a/maritime-ai-service/app/api/v1/course_generation.py
+++ b/maritime-ai-service/app/api/v1/course_generation.py
@@ -9,7 +9,7 @@ Design spec v2.0 (2026-03-22), expert-reviewed.
 
 Endpoints:
   POST /course-generation/outline          — upload doc, generate outline
-  POST /course-generation/{id}/expand      — expand approved chapters
+  POST /course-generation/{id}/expand      — legacy direct LMS expansion
   POST /course-generation/{id}/retry/{idx} — retry a failed chapter
   GET  /course-generation/{id}             — poll job status
 """
@@ -161,9 +161,11 @@ async def expand_chapters(
     req: ExpandRequest,
     auth: AuthenticatedUser = Depends(require_auth),
 ):
-    """Expand approved chapters into full content (Phase 2).
+    """Legacy path: expand approved chapters and push directly to LMS.
 
-    Creates course shell in LMS if no course_id provided, then expands each chapter.
+    Requires legacy_lms_mutation_confirmed=true because it creates a course
+    shell in LMS if no course_id is provided, then pushes expanded chapters.
+    Product LMS doc-to-course must use preview -> teacher confirm -> apply.
     """
     return await expand_chapters_impl(
         generation_id=generation_id,

--- a/maritime-ai-service/app/api/v1/course_generation_endpoint_runtime.py
+++ b/maritime-ai-service/app/api/v1/course_generation_endpoint_runtime.py
@@ -9,6 +9,74 @@ from uuid import uuid4
 
 from fastapi import HTTPException, UploadFile
 
+SAFE_DOC_TO_COURSE_CONTRACT = "host_action_preview_apply"
+LEGACY_DIRECT_EXPAND_CONTRACT = "legacy_course_generation_expand"
+LEGACY_EXPAND_CONFIRMATION_REQUIRED = {
+    "code": "legacy_lms_mutation_confirmation_required",
+    "message": (
+        "POST /course-generation/{generation_id}/expand is a legacy direct LMS "
+        "mutation path. Product LMS doc-to-course must use preview -> teacher "
+        "confirm -> apply instead."
+    ),
+    "required_field": "legacy_lms_mutation_confirmed",
+    "safe_contract": SAFE_DOC_TO_COURSE_CONTRACT,
+    "issue": "meiiie/wiii#285",
+}
+
+
+def _source_pages(value: Any) -> list[Any]:
+    if not isinstance(value, list):
+        return []
+    return [page for page in value if page is not None]
+
+
+def build_outline_source_references(outline: Any) -> list[dict[str, Any]]:
+    if not isinstance(outline, dict):
+        return []
+
+    chapters = outline.get("chapters")
+    if not isinstance(chapters, list):
+        return []
+
+    references: list[dict[str, Any]] = []
+    for chapter_index, chapter in enumerate(chapters):
+        if not isinstance(chapter, dict):
+            continue
+
+        chapter_title = chapter.get("title")
+        chapter_pages = _source_pages(chapter.get("sourcePages"))
+        if chapter_pages:
+            references.append(
+                {
+                    "kind": "chapter",
+                    "chapter_index": chapter_index,
+                    "title": chapter_title,
+                    "source_pages": chapter_pages,
+                }
+            )
+
+        lessons = chapter.get("lessons")
+        if not isinstance(lessons, list):
+            continue
+
+        for lesson_index, lesson in enumerate(lessons):
+            if not isinstance(lesson, dict):
+                continue
+            lesson_pages = _source_pages(lesson.get("sourcePages"))
+            if not lesson_pages:
+                continue
+            references.append(
+                {
+                    "kind": "lesson",
+                    "chapter_index": chapter_index,
+                    "lesson_index": lesson_index,
+                    "chapter_title": chapter_title,
+                    "title": lesson.get("title"),
+                    "source_pages": lesson_pages,
+                }
+            )
+    return references
+
 
 async def list_generation_jobs_impl(
     *,
@@ -126,6 +194,14 @@ async def expand_chapters_impl(
     if job["phase"] != "OUTLINE_READY":
         raise HTTPException(400, f"Cannot expand: phase is '{job['phase']}', expected 'OUTLINE_READY'")
     ensure_teacher_matches_auth_fn(req.teacher_id, auth)
+    if not req.legacy_lms_mutation_confirmed:
+        raise HTTPException(
+            409,
+            {
+                **LEGACY_EXPAND_CONFIRMATION_REQUIRED,
+                "generation_id": generation_id,
+            },
+        )
 
     outline = job.get("outline") or {}
     chapters = outline.get("chapters") or []
@@ -154,6 +230,8 @@ async def expand_chapters_impl(
         "generation_id": generation_id,
         "phase": "EXPANDING",
         "progress_percent": max(job.get("progress_percent", 40), 45),
+        "mutation_contract": LEGACY_DIRECT_EXPAND_CONTRACT,
+        "safe_product_contract": SAFE_DOC_TO_COURSE_CONTRACT,
     }
 
 
@@ -360,6 +438,7 @@ async def get_generation_status_impl(
         generation_id=job["id"],
         phase=job["phase"],
         outline=job.get("outline"),
+        source_references=build_outline_source_references(job.get("outline")),
         course_id=job.get("course_id"),
         completed_chapters=job.get("completed_chapters", []),
         failed_chapters=job.get("failed_chapters", []),

--- a/maritime-ai-service/app/api/v1/course_generation_schemas.py
+++ b/maritime-ai-service/app/api/v1/course_generation_schemas.py
@@ -32,6 +32,7 @@ class GenerationStatusResponse(BaseModel):
     generation_id: str
     phase: str
     outline: Optional[dict] = None
+    source_references: list[dict] = Field(default_factory=list)
     course_id: Optional[str] = None
     completed_chapters: list[dict] = Field(default_factory=list)
     failed_chapters: list[dict] = Field(default_factory=list)
@@ -56,6 +57,13 @@ class ExpandRequest(BaseModel):
     course_title: str
     approved_chapters: list[int] = Field(min_length=1)
     language: str = "vi"
+    legacy_lms_mutation_confirmed: bool = Field(
+        default=False,
+        description=(
+            "Explicit opt-in for the legacy direct LMS mutation path. "
+            "Product LMS doc-to-course flows must use preview -> teacher confirm -> apply."
+        ),
+    )
 
     @field_validator("approved_chapters")
     @classmethod

--- a/maritime-ai-service/tests/unit/test_course_generation_flow.py
+++ b/maritime-ai-service/tests/unit/test_course_generation_flow.py
@@ -19,6 +19,11 @@ from app.api.v1.course_generation import (
     _run_outline_phase,
     _run_retry_chapter,
 )
+from app.api.v1.course_generation_endpoint_runtime import (
+    expand_chapters_impl,
+    get_generation_status_impl,
+)
+from app.api.v1.course_generation_schemas import GenerationStatusResponse
 from app.models.course_generation import ChapterContentSchema, CourseOutlineSchema
 from app.engine.context.adapters.lms import LMSHostAdapter
 from app.engine.context.host_context import from_legacy_page_context
@@ -194,6 +199,158 @@ def test_require_generation_job_access_allows_admin_bypass():
         {"teacher_id": "teacher-1", "organization_id": "org-a"},
         auth,
     )
+
+
+@pytest.mark.asyncio
+async def test_expand_chapters_impl_requires_legacy_mutation_confirmation():
+    repo = _FakeRepo([
+        {
+            "id": "gen-1",
+            "teacher_id": "teacher-1",
+            "organization_id": "org-a",
+            "phase": "OUTLINE_READY",
+            "outline": {"chapters": [{"title": "Chuong 1", "sourcePages": [1]}]},
+            "progress_percent": 40,
+        }
+    ])
+    auth = AuthenticatedUser(
+        user_id="teacher-1",
+        auth_method="jwt",
+        role="teacher",
+        organization_id="org-a",
+    )
+    req = ExpandRequest(
+        teacher_id="teacher-1",
+        category_id="category-1",
+        course_title="Khoa hoc",
+        approved_chapters=[0],
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await expand_chapters_impl(
+            generation_id="gen-1",
+            req=req,
+            auth=auth,
+            get_course_gen_repo_fn=lambda: repo,
+            require_generation_job_access_fn=_require_generation_job_access,
+            ensure_teacher_matches_auth_fn=_ensure_teacher_matches_auth,
+            normalize_approved_chapters_fn=_normalize_approved_chapters,
+            dispatch_course_generation_task_fn=lambda *args, **kwargs: None,
+            run_expand_phase_fn=lambda *args, **kwargs: None,
+        )
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail["code"] == "legacy_lms_mutation_confirmation_required"
+    assert exc.value.detail["required_field"] == "legacy_lms_mutation_confirmed"
+    assert repo.phase_updates == []
+
+
+@pytest.mark.asyncio
+async def test_expand_chapters_impl_allows_explicit_legacy_mutation_confirmation():
+    repo = _FakeRepo([
+        {
+            "id": "gen-1",
+            "teacher_id": "teacher-1",
+            "organization_id": "org-a",
+            "phase": "OUTLINE_READY",
+            "outline": {"chapters": [{"title": "Chuong 1", "sourcePages": [1]}]},
+            "progress_percent": 40,
+        }
+    ])
+    auth = AuthenticatedUser(
+        user_id="teacher-1",
+        auth_method="jwt",
+        role="teacher",
+        organization_id="org-a",
+    )
+    req = ExpandRequest(
+        teacher_id="teacher-1",
+        category_id="category-1",
+        course_title="Khoa hoc",
+        approved_chapters=[0],
+        legacy_lms_mutation_confirmed=True,
+    )
+    dispatched: list[tuple[str, str]] = []
+
+    async def fake_run_expand(generation_id, expand_request):
+        return None
+
+    def fake_dispatch(coro, *, label, generation_id):
+        dispatched.append((label, generation_id))
+        coro.close()
+
+    result = await expand_chapters_impl(
+        generation_id="gen-1",
+        req=req,
+        auth=auth,
+        get_course_gen_repo_fn=lambda: repo,
+        require_generation_job_access_fn=_require_generation_job_access,
+        ensure_teacher_matches_auth_fn=_ensure_teacher_matches_auth,
+        normalize_approved_chapters_fn=_normalize_approved_chapters,
+        dispatch_course_generation_task_fn=fake_dispatch,
+        run_expand_phase_fn=fake_run_expand,
+    )
+
+    assert result["phase"] == "EXPANDING"
+    assert result["mutation_contract"] == "legacy_course_generation_expand"
+    assert result["safe_product_contract"] == "host_action_preview_apply"
+    assert repo.phase_updates[-1][2]["expand_request"]["legacy_lms_mutation_confirmed"] is True
+    assert dispatched == [("course-gen:expand:gen-1", "gen-1")]
+
+
+@pytest.mark.asyncio
+async def test_get_generation_status_includes_outline_source_references():
+    repo = _FakeRepo([
+        {
+            "id": "gen-1",
+            "teacher_id": "teacher-1",
+            "organization_id": "org-a",
+            "phase": "OUTLINE_READY",
+            "outline": {
+                "chapters": [
+                    {
+                        "title": "Chuong 1",
+                        "sourcePages": [1, 2],
+                        "lessons": [
+                            {"title": "Bai 1", "sourcePages": [3]},
+                            {"title": "Bai 2"},
+                        ],
+                    }
+                ]
+            },
+        }
+    ])
+    auth = AuthenticatedUser(
+        user_id="teacher-1",
+        auth_method="jwt",
+        role="teacher",
+        organization_id="org-a",
+    )
+
+    result = await get_generation_status_impl(
+        generation_id="gen-1",
+        auth=auth,
+        generation_status_response_cls=GenerationStatusResponse,
+        get_course_gen_repo_fn=lambda: repo,
+        require_generation_job_access_fn=_require_generation_job_access,
+    )
+
+    assert result.source_references == [
+        {
+            "kind": "chapter",
+            "chapter_index": 0,
+            "title": "Chuong 1",
+            "source_pages": [1, 2],
+        },
+        {
+            "kind": "lesson",
+            "chapter_index": 0,
+            "lesson_index": 0,
+            "chapter_title": "Chuong 1",
+            "title": "Bai 1",
+            "source_pages": [3],
+        },
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- mark `POST /course-generation/{generation_id}/expand` as a legacy direct LMS mutation path and require `legacy_lms_mutation_confirmed=true`
- expose `source_references` on course-generation status so LMS previews can preserve teacher-verifiable citations
- document the product-safe LMS doc-to-course contract: preview -> teacher confirm -> apply

Refs #285.

## Verification
- `uv run --extra dev python -m pytest tests/unit/test_course_generation_flow.py -q` initially created the venv but failed because `structlog` is in `requirements.txt` and not in the pyproject-created env
- `uv pip install --python .\.venv\Scripts\python.exe "structlog>=25.5.0"`
- `.\.venv\Scripts\python.exe -m pytest tests/unit/test_course_generation_flow.py -q` -> 24 passed
- `.\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> pass
- `git diff --check` -> pass
- `python scripts/agent_coordination/watcher.py digest --limit 20` -> watcher.py not present on this branch

## Risk / Rollback
- Risk: existing clients that call legacy `/expand` without the new opt-in now get HTTP 409. This is intentional for product safety; preview/apply flows should not call this endpoint.
- Runtime note: already-persisted legacy resume/recovery jobs remain runtime-owned and are not the safe product doc-to-course flow.
- Rollback: revert this PR to restore previous direct expand behavior.

## LMS Coordination
LMS still needs its own PR for `authoring.preview_lesson_patch`, `authoring.apply_lesson_patch`, preview-token binding, and source/citation display. Wiii does not modify the LMS repo in this PR.
