### PR TITLE
fix: preserve LMS teacher role for host capabilities

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/context_injection.py
+++ b/maritime-ai-service/app/engine/multi_agent/context_injection.py
@@ -32,6 +32,31 @@ from app.engine.multi_agent.visual_intent_resolver import resolve_visual_intent
 logger = logging.getLogger(__name__)
 
 
+def _effective_host_user_role(state: dict, ctx: dict, host_ctx: Any) -> str | None:
+    """Resolve host role without silently downgrading embedded teacher flows.
+
+    LMS embeds can send the role in the shared chat context while the nested
+    `host_context.user_role` is absent. Capability filtering must honor the
+    explicit turn role in that case; otherwise authoring preview tools are
+    filtered as if the teacher were a student.
+    """
+
+    candidates = [
+        getattr(host_ctx, "user_role", None),
+        ctx.get("host_role"),
+        ctx.get("user_role"),
+        state.get("host_role"),
+        state.get("user_role"),
+        state.get("role"),
+    ]
+    for candidate in candidates:
+        value = getattr(candidate, "value", candidate)
+        role = str(value or "").strip().lower()
+        if role:
+            return role
+    return None
+
+
 def _inject_host_context(state: dict) -> str:
     """Graph-level host context injection.
 
@@ -49,9 +74,12 @@ def _inject_host_context(state: dict) -> str:
             from app.engine.context.adapters import get_host_adapter
 
             host_ctx = HostContext(**raw_host) if isinstance(raw_host, dict) else raw_host
+            effective_user_role = _effective_host_user_role(state, ctx, host_ctx)
+            if effective_user_role and not host_ctx.user_role:
+                host_ctx = host_ctx.model_copy(update={"user_role": effective_user_role})
             filtered_host_actions = filter_host_actions_for_org(
                 host_ctx.available_actions or [],
-                user_role=host_ctx.user_role,
+                user_role=effective_user_role,
                 organization_id=state.get("organization_id") or ctx.get("organization_id"),
                 user_id=str(state.get("user_id") or ""),
             )
@@ -66,7 +94,7 @@ def _inject_host_context(state: dict) -> str:
                 try:
                     filtered_caps = filter_host_capabilities_for_org(
                         raw_caps,
-                        user_role=host_ctx.user_role,
+                        user_role=effective_user_role,
                         organization_id=state.get("organization_id") or ctx.get("organization_id"),
                         user_id=str(state.get("user_id") or ""),
                     )
@@ -74,7 +102,7 @@ def _inject_host_context(state: dict) -> str:
                     ctx["host_capabilities"] = filtered_caps
                     state["host_capabilities_prompt"] = format_host_capabilities_for_prompt(
                         filtered_caps,
-                        user_role=host_ctx.user_role,
+                        user_role=effective_user_role,
                     )
                 except Exception as exc:
                     logger.warning("[GRAPH] host capabilities format failed: %s", exc)
@@ -91,7 +119,7 @@ def _inject_host_context(state: dict) -> str:
                     skills = loader.load_skills(
                         host_ctx.host_type,
                         page_type,
-                        user_role=host_ctx.user_role,
+                        user_role=effective_user_role,
                         workflow_stage=host_ctx.workflow_stage,
                     )
                     skill_prompt = loader.get_prompt_addition(skills)
@@ -118,9 +146,12 @@ def _inject_host_context(state: dict) -> str:
                 student_state=ctx.get("student_state"),
                 available_actions=ctx.get("available_actions"),
             )
+            effective_user_role = _effective_host_user_role(state, ctx, host_ctx)
+            if effective_user_role and not host_ctx.user_role:
+                host_ctx = host_ctx.model_copy(update={"user_role": effective_user_role})
             filtered_host_actions = filter_host_actions_for_org(
                 host_ctx.available_actions or [],
-                user_role=host_ctx.user_role,
+                user_role=effective_user_role,
                 organization_id=state.get("organization_id") or ctx.get("organization_id"),
                 user_id=str(state.get("user_id") or ""),
             )
@@ -135,7 +166,7 @@ def _inject_host_context(state: dict) -> str:
                 try:
                     filtered_caps = filter_host_capabilities_for_org(
                         raw_caps,
-                        user_role=host_ctx.user_role,
+                        user_role=effective_user_role,
                         organization_id=state.get("organization_id") or ctx.get("organization_id"),
                         user_id=str(state.get("user_id") or ""),
                     )
@@ -143,7 +174,7 @@ def _inject_host_context(state: dict) -> str:
                     ctx["host_capabilities"] = filtered_caps
                     state["host_capabilities_prompt"] = format_host_capabilities_for_prompt(
                         filtered_caps,
-                        user_role=host_ctx.user_role,
+                        user_role=effective_user_role,
                     )
                 except Exception as exc:
                     logger.warning("[GRAPH] legacy host capabilities format failed: %s", exc)
@@ -160,7 +191,7 @@ def _inject_host_context(state: dict) -> str:
                     skills = loader.load_skills(
                         host_ctx.host_type,
                         page_type,
-                        user_role=host_ctx.user_role,
+                        user_role=effective_user_role,
                         workflow_stage=host_ctx.workflow_stage,
                     )
                     skill_prompt = loader.get_prompt_addition(skills)

--- a/maritime-ai-service/tests/unit/test_sprint222_graph_injection.py
+++ b/maritime-ai-service/tests/unit/test_sprint222_graph_injection.py
@@ -88,6 +88,45 @@ def test_inject_host_context_populates_host_capabilities_prompt():
     assert "authoring.generate_lesson" in state["host_capabilities_prompt"]
 
 
+def test_inject_host_context_uses_turn_role_when_host_role_missing():
+    from app.engine.multi_agent.graph import _inject_host_context
+
+    state = {
+        "organization_id": "maritime-lms",
+        "user_id": "teacher-1",
+        "context": {
+            "user_role": "teacher",
+            "host_context": {
+                "host_type": "lms",
+                "page": {"type": "course_editor", "title": "Curriculum"},
+            },
+            "host_capabilities": {
+                "host_type": "lms",
+                "host_name": "Maritime LMS",
+                "resources": ["current-page"],
+                "surfaces": ["ai_sidebar"],
+                "tools": [
+                    {
+                        "name": "authoring.preview_lesson_patch",
+                        "description": "Preview lesson patch",
+                        "roles": ["teacher", "admin"],
+                        "permission": "manage:courses",
+                        "requires_confirmation": False,
+                        "mutates_state": False,
+                    }
+                ],
+            },
+        },
+    }
+
+    result = _inject_host_context(state)
+    assert "<host_context" in result
+    assert state["host_context"]["user_role"] == "teacher"
+    assert "host_capabilities_prompt" in state
+    assert "authoring.preview_lesson_patch" in state["host_capabilities_prompt"]
+    assert state["host_capabilities"]["tools"][0]["name"] == "authoring.preview_lesson_patch"
+
+
 def test_inject_host_context_filters_disallowed_capabilities_for_student():
     from app.engine.multi_agent.graph import _inject_host_context
 


### PR DESCRIPTION
## Summary
- Preserve the explicit turn/user role when LMS host_context omits user_role, instead of filtering host capabilities as student.
- Keep teacher-only preview tools such as authoring.preview_lesson_patch available for uploaded document preview flows.
- Add regression coverage for the LMS embed shape that sends context.user_role=teacher with no nested host_context.user_role.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_sprint222_graph_injection.py::test_inject_host_context_uses_turn_role_when_host_role_missing tests/unit/test_sprint222_graph_injection.py::test_inject_host_context_filters_disallowed_capabilities_for_student tests/unit/test_tool_collection_host_ui.py tests/unit/test_direct_node_provider_errors.py::test_direct_response_node_runs_document_preview_tool_before_llm tests/unit/test_document_context_api.py tests/unit/test_direct_tool_rounds_runtime.py -q` -> 61 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk / rollback
- Narrow context-role fallback only. Explicit `host_context.user_role` still wins, so student pages remain filtered.
- Rollback: revert this commit to restore previous filtering behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user role resolution from multiple sources to ensure consistent role-based access and capability filtering across the system.

* **Tests**
  * Added test coverage to verify proper user role derivation when primary role source is unavailable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/296)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->