### PR TITLE
Fix LMS document preview host-action preflight

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -1072,30 +1072,34 @@ def _image_payload_attr(image: Any, key: str, default: Any = None) -> Any:
 
 
 def _has_uploaded_document_context(ctx: dict[str, Any]) -> bool:
-    document_context = ctx.get("document_context")
+    ctx = _as_plain_direct_mapping(ctx)
+    document_context = _as_plain_direct_mapping(ctx.get("document_context"))
     if not isinstance(document_context, dict):
         return False
     attachments = document_context.get("attachments")
     if not isinstance(attachments, list):
         return False
-    return any(
-        isinstance(item, dict) and str(item.get("markdown") or "").strip()
-        for item in attachments
-    )
+    for item in attachments:
+        attachment = _as_plain_direct_mapping(item)
+        if attachment and str(attachment.get("markdown") or "").strip():
+            return True
+    return False
 
 
 def _uploaded_document_attachments(ctx: dict[str, Any]) -> list[dict[str, Any]]:
-    document_context = ctx.get("document_context")
+    ctx = _as_plain_direct_mapping(ctx)
+    document_context = _as_plain_direct_mapping(ctx.get("document_context"))
     if not isinstance(document_context, dict):
         return []
     attachments = document_context.get("attachments")
     if not isinstance(attachments, list):
         return []
-    return [
-        item
-        for item in attachments
-        if isinstance(item, dict) and str(item.get("markdown") or "").strip()
-    ]
+    parsed: list[dict[str, Any]] = []
+    for item in attachments:
+        attachment = _as_plain_direct_mapping(item)
+        if attachment and str(attachment.get("markdown") or "").strip():
+            parsed.append(attachment)
+    return parsed
 
 
 def _first_markdown_line(markdown: str, label: str) -> str:
@@ -2103,6 +2107,108 @@ async def direct_response_node_impl(
             node="direct",
             provenance="document_context_plan",
         )
+    if (
+        not response
+        and has_uploaded_document_context
+        and _looks_uploaded_document_preview_request(query)
+    ):
+        routing_meta = state.get("routing_metadata")
+        if not isinstance(routing_meta, dict):
+            routing_meta = {}
+            state["routing_metadata"] = routing_meta
+        preview_tools, preview_force_tools, doc_preview_debug = (
+            _rebind_document_preview_host_action_tool(
+                tools=[],
+                force_tools=False,
+                query=query,
+                state=state,
+                ctx=ctx_for_preflight,
+            )
+        )
+        routing_meta["doc_preview_preflight"] = doc_preview_debug
+        if _has_document_preview_host_action_tool(preview_tools):
+            try:
+                preview_runtime_context = build_tool_runtime_context(
+                    event_bus_id=bus_id,
+                    request_id=ctx_for_preflight.get("request_id"),
+                    session_id=state.get("session_id"),
+                    organization_id=state.get("organization_id"),
+                    user_id=state.get("user_id"),
+                    user_role=ctx_for_preflight.get("user_role", "student"),
+                    node="direct",
+                    source="agentic_loop",
+                    metadata=build_visual_tool_runtime_metadata(state, query),
+                )
+                (
+                    preview_llm_response,
+                    preview_messages,
+                    preview_tool_call_events,
+                ) = await execute_direct_tool_rounds(
+                    object(),
+                    object(),
+                    [],
+                    preview_tools,
+                    push_event,
+                    runtime_context_base=preview_runtime_context,
+                    max_rounds=1,
+                    query=query,
+                    state=state,
+                    forced_tool_choice=_DOC_PREVIEW_HOST_ACTION_TOOL,
+                    llm_base=None,
+                    native_tool_messages=False,
+                )
+                if preview_tool_call_events:
+                    state["tool_call_events"] = preview_tool_call_events
+
+                response, _preview_thinking, tools_used = extract_direct_response(
+                    preview_llm_response,
+                    preview_messages,
+                )
+                response = sanitize_structured_visual_answer_text(
+                    response,
+                    tool_call_events=preview_tool_call_events,
+                )
+                response = sanitize_wiii_house_text(response, query=query)
+                response = _strip_direct_inline_private_asides(response)
+                response = _strip_dsml_residue(response).strip()
+                if not response:
+                    response = (
+                        "Mình đã gửi bản preview bài học sang LMS. "
+                        "Giáo viên cần xem diff/citation rồi bấm Apply để cấp approval_token."
+                    )
+                if not tools_used:
+                    preview_tool_names = sorted({
+                        str(event.get("name") or "")
+                        for event in preview_tool_call_events
+                        if event.get("name")
+                    })
+                    tools_used = [
+                        {"name": name}
+                        for name in preview_tool_names
+                        if name
+                    ]
+                if tools_used:
+                    state["tools_used"] = tools_used
+                response_type = "document_preview_host_action"
+                routing_meta["doc_preview_preflight"] = {
+                    **doc_preview_debug,
+                    "status": "executed",
+                    "tool_count": len(preview_tools),
+                    "force_tools": preview_force_tools,
+                }
+                logger.info(
+                    "[DIRECT] Executed LMS document preview host action before planner LLM"
+                )
+            except Exception as preview_error:
+                routing_meta["doc_preview_preflight"] = {
+                    **doc_preview_debug,
+                    "status": "execution_failed",
+                    "error": type(preview_error).__name__,
+                }
+                logger.warning(
+                    "[DIRECT] Early document preview host action failed: %s",
+                    preview_error,
+                )
     if ctx_for_preflight.get("image_input_error") and has_uploaded_document_context:
         ctx_for_preflight["images"] = []
     if (

--- a/maritime-ai-service/tests/unit/test_direct_node_provider_errors.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_provider_errors.py
@@ -315,8 +315,109 @@ async def test_direct_response_node_rebinds_document_preview_tool_when_collectio
     assert result["final_response"] == "Preview sent to LMS."
     assert captured["forced_tool_choice"] == "host_action__authoring__preview_lesson_patch"
     assert captured["tool_names"] == ["host_action__authoring__preview_lesson_patch"]
-    assert result["routing_metadata"]["doc_preview_runtime"]["status"] == "rebound"
+    assert result["routing_metadata"]["doc_preview_preflight"]["status"] == "executed"
     assert result["tool_call_events"][0]["type"] == "call"
+
+
+@pytest.mark.asyncio
+async def test_direct_response_node_preflights_document_preview_before_tool_collection():
+    state = _base_state()
+    state.update(
+        {
+            "query": (
+                "Dua tren tai lieu Word vua upload, tao ban xem truoc "
+                "preview_lesson_patch co source_references va approval_token."
+            ),
+            "session_id": "session-doc-preview-preflight",
+            "routing_metadata": {
+                "method": "deterministic_document_context_guard",
+                "intent": "uploaded_file_context",
+            },
+            "context": {
+                "response_language": "vi",
+                "user_role": "teacher",
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "lesson.docx",
+                            "markdown": "Marker WIII_DOC_GOAL_PREFLIGHT\nNguon trang 4.",
+                        }
+                    ]
+                },
+                "host_capabilities": {
+                    "tools": [
+                        {
+                            "name": "authoring.preview_lesson_patch",
+                            "description": "Preview lesson patch",
+                            "roles": ["teacher"],
+                            "permission": "manage:courses",
+                            "mutates_state": False,
+                            "requires_confirmation": False,
+                        },
+                    ]
+                },
+            },
+        }
+    )
+
+    captured: dict[str, object] = {}
+
+    async def fake_execute_direct_tool_rounds(*args, **kwargs):
+        captured["forced_tool_choice"] = kwargs.get("forced_tool_choice")
+        captured["tool_names"] = [
+            getattr(tool, "name", getattr(tool, "__name__", ""))
+            for tool in args[3]
+        ]
+        return (
+            SimpleNamespace(content="Preview sent to LMS."),
+            [],
+            [
+                {
+                    "type": "call",
+                    "name": "host_action__authoring__preview_lesson_patch",
+                },
+                {
+                    "type": "host_action",
+                    "name": "host_action__authoring__preview_lesson_patch",
+                },
+            ],
+        )
+
+    kwargs = _base_direct_kwargs()
+    kwargs.update(
+        {
+            "looks_identity_selfhood_turn": lambda *_args, **_kwargs: False,
+            "get_effective_provider": lambda *_args, **_kwargs: None,
+            "get_explicit_user_provider": lambda *_args, **_kwargs: None,
+            "collect_direct_tools": lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("document preview preflight must not depend on tool collection")
+            ),
+            "execute_direct_tool_rounds": fake_execute_direct_tool_rounds,
+            "extract_direct_response": lambda *_args, **_kwargs: (
+                "Preview sent to LMS.",
+                "Preview was created from a declared host capability.",
+                [],
+            ),
+        }
+    )
+
+    with (
+        patch(
+            "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_native_llm",
+            side_effect=AssertionError("preview host action should not need native LLM"),
+        ),
+        patch(
+            "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_llm",
+            side_effect=AssertionError("preview host action should not need planner LLM"),
+        ),
+    ):
+        result = await direct_response_node_impl(state, **kwargs)
+
+    assert result["final_response"] == "Preview sent to LMS."
+    assert captured["forced_tool_choice"] == "host_action__authoring__preview_lesson_patch"
+    assert captured["tool_names"] == ["host_action__authoring__preview_lesson_patch"]
+    assert result["routing_metadata"]["doc_preview_preflight"]["status"] == "executed"
+    assert result["tool_call_events"][1]["type"] == "host_action"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Execute the safe LMS `authoring.preview_lesson_patch` host action before direct LLM/tool-selection when a teacher uploaded document asks for a preview.
- Keep the path preview-only and host-declared: no apply/publish/delete mutation is generated here.
- Make uploaded document context helpers tolerate Pydantic-like mappings as well as plain dicts.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_node_provider_errors.py tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_tool_collection_host_ui.py tests/unit/test_document_context_api.py -q` -> 91 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk / Rollback
- Risk is limited to uploaded-document preview requests that already include declared LMS host capability `authoring.preview_lesson_patch`.
- Rollback by reverting this commit; older LLM-driven behavior returns, but product smoke may again show prose payload instead of host action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced document context detection with safer normalization for uploaded documents.
  * Improved document preview request handling with early preflight execution path.

* **Tests**
  * Added test coverage for document preview preflight workflow execution and ordering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/298)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->