### PR TITLE
Force document uploads through preview host action

### DIFF
--- a/maritime-ai-service/app/engine/context/action_tools.py
+++ b/maritime-ai-service/app/engine/context/action_tools.py
@@ -105,6 +105,10 @@ def _format_input_contract(action_name: str, action_def: dict[str, Any]) -> str:
             "For document-derived lesson/course previews, include `source_references` "
             "from the uploaded source document so the teacher can verify citations."
         )
+        lines.append(
+            "When an uploaded Word/PDF/document is the source, build `content` from that "
+            "document context and keep preview-only behavior; do not call an apply action."
+        )
 
     return "\n" + "\n".join(lines)
 

--- a/maritime-ai-service/app/engine/multi_agent/tool_collection.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_collection.py
@@ -203,6 +203,56 @@ def _routing_intent(state: Optional[AgentState]) -> str:
     return str(metadata.get("intent") or "").strip().lower()
 
 
+def _has_uploaded_document_context_state(state: Optional[AgentState]) -> bool:
+    if not isinstance(state, dict):
+        return False
+    context = state.get("context")
+    if not isinstance(context, dict):
+        return False
+    document_context = context.get("document_context")
+    if not isinstance(document_context, dict):
+        return False
+    attachments = document_context.get("attachments")
+    if not isinstance(attachments, list):
+        return False
+    return any(
+        isinstance(item, dict) and str(item.get("markdown") or "").strip()
+        for item in attachments
+    )
+
+
+def _looks_like_document_preview_request(query: str, state: Optional[AgentState]) -> bool:
+    if not _has_uploaded_document_context_state(state):
+        return False
+    normalized = _normalize_for_intent(query)
+    return any(
+        marker in normalized
+        for marker in (
+            "preview",
+            "xem truoc",
+            "ban xem truoc",
+            "ban nhap",
+            "draft",
+            "cap nhat bai hoc",
+            "tao bai hoc",
+            "lesson patch",
+            "preview_lesson_patch",
+            "source_references",
+            "citation",
+            "trich dan",
+            "nguon",
+        )
+    )
+
+
+def _document_preview_host_action_tools(tools: list[Any]) -> list[Any]:
+    return [
+        tool
+        for tool in tools
+        if _tool_name(tool).lower() == "host_action__authoring__preview_lesson_patch"
+    ]
+
+
 def _should_use_no_tools_for_direct_prose(
     *,
     query: str,
@@ -444,6 +494,14 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
     if _is_host_ui_navigation_route(state):
         scoped_host_tools = _host_action_tools(_direct_tools)
         return scoped_host_tools, bool(scoped_host_tools)
+
+    if _looks_like_document_preview_request(query, state):
+        preview_tools = _document_preview_host_action_tools(_direct_tools)
+        if preview_tools:
+            logger.info(
+                "[DIRECT] Forcing LMS document preview host action for uploaded document context"
+            )
+            return preview_tools[:1], True
 
     if _looks_reasoning_safety_meta_turn(query) and _routing_intent(state) in {
         "general",

--- a/maritime-ai-service/tests/unit/test_tool_collection_host_ui.py
+++ b/maritime-ai-service/tests/unit/test_tool_collection_host_ui.py
@@ -139,6 +139,90 @@ def test_host_ui_route_binds_pointy_tools_without_keyword_match(monkeypatch):
 # ─────────────────────────────────────────────────────────────────────────
 
 
+def test_uploaded_document_preview_request_forces_preview_host_action(monkeypatch):
+    from app.engine.multi_agent import tool_collection as module
+
+    monkeypatch.setattr(module.settings, "enable_character_tools", False, raising=False)
+    monkeypatch.setattr(module.settings, "enable_lms_integration", False, raising=False)
+    monkeypatch.setattr(module.settings, "enable_host_actions", True, raising=False)
+    monkeypatch.setattr(module.settings, "enable_structured_visuals", False, raising=False)
+    monkeypatch.setattr(module, "_needs_web_search", lambda _query: False)
+    monkeypatch.setattr(module, "_needs_datetime", lambda _query: False)
+    monkeypatch.setattr(module, "_needs_news_search", lambda _query: False)
+    monkeypatch.setattr(module, "_needs_legal_search", lambda _query: False)
+    monkeypatch.setattr(module, "_needs_lms_query", lambda _query: False)
+    monkeypatch.setattr(module, "_needs_direct_knowledge_search", lambda _query: False)
+    monkeypatch.setattr(module, "_needs_analysis_tool", lambda _query: False)
+    monkeypatch.setattr(module, "_needs_pointy", lambda _query: False)
+    monkeypatch.setattr(module, "_infer_direct_thinking_mode", lambda *_args, **_kwargs: "general")
+    monkeypatch.setattr(module, "filter_tools_for_role", lambda tools, _role: tools)
+    monkeypatch.setattr(module, "filter_tools_for_visual_intent", lambda tools, *_args, **_kwargs: tools)
+    monkeypatch.setattr(
+        module,
+        "resolve_visual_intent",
+        lambda _query: SimpleNamespace(
+            force_tool=False,
+            mode="text",
+            visual_type=None,
+            preferred_tool=None,
+            presentation_intent="text",
+        ),
+    )
+
+    host_tools = [
+        SimpleNamespace(name="host_action__authoring__preview_lesson_patch"),
+        SimpleNamespace(name="host_action__authoring__apply_lesson_patch"),
+    ]
+
+    def fake_load_attr(module_name: str, attr_name: str):
+        if module_name.endswith("utility_tools"):
+            return SimpleNamespace(name=attr_name)
+        if module_name.endswith("web_search_tools"):
+            return SimpleNamespace(name=attr_name)
+        if module_name.endswith("web_fetch_tool"):
+            return SimpleNamespace(name=attr_name)
+        if module_name.endswith("agent_tools") and attr_name == "RAG_KNOWLEDGE_TOOL":
+            return SimpleNamespace(name="tool_rag_knowledge")
+        if module_name.endswith("action_tools") and attr_name == "generate_host_action_tools":
+            return lambda *args, **kwargs: host_tools
+        if module_name.endswith("direct_intent") and attr_name == "_needs_maritime_search":
+            return lambda _query: False
+        if module_name.endswith("direct_intent") and attr_name == "_normalize_for_intent":
+            return lambda query: str(query).lower()
+        if attr_name == "get_visual_tools":
+            return lambda: [SimpleNamespace(name="tool_generate_visual")]
+        raise AssertionError(f"Unexpected load: {module_name}.{attr_name}")
+
+    monkeypatch.setattr(module, "_load_attr", fake_load_attr)
+
+    tools, force_tools = module._collect_direct_tools(
+        "Dua tren tai lieu vua upload, hay tao preview_lesson_patch co source_references.",
+        user_role="teacher",
+        state={
+            "routing_metadata": {"intent": "uploaded_file_context"},
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "lesson.docx",
+                            "markdown": "Marker WIII_DOC_GOAL_123\nNguon trang 4.",
+                        }
+                    ]
+                }
+            },
+            "host_capabilities": {
+                "tools": [
+                    {"name": "authoring.preview_lesson_patch"},
+                    {"name": "authoring.apply_lesson_patch"},
+                ]
+            },
+        },
+    )
+
+    assert [tool.name for tool in tools] == ["host_action__authoring__preview_lesson_patch"]
+    assert force_tools is True
+
+
 def test_force_skills_reads_from_state_context_dict():
     """v3.0 F3 fix: state['context']['force_skills'] is the canonical
     location (NOT state['force_skills']) per graph_stream_runtime


### PR DESCRIPTION
## Summary
- force uploaded-document lesson preview requests to the exact LMS host action uthoring.preview_lesson_patch
- keep mutating apply actions behind LMS approval token by only forcing preview
- strengthen host-action tool contract for document-derived source references

## Verification
- cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_tool_collection_host_ui.py tests/unit/test_sprint222b_action_tools.py -q -> 25 passed
- cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7 -> pass
- git diff --check -> pass

Refs #285