### PR TITLE
Fix safe document preview host action fallback

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/tool_collection.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_collection.py
@@ -253,6 +253,40 @@ def _document_preview_host_action_tools(tools: list[Any]) -> list[Any]:
     ]
 
 
+def _host_capability_tools_from_state(state: Optional[AgentState]) -> list[dict[str, Any]]:
+    if not isinstance(state, dict):
+        return []
+    raw_caps = state.get("host_capabilities")
+    if not raw_caps:
+        context = state.get("context")
+        if isinstance(context, dict):
+            raw_caps = context.get("host_capabilities") or {}
+    if not isinstance(raw_caps, dict):
+        return []
+    capabilities_tools = raw_caps.get("tools")
+    if not isinstance(capabilities_tools, list):
+        return []
+    return [tool for tool in capabilities_tools if isinstance(tool, dict)]
+
+
+def _safe_document_preview_capability_tools(
+    capabilities_tools: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Allow a preview-only bridge even if the global host-action flag is off.
+
+    This fallback is intentionally narrow: it binds only the non-mutating LMS
+    preview action needed for uploaded document -> teacher preview flows. Apply,
+    publish, delete, grading, payment, and other host mutations remain disabled
+    unless `enable_host_actions` is explicitly enabled.
+    """
+    return [
+        tool
+        for tool in capabilities_tools
+        if str(tool.get("name") or "").strip().lower()
+        == "authoring.preview_lesson_patch"
+    ]
+
+
 def _should_use_no_tools_for_direct_prose(
     *,
     query: str,
@@ -468,10 +502,18 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
         logger.debug("[DIRECT] LMS tools unavailable: %s", _e)
 
     try:
-        if getattr(settings, "enable_host_actions", False) and state is not None:
-            raw_caps = state.get("host_capabilities") or ((state.get("context") or {}).get("host_capabilities") or {})
-            capabilities_tools = raw_caps.get("tools") if isinstance(raw_caps, dict) else []
-            if capabilities_tools:
+        if state is not None:
+            capabilities_tools = _host_capability_tools_from_state(state)
+            host_actions_enabled = getattr(settings, "enable_host_actions", False)
+            safe_doc_preview_fallback = (
+                not host_actions_enabled
+                and _looks_like_document_preview_request(query, state)
+            )
+            if safe_doc_preview_fallback:
+                capabilities_tools = _safe_document_preview_capability_tools(
+                    capabilities_tools
+                )
+            if capabilities_tools and (host_actions_enabled or safe_doc_preview_fallback):
                 generate_host_action_tools = _load_attr(
                     "app.engine.context.action_tools",
                     "generate_host_action_tools",

--- a/maritime-ai-service/tests/unit/test_tool_collection_host_ui.py
+++ b/maritime-ai-service/tests/unit/test_tool_collection_host_ui.py
@@ -223,6 +223,99 @@ def test_uploaded_document_preview_request_forces_preview_host_action(monkeypatc
     assert force_tools is True
 
 
+def test_uploaded_document_preview_binds_safe_preview_when_global_host_actions_disabled(monkeypatch):
+    from app.engine.multi_agent import tool_collection as module
+
+    monkeypatch.setattr(module.settings, "enable_character_tools", False, raising=False)
+    monkeypatch.setattr(module.settings, "enable_lms_integration", False, raising=False)
+    monkeypatch.setattr(module.settings, "enable_host_actions", False, raising=False)
+    monkeypatch.setattr(module.settings, "enable_structured_visuals", False, raising=False)
+    monkeypatch.setattr(module, "_needs_web_search", lambda _query: False)
+    monkeypatch.setattr(module, "_needs_datetime", lambda _query: False)
+    monkeypatch.setattr(module, "_needs_news_search", lambda _query: False)
+    monkeypatch.setattr(module, "_needs_legal_search", lambda _query: False)
+    monkeypatch.setattr(module, "_needs_lms_query", lambda _query: False)
+    monkeypatch.setattr(module, "_needs_direct_knowledge_search", lambda _query: False)
+    monkeypatch.setattr(module, "_needs_analysis_tool", lambda _query: False)
+    monkeypatch.setattr(module, "_needs_pointy", lambda _query: False)
+    monkeypatch.setattr(module, "_infer_direct_thinking_mode", lambda *_args, **_kwargs: "general")
+    monkeypatch.setattr(module, "filter_tools_for_role", lambda tools, _role: tools)
+    monkeypatch.setattr(module, "filter_tools_for_visual_intent", lambda tools, *_args, **_kwargs: tools)
+    monkeypatch.setattr(
+        module,
+        "resolve_visual_intent",
+        lambda _query: SimpleNamespace(
+            force_tool=False,
+            mode="text",
+            visual_type=None,
+            preferred_tool=None,
+            presentation_intent="text",
+        ),
+    )
+
+    generated_from: list[dict] = []
+
+    def fake_generate_host_action_tools(capabilities_tools, *_args, **_kwargs):
+        generated_from.extend(capabilities_tools)
+        return [
+            SimpleNamespace(
+                name="host_action__"
+                + str(tool["name"]).replace(".", "__")
+            )
+            for tool in capabilities_tools
+        ]
+
+    def fake_load_attr(module_name: str, attr_name: str):
+        if module_name.endswith("utility_tools"):
+            return SimpleNamespace(name=attr_name)
+        if module_name.endswith("web_search_tools"):
+            return SimpleNamespace(name=attr_name)
+        if module_name.endswith("web_fetch_tool"):
+            return SimpleNamespace(name=attr_name)
+        if module_name.endswith("agent_tools") and attr_name == "RAG_KNOWLEDGE_TOOL":
+            return SimpleNamespace(name="tool_rag_knowledge")
+        if module_name.endswith("action_tools") and attr_name == "generate_host_action_tools":
+            return fake_generate_host_action_tools
+        if module_name.endswith("direct_intent") and attr_name == "_needs_maritime_search":
+            return lambda _query: False
+        if module_name.endswith("direct_intent") and attr_name == "_normalize_for_intent":
+            return lambda query: str(query).lower()
+        if attr_name == "get_visual_tools":
+            return lambda: [SimpleNamespace(name="tool_generate_visual")]
+        raise AssertionError(f"Unexpected load: {module_name}.{attr_name}")
+
+    monkeypatch.setattr(module, "_load_attr", fake_load_attr)
+
+    tools, force_tools = module._collect_direct_tools(
+        "Tao ban preview_lesson_patch tu Word vua upload, co citation va source_references.",
+        user_role="teacher",
+        state={
+            "routing_metadata": {"intent": "uploaded_file_context"},
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "lesson.docx",
+                            "markdown": "Marker WIII_DOC_GOAL_456\nNguon trang 2.",
+                        }
+                    ]
+                }
+            },
+            "host_capabilities": {
+                "tools": [
+                    {"name": "authoring.preview_lesson_patch"},
+                    {"name": "authoring.apply_lesson_patch"},
+                    {"name": "course.publish"},
+                ]
+            },
+        },
+    )
+
+    assert [tool.name for tool in tools] == ["host_action__authoring__preview_lesson_patch"]
+    assert [tool["name"] for tool in generated_from] == ["authoring.preview_lesson_patch"]
+    assert force_tools is True
+
+
 def test_force_skills_reads_from_state_context_dict():
     """v3.0 F3 fix: state['context']['force_skills'] is the canonical
     location (NOT state['force_skills']) per graph_stream_runtime


### PR DESCRIPTION
## Summary
- Bind only `authoring.preview_lesson_patch` for uploaded-document preview requests when global host actions are disabled.
- Keep apply/publish/delete and other mutating host actions unavailable unless `enable_host_actions` is explicitly enabled.
- Add regression coverage for the fallback so document-to-course preview can reach the LMS diff/citation approval gate.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_tool_collection_host_ui.py tests/unit/test_document_context_api.py tests/unit/test_direct_tool_rounds_runtime.py -q` -> 58 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk / rollback
- Narrow runtime fallback for preview-only host action; mutations remain gated behind the normal host action flag and LMS approval flow.
- Roll back by reverting this PR if preview binding causes unexpected host bridge behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Document previews now work safely with a preview-only fallback when global host actions are disabled.

* **Bug Fixes**
  * Improved capability extraction for safer tool collection in document preview scenarios.

* **Tests**
  * Added test coverage for document preview behavior with disabled host actions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/294)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->