### PR TITLE
fix: rebind LMS document preview host action at runtime

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -73,6 +73,142 @@ def _has_document_preview_host_action_tool(tools: list[Any]) -> bool:
         for tool in tools
     )
 
+
+def _as_plain_direct_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if hasattr(value, "model_dump"):
+        try:
+            dumped = value.model_dump(exclude_none=True)
+            return dumped if isinstance(dumped, dict) else {}
+        except Exception:
+            return {}
+    if hasattr(value, "dict"):
+        try:
+            dumped = value.dict(exclude_none=True)
+            return dumped if isinstance(dumped, dict) else {}
+        except Exception:
+            return {}
+    return {}
+
+
+def _extract_document_preview_capabilities(
+    state: dict[str, Any],
+    ctx: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Recover the preview capability from raw runtime state if collection misses it."""
+
+    state_context = state.get("context") if isinstance(state.get("context"), dict) else {}
+    raw_sources = [
+        state.get("host_capabilities"),
+        ctx.get("host_capabilities"),
+        state_context.get("host_capabilities") if isinstance(state_context, dict) else None,
+    ]
+    preview_capabilities: list[dict[str, Any]] = []
+    for raw_caps in raw_sources:
+        caps = _as_plain_direct_mapping(raw_caps)
+        raw_tools = caps.get("tools")
+        if not isinstance(raw_tools, list):
+            continue
+        for raw_tool in raw_tools:
+            tool_def = _as_plain_direct_mapping(raw_tool)
+            if (
+                str(tool_def.get("name") or "").strip().lower()
+                == "authoring.preview_lesson_patch"
+            ):
+                preview_capabilities.append(tool_def)
+    return preview_capabilities
+
+
+def _direct_role_candidates(state: dict[str, Any], ctx: dict[str, Any]) -> list[str]:
+    state_context = state.get("context") if isinstance(state.get("context"), dict) else {}
+    host_context = _as_plain_direct_mapping(
+        ctx.get("host_context")
+        or (state_context.get("host_context") if isinstance(state_context, dict) else None)
+        or state.get("host_context")
+    )
+    candidates = [
+        ctx.get("user_role"),
+        state_context.get("user_role") if isinstance(state_context, dict) else None,
+        state.get("user_role"),
+        state.get("role"),
+        host_context.get("user_role"),
+        host_context.get("host_role"),
+    ]
+    roles: list[str] = []
+    for candidate in candidates:
+        value = getattr(candidate, "value", candidate)
+        role = str(value or "").strip().lower()
+        if role and role not in roles:
+            roles.append(role)
+    return roles
+
+
+def _rebind_document_preview_host_action_tool(
+    *,
+    tools: list[Any],
+    force_tools: bool,
+    query: str,
+    state: dict[str, Any],
+    ctx: dict[str, Any],
+) -> tuple[list[Any], bool, dict[str, Any]]:
+    """Bind only the declared, non-mutating LMS preview action if collection lost it."""
+
+    if _has_document_preview_host_action_tool(tools):
+        return tools, True, {
+            "status": "already_bound",
+            "tool_count": len(tools),
+        }
+
+    preview_capabilities = _extract_document_preview_capabilities(state, ctx)
+    debug: dict[str, Any] = {
+        "status": "missing_capability",
+        "tool_count": len(tools),
+        "preview_capability_count": len(preview_capabilities),
+    }
+    if not preview_capabilities:
+        return tools, force_tools, debug
+
+    roles = _direct_role_candidates(state, ctx)
+    debug["role_candidates"] = roles[:4]
+    for role in roles or ["student"]:
+        try:
+            from app.engine.context.action_tools import generate_host_action_tools
+
+            generated = generate_host_action_tools(
+                preview_capabilities,
+                role,
+                event_bus_id=state.get("_event_bus_id") or state.get("session_id") or "",
+                approval_context={
+                    "query": query,
+                    "host_action_feedback": (ctx.get("host_action_feedback") or {}),
+                },
+            )
+        except Exception as exc:
+            debug.update({"status": "generation_failed", "error": type(exc).__name__})
+            logger.debug("[DIRECT] Document preview host action rebind failed: %s", exc)
+            return tools, force_tools, debug
+
+        preview_tools = [
+            tool
+            for tool in generated
+            if str(getattr(tool, "name", "") or getattr(tool, "__name__", "")).strip().lower()
+            == _DOC_PREVIEW_HOST_ACTION_TOOL
+        ]
+        if preview_tools:
+            debug.update({
+                "status": "rebound",
+                "role": role,
+                "tool_count": len(preview_tools),
+            })
+            logger.info(
+                "[DIRECT] Rebound LMS document preview host action from runtime capabilities"
+            )
+            return preview_tools[:1], True, debug
+
+    debug["status"] = "role_filtered"
+    return tools, force_tools, debug
+
 _HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS = 45.0  # Phase F3 (2026-05-06): bumped 24→45s. NVIDIA DeepSeek tool-heavy pointy turns (inventory + show + synthesis) regularly hit 25-35s; 24s caused canned fallback even when LLM was actively succeeding.
 
 # DSML tool-call markup that NVIDIA DeepSeek occasionally leaks into prose
@@ -2422,6 +2558,17 @@ async def direct_response_node_impl(
                         )
                 except Exception as selection_error:
                     logger.debug("[DIRECT] Runtime tool selection skipped: %s", selection_error)
+
+                if has_uploaded_document_context and _looks_uploaded_document_preview_request(query):
+                    tools, force_tools, doc_preview_debug = _rebind_document_preview_host_action_tool(
+                        tools=tools,
+                        force_tools=force_tools,
+                        query=query,
+                        state=state,
+                        ctx=ctx,
+                    )
+                    if isinstance(state.get("routing_metadata"), dict):
+                        state["routing_metadata"]["doc_preview_runtime"] = doc_preview_debug
 
             if (
                 not response

--- a/maritime-ai-service/tests/unit/test_direct_node_provider_errors.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_provider_errors.py
@@ -170,7 +170,7 @@ async def test_direct_response_node_runs_document_preview_tool_before_llm():
         captured["forced_tool_choice"] = kwargs.get("forced_tool_choice")
         captured["tools"] = args[3]
         return (
-            SimpleNamespace(content="Mình đã gửi bản preview sang LMS."),
+            SimpleNamespace(content="Preview sent to LMS."),
             [],
             [
                 {
@@ -217,6 +217,105 @@ async def test_direct_response_node_runs_document_preview_tool_before_llm():
 
     assert result["final_response"] == "Mình đã gửi bản preview sang LMS."
     assert captured["forced_tool_choice"] == "host_action__authoring__preview_lesson_patch"
+    assert result["tool_call_events"][0]["type"] == "call"
+
+
+@pytest.mark.asyncio
+async def test_direct_response_node_rebinds_document_preview_tool_when_collection_misses():
+    state = _base_state()
+    state.update(
+        {
+            "query": (
+                "Dua tren tai lieu Word vua upload, tao preview_lesson_patch "
+                "co source_references va approval_token cho bai hoc hien tai."
+            ),
+            "session_id": "session-doc-preview",
+            "routing_metadata": {
+                "method": "deterministic_document_context_guard",
+                "intent": "uploaded_file_context",
+            },
+            "context": {
+                "response_language": "vi",
+                "user_role": "teacher",
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "lesson.docx",
+                            "markdown": "Marker WIII_DOC_GOAL_456\nNguon trang 5.",
+                        }
+                    ]
+                },
+                "host_capabilities": {
+                    "tools": [
+                        {
+                            "name": "authoring.preview_lesson_patch",
+                            "description": "Preview lesson patch",
+                            "roles": ["teacher"],
+                            "permission": "manage:courses",
+                            "mutates_state": False,
+                            "requires_confirmation": False,
+                        },
+                    ]
+                },
+            },
+        }
+    )
+
+    captured: dict[str, object] = {}
+
+    async def fake_execute_direct_tool_rounds(*args, **kwargs):
+        captured["forced_tool_choice"] = kwargs.get("forced_tool_choice")
+        captured["tool_names"] = [
+            getattr(tool, "name", getattr(tool, "__name__", ""))
+            for tool in args[3]
+        ]
+        return (
+            SimpleNamespace(content="Preview sent to LMS."),
+            [],
+            [
+                {
+                    "type": "call",
+                    "name": "host_action__authoring__preview_lesson_patch",
+                },
+                {
+                    "type": "host_action",
+                    "name": "host_action__authoring__preview_lesson_patch",
+                },
+            ],
+        )
+
+    kwargs = _base_direct_kwargs()
+    kwargs.update(
+        {
+            "looks_identity_selfhood_turn": lambda *_args, **_kwargs: False,
+            "get_effective_provider": lambda *_args, **_kwargs: None,
+            "get_explicit_user_provider": lambda *_args, **_kwargs: None,
+            "collect_direct_tools": lambda *_args, **_kwargs: ([], False),
+            "execute_direct_tool_rounds": fake_execute_direct_tool_rounds,
+            "extract_direct_response": lambda *_args, **_kwargs: (
+                "Preview sent to LMS.",
+                "Preview was created from a declared host capability.",
+                [],
+            ),
+        }
+    )
+
+    with (
+        patch(
+            "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_native_llm",
+            side_effect=AssertionError("preview host action should not need native LLM"),
+        ),
+        patch(
+            "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_llm",
+            side_effect=AssertionError("preview host action should not need planner LLM"),
+        ),
+    ):
+        result = await direct_response_node_impl(state, **kwargs)
+
+    assert result["final_response"] == "Preview sent to LMS."
+    assert captured["forced_tool_choice"] == "host_action__authoring__preview_lesson_patch"
+    assert captured["tool_names"] == ["host_action__authoring__preview_lesson_patch"]
+    assert result["routing_metadata"]["doc_preview_runtime"]["status"] == "rebound"
     assert result["tool_call_events"][0]["type"] == "call"
 
 


### PR DESCRIPTION
## Summary
- Add a preview-only runtime rebind path for `authoring.preview_lesson_patch` when direct tool collection/selection drops it.
- Require the host to have declared the preview capability on the current turn, and keep apply/publish/delete actions out of this fallback.
- Record safe `doc_preview_runtime` debug metadata in routing metadata so production smoke can distinguish missing capability vs role filtering vs rebind.
- Add regression coverage where `collect_direct_tools` returns no tools but the LMS host capability exists.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_node_provider_errors.py::test_direct_response_node_rebinds_document_preview_tool_when_collection_misses tests/unit/test_direct_node_provider_errors.py::test_direct_response_node_runs_document_preview_tool_before_llm tests/unit/test_tool_collection_host_ui.py tests/unit/test_document_context_api.py tests/unit/test_direct_tool_rounds_runtime.py -q` -> 60 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk / rollback
- Runtime fallback is deliberately narrow: only non-mutating LMS preview action, only if declared by host capabilities.
- Rollback: revert this commit; prior behavior remains available but production doc preview smoke currently lacks `host_action` events without this guard.