### PR TITLE
Fix document preview host action before planner LLM

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -63,6 +63,16 @@ from app.engine.multi_agent.supervisor_runtime_support import (
 
 logger = logging.getLogger(__name__)
 
+_DOC_PREVIEW_HOST_ACTION_TOOL = "host_action__authoring__preview_lesson_patch"
+
+
+def _has_document_preview_host_action_tool(tools: list[Any]) -> bool:
+    return any(
+        str(getattr(tool, "name", "") or getattr(tool, "__name__", "")).strip().lower()
+        == _DOC_PREVIEW_HOST_ACTION_TOOL
+        for tool in tools
+    )
+
 _HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS = 45.0  # Phase F3 (2026-05-06): bumped 24→45s. NVIDIA DeepSeek tool-heavy pointy turns (inventory + show + synthesis) regularly hit 25-35s; 24s caused canned fallback even when LLM was actively succeeding.
 
 # DSML tool-call markup that NVIDIA DeepSeek occasionally leaks into prose
@@ -2320,7 +2330,10 @@ async def direct_response_node_impl(
                 and not visual_decision.force_tool
             )
             direct_provider_override = explicit_user_provider or preferred_provider
-            is_codebase_source_turn = _is_codebase_analysis_query(query)
+            is_codebase_source_turn = _is_codebase_analysis_query(query) and not (
+                has_uploaded_document_context
+                and _looks_uploaded_document_preview_request(query)
+            )
             explicit_web_search_turn = _is_explicit_web_search_turn_for_direct(query, state)
 
             if is_short_house_chatter or is_identity_turn or is_emotional_support_turn:
@@ -2380,6 +2393,12 @@ async def direct_response_node_impl(
                         query,
                         ctx.get("user_role", "student"),
                     )
+                    if (
+                        has_uploaded_document_context
+                        and _looks_uploaded_document_preview_request(query)
+                        and _DOC_PREVIEW_HOST_ACTION_TOOL not in must_include_names
+                    ):
+                        must_include_names.append(_DOC_PREVIEW_HOST_ACTION_TOOL)
                     # Merge force-bound names into must_include so the
                     # recommender (max_tools=7) cannot prune them out
                     # when the bound list is large.
@@ -2404,6 +2423,80 @@ async def direct_response_node_impl(
                 except Exception as selection_error:
                     logger.debug("[DIRECT] Runtime tool selection skipped: %s", selection_error)
 
+            if (
+                not response
+                and has_uploaded_document_context
+                and _looks_uploaded_document_preview_request(query)
+                and _has_document_preview_host_action_tool(tools)
+            ):
+                try:
+                    preview_runtime_context = build_tool_runtime_context(
+                        event_bus_id=bus_id,
+                        request_id=ctx.get("request_id"),
+                        session_id=state.get("session_id"),
+                        organization_id=state.get("organization_id"),
+                        user_id=state.get("user_id"),
+                        user_role=ctx.get("user_role", "student"),
+                        node="direct",
+                        source="agentic_loop",
+                        metadata=build_visual_tool_runtime_metadata(state, query),
+                    )
+                    llm_response, messages, tool_call_events = await execute_direct_tool_rounds(
+                        object(),
+                        object(),
+                        messages,
+                        tools,
+                        push_event,
+                        runtime_context_base=preview_runtime_context,
+                        max_rounds=1,
+                        query=query,
+                        state=state,
+                        forced_tool_choice=_DOC_PREVIEW_HOST_ACTION_TOOL,
+                        llm_base=None,
+                        native_tool_messages=False,
+                    )
+                    if tool_call_events:
+                        state["tool_call_events"] = tool_call_events
+
+                    response, thinking_content, tools_used = extract_direct_response(
+                        llm_response,
+                        messages,
+                    )
+                    response = sanitize_structured_visual_answer_text(
+                        response,
+                        tool_call_events=tool_call_events,
+                    )
+                    response = sanitize_wiii_house_text(response, query=query)
+                    response = _strip_direct_inline_private_asides(response)
+                    response = _strip_dsml_residue(response).strip()
+                    if not tools_used:
+                        preview_tool_names = sorted({
+                            str(event.get("name") or "")
+                            for event in tool_call_events
+                            if event.get("name")
+                        })
+                        tools_used = [
+                            {"name": name}
+                            for name in preview_tool_names
+                            if name
+                        ]
+                    if tools_used:
+                        state["tools_used"] = tools_used
+                    tracer.end_step(
+                        result="Deterministic uploaded-document preview host action",
+                        confidence=0.9,
+                        details={
+                            "response_type": "document_preview_host_action",
+                            "tools_bound": len(tools),
+                            "force_tools": force_tools,
+                        },
+                    )
+                except Exception as preview_error:
+                    logger.warning(
+                        "[DIRECT] Deterministic document preview pre-LLM path failed: %s",
+                        preview_error,
+                    )
+
             direct_node_id = "direct_identity" if is_identity_turn else "direct"
 
             from app.engine.multi_agent.openai_stream_runtime import (
@@ -2419,7 +2512,7 @@ async def direct_response_node_impl(
                 and not is_codebase_source_turn
             )
             llm = None
-            if native_direct_possible:
+            if native_direct_possible and not response:
                 llm = AgentConfigRegistry.get_native_llm(
                     direct_node_id,
                     effort_override=thinking_effort,
@@ -2430,7 +2523,7 @@ async def direct_response_node_impl(
                     getattr(llm, "_wiii_provider_name", None)
                 ):
                     llm = None
-            if llm is None:
+            if llm is None and not response:
                 llm = AgentConfigRegistry.get_llm(
                     direct_node_id,
                     effort_override=thinking_effort,

--- a/maritime-ai-service/tests/unit/test_direct_node_provider_errors.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_provider_errors.py
@@ -132,6 +132,95 @@ async def test_direct_response_node_uses_pointy_fast_path_even_if_router_mislabe
 
 
 @pytest.mark.asyncio
+async def test_direct_response_node_runs_document_preview_tool_before_llm():
+    state = _base_state()
+    state.update(
+        {
+            "query": (
+                "Dua tren tai lieu Word vua upload, tao preview_lesson_patch "
+                "co source_references cho bai hoc hien tai."
+            ),
+            "routing_metadata": {
+                "method": "deterministic_document_context_guard",
+                "intent": "uploaded_file_context",
+            },
+            "context": {
+                "response_language": "vi",
+                "user_role": "teacher",
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "lesson.docx",
+                            "markdown": "Marker WIII_DOC_GOAL_789\nNguon trang 4.",
+                        }
+                    ]
+                },
+                "host_capabilities": {
+                    "tools": [
+                        {"name": "authoring.preview_lesson_patch"},
+                    ]
+                },
+            },
+        }
+    )
+
+    captured: dict[str, object] = {}
+
+    async def fake_execute_direct_tool_rounds(*args, **kwargs):
+        captured["forced_tool_choice"] = kwargs.get("forced_tool_choice")
+        captured["tools"] = args[3]
+        return (
+            SimpleNamespace(content="Mình đã gửi bản preview sang LMS."),
+            [],
+            [
+                {
+                    "type": "call",
+                    "name": "host_action__authoring__preview_lesson_patch",
+                },
+                {
+                    "type": "host_action",
+                    "name": "host_action__authoring__preview_lesson_patch",
+                },
+            ],
+        )
+
+    kwargs = _base_direct_kwargs()
+    kwargs.update(
+        {
+            "looks_identity_selfhood_turn": lambda *_args, **_kwargs: False,
+            "get_effective_provider": lambda *_args, **_kwargs: None,
+            "get_explicit_user_provider": lambda *_args, **_kwargs: None,
+            "collect_direct_tools": lambda *_args, **_kwargs: (
+                [SimpleNamespace(name="host_action__authoring__preview_lesson_patch")],
+                True,
+            ),
+            "execute_direct_tool_rounds": fake_execute_direct_tool_rounds,
+            "extract_direct_response": lambda *_args, **_kwargs: (
+                "Mình đã gửi bản preview sang LMS.",
+                "Tạo preview từ tài liệu upload trước khi gọi LLM.",
+                [],
+            ),
+        }
+    )
+
+    with (
+        patch(
+            "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_native_llm",
+            side_effect=AssertionError("preview host action should not need native LLM"),
+        ),
+        patch(
+            "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_llm",
+            side_effect=AssertionError("preview host action should not need planner LLM"),
+        ),
+    ):
+        result = await direct_response_node_impl(state, **kwargs)
+
+    assert result["final_response"] == "Mình đã gửi bản preview sang LMS."
+    assert captured["forced_tool_choice"] == "host_action__authoring__preview_lesson_patch"
+    assert result["tool_call_events"][0]["type"] == "call"
+
+
+@pytest.mark.asyncio
 async def test_direct_response_node_handles_image_input_with_vision_before_llm():
     async def fake_analyze_image_for_query(**kwargs):
         assert kwargs["image_base64"] == "iVBORw0KGgo="


### PR DESCRIPTION
## Summary
- Prevent uploaded-document preview prompts containing `source_references` from being misclassified as codebase/source-analysis turns.
- Preserve `host_action__authoring__preview_lesson_patch` through runtime tool selection for document preview requests.
- Execute the deterministic preview host action before planner/native LLM acquisition so preview/diff/citation flow does not fall back to prose when a provider is unavailable.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_node_provider_errors.py tests/unit/test_document_context_api.py tests/unit/test_tool_collection_host_ui.py tests/unit/test_direct_tool_rounds_runtime.py -q` -> 89 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk / rollback
- Scope is restricted to uploaded-document preview requests with the preview host action already bound.
- Apply/publish/mutating actions remain outside this deterministic pre-LLM path and still require LMS approval flow.
- Roll back by reverting this PR if document preview host action routing regresses.