### PR TITLE
fix: clean Word upload preview titles

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -115,10 +115,32 @@ def _should_request_uploaded_doc_preview(
 
 def _first_nonempty_line(text: str) -> str:
     for line in str(text or "").replace("\\_", "_").splitlines():
-        line = line.strip(" #\t\r\n")
+        line = _clean_doc_preview_line(line)
         if line:
             return line[:140]
     return "Tài liệu đã tải lên"
+
+
+def _clean_doc_preview_line(value: str) -> str:
+    line = str(value or "").replace("\\_", "_").strip()
+    if not line:
+        return ""
+    lowered = line.lower()
+    if line.startswith("![") or "data:image" in lowered or "base64" in lowered:
+        return ""
+    if "<w:" in lowered or "</w:" in lowered:
+        return ""
+    if line.startswith("|") and line.endswith("|"):
+        return ""
+    line = re.sub(r"!\[[^\]]*\]\([^)]*\)", "", line)
+    line = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", line)
+    line = re.sub(r"[*_`]+", "", line)
+    line = re.sub(r"\s+", " ", line).strip(" #*-:\t\r\n|")
+    if not line or not re.search(r"[\wÀ-ỹ]", line, flags=re.IGNORECASE):
+        return ""
+    if set(line) <= {"-", "|", " ", ":"}:
+        return ""
+    return line[:220]
 
 
 def _extract_marker(text: str) -> str:
@@ -131,7 +153,7 @@ def _extract_relevant_lines(markdown: str, markers: tuple[str, ...], *, limit: i
     normalized_markers = tuple(_normalize_doc_preview_text(marker) for marker in markers)
     selected: list[str] = []
     for raw_line in str(markdown or "").replace("\\_", "_").splitlines():
-        line = raw_line.strip(" -*\t\r\n")
+        line = _clean_doc_preview_line(raw_line)
         if not line:
             continue
         normalized_line = _normalize_doc_preview_text(line)
@@ -140,6 +162,43 @@ def _extract_relevant_lines(markdown: str, markers: tuple[str, ...], *, limit: i
         if len(selected) >= limit:
             break
     return selected
+
+
+def _extract_doc_preview_title_from_query(query: str) -> str:
+    match = re.search(
+        r"(?:title|tiêu đề|tieu de)\s*(?:là|la|is|:)\s*[\"“”']([^\"“”']{3,140})[\"“”']",
+        str(query or ""),
+        flags=re.IGNORECASE,
+    )
+    if match:
+        return _clean_doc_preview_line(match.group(1))
+    return ""
+
+
+def _focus_doc_preview_markdown(query: str, markdown: str) -> str:
+    normalized_query = _normalize_doc_preview_text(query)
+    role_markers: tuple[str, ...] = ()
+    if any(marker in normalized_query for marker in ("giang vien", "teacher")):
+        role_markers = ("huong dan cho giang vien", "danh cho giang vien")
+    elif any(marker in normalized_query for marker in ("hoc vien", "student")):
+        role_markers = ("huong dan cho hoc vien", "danh cho hoc vien")
+    elif any(marker in normalized_query for marker in ("quan ly", "manager", "admin")):
+        role_markers = ("huong dan cho quan ly", "quan tri", "admin")
+    if not role_markers:
+        return markdown
+
+    lines = str(markdown or "").replace("\\_", "_").splitlines()
+    normalized_markers = tuple(_normalize_doc_preview_text(marker) for marker in role_markers)
+    for index, raw_line in enumerate(lines):
+        cleaned = _clean_doc_preview_line(raw_line)
+        if not cleaned:
+            continue
+        normalized_line = _normalize_doc_preview_text(cleaned)
+        if any(marker in normalized_line for marker in normalized_markers):
+            start = max(0, index - 2)
+            end = min(len(lines), index + 140)
+            return "\n".join(lines[start:end])
+    return markdown
 
 
 def _extract_source_pages(query: str, markdown: str) -> tuple[int | None, int | None]:
@@ -180,48 +239,95 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
         if str(item.get("markdown") or "").strip()
     )
     first_attachment = attachments[0] if attachments else {}
+    query_title = _extract_doc_preview_title_from_query(query)
     title_source = (
         str(first_attachment.get("title") or "").strip()
+        or query_title
         or _first_nonempty_line(combined_markdown)
         or str(first_attachment.get("file_name") or "").strip()
         or "Tài liệu đã tải lên"
     )
+    focused_markdown = _focus_doc_preview_markdown(query, combined_markdown)
     marker = _extract_marker(query) or _extract_marker(combined_markdown)
     goals = _extract_relevant_lines(
-        combined_markdown,
+        focused_markdown,
         ("muc tieu hoc tap", "learning objective", "objective", "muc tieu"),
         limit=4,
     )
+    if not goals:
+        goals = _extract_relevant_lines(
+            focused_markdown,
+            ("giang vien", "teacher", "hoc vien", "lms", "khoa hoc", "bai hoc"),
+            limit=4,
+        )
     checklist = _extract_relevant_lines(
-        combined_markdown,
-        ("checklist", "nguon trang", "source page", "approval_token"),
+        focused_markdown,
+        (
+            "checklist",
+            "nguon trang",
+            "source page",
+            "approval_token",
+            "quy trinh",
+            "thao tac",
+            "tao khoa",
+            "soan",
+            "xuat ban",
+            "quiz",
+        ),
         limit=5,
     )
     if not goals:
-        goals = [_first_nonempty_line(combined_markdown)]
+        goals = [_first_nonempty_line(focused_markdown) or _first_nonempty_line(combined_markdown)]
     if not checklist:
-        checklist = _extract_relevant_lines(combined_markdown, ("quy trinh", "kiem tra", "xac nhan"), limit=4)
+        checklist = _extract_relevant_lines(focused_markdown, ("quy trinh", "kiem tra", "xac nhan"), limit=4)
     if not checklist:
         checklist = goals[:2]
 
-    source_excerpt = " ".join(checklist[:2])[:360] or _first_nonempty_line(combined_markdown)
+    source_excerpt = " ".join(checklist[:2])[:360] or _first_nonempty_line(focused_markdown) or _first_nonempty_line(combined_markdown)
     page_start, page_end = _extract_source_pages(query, combined_markdown)
+    domain_text = _normalize_doc_preview_text(f"{query}\n{title_source}\n{combined_markdown[:2000]}")
+    is_lms_manual = any(marker in domain_text for marker in ("lms", "holilihu", "giang vien", "hoc vien", "quan ly"))
+    checklist_heading = (
+        "## Checklist thao tác / nội dung cần nắm"
+        if is_lms_manual
+        else "## Checklist trực ca / nội dung cần nắm"
+    )
+    discussion_lines = (
+        [
+            "- Giảng viên thực hành mở đúng khu vực quản lý khóa học, kiểm tra bài học và xác nhận dữ liệu trước khi lưu.",
+            "- Nhóm nhỏ ghi lại lỗi thường gặp khi đăng nhập, tạo nội dung hoặc kiểm tra tiến độ học viên.",
+        ]
+        if is_lms_manual
+        else [
+            "- Học viên đối chiếu checklist trong tài liệu với một tình huống trực ca thực tế.",
+            "- Nhóm nhỏ xác định rủi ro, người cần báo cáo và bằng chứng cần ghi vào nhật ký.",
+        ]
+    )
+    quick_questions = (
+        [
+            "- Khi tạo hoặc cập nhật bài học trong LMS, giảng viên cần kiểm tra những mục nào trước khi xuất bản?",
+            "- Khi học viên báo lỗi đăng nhập hoặc không thấy nội dung, cần thu thập thông tin nào để hỗ trợ?",
+        ]
+        if is_lms_manual
+        else [
+            "- Khi tầm nhìn hạn chế, người trực ca cần xác nhận những nguồn thông tin nào trước khi đổi hướng?",
+            "- Khi có nguy cơ va chạm, quy trình báo cáo và ghi log nên diễn ra như thế nào?",
+        ]
+    )
     content_lines = [
         f"# Bản nháp bài học từ tài liệu: {title_source}",
         "",
         "## Mục tiêu học tập",
         *[f"- {line}" for line in goals[:4]],
         "",
-        "## Checklist trực ca / nội dung cần nắm",
+        checklist_heading,
         *[f"- {line}" for line in checklist[:5]],
         "",
         "## Hoạt động thảo luận",
-        "- Học viên đối chiếu checklist trong tài liệu với một tình huống trực ca thực tế.",
-        "- Nhóm nhỏ xác định rủi ro, người cần báo cáo và bằng chứng cần ghi vào nhật ký.",
+        *discussion_lines,
         "",
         "## Câu hỏi kiểm tra nhanh",
-        "- Khi tầm nhìn hạn chế, người trực ca cần xác nhận những nguồn thông tin nào trước khi đổi hướng?",
-        "- Khi có nguy cơ va chạm, quy trình báo cáo và ghi log nên diễn ra như thế nào?",
+        *quick_questions,
     ]
     if marker:
         content_lines.extend(["", f"Marker kiểm thử: {marker}"])

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -426,6 +426,57 @@ async def test_uploaded_document_preview_runs_host_action_without_planner_llm():
     assert "preview" in llm_response.content.lower()
 
 
+def test_uploaded_doc_preview_skips_logo_data_uri_and_focuses_teacher_manual():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        _build_uploaded_doc_preview_params,
+    )
+
+    markdown = (
+        "![Logo Trường Đại học Hàng hải Việt Nam](data:image/png;base64...)\n\n"
+        "**HƯỚNG DẪN SỬ DỤNG\n"
+        "HOLILIHU ONLINE LMS**\n\n"
+        "| **Vai trò** | **Nên đọc trước** | **Mục tiêu sau khi đọc** |\n"
+        "| --- | --- | --- |\n"
+        "| **Giảng viên** | Phần 4 và 5 | Biết tạo khóa, soạn nội dung và xuất bản. |\n\n"
+        "# 4. Hướng Dẫn Cho Giảng Viên\n"
+        "Mục tiêu học tập: giảng viên biết tạo khóa học, soạn bài học và kiểm tra trước khi xuất bản.\n"
+        "Quy trình thao tác: mở trang quản lý khóa học, cập nhật bài học, thêm tài liệu và kiểm tra quiz.\n"
+        "Checklist triển khai: xác nhận tiêu đề, nội dung, tài liệu đính kèm, trạng thái xuất bản và quyền truy cập học viên.\n"
+    )
+    params = _build_uploaded_doc_preview_params(
+        (
+            'Dựa trên tài liệu Word, tạo preview cho giáo viên. '
+            'Trong preview gửi source_references title là "Hướng dẫn sử dụng HoLiLiHu LMS". '
+            'Marker WIII_DOC_GOAL_REAL_MANUAL.'
+        ),
+        {
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "Huong_dan_su_dung_HoLiLiHu_LMS_Chi_tiet_2026-05-10.docx",
+                            "markdown": markdown,
+                        }
+                    ]
+                },
+                "page_context": {"lesson_id": "lesson-manual"},
+            }
+        },
+    )
+
+    content = params["content"]
+    assert params["title"] == "Bản nháp: Hướng dẫn sử dụng HoLiLiHu LMS"
+    assert params["lesson_id"] == "lesson-manual"
+    assert params["source_references"][0]["title"] == "Hướng dẫn sử dụng HoLiLiHu LMS"
+    assert "Logo Trường Đại học Hàng hải" not in params["title"]
+    assert "data:image" not in content
+    assert "| **Vai trò**" not in content
+    assert "## Checklist thao tác / nội dung cần nắm" in content
+    assert "giảng viên biết tạo khóa học" in content
+    assert "trực ca" not in content.lower()
+    assert "WIII_DOC_GOAL_REAL_MANUAL" in content
+
+
 @pytest.mark.asyncio
 async def test_execute_direct_tool_rounds_forwards_runtime_tier_to_failover_helper():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (


### PR DESCRIPTION
## Summary
- Skip image/data URI/table noise when deriving document preview titles and source lines.
- Prefer explicit source title from the teacher prompt when present.
- Focus uploaded Word previews on the requested role section, especially teacher manuals, and use LMS-specific checklist/discussion copy instead of maritime watchkeeping defaults.

## Verification
- cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py -q
- cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7
- git diff --check

## Risk / rollback
- Risk is limited to deterministic preview construction for uploaded document context. Roll back this commit if document-preview title/content selection regresses.