### PR TITLE
fix: route document previews past upload fact fast-path

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -1037,12 +1037,37 @@ def _uploaded_context_has_video(ctx: dict[str, Any]) -> bool:
     )
 
 
+def _looks_uploaded_document_preview_request(query: str) -> bool:
+    """Route document-to-course preview requests away from fact fast-paths."""
+    folded = _fold_direct_text(query)
+    if not folded:
+        return False
+    preview_markers = (
+        "approval_token",
+        "ban nhap",
+        "ban xem truoc",
+        "citation",
+        "diff",
+        "lesson patch",
+        "preview",
+        "preview_lesson_patch",
+        "source references",
+        "source_references",
+        "tao ban xem truoc",
+        "trich dan",
+        "xem truoc",
+    )
+    return any(marker in folded for marker in preview_markers)
+
+
 def _looks_uploaded_context_fact_query(query: str, ctx: dict[str, Any]) -> bool:
     """Keep direct fact extraction from uploaded markdown off the slow LLM path."""
     if not _has_uploaded_document_context(ctx):
         return False
     folded = _fold_direct_text(query)
     if not folded:
+        return False
+    if _looks_uploaded_document_preview_request(query):
         return False
     if len([token for token in folded.split() if token]) > 90:
         return False

--- a/maritime-ai-service/tests/unit/test_document_context_api.py
+++ b/maritime-ai-service/tests/unit/test_document_context_api.py
@@ -331,6 +331,37 @@ def test_uploaded_document_marker_query_stays_deterministic():
     assert "Voice must be optional" in answer
 
 
+def test_uploaded_document_preview_request_bypasses_fact_fast_path():
+    from app.engine.multi_agent.direct_node_runtime import (
+        _looks_uploaded_context_fact_query,
+        _looks_uploaded_document_preview_request,
+    )
+
+    ctx = {
+        "document_context": {
+            "attachments": [
+                {
+                    "file_name": "bridge-watch.docx",
+                    "media_kind": "document",
+                    "parser": "markitdown",
+                    "markdown": (
+                        "Sổ tay trực ca buồng lái\n"
+                        "Marker kiểm thử: WIII_DOC_GOAL_123\n"
+                        "Checklist nguồn trang 4: xác nhận người trực ca.\n"
+                    ),
+                }
+            ]
+        }
+    }
+    query = (
+        "Dựa trên tài liệu Word vừa upload, hãy tạo preview_lesson_patch "
+        "có source_references page 4-5 và approval_token cho lesson hiện tại."
+    )
+
+    assert _looks_uploaded_document_preview_request(query)
+    assert not _looks_uploaded_context_fact_query(query, ctx)
+
+
 def test_uploaded_document_visual_guard_does_not_describe_frames_without_vision():
     from app.engine.multi_agent.direct_node_runtime import (
         _build_uploaded_document_visual_guard_answer,


### PR DESCRIPTION
## Summary
- Prevent uploaded-document preview/diff/citation requests from being handled by the deterministic uploaded-file fact fast-path.
- Keep simple uploaded-file fact queries deterministic, but force doc-to-course preview prompts through the host-action tool path.
- Add regression coverage for preview_lesson_patch + source_references + approval_token wording.

## Verification
- cd maritime-ai-service && .\\.venv\\Scripts\\python.exe -m pytest tests/unit/test_document_context_api.py tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_tool_collection_host_ui.py -q -> 57 passed
- cd maritime-ai-service && .\\.venv\\Scripts\\ruff.exe check app/ --select=E9,F63,F7 -> passed
- git diff --check -> passed

## Risk / rollback
- Narrow classifier change only affects uploaded-document turns containing explicit preview/diff/citation/source_references/approval_token language.
- Roll back this commit if ordinary uploaded-file fact extraction regresses.