### PR TITLE
Respect LMS host preview approval gate

### DIFF
--- a/wiii-desktop/src/__tests__/preview-panel-ui.test.tsx
+++ b/wiii-desktop/src/__tests__/preview-panel-ui.test.tsx
@@ -259,6 +259,68 @@ describe("PreviewPanel host action operator flow", () => {
     expect(useHostContextStore.getState().requestAction).not.toHaveBeenCalled();
   });
 
+  it("forwards the LMS approval token when the host preview already confirmed apply", async () => {
+    const preview = makeLessonPatchPreview({
+      approval_token: "approval-lesson-1",
+    });
+    const requestAction = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        summary: "Applied with LMS approval.",
+      },
+    });
+    useHostContextStore.setState({
+      capabilities: {
+        host_type: "lms",
+        host_name: "LMS",
+        version: "1",
+        resources: ["course"],
+        surfaces: ["right_sidebar"],
+        tools: [
+          {
+            name: "authoring.apply_lesson_patch",
+            description: "Apply a teacher-approved lesson patch.",
+            input_schema: {
+              type: "object",
+              properties: {
+                preview_token: { type: "string" },
+                approval_token: { type: "string" },
+              },
+              required: ["preview_token", "approval_token"],
+            },
+            requires_confirmation: true,
+            mutates_state: true,
+          },
+        ],
+      },
+      requestAction,
+    } as never);
+
+    seedConversation([preview]);
+    useUIStore.getState().openPreview("host-preview-lesson-1");
+
+    render(<PreviewPanel inline />);
+
+    const button = screen.getByRole("button", {
+      name: "Xác nhận áp dụng vào bài học",
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(requestAction).toHaveBeenCalledWith(
+        "authoring.apply_lesson_patch",
+        {
+          preview_token: "preview-lesson-1",
+          approval_token: "approval-lesson-1",
+        },
+        expect.stringMatching(/^req-preview-apply-/),
+      );
+    });
+    expect(await screen.findByText("Applied with LMS approval.")).toBeTruthy();
+  });
+
   it("treats host_preview_approval_required as the expected LMS safety gate", async () => {
     const preview = makeLessonPatchPreview();
     const requestAction = vi.fn().mockResolvedValue({

--- a/wiii-desktop/src/__tests__/preview-panel-ui.test.tsx
+++ b/wiii-desktop/src/__tests__/preview-panel-ui.test.tsx
@@ -45,8 +45,65 @@ function seedConversation(previews: PreviewItemData[]) {
   });
 }
 
+function makeLessonPatchPreview(
+  metadataOverrides: Record<string, unknown> = {},
+): PreviewItemData {
+  return {
+    preview_type: "host_action",
+    preview_id: "host-preview-lesson-1",
+    title: "Preview cap nhat bai hoc: Bai hoc goc",
+    snippet:
+      "Lesson patch preview ready. Confirm explicitly when you want me to apply it.",
+    metadata: {
+      preview_kind: "lesson_patch",
+      preview_token: "preview-lesson-1",
+      apply_action: "authoring.apply_lesson_patch",
+      lesson_id: "lesson-1",
+      target_label: "Bai hoc goc",
+      lesson_before: {
+        title: "Bai hoc goc",
+        description: "Mo ta cu",
+        content_excerpt: "Noi dung cu",
+        blocks: [
+          { id: "b1", type: "text", label: "Doan 1", excerpt: "Noi dung cu" },
+        ],
+      },
+      lesson_after: {
+        title: "Bai hoc moi",
+        description: "Mo ta cu",
+        content_excerpt: "Noi dung moi",
+        blocks: [
+          {
+            id: "b1",
+            type: "text",
+            label: "Doan 1",
+            excerpt: "Noi dung moi",
+          },
+        ],
+      },
+      block_diff: {
+        changed: 1,
+        added: 0,
+        removed: 0,
+        unchanged: 0,
+        items: [
+          {
+            index: 0,
+            status: "changed",
+            before: { id: "b1", label: "Doan 1", excerpt: "Noi dung cu" },
+            after: { id: "b1", label: "Doan 1", excerpt: "Noi dung moi" },
+          },
+        ],
+      },
+      ...metadataOverrides,
+    },
+  };
+}
+
 describe("PreviewPanel host action operator flow", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+
     useChatStore.setState({
       conversations: [],
       activeConversationId: null,
@@ -110,55 +167,7 @@ describe("PreviewPanel host action operator flow", () => {
   });
 
   it("renders block diff details and confirms apply from the right sidebar preview", async () => {
-    const preview: PreviewItemData = {
-      preview_type: "host_action",
-      preview_id: "host-preview-lesson-1",
-      title: "Preview cap nhat bai hoc: Bai hoc goc",
-      snippet:
-        "Lesson patch preview ready. Confirm explicitly when you want me to apply it.",
-      metadata: {
-        preview_kind: "lesson_patch",
-        preview_token: "preview-lesson-1",
-        apply_action: "authoring.apply_lesson_patch",
-        lesson_id: "lesson-1",
-        target_label: "Bai hoc goc",
-        lesson_before: {
-          title: "Bai hoc goc",
-          description: "Mo ta cu",
-          content_excerpt: "Noi dung cu",
-          blocks: [
-            { id: "b1", type: "text", label: "Doan 1", excerpt: "Noi dung cu" },
-          ],
-        },
-        lesson_after: {
-          title: "Bai hoc moi",
-          description: "Mo ta cu",
-          content_excerpt: "Noi dung moi",
-          blocks: [
-            {
-              id: "b1",
-              type: "text",
-              label: "Doan 1",
-              excerpt: "Noi dung moi",
-            },
-          ],
-        },
-        block_diff: {
-          changed: 1,
-          added: 0,
-          removed: 0,
-          unchanged: 0,
-          items: [
-            {
-              index: 0,
-              status: "changed",
-              before: { id: "b1", label: "Doan 1", excerpt: "Noi dung cu" },
-              after: { id: "b1", label: "Doan 1", excerpt: "Noi dung moi" },
-            },
-          ],
-        },
-      },
-    };
+    const preview = makeLessonPatchPreview();
 
     seedConversation([preview]);
     useUIStore.getState().openPreview("host-preview-lesson-1");
@@ -202,5 +211,86 @@ describe("PreviewPanel host action operator flow", () => {
     expect(
       await screen.findByText("Applied lesson patch to lesson lesson-1."),
     ).toBeTruthy();
+  });
+
+  it("keeps Wiii apply disabled when the host requires its own approval token", () => {
+    const preview = makeLessonPatchPreview();
+    useHostContextStore.setState({
+      capabilities: {
+        host_type: "lms",
+        host_name: "LMS",
+        version: "1",
+        resources: ["course"],
+        surfaces: ["right_sidebar"],
+        tools: [
+          {
+            name: "authoring.apply_lesson_patch",
+            description: "Apply a teacher-approved lesson patch.",
+            input_schema: {
+              type: "object",
+              properties: {
+                preview_token: { type: "string" },
+                approval_token: { type: "string" },
+              },
+              required: ["preview_token", "approval_token"],
+            },
+            requires_confirmation: true,
+            mutates_state: true,
+          },
+        ],
+      },
+    } as never);
+
+    seedConversation([preview]);
+    useUIStore.getState().openPreview("host-preview-lesson-1");
+
+    render(<PreviewPanel inline />);
+
+    const button = screen.getByRole("button", {
+      name: "Xác nhận áp dụng vào bài học",
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(
+      screen.getByText(/LMS đang giữ quyền áp dụng trong hộp thoại preview/),
+    ).toBeTruthy();
+
+    fireEvent.click(button);
+
+    expect(useHostContextStore.getState().requestAction).not.toHaveBeenCalled();
+  });
+
+  it("treats host_preview_approval_required as the expected LMS safety gate", async () => {
+    const preview = makeLessonPatchPreview();
+    const requestAction = vi.fn().mockResolvedValue({
+      success: false,
+      error: "host_preview_approval_required",
+    });
+    useHostContextStore.setState({
+      requestAction,
+    } as never);
+
+    seedConversation([preview]);
+    useUIStore.getState().openPreview("host-preview-lesson-1");
+
+    render(<PreviewPanel inline />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Xác nhận áp dụng vào bài học" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/LMS đang giữ quyền áp dụng trong hộp thoại preview/),
+      ).toBeTruthy();
+    });
+
+    const { submitHostActionAudit } = await import("@/api/host-actions");
+    expect(submitHostActionAudit).not.toHaveBeenCalled();
+    expect(useToastStore.getState().toasts).toEqual([
+      expect.objectContaining({
+        type: "info",
+        message: expect.stringContaining("LMS đang giữ quyền áp dụng"),
+      }),
+    ]);
   });
 });

--- a/wiii-desktop/src/components/layout/PreviewPanel.tsx
+++ b/wiii-desktop/src/components/layout/PreviewPanel.tsx
@@ -928,14 +928,23 @@ function hostActionRequiresInput(
   const capabilityTools = hostCapabilities?.tools ?? [];
   const contextActions = hostContext?.available_actions ?? [];
   return [...capabilityTools, ...contextActions].some((tool) => {
+    if (!tool || typeof tool !== "object") {
+      return false;
+    }
+    const candidate = tool as {
+      action?: unknown;
+      input_schema?: unknown;
+      name?: unknown;
+    };
     const toolName =
-      "name" in tool && typeof tool.name === "string"
-        ? tool.name
-        : "action" in tool && typeof tool.action === "string"
-          ? tool.action
+      typeof candidate.name === "string"
+        ? candidate.name
+        : typeof candidate.action === "string"
+          ? candidate.action
           : "";
     return (
-      toolName === action && schemaRequiresProperty(tool.input_schema, property)
+      toolName === action &&
+      schemaRequiresProperty(candidate.input_schema, property)
     );
   });
 }

--- a/wiii-desktop/src/components/layout/PreviewPanel.tsx
+++ b/wiii-desktop/src/components/layout/PreviewPanel.tsx
@@ -12,12 +12,18 @@ import {
 } from "@/api/host-actions";
 import { useUIStore } from "@/stores/ui-store";
 import { useChatStore } from "@/stores/chat-store";
-import { useHostContextStore } from "@/stores/host-context-store";
+import {
+  useHostContextStore,
+  type ActionResult,
+} from "@/stores/host-context-store";
 import { useToastStore } from "@/stores/toast-store";
 import { MarkdownRenderer } from "@/components/common/MarkdownRenderer";
 import { LazyImage } from "@/components/chat/PreviewCard";
 import { slideInRight } from "@/lib/animations";
 import type { PreviewItemData } from "@/api/types";
+
+const HOST_PREVIEW_APPROVAL_REQUIRED_MESSAGE =
+  "LMS đang giữ quyền áp dụng trong hộp thoại preview. Hãy xác nhận trực tiếp trong LMS để Wiii không tự thay đổi dữ liệu.";
 
 /** Shared content for both inline and overlay modes */
 function PreviewPanelContent({
@@ -173,8 +179,26 @@ function ExpandedPreview({ item }: { item: PreviewItemData }) {
     typeof item.metadata?.preview_token === "string"
       ? item.metadata.preview_token
       : "";
+  const approvalToken =
+    typeof item.metadata?.approval_token === "string"
+      ? item.metadata.approval_token
+      : "";
+  const applyNeedsHostApproval = Boolean(
+    applyConfig &&
+      !approvalToken &&
+      hostActionRequiresInput(
+        applyConfig.action,
+        "approval_token",
+        hostCapabilities,
+        hostContext,
+      ),
+  );
   const canExecuteApply = Boolean(
-    isHostAction && applyConfig && previewToken && hostContext?.host_type,
+    isHostAction &&
+      applyConfig &&
+      previewToken &&
+      hostContext?.host_type &&
+      !applyNeedsHostApproval,
   );
 
   useEffect(() => {
@@ -192,14 +216,27 @@ function ExpandedPreview({ item }: { item: PreviewItemData }) {
       message: "Wiii đang gửi xác nhận sang LMS...",
     });
     try {
+      const applyParams: Record<string, string> = {
+        preview_token: previewToken,
+      };
+      if (approvalToken) {
+        applyParams.approval_token = approvalToken;
+      }
+
       const result = await useHostContextStore
         .getState()
-        .requestAction(
-          applyConfig.action,
-          { preview_token: previewToken },
-          requestId,
-        );
+        .requestAction(applyConfig.action, applyParams, requestId);
       if (!result.success) {
+        if (isHostPreviewApprovalRequired(result)) {
+          setOperatorState({
+            status: "idle",
+            message: HOST_PREVIEW_APPROVAL_REQUIRED_MESSAGE,
+          });
+          useToastStore
+            .getState()
+            .addToast("info", HOST_PREVIEW_APPROVAL_REQUIRED_MESSAGE, 4500);
+          return;
+        }
         throw new Error(result.error || "Không thể áp dụng thay đổi này.");
       }
 
@@ -228,6 +265,16 @@ function ExpandedPreview({ item }: { item: PreviewItemData }) {
         });
       }
     } catch (error) {
+      if (isHostPreviewApprovalRequired(error)) {
+        setOperatorState({
+          status: "idle",
+          message: HOST_PREVIEW_APPROVAL_REQUIRED_MESSAGE,
+        });
+        useToastStore
+          .getState()
+          .addToast("info", HOST_PREVIEW_APPROVAL_REQUIRED_MESSAGE, 4500);
+        return;
+      }
       const message =
         error instanceof Error
           ? error.message
@@ -355,7 +402,9 @@ function ExpandedPreview({ item }: { item: PreviewItemData }) {
                 className="mt-2 text-xs text-text-secondary"
               >
                 {!canExecuteApply && operatorState.status === "idle"
-                  ? "CTA này chỉ hoạt động khi Wiii đang được nhúng trong host sidebar có bridge xác nhận."
+                  ? applyNeedsHostApproval
+                    ? HOST_PREVIEW_APPROVAL_REQUIRED_MESSAGE
+                    : "CTA này chỉ hoạt động khi Wiii đang được nhúng trong host sidebar có bridge xác nhận."
                   : operatorState.message}
               </div>
             </div>
@@ -866,6 +915,61 @@ function resolveHostActionApplyConfig(item: PreviewItemData): {
     label: "Xác nhận áp dụng",
     successLabel: "Đã áp dụng thay đổi vào host.",
   };
+}
+
+function hostActionRequiresInput(
+  action: string,
+  property: string,
+  hostCapabilities: ReturnType<
+    typeof useHostContextStore.getState
+  >["capabilities"],
+  hostContext: ReturnType<typeof useHostContextStore.getState>["currentContext"],
+): boolean {
+  const capabilityTools = hostCapabilities?.tools ?? [];
+  const contextActions = hostContext?.available_actions ?? [];
+  return [...capabilityTools, ...contextActions].some((tool) => {
+    const toolName =
+      "name" in tool && typeof tool.name === "string"
+        ? tool.name
+        : "action" in tool && typeof tool.action === "string"
+          ? tool.action
+          : "";
+    return (
+      toolName === action && schemaRequiresProperty(tool.input_schema, property)
+    );
+  });
+}
+
+function schemaRequiresProperty(schema: unknown, property: string): boolean {
+  if (!schema || typeof schema !== "object") {
+    return false;
+  }
+  const required = (schema as { required?: unknown }).required;
+  return (
+    Array.isArray(required) &&
+    required.some((field) => field === property)
+  );
+}
+
+function isHostPreviewApprovalRequired(result: unknown): boolean {
+  if (result instanceof Error) {
+    return result.message.includes("host_preview_approval_required");
+  }
+  if (!result || typeof result !== "object") {
+    return false;
+  }
+
+  const actionResult = result as ActionResult;
+  const error = typeof actionResult.error === "string" ? actionResult.error : "";
+  const code =
+    typeof actionResult.data?.code === "string"
+      ? actionResult.data.code
+      : typeof actionResult.data?.error_code === "string"
+        ? actionResult.data.error_code
+        : "";
+  return [error, code].some((value) =>
+    value.includes("host_preview_approval_required"),
+  );
 }
 
 function mapManualHostActionAuditEvent(


### PR DESCRIPTION
## Summary
- Detect when a host action schema requires a host-only `approval_token` and keep the Wiii preview-panel apply CTA disabled unless that token is present.
- Treat `host_preview_approval_required` as the expected LMS safety gate with an informational message instead of a generic apply failure.
- Add preview-panel tests for the disabled approval-token path and the no-audit `host_preview_approval_required` response.

## Safety
- Wiii does not bypass LMS approval. When LMS advertises `approval_token` as required, the teacher must confirm in the LMS preview dialog.
- Failed direct apply attempts with `host_preview_approval_required` do not create `apply_confirmed` audit events.
- No LMS repo files, deployment files, generated embed output, secrets, or env files are changed.

## Coordination
- Refs meiiie/wiii#283.
- Coordinates with linhlinhlin/LMS_hohulili#404, which introduces the host-approved preview dialog and host-only approval token.

## Validation
- `cd wiii-desktop; npx vitest run src/__tests__/preview-panel-ui.test.tsx` -> 3 passed
- `cd wiii-desktop; npx tsc --noEmit` -> pass
- `cd wiii-desktop; npm run build:embed` -> pass (existing chunk/dynamic-import warnings)
- `git diff --check` -> pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added host approval workflow to lesson patch previews. The Apply button is disabled when host approval is required, with appropriate status messaging displayed for approval pending state.

* **Tests**
  * Expanded test coverage for host approval scenarios and error handling in preview workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/289)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->