### PR TITLE
Surface source reference schema for LMS host previews

### DIFF
--- a/maritime-ai-service/app/engine/context/action_tools.py
+++ b/maritime-ai-service/app/engine/context/action_tools.py
@@ -77,6 +77,38 @@ def _expected_preview_kind(action_name: str) -> str | None:
     return None
 
 
+def _format_input_contract(action_name: str, action_def: dict[str, Any]) -> str:
+    input_schema = action_def.get("input_schema")
+    if not isinstance(input_schema, dict):
+        return ""
+
+    properties = input_schema.get("properties")
+    if not isinstance(properties, dict) or not properties:
+        return ""
+
+    fields = [str(name) for name in properties.keys() if str(name).strip()]
+    if not fields:
+        return ""
+
+    lines = ["Input fields: " + ", ".join(fields[:12])]
+    required = input_schema.get("required")
+    if isinstance(required, list):
+        required_fields = [str(name) for name in required if str(name).strip()]
+        if required_fields:
+            lines.append("Required: " + ", ".join(required_fields[:12]))
+
+    if (
+        action_name.strip().lower().endswith("preview_lesson_patch")
+        and "source_references" in properties
+    ):
+        lines.append(
+            "For document-derived lesson/course previews, include `source_references` "
+            "from the uploaded source document so the teacher can verify citations."
+        )
+
+    return "\n" + "\n".join(lines)
+
+
 def generate_host_action_tools(
     capabilities_tools: list[dict[str, Any]],
     user_role: str,
@@ -97,6 +129,7 @@ def generate_host_action_tools(
     for action_def in available:
         action_name = action_def["name"]
         description = action_def.get("description", f"Execute {action_name} on host")
+        input_contract = _format_input_contract(action_name, action_def)
 
         def _make_tool_fn(name: str, br: HostActionBridge, bus_id: str, definition: dict[str, Any]):
             def tool_fn(**kwargs: Any) -> str:
@@ -140,7 +173,7 @@ def generate_host_action_tools(
         tool = StructuredTool.from_function(
             func=_make_tool_fn(action_name, bridge, event_bus_id, action_def),
             name=host_action_tool_name(action_name),
-            description=f"[Host Action: {action_name}] {description}",
+            description=f"[Host Action: {action_name}] {description}{input_contract}",
         )
         tools.append(tool)
 

--- a/maritime-ai-service/tests/unit/test_sprint222b_action_tools.py
+++ b/maritime-ai-service/tests/unit/test_sprint222b_action_tools.py
@@ -1,4 +1,6 @@
 """Sprint 222b Phase 5: Dynamic tool generation from host capabilities."""
+import json
+
 import pytest
 
 
@@ -187,3 +189,90 @@ class TestGenerateHostActionTools:
         result = tools[0].invoke({})
         assert '"status": "preview_required"' in result
         assert '"expected_preview_kind": "quiz_publish"' in result
+
+    def test_preview_lesson_tool_description_mentions_source_references_schema(self):
+        from app.engine.context.action_tools import generate_host_action_tools
+
+        tools = generate_host_action_tools(
+            [
+                {
+                    "name": "authoring.preview_lesson_patch",
+                    "description": "Preview lesson changes",
+                    "roles": ["teacher"],
+                    "input_schema": {
+                        "type": "object",
+                        "required": ["lesson_id"],
+                        "properties": {
+                            "lesson_id": {"type": "string"},
+                            "title": {"type": "string"},
+                            "content": {"type": "string"},
+                            "source_references": {
+                                "type": "array",
+                                "items": {"type": "object"},
+                            },
+                        },
+                    },
+                }
+            ],
+            "teacher",
+            event_bus_id="bus-1",
+        )
+
+        assert (
+            "Input fields: lesson_id, title, content, source_references"
+            in tools[0].description
+        )
+        assert "Required: lesson_id" in tools[0].description
+        assert "include `source_references`" in tools[0].description
+
+    def test_preview_lesson_tool_passes_source_references_to_host(self):
+        from app.engine.context.action_tools import generate_host_action_tools
+
+        tools = generate_host_action_tools(
+            [
+                {
+                    "name": "authoring.preview_lesson_patch",
+                    "description": "Preview lesson changes",
+                    "roles": ["teacher"],
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "lesson_id": {"type": "string"},
+                            "source_references": {
+                                "type": "array",
+                                "items": {"type": "object"},
+                            },
+                        },
+                    },
+                }
+            ],
+            "teacher",
+            event_bus_id="bus-1",
+        )
+
+        result = json.loads(
+            tools[0].invoke(
+                {
+                    "lesson_id": "lesson-1",
+                    "source_references": [
+                        {
+                            "kind": "chapter",
+                            "page_start": 2,
+                            "page_end": 3,
+                            "excerpt": "Nguon tai lieu",
+                        }
+                    ],
+                }
+            )
+        )
+
+        assert result["status"] == "action_requested"
+        assert result["action"] == "authoring.preview_lesson_patch"
+        assert result["params"]["source_references"] == [
+            {
+                "kind": "chapter",
+                "page_start": 2,
+                "page_end": 3,
+                "excerpt": "Nguon tai lieu",
+            }
+        ]


### PR DESCRIPTION
## Summary
- include host-declared input fields and required fields in generated host-action tool descriptions
- add an explicit `source_references` hint for `authoring.preview_lesson_patch` when the LMS capability schema exposes that field
- add tests proving Wiii passes `source_references` through to LMS preview actions

Refs #285.

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests/unit/test_sprint222b_action_tools.py -q` -> 13 passed
- `.\.venv\Scripts\ruff.exe check app/engine/context/action_tools.py tests/unit/test_sprint222b_action_tools.py --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk / Rollback
- Risk: low; this changes host-action tool descriptions and tests, and keeps runtime payload pass-through behavior intact.
- Rollback: revert this PR to remove schema/hint text from generated host action tool descriptions.

## LMS Coordination
This complements linhlinhlin/LMS_hohulili#404: when LMS exposes `source_references` on `authoring.preview_lesson_patch`, Wiii's generated tool now tells the model to include those document citations in the preview payload.
