### PR TITLE
Ignore production env backup artifacts in deploy lane

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -139,6 +139,15 @@ jobs:
             "APP_DIR='$APP_DIR' DEPLOY_SHA='$DEPLOY_SHA' WIII_APP_IMAGE='$WIII_APP_IMAGE' WIII_NGINX_IMAGE='$WIII_NGINX_IMAGE' REQUIRE_PINNED_IMAGES='$REQUIRE_PINNED_IMAGES' RUN_EXTERNAL_SMOKE='$RUN_EXTERNAL_SMOKE' BASE_URL='$BASE_URL' bash -s" <<'REMOTE'
           set -euo pipefail
           cd "$APP_DIR"
+          shopt -s nullglob
+          env_backups=(maritime-ai-service/.env.production.bak-*)
+          if [ "${#env_backups[@]}" -gt 0 ]; then
+            backup_dir="${HOME}/.wiii-deploy-env-backups/$(date -u +%Y%m%d_%H%M%S)"
+            mkdir -p "$backup_dir"
+            chmod 700 "${HOME}/.wiii-deploy-env-backups"
+            mv -- "${env_backups[@]}" "$backup_dir"/
+            echo "Moved ${#env_backups[@]} local env backup file(s) out of checkout before deploy."
+          fi
           bash ./maritime-ai-service/scripts/deploy/deploy.sh
           REMOTE
 

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ test-results/
 Documents/
 maritime-ai-service/.tmp-workspace/
 maritime-ai-service/.env.soul-agi
+maritime-ai-service/.env.production.bak-*
 wiii-desktop/scripts/screenshots/
 
 # === Local agent scratch artifacts ===


### PR DESCRIPTION
## Summary
- Move local `.env.production.bak-*` files out of the production checkout before running the deploy dirty-tree guard.
- Ignore the same backup pattern in git so future deploy-generated env backups do not block release sync.

## Verification
- `git diff --check` passed.

## Risk / rollback
- Narrow scope: only exact `.env.production.bak-*` artifacts are moved to `$HOME/.wiii-deploy-env-backups/<timestamp>` on the production VM.
- Dirty-tree guard remains active for all other untracked or modified files.
- Rollback: revert this commit if deployment backup handling should be restored to strict blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced the production deployment workflow to automatically back up and preserve environment configuration files, ensuring safer and more reliable deployments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/290)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->