### PR TITLE
Show source references in LMS host previews

### DIFF
--- a/wiii-desktop/src/__tests__/host-action-sse.test.ts
+++ b/wiii-desktop/src/__tests__/host-action-sse.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { buildHostActionPreviewItem } from "@/hooks/useSSEStream";
 import { useHostContextStore } from "@/stores/host-context-store";
+import type { HostContext } from "@/stores/host-context-store";
 
 describe("Host Action SSE + PostMessage Integration (Sprint 222b)", () => {
   it("wiii:action-response resolves pending action", async () => {
@@ -65,6 +66,12 @@ describe("Host Action SSE + PostMessage Integration (Sprint 222b)", () => {
   });
 
   it("preserves source references from host preview responses", () => {
+    const hostContext = {
+      host_type: "lms",
+      page: { type: "course_editor", title: "Course editor" },
+      workflow_stage: "editing",
+    } satisfies HostContext;
+
     const item = buildHostActionPreviewItem(
       "authoring.preview_lesson_patch",
       "req-source-1",
@@ -84,11 +91,7 @@ describe("Host Action SSE + PostMessage Integration (Sprint 222b)", () => {
           },
         ],
       },
-      {
-        host_type: "lms",
-        page: { type: "course_editor", title: "Course editor" },
-        workflow_stage: "editing",
-      } as never,
+      hostContext,
     );
 
     expect(item?.metadata?.source_references).toMatchObject([

--- a/wiii-desktop/src/__tests__/host-action-sse.test.ts
+++ b/wiii-desktop/src/__tests__/host-action-sse.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { buildHostActionPreviewItem } from "@/hooks/useSSEStream";
 import { useHostContextStore } from "@/stores/host-context-store";
 
 describe("Host Action SSE + PostMessage Integration (Sprint 222b)", () => {
@@ -61,5 +62,43 @@ describe("Host Action SSE + PostMessage Integration (Sprint 222b)", () => {
     const feedback = useHostContextStore.getState().getActionFeedbackForRequest();
     expect(feedback?.last_action_result?.data?.preview_kind).toBe("quiz_commit");
     expect(feedback?.last_action_result?.summary).toBe("Quiz preview ready.");
+  });
+
+  it("preserves source references from host preview responses", () => {
+    const item = buildHostActionPreviewItem(
+      "authoring.preview_lesson_patch",
+      "req-source-1",
+      {},
+      {
+        preview_token: "lesson-preview-123",
+        preview_kind: "lesson_patch",
+        summary: "Lesson patch preview ready.",
+        lesson_title: "Bai hoc nguon",
+        source_references: [
+          {
+            kind: "lesson",
+            chapter_index: 1,
+            lesson_index: 0,
+            title: "Muc tai lieu",
+            source_pages: [7, "8-9"],
+          },
+        ],
+      },
+      {
+        host_type: "lms",
+        page: { type: "course_editor", title: "Course editor" },
+        workflow_stage: "editing",
+      } as never,
+    );
+
+    expect(item?.metadata?.source_references).toMatchObject([
+      {
+        kind: "lesson",
+        chapter_index: 1,
+        lesson_index: 0,
+        title: "Muc tai lieu",
+        source_pages: [7, "8-9"],
+      },
+    ]);
   });
 });

--- a/wiii-desktop/src/__tests__/preview-panel-ui.test.tsx
+++ b/wiii-desktop/src/__tests__/preview-panel-ui.test.tsx
@@ -167,7 +167,17 @@ describe("PreviewPanel host action operator flow", () => {
   });
 
   it("renders block diff details and confirms apply from the right sidebar preview", async () => {
-    const preview = makeLessonPatchPreview();
+    const preview = makeLessonPatchPreview({
+      source_references: [
+        {
+          kind: "chapter",
+          chapter_index: 0,
+          title: "Doc chuong 1",
+          source_pages: [4, 5],
+          excerpt: "Noi dung goc tu tai lieu.",
+        },
+      ],
+    });
 
     seedConversation([preview]);
     useUIStore.getState().openPreview("host-preview-lesson-1");
@@ -182,6 +192,10 @@ describe("PreviewPanel host action operator flow", () => {
     const diffQueries = within(blockDiffSection as HTMLElement);
     expect(diffQueries.getByText("Noi dung cu")).toBeTruthy();
     expect(diffQueries.getByText("Noi dung moi")).toBeTruthy();
+    expect(screen.getByText("Nguon tai lieu")).toBeTruthy();
+    expect(screen.getByText("Doc chuong 1")).toBeTruthy();
+    expect(screen.getByText("Trang 4, 5")).toBeTruthy();
+    expect(screen.getByText("Noi dung goc tu tai lieu.")).toBeTruthy();
 
     fireEvent.click(
       screen.getByRole("button", { name: "Xác nhận áp dụng vào bài học" }),

--- a/wiii-desktop/src/components/layout/PreviewPanel.tsx
+++ b/wiii-desktop/src/components/layout/PreviewPanel.tsx
@@ -20,6 +20,12 @@ import { useToastStore } from "@/stores/toast-store";
 import { MarkdownRenderer } from "@/components/common/MarkdownRenderer";
 import { LazyImage } from "@/components/chat/PreviewCard";
 import { slideInRight } from "@/lib/animations";
+import {
+  formatSourcePages,
+  normalizeSourceReferences,
+  sourceReferenceLabel,
+  type PreviewSourceReference,
+} from "@/lib/source-references";
 import type { PreviewItemData } from "@/api/types";
 
 const HOST_PREVIEW_APPROVAL_REQUIRED_MESSAGE =
@@ -167,6 +173,11 @@ function ExpandedPreview({ item }: { item: PreviewItemData }) {
   const isHostAction = item.preview_type === "host_action";
   const metadataEntries = isHostAction
     ? buildHostActionMetadataEntries(item)
+    : [];
+  const sourceReferences = isHostAction
+    ? normalizeSourceReferences(
+        item.metadata?.source_references ?? item.metadata?.sourceReferences,
+      )
     : [];
   const hostContext = useHostContextStore((s) => s.currentContext);
   const hostCapabilities = useHostContextStore((s) => s.capabilities);
@@ -344,6 +355,9 @@ function ExpandedPreview({ item }: { item: PreviewItemData }) {
                 </div>
               ))}
             </div>
+          )}
+          {sourceReferences.length > 0 && (
+            <HostActionSourceReferences references={sourceReferences} />
           )}
           {(item.metadata?.next_step as string | undefined) && (
             <div className="rounded-lg bg-[var(--accent)]/8 px-3 py-2 text-sm text-text">
@@ -659,6 +673,55 @@ function renderHostActionPreviewDetails(item: PreviewItemData) {
   }
 
   return null;
+}
+
+function HostActionSourceReferences({
+  references,
+}: {
+  references: PreviewSourceReference[];
+}) {
+  return (
+    <section
+      aria-label="Nguon tai lieu"
+      className="rounded-lg border border-border bg-surface px-3 py-3"
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="text-[11px] uppercase tracking-wider text-text-tertiary">
+          Nguon tai lieu
+        </div>
+        <span className="rounded-full bg-surface-secondary px-2 py-0.5 text-[11px] text-text-secondary">
+          {references.length}
+        </span>
+      </div>
+      <div className="space-y-2">
+        {references.map((ref, index) => (
+          <div
+            key={`${ref.kind || "source"}-${ref.chapter_index ?? "x"}-${ref.lesson_index ?? "x"}-${index}`}
+            className="rounded-md bg-surface-secondary px-3 py-2"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-medium text-text">
+                {sourceReferenceLabel(ref)}
+              </span>
+              <span className="rounded-full bg-surface px-2 py-0.5 text-[11px] text-text-secondary">
+                Trang {formatSourcePages(ref.source_pages)}
+              </span>
+              {ref.kind && (
+                <span className="rounded-full bg-surface px-2 py-0.5 text-[11px] uppercase tracking-wider text-text-tertiary">
+                  {ref.kind}
+                </span>
+              )}
+            </div>
+            {ref.excerpt && (
+              <div className="mt-1 text-xs leading-relaxed text-text-secondary">
+                {ref.excerpt}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
 }
 
 function HostActionBlockDiffCard({
@@ -1011,6 +1074,9 @@ function buildManualHostActionAuditRequest(
   if (!eventType) {
     return null;
   }
+  const sourceReferences = normalizeSourceReferences(
+    item.metadata?.source_references ?? item.metadata?.sourceReferences,
+  );
 
   return {
     event_type: eventType,
@@ -1069,6 +1135,8 @@ function buildManualHostActionAuditRequest(
         typeof item.metadata?.question_count === "number"
           ? item.metadata.question_count
           : undefined,
+      source_references:
+        sourceReferences.length > 0 ? sourceReferences : undefined,
     },
   };
 }

--- a/wiii-desktop/src/hooks/useSSEStream.ts
+++ b/wiii-desktop/src/hooks/useSSEStream.ts
@@ -25,6 +25,7 @@ import { useModelStore } from "@/stores/model-store";
 import { useAuthStore } from "@/stores/auth-store";
 import { StreamBuffer } from "@/lib/stream-buffer";
 import { stripWiiiInternalMarkup } from "@/lib/internal-markup";
+import { normalizeSourceReferences } from "@/lib/source-references";
 import {
   POINTY_FAST_PATH_SOURCE,
   buildPointyFastPathAction,
@@ -245,7 +246,7 @@ function mapHostActionAuditEvent(action: string): HostActionAuditEventType | nul
   }
 }
 
-function buildHostActionPreviewItem(
+export function buildHostActionPreviewItem(
   action: string,
   requestId: string,
   params: Record<string, unknown>,
@@ -257,6 +258,9 @@ function buildHostActionPreviewItem(
 
   const previewKind = typeof data.preview_kind === "string" ? data.preview_kind : "";
   const summary = typeof data.summary === "string" ? data.summary.trim() : "Preview is ready.";
+  const sourceReferences = normalizeSourceReferences(
+    data.source_references ?? data.sourceReferences,
+  );
   const changedFields = Array.isArray(data.changed_fields)
     ? data.changed_fields.filter((field): field is string => typeof field === "string" && field.trim().length > 0)
     : [];
@@ -327,6 +331,8 @@ function buildHostActionPreviewItem(
         data.publish_plan && typeof data.publish_plan === "object"
           ? data.publish_plan
           : undefined,
+      source_references:
+        sourceReferences.length > 0 ? sourceReferences : undefined,
       requires_confirmation: true,
       workflow_stage: hostContext?.workflow_stage,
       page_type: hostContext?.page?.type,
@@ -347,6 +353,9 @@ function buildHostActionAuditRequest(
   if (!eventType) return null;
 
   const data = result.data || {};
+  const sourceReferences = normalizeSourceReferences(
+    data.source_references ?? data.sourceReferences,
+  );
   return {
     event_type: eventType,
     action,
@@ -406,6 +415,8 @@ function buildHostActionAuditRequest(
         data.publish_plan && typeof data.publish_plan === "object"
           ? data.publish_plan
           : undefined,
+      source_references:
+        sourceReferences.length > 0 ? sourceReferences : undefined,
     },
   };
 }

--- a/wiii-desktop/src/lib/source-references.ts
+++ b/wiii-desktop/src/lib/source-references.ts
@@ -1,0 +1,95 @@
+export type PreviewSourceReference = {
+  kind?: string;
+  title?: string;
+  chapter_title?: string;
+  chapter_index?: number;
+  lesson_index?: number;
+  source_pages: Array<number | string>;
+  excerpt?: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function optionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizePageValue(value: unknown): number | string | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  return null;
+}
+
+function normalizePages(record: Record<string, unknown>): Array<number | string> {
+  const raw =
+    record.source_pages ??
+    record.sourcePages ??
+    record.pages ??
+    record.page_numbers ??
+    record.pageNumbers;
+  const values = Array.isArray(raw) ? raw : [raw];
+  return values
+    .map(normalizePageValue)
+    .filter((page): page is number | string => page != null);
+}
+
+export function normalizeSourceReferences(
+  value: unknown,
+): PreviewSourceReference[] {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map(asRecord)
+    .filter((record): record is Record<string, unknown> => record != null)
+    .map((record): PreviewSourceReference | null => {
+      const sourcePages = normalizePages(record);
+      if (sourcePages.length === 0) return null;
+      const ref: PreviewSourceReference = { source_pages: sourcePages };
+      const kind = optionalString(record.kind);
+      const title = optionalString(record.title);
+      const chapterTitle = optionalString(record.chapter_title ?? record.chapterTitle);
+      const chapterIndex = optionalNumber(record.chapter_index ?? record.chapterIndex);
+      const lessonIndex = optionalNumber(record.lesson_index ?? record.lessonIndex);
+      const excerpt = optionalString(record.excerpt);
+      if (kind) ref.kind = kind;
+      if (title) ref.title = title;
+      if (chapterTitle) ref.chapter_title = chapterTitle;
+      if (typeof chapterIndex === "number") ref.chapter_index = chapterIndex;
+      if (typeof lessonIndex === "number") ref.lesson_index = lessonIndex;
+      if (excerpt) ref.excerpt = excerpt;
+      return ref;
+    })
+    .filter((ref): ref is PreviewSourceReference => ref != null);
+}
+
+export function formatSourcePages(pages: Array<number | string>): string {
+  return pages.map((page) => String(page)).join(", ");
+}
+
+export function sourceReferenceLabel(ref: PreviewSourceReference): string {
+  if (ref.title) return ref.title;
+  if (ref.chapter_title) return ref.chapter_title;
+  if (typeof ref.chapter_index === "number" && typeof ref.lesson_index === "number") {
+    return `Chuong ${ref.chapter_index + 1}, bai ${ref.lesson_index + 1}`;
+  }
+  if (typeof ref.chapter_index === "number") {
+    return `Chuong ${ref.chapter_index + 1}`;
+  }
+  return ref.kind || "Nguon";
+}


### PR DESCRIPTION
## Summary
- preserve `source_references` / `sourceReferences` from host-action preview responses in Wiii preview metadata
- render source/page references in the host-action PreviewPanel before teacher confirmation
- include source references in host-action audit metadata and cover the SSE/UI path with tests

Refs #285.

## Verification
- `npx vitest run src/__tests__/host-action-sse.test.ts src/__tests__/preview-panel-ui.test.tsx` -> 2 files, 6 tests passed
- `npx tsc --noEmit` -> pass
- `npm run build:embed` -> pass, with existing chunk-size and ineffective-dynamic-import warnings
- `git diff --check` -> pass, with CRLF normalization warning for `src/__tests__/host-action-sse.test.ts`

## Risk / Rollback
- Risk: low; this is display/audit metadata plumbing for host-action previews and does not change apply execution semantics.
- Rollback: revert this PR to stop rendering or preserving `source_references` in desktop host previews.

## LMS Coordination
This complements the LMS preview/apply contract: once LMS returns `source_references` from `authoring.preview_lesson_patch`, Wiii will keep and show them in the teacher confirmation panel. LMS still owns preview-token validation and apply-side mutation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Host action previews now display a source references section, showing chapter titles, page ranges, and excerpts.
  * Source reference metadata is automatically normalized and preserved when applying audits.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/287)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->