### PR TITLE
Polish document preview Vietnamese UX

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -118,7 +118,7 @@ def _first_nonempty_line(text: str) -> str:
         line = line.strip(" #\t\r\n")
         if line:
             return line[:140]
-    return "Tai lieu da tai len"
+    return "Tài liệu đã tải lên"
 
 
 def _extract_marker(text: str) -> str:
@@ -184,7 +184,7 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
         str(first_attachment.get("title") or "").strip()
         or _first_nonempty_line(combined_markdown)
         or str(first_attachment.get("file_name") or "").strip()
-        or "Tai lieu da tai len"
+        or "Tài liệu đã tải lên"
     )
     marker = _extract_marker(query) or _extract_marker(combined_markdown)
     goals = _extract_relevant_lines(
@@ -207,27 +207,27 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
     source_excerpt = " ".join(checklist[:2])[:360] or _first_nonempty_line(combined_markdown)
     page_start, page_end = _extract_source_pages(query, combined_markdown)
     content_lines = [
-        f"# Ban nhap bai hoc tu tai lieu: {title_source}",
+        f"# Bản nháp bài học từ tài liệu: {title_source}",
         "",
-        "## Muc tieu hoc tap",
+        "## Mục tiêu học tập",
         *[f"- {line}" for line in goals[:4]],
         "",
-        "## Checklist truc ca / noi dung can nam",
+        "## Checklist trực ca / nội dung cần nắm",
         *[f"- {line}" for line in checklist[:5]],
         "",
-        "## Hoat dong thao luan",
-        "- Hoc vien doi chieu checklist trong tai lieu voi mot tinh huong truc ca thuc te.",
-        "- Nhom nho xac dinh rui ro, nguoi can bao cao, va bang chung can ghi vao nhat ky.",
+        "## Hoạt động thảo luận",
+        "- Học viên đối chiếu checklist trong tài liệu với một tình huống trực ca thực tế.",
+        "- Nhóm nhỏ xác định rủi ro, người cần báo cáo và bằng chứng cần ghi vào nhật ký.",
         "",
-        "## Cau hoi kiem tra nhanh",
-        "- Khi tam nhin han che, nguoi truc ca can xac nhan nhung nguon thong tin nao truoc khi doi huong?",
-        "- Khi co nguy co va cham, quy trinh bao cao va ghi log nen dien ra nhu the nao?",
+        "## Câu hỏi kiểm tra nhanh",
+        "- Khi tầm nhìn hạn chế, người trực ca cần xác nhận những nguồn thông tin nào trước khi đổi hướng?",
+        "- Khi có nguy cơ va chạm, quy trình báo cáo và ghi log nên diễn ra như thế nào?",
     ]
     if marker:
-        content_lines.extend(["", f"Marker kiem thu: {marker}"])
+        content_lines.extend(["", f"Marker kiểm thử: {marker}"])
 
     params: dict[str, Any] = {
-        "title": f"Ban nhap: {title_source[:90]}",
+        "title": f"Bản nháp: {title_source[:90]}",
         "content": "\n".join(content_lines),
         "source_references": [
             {

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -364,11 +364,11 @@ async def test_uploaded_document_preview_runs_host_action_without_planner_llm():
         return None
 
     markdown = (
-        "So tay truc ca buong lai\n"
-        "Marker kiem thu: WIII_DOC_GOAL_123\n"
-        "Muc tieu hoc tap 1: giai thich quy trinh truc ca khi tam nhin han che.\n"
-        "Checklist nguon trang 4: xac nhan nguoi truc ca, kiem tra thiet bi dinh vi.\n"
-        "Checklist nguon trang 5: bao thuyen truong, giam toc an toan, ghi nhat ky.\n"
+        "Sổ tay trực ca buồng lái\n"
+        "Marker kiểm thử: WIII_DOC_GOAL_123\n"
+        "Mục tiêu học tập 1: giải thích quy trình trực ca khi tầm nhìn hạn chế.\n"
+        "Checklist nguồn trang 4: xác nhận người trực ca, kiểm tra thiết bị định vị.\n"
+        "Checklist nguồn trang 5: báo thuyền trưởng, giảm tốc an toàn, ghi nhật ký.\n"
     )
     state = {
         "context": {
@@ -411,6 +411,13 @@ async def test_uploaded_document_preview_runs_host_action_without_planner_llm():
 
     preview_args = captured["args"]
     assert preview_args["lesson_id"] == "lesson-from-url"
+    assert preview_args["title"].startswith("Bản nháp:")
+    assert "# Bản nháp bài học từ tài liệu:" in preview_args["content"]
+    assert "## Mục tiêu học tập" in preview_args["content"]
+    assert "## Hoạt động thảo luận" in preview_args["content"]
+    assert "Marker kiểm thử: WIII_DOC_GOAL_123" in preview_args["content"]
+    assert "Ban nhap" not in preview_args["content"]
+    assert "Muc tieu hoc tap" not in preview_args["content"]
     assert "WIII_DOC_GOAL_123" in preview_args["content"]
     assert preview_args["source_references"][0]["page_start"] == 4
     assert preview_args["source_references"][0]["page_end"] == 5

--- a/wiii-desktop/src/__tests__/host-action-sse.test.ts
+++ b/wiii-desktop/src/__tests__/host-action-sse.test.ts
@@ -80,13 +80,13 @@ describe("Host Action SSE + PostMessage Integration (Sprint 222b)", () => {
         preview_token: "lesson-preview-123",
         preview_kind: "lesson_patch",
         summary: "Lesson patch preview ready.",
-        lesson_title: "Bai hoc nguon",
+        lesson_title: "Bài học nguồn",
         source_references: [
           {
             kind: "lesson",
             chapter_index: 1,
             lesson_index: 0,
-            title: "Muc tai lieu",
+            title: "Mục tài liệu",
             source_pages: [7, "8-9"],
           },
         ],
@@ -99,9 +99,13 @@ describe("Host Action SSE + PostMessage Integration (Sprint 222b)", () => {
         kind: "lesson",
         chapter_index: 1,
         lesson_index: 0,
-        title: "Muc tai lieu",
+        title: "Mục tài liệu",
         source_pages: [7, "8-9"],
       },
     ]);
+    expect(item?.title).toBe("Xem trước cập nhật bài học: Bài học nguồn");
+    expect(item?.metadata?.next_step).toBe(
+      "Xem bản xem trước rồi xác nhận rõ ràng nếu bạn muốn Wiii áp dụng thay đổi này vào LMS.",
+    );
   });
 });

--- a/wiii-desktop/src/__tests__/preview-cards.test.ts
+++ b/wiii-desktop/src/__tests__/preview-cards.test.ts
@@ -135,7 +135,7 @@ describe("PreviewItemData — Type Shape", () => {
     const item: PreviewItemData = {
       preview_type: "host_action",
       preview_id: "host-action-1",
-      title: "Preview cap nhat bai hoc",
+      title: "Xem trước cập nhật bài học",
       snippet: "Preview ready. Confirm explicitly when you want me to apply it.",
       metadata: {
         preview_kind: "lesson_patch",

--- a/wiii-desktop/src/__tests__/preview-panel-ui.test.tsx
+++ b/wiii-desktop/src/__tests__/preview-panel-ui.test.tsx
@@ -51,7 +51,7 @@ function makeLessonPatchPreview(
   return {
     preview_type: "host_action",
     preview_id: "host-preview-lesson-1",
-    title: "Preview cap nhat bai hoc: Bai hoc goc",
+    title: "Xem trước cập nhật bài học: Bài học gốc",
     snippet:
       "Lesson patch preview ready. Confirm explicitly when you want me to apply it.",
     metadata: {
@@ -192,7 +192,7 @@ describe("PreviewPanel host action operator flow", () => {
     const diffQueries = within(blockDiffSection as HTMLElement);
     expect(diffQueries.getByText("Noi dung cu")).toBeTruthy();
     expect(diffQueries.getByText("Noi dung moi")).toBeTruthy();
-    expect(screen.getByText("Nguon tai lieu")).toBeTruthy();
+    expect(screen.getByText("Nguồn tài liệu")).toBeTruthy();
     expect(screen.getByText("Doc chuong 1")).toBeTruthy();
     expect(screen.getByText("Trang 4, 5")).toBeTruthy();
     expect(screen.getByText("Noi dung goc tu tai lieu.")).toBeTruthy();

--- a/wiii-desktop/src/__tests__/preview-panel.test.ts
+++ b/wiii-desktop/src/__tests__/preview-panel.test.ts
@@ -165,7 +165,7 @@ describe("PreviewPanel — Selected Preview", () => {
       makePreviewItem({
         preview_id: "host-preview-1",
         preview_type: "host_action",
-        title: "Preview quiz publish",
+        title: "Xem trước phát hành bài kiểm tra",
         snippet: "Quiz publish preview ready.",
         metadata: {
           preview_kind: "quiz_publish",
@@ -191,7 +191,7 @@ describe("PreviewPanel — Selected Preview", () => {
       makePreviewItem({
         preview_id: "host-preview-diff-1",
         preview_type: "host_action",
-        title: "Preview cap nhat bai hoc",
+        title: "Xem trước cập nhật bài học",
         snippet: "Lesson patch preview ready.",
         metadata: {
           preview_kind: "lesson_patch",

--- a/wiii-desktop/src/components/layout/PreviewPanel.tsx
+++ b/wiii-desktop/src/components/layout/PreviewPanel.tsx
@@ -682,12 +682,12 @@ function HostActionSourceReferences({
 }) {
   return (
     <section
-      aria-label="Nguon tai lieu"
+      aria-label="Nguồn tài liệu"
       className="rounded-lg border border-border bg-surface px-3 py-3"
     >
       <div className="mb-2 flex items-center justify-between gap-2">
         <div className="text-[11px] uppercase tracking-wider text-text-tertiary">
-          Nguon tai lieu
+          Nguồn tài liệu
         </div>
         <span className="rounded-full bg-surface-secondary px-2 py-0.5 text-[11px] text-text-secondary">
           {references.length}

--- a/wiii-desktop/src/hooks/useSSEStream.ts
+++ b/wiii-desktop/src/hooks/useSSEStream.ts
@@ -283,12 +283,12 @@ export function buildHostActionPreviewItem(
 
   const title =
     previewKind === "lesson_patch"
-      ? `Preview cap nhat bai hoc: ${targetLabel}`
+      ? `Xem trước cập nhật bài học: ${targetLabel}`
       : previewKind === "quiz_commit"
-        ? `Preview quiz: ${targetLabel}`
+        ? `Xem trước bài kiểm tra: ${targetLabel}`
         : previewKind === "quiz_publish"
-          ? `Preview publish quiz: ${targetLabel}`
-          : `Preview host action: ${targetLabel}`;
+          ? `Xem trước phát hành bài kiểm tra: ${targetLabel}`
+          : `Xem trước thao tác LMS: ${targetLabel}`;
 
   return {
     preview_id: `host-action-${requestId}`,
@@ -336,7 +336,7 @@ export function buildHostActionPreviewItem(
       requires_confirmation: true,
       workflow_stage: hostContext?.workflow_stage,
       page_type: hostContext?.page?.type,
-      next_step: "Xem preview roi xac nhan ro rang neu ban muon Wiii ap dung thay doi nay vao LMS.",
+      next_step: "Xem bản xem trước rồi xác nhận rõ ràng nếu bạn muốn Wiii áp dụng thay đổi này vào LMS.",
     },
   };
 }

--- a/wiii-desktop/src/lib/source-references.ts
+++ b/wiii-desktop/src/lib/source-references.ts
@@ -86,10 +86,10 @@ export function sourceReferenceLabel(ref: PreviewSourceReference): string {
   if (ref.title) return ref.title;
   if (ref.chapter_title) return ref.chapter_title;
   if (typeof ref.chapter_index === "number" && typeof ref.lesson_index === "number") {
-    return `Chuong ${ref.chapter_index + 1}, bai ${ref.lesson_index + 1}`;
+    return `Chương ${ref.chapter_index + 1}, bài ${ref.lesson_index + 1}`;
   }
   if (typeof ref.chapter_index === "number") {
-    return `Chuong ${ref.chapter_index + 1}`;
+    return `Chương ${ref.chapter_index + 1}`;
   }
-  return ref.kind || "Nguon";
+  return ref.kind || "Nguồn";
 }


### PR DESCRIPTION
## Summary
- Changes deterministic document-preview fallback content from no-accent placeholders (Ban nhap, Muc tieu hoc tap) to polished Vietnamese copy.
- Localizes Wiii desktop host-action preview card titles, source-reference labels, and next-step copy.
- Adds/updates tests so document-preview output keeps Vietnamese headings and avoids the old no-accent strings.

## Verification
- cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py -q -> 33 passed
- cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7 -> pass
- cd wiii-desktop && npx vitest run src/__tests__/host-action-sse.test.ts src/__tests__/preview-panel-ui.test.tsx src/__tests__/preview-panel.test.ts src/__tests__/preview-cards.test.ts -> 4 files, 64 passed
- cd wiii-desktop && npx tsc --noEmit -> pass
- git diff --check -> pass (line-ending warnings only)

## Risk / rollback
- Low risk: text/copy polish only, no approval-gate or mutation behavior changes.
- Rollback: revert this commit if any downstream UX snapshot unexpectedly depends on the old no-accent labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Enhanced Vietnamese language support across the application with proper diacritics and accents.
  * Updated document preview titles, section headings, and UI labels to display Vietnamese text correctly.
  * Improved consistency of Vietnamese terminology in markers and navigation elements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/301)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->