### PR TITLE
fix: preserve long document sections for preview context

### DIFF
--- a/maritime-ai-service/app/api/v1/document_context.py
+++ b/maritime-ai-service/app/api/v1/document_context.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import tempfile
+import unicodedata
 from pathlib import Path
 from typing import Any, Literal
 
@@ -28,6 +30,9 @@ MAX_DOCUMENT_UPLOAD_BYTES = 20 * 1024 * 1024
 MAX_VIDEO_UPLOAD_BYTES = 80 * 1024 * 1024
 MAX_MARKDOWN_CHARS = 30_000
 MAX_SECTION_TITLES = 24
+MAX_SECTION_SNIPPETS = 80
+MAX_SECTION_SNIPPET_CHARS = 1_500
+MAX_SECTION_SNIPPET_TOTAL_CHARS = 80_000
 MAX_EXTRACTED_IMAGES = 5
 
 DOCUMENT_EXTENSIONS = {
@@ -61,6 +66,16 @@ class DocumentContextExtractedImage(BaseModel):
     detail: Literal["auto", "low", "high"] = "low"
 
 
+class DocumentContextSectionSnippet(BaseModel):
+    title: str
+    markdown: str
+    char_start: int
+    char_end: int
+    source_pages: list[int] = Field(default_factory=list)
+    page_start: int | None = None
+    page_end: int | None = None
+
+
 class DocumentContextParseResponse(BaseModel):
     file_name: str
     mime_type: str | None = None
@@ -70,6 +85,7 @@ class DocumentContextParseResponse(BaseModel):
     title: str | None = None
     page_count: int | None = None
     section_titles: list[str] = Field(default_factory=list)
+    section_snippets: list[DocumentContextSectionSnippet] = Field(default_factory=list)
     markdown: str
     char_count: int
     truncated: bool = False
@@ -147,6 +163,133 @@ def _build_video_parser():
     return parser
 
 
+def _clean_section_title(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip(" #\t\r\n"))[:180]
+
+
+def _score_section_title(value: str) -> int:
+    normalized = (
+        re.sub(r"[\u0300-\u036f]", "", unicodedata.normalize("NFD", str(value or "").lower()))
+        .replace("đ", "d")
+        .replace("Đ", "D")
+    )
+    if re.search(r"\b(giang vien|giao vien|teacher|instructor)\b", normalized):
+        return 100
+    if re.search(
+        r"(tao khoa|soan|chuong va bai|cau hoi|bai tap|xuat ban|quiz|video tuong tac)",
+        normalized,
+    ):
+        return 85
+    if re.search(r"\b(hoc vien|student|learner)\b", normalized):
+        return 65
+    if re.search(r"\b(quan ly|admin|manager)\b", normalized):
+        return 55
+    if re.search(r"(checklist|quy trinh|van hanh|troubleshoot|xu ly loi)", normalized):
+        return 45
+    return 0
+
+
+def _section_pages(section_map: dict[str, list[int]], title: str) -> list[int]:
+    pages = section_map.get(title) or section_map.get(_clean_section_title(title)) or []
+    clean_pages: list[int] = []
+    for page in pages:
+        try:
+            parsed_page = int(page)
+        except (TypeError, ValueError):
+            continue
+        if parsed_page > 0 and parsed_page not in clean_pages:
+            clean_pages.append(parsed_page)
+    return clean_pages
+
+
+def _select_section_indices(candidates: list[dict[str, Any]]) -> list[int]:
+    if len(candidates) <= MAX_SECTION_SNIPPETS:
+        return list(range(len(candidates)))
+
+    selected: set[int] = set(range(min(8, len(candidates))))
+    selected.update(range(max(0, len(candidates) - 8), len(candidates)))
+
+    priority_indices = sorted(
+        range(len(candidates)),
+        key=lambda idx: (
+            -int(candidates[idx].get("priority") or 0),
+            int(candidates[idx].get("start") or 0),
+        ),
+    )
+    for index in priority_indices:
+        if len(selected) >= MAX_SECTION_SNIPPETS:
+            break
+        if int(candidates[index].get("priority") or 0) <= 0:
+            break
+        selected.add(index)
+
+    if len(selected) < MAX_SECTION_SNIPPETS:
+        stride = max(1, len(candidates) // MAX_SECTION_SNIPPETS)
+        for index in range(0, len(candidates), stride):
+            selected.add(index)
+            if len(selected) >= MAX_SECTION_SNIPPETS:
+                break
+
+    return sorted(selected)
+
+
+def _build_section_snippets(
+    *,
+    raw_markdown: str,
+    section_map: dict[str, list[int]],
+) -> list[DocumentContextSectionSnippet]:
+    headings: list[dict[str, Any]] = []
+    for match in re.finditer(r"(?m)^\s{0,3}#{1,6}\s+(.+?)\s*$", raw_markdown):
+        title = _clean_section_title(match.group(1))
+        if title:
+            headings.append(
+                {
+                    "title": title,
+                    "start": match.start(),
+                    "priority": _score_section_title(title),
+                }
+            )
+    if not headings:
+        return []
+
+    candidates: list[dict[str, Any]] = []
+    for index, heading in enumerate(headings):
+        start = int(heading["start"])
+        end = int(headings[index + 1]["start"]) if index + 1 < len(headings) else len(raw_markdown)
+        section_text = raw_markdown[start:end].strip()
+        if not section_text:
+            continue
+        candidates.append({**heading, "end": end, "markdown": section_text})
+
+    snippets: list[DocumentContextSectionSnippet] = []
+    total_chars = 0
+    for index in _select_section_indices(candidates):
+        candidate = candidates[index]
+        section_text = str(candidate["markdown"]).strip()
+        snippet_text = section_text[:MAX_SECTION_SNIPPET_CHARS].rstrip()
+        if len(snippet_text) < len(section_text):
+            snippet_text = f"{snippet_text}\n\n[Section excerpt truncated]"
+        if not snippet_text:
+            continue
+        if total_chars + len(snippet_text) > MAX_SECTION_SNIPPET_TOTAL_CHARS:
+            break
+        title = str(candidate["title"])
+        pages = _section_pages(section_map, title)
+        snippets.append(
+            DocumentContextSectionSnippet(
+                title=title,
+                markdown=snippet_text,
+                char_start=int(candidate["start"]),
+                char_end=int(candidate["end"]),
+                source_pages=pages,
+                page_start=min(pages) if pages else None,
+                page_end=max(pages) if pages else None,
+            )
+        )
+        total_chars += len(snippet_text)
+    return snippets
+
+
 def _response_from_parsed(
     *,
     parsed: ParsedDocument,
@@ -168,6 +311,10 @@ def _response_from_parsed(
         for title in (parsed.section_map or {}).keys()
         if str(title).strip()
     ][:MAX_SECTION_TITLES]
+    section_snippets = _build_section_snippets(
+        raw_markdown=raw_markdown,
+        section_map=parsed.section_map or {},
+    )
     extracted_images: list[DocumentContextExtractedImage] = []
     for index, image in enumerate(parsed.images[:MAX_EXTRACTED_IMAGES], start=1):
         if not isinstance(image, dict):
@@ -195,6 +342,7 @@ def _response_from_parsed(
         title=str(metadata.get("title") or file_name),
         page_count=parsed.page_count,
         section_titles=section_titles,
+        section_snippets=section_snippets,
         markdown=markdown,
         char_count=len(raw_markdown),
         truncated=truncated,

--- a/maritime-ai-service/tests/unit/test_document_context_api.py
+++ b/maritime-ai-service/tests/unit/test_document_context_api.py
@@ -25,6 +25,31 @@ class FakeMarkItDownParser:
         )
 
 
+class FakeLongManualParser:
+    is_available = True
+
+    async def parse(self, file_path: str, options=None):
+        early = "# 1. Tong Quan\n\n" + ("Gioi thieu he thong LMS.\n" * 500)
+        filler = "# 2. Noi Dung Nen\n\n" + ("Dong dem truoc section quan trong.\n" * 1400)
+        late_teacher = (
+            "# 9. Huong Dan Cho Giang Vien\n\n"
+            "Giang vien tao khoa hoc, soan chuong va bai, them video tuong tac, "
+            "tao cau hoi va gui duyet truoc khi xuat ban.\n"
+        )
+        markdown = early + filler + late_teacher
+        return ParsedDocument(
+            markdown=markdown,
+            page_count=12,
+            metadata={"title": "Long LMS Manual", "parser": "markitdown"},
+            section_map={
+                "1. Tong Quan": [1],
+                "2. Noi Dung Nen": [2],
+                "9. Huong Dan Cho Giang Vien": [9, 10],
+            },
+            images=[],
+        )
+
+
 class FakeVideoParser:
     is_available = True
 
@@ -112,6 +137,31 @@ def test_parse_document_context_uses_markitdown(monkeypatch):
     assert response.section_titles == ["Safety Brief"]
     assert "Rule 5" in response.markdown
     assert response.char_count == len("# Safety Brief\n\nRule 5: keep a proper lookout.")
+
+
+def test_parse_document_context_keeps_late_sections_as_snippets(monkeypatch):
+    from app.api.v1 import document_context as module
+
+    monkeypatch.setattr(module, "_build_parser", lambda: FakeLongManualParser())
+
+    response = asyncio.run(
+        module.parse_document_context(
+            SimpleNamespace(user_id="u"),
+            _upload_file("long-manual.docx", b"docx-bytes"),
+        )
+    )
+
+    assert response.truncated is True
+    assert "Huong Dan Cho Giang Vien" not in response.markdown
+    late_snippet = next(
+        snippet
+        for snippet in response.section_snippets
+        if snippet.title == "9. Huong Dan Cho Giang Vien"
+    )
+    assert late_snippet.source_pages == [9, 10]
+    assert late_snippet.page_start == 9
+    assert late_snippet.page_end == 10
+    assert "them video tuong tac" in late_snippet.markdown
 
 
 def test_document_context_prompt_block_bounds_and_labels():

--- a/wiii-desktop/src/__tests__/document-context.test.ts
+++ b/wiii-desktop/src/__tests__/document-context.test.ts
@@ -58,6 +58,46 @@ describe("document context helpers", () => {
     expect(bounded).not.toContain("data:image");
   });
 
+  it("retrieves important sections from backend snippets beyond the truncated markdown", () => {
+    const truncatedMarkdown = [
+      "# HoLiLiHu LMS",
+      "Phan dau tai lieu ".repeat(900),
+      "# 2. Noi dung nen",
+      "Doan dem khong lien quan ".repeat(900),
+    ].join("\n\n");
+
+    const context = buildChatDocumentContext([
+      makeDoc({
+        markdown: truncatedMarkdown,
+        char_count: truncatedMarkdown.length + 18_000,
+        truncated: true,
+        section_snippets: [
+          {
+            title: "2. Noi dung nen",
+            markdown: "# 2. Noi dung nen\n\nDoan dem khong lien quan.",
+            char_start: 10_000,
+            char_end: 13_000,
+            source_pages: [2],
+          },
+          {
+            title: "9. Hướng Dẫn Cho Giảng Viên",
+            markdown:
+              "# 9. Hướng Dẫn Cho Giảng Viên\n\nGiảng viên tạo khóa học, soạn chương và bài, thêm video tương tác, tạo câu hỏi và gửi duyệt.",
+            char_start: 45_000,
+            char_end: 48_000,
+            source_pages: [9, 10],
+          },
+        ],
+      }),
+    ], 2_800);
+    const bounded = context?.attachments[0].markdown || "";
+
+    expect(bounded.length).toBeLessThanOrEqual(2_800);
+    expect(bounded).toContain("Hướng Dẫn Cho Giảng Viên");
+    expect(bounded).toContain("Nguồn section: 9. Hướng Dẫn Cho Giảng Viên (trang 9-10)");
+    expect(bounded).toContain("thêm video tương tác");
+  });
+
   it("strips markdown from display attachments", () => {
     const display = toDisplayDocumentAttachment(makeDoc());
 

--- a/wiii-desktop/src/api/document-context.ts
+++ b/wiii-desktop/src/api/document-context.ts
@@ -9,6 +9,16 @@ export interface DocumentContextExtractedImage {
   detail?: "auto" | "low" | "high";
 }
 
+export interface DocumentContextSectionSnippet {
+  title: string;
+  markdown: string;
+  char_start: number;
+  char_end: number;
+  source_pages?: number[];
+  page_start?: number | null;
+  page_end?: number | null;
+}
+
 export interface DocumentContextParseResponse {
   file_name: string;
   mime_type?: string | null;
@@ -18,6 +28,7 @@ export interface DocumentContextParseResponse {
   title?: string | null;
   page_count?: number | null;
   section_titles: string[];
+  section_snippets?: DocumentContextSectionSnippet[];
   markdown: string;
   char_count: number;
   truncated: boolean;

--- a/wiii-desktop/src/components/chat/ChatInput.tsx
+++ b/wiii-desktop/src/components/chat/ChatInput.tsx
@@ -17,7 +17,7 @@ import {
   toDisplayDocumentAttachment,
   type ParsedDocumentForContext,
 } from "@/lib/document-context";
-import type { DocumentContextExtractedImage } from "@/api/document-context";
+import type { DocumentContextExtractedImage, DocumentContextSectionSnippet } from "@/api/document-context";
 import {
   parseSkillMentions,
   detectMentionTyping,
@@ -93,6 +93,7 @@ interface AttachedDocument {
   truncated?: boolean;
   extracted_images?: DocumentContextExtractedImage[];
   extracted_image_count?: number;
+  section_snippets?: DocumentContextSectionSnippet[];
   markdown?: string;
   status: "parsing" | "ready" | "error";
   error?: string;
@@ -159,6 +160,7 @@ function toParsedDocumentForContext(doc: AttachedDocument): ParsedDocumentForCon
     char_count: doc.char_count,
     extracted_images: doc.extracted_images,
     extracted_image_count: doc.extracted_image_count,
+    section_snippets: doc.section_snippets,
     truncated: doc.truncated,
     markdown: doc.markdown,
   };
@@ -484,6 +486,7 @@ export function ChatInput({ onSend, onCancel, editingMessage, onClearEdit, cente
                   char_count: parsed.char_count,
                   extracted_images: parsed.extracted_images || [],
                   extracted_image_count: parsed.extracted_image_count || 0,
+                  section_snippets: parsed.section_snippets || [],
                   truncated: parsed.truncated,
                   markdown: parsed.markdown,
                   status: "ready",

--- a/wiii-desktop/src/lib/document-context.ts
+++ b/wiii-desktop/src/lib/document-context.ts
@@ -4,7 +4,10 @@ import type {
   ChatDocumentContextAttachment,
   ImageInput,
 } from "@/api/types";
-import type { DocumentContextExtractedImage } from "@/api/document-context";
+import type {
+  DocumentContextExtractedImage,
+  DocumentContextSectionSnippet,
+} from "@/api/document-context";
 
 export const MAX_DOCUMENT_CONTEXT_CHARS = 8_000;
 const SECTION_CONTEXT_TITLE_LIMIT = 28;
@@ -18,9 +21,18 @@ interface MarkdownSection {
   priority: number;
 }
 
+interface ContextSection {
+  title: string;
+  markdown: string;
+  start: number;
+  priority: number;
+  sourcePages: number[];
+}
+
 export interface ParsedDocumentForContext extends ChatDocumentContextAttachment {
   id: string;
   extracted_images?: DocumentContextExtractedImage[];
+  section_snippets?: DocumentContextSectionSnippet[];
 }
 
 export function toDisplayDocumentAttachment(
@@ -105,18 +117,18 @@ function buildBoundedDocumentMarkdown(
   const markdown = normalizeDocumentMarkdown(doc.markdown);
   if (markdown.length <= maxChars) return markdown.trim();
 
-  const sections = extractMarkdownSections(markdown);
+  const sections = buildContextSections(doc, markdown);
   if (sections.length === 0 || maxChars < 1_200) {
     return markdown.slice(0, maxChars).trim();
   }
 
-  const title = `# Tai lieu upload: ${doc.file_name}`;
+  const title = `# Tài liệu upload: ${doc.file_name}`;
   const outline = renderSectionOutline(sections);
   const headBudget = Math.min(1_500, Math.max(700, Math.floor(maxChars * 0.22)));
   const chunks: string[] = [
     title,
     outline,
-    "## Trich doan dau tai lieu",
+    "## Trích đoạn đầu tài liệu",
     markdown.slice(0, headBudget).trim(),
   ];
 
@@ -126,16 +138,13 @@ function buildBoundedDocumentMarkdown(
     .slice(0, PRIORITY_SECTION_LIMIT);
 
   if (prioritySections.length > 0) {
-    chunks.push("## Trich doan uu tien theo vai tro/chu de");
+    chunks.push("## Trích đoạn ưu tiên theo vai trò/chủ đề");
     for (const section of prioritySections) {
       chunks.push(
         [
           `### ${section.title}`,
-          markdown
-            .slice(section.start, section.end)
-            .trim()
-            .slice(0, PRIORITY_SECTION_CHARS)
-            .trim(),
+          formatSectionSourceLine(section),
+          section.markdown.slice(0, PRIORITY_SECTION_CHARS).trim(),
         ]
           .filter(Boolean)
           .join("\n"),
@@ -144,7 +153,7 @@ function buildBoundedDocumentMarkdown(
   }
 
   const tailBudget = Math.min(900, Math.max(350, Math.floor(maxChars * 0.12)));
-  chunks.push("## Trich doan cuoi tai lieu", markdown.slice(-tailBudget).trim());
+  chunks.push("## Trích đoạn cuối tài liệu", markdown.slice(-tailBudget).trim());
 
   return compactToBudget(chunks.join("\n\n"), maxChars);
 }
@@ -175,6 +184,69 @@ function extractMarkdownSections(markdown: string): MarkdownSection[] {
   }));
 }
 
+function buildContextSections(
+  doc: ParsedDocumentForContext,
+  fallbackMarkdown: string,
+): ContextSection[] {
+  const snippetSections = (doc.section_snippets || [])
+    .map((snippet, index) => {
+      const markdown = normalizeDocumentMarkdown(snippet.markdown || "");
+      const title = snippet.title?.trim() || firstMarkdownHeading(markdown) || `Section ${index + 1}`;
+      if (!markdown.trim()) return null;
+      const sourcePages = normalizeSourcePages(snippet);
+      return {
+        title,
+        markdown,
+        start: Number.isFinite(snippet.char_start) ? snippet.char_start : index,
+        priority: scoreSectionTitle(title),
+        sourcePages,
+      };
+    })
+    .filter((section): section is ContextSection => section !== null);
+
+  if (snippetSections.length > 0) return snippetSections;
+
+  return extractMarkdownSections(fallbackMarkdown).map((section) => ({
+    title: section.title,
+    markdown: fallbackMarkdown.slice(section.start, section.end).trim(),
+    start: section.start,
+    priority: section.priority,
+    sourcePages: [],
+  }));
+}
+
+function firstMarkdownHeading(markdown: string): string {
+  const match = /^#{1,6}\s+(.+?)\s*$/m.exec(markdown);
+  return match?.[1]?.trim() || "";
+}
+
+function normalizeSourcePages(snippet: DocumentContextSectionSnippet): number[] {
+  const pages = Array.isArray(snippet.source_pages) ? snippet.source_pages : [];
+  const explicit = pages
+    .map((page) => Number(page))
+    .filter((page) => Number.isFinite(page) && page > 0);
+  if (explicit.length > 0) return [...new Set(explicit)];
+  const start = Number(snippet.page_start);
+  const end = Number(snippet.page_end);
+  if (!Number.isFinite(start) || start <= 0) return [];
+  if (!Number.isFinite(end) || end <= start) return [start];
+  const range: number[] = [];
+  for (let page = start; page <= end && range.length < 12; page += 1) {
+    range.push(page);
+  }
+  return range;
+}
+
+function formatSectionSourceLine(section: ContextSection): string {
+  const pages = section.sourcePages || [];
+  if (pages.length === 0) return "";
+  const pageText =
+    pages.length === 1
+      ? `trang ${pages[0]}`
+      : `trang ${Math.min(...pages)}-${Math.max(...pages)}`;
+  return `Nguồn section: ${section.title} (${pageText})`;
+}
+
 function scoreSectionTitle(title: string): number {
   const normalized = stripVietnameseDiacritics(title).toLowerCase();
   if (/\b(giang vien|giao vien|teacher|instructor)\b/.test(normalized)) return 100;
@@ -195,12 +267,12 @@ function stripVietnameseDiacritics(value: string): string {
     .replace(/Đ/g, "D");
 }
 
-function renderSectionOutline(sections: MarkdownSection[]): string {
+function renderSectionOutline(sections: Array<{ title: string }>): string {
   const titles = sections
     .slice(0, SECTION_CONTEXT_TITLE_LIMIT)
     .map((section) => `- ${section.title}`)
     .join("\n");
-  return `## Muc luc phat hien\n${titles}`;
+  return `## Mục lục phát hiện\n${titles}`;
 }
 
 function compactToBudget(text: string, maxChars: number): string {


### PR DESCRIPTION
## Summary
- Add backend `section_snippets` to document-context parse responses so long manuals keep late/important sections even when the main markdown is bounded.
- Teach the desktop document-context builder to choose role/topic-priority sections from those snippets before sending per-turn chat/RAG context.
- Polish internal document excerpt headings to Vietnamese with accents and add regression tests for late teacher sections.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_document_context_api.py tests/unit/test_direct_tool_rounds_runtime.py -q` -> 48 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> passed
- `cd wiii-desktop && npx vitest run src/__tests__/document-context.test.ts` -> 6 passed
- `cd wiii-desktop && npx tsc --noEmit` -> passed
- `cd wiii-desktop && npm run build:embed` -> passed, existing bundle-size warnings only
- `git diff --check` -> passed, existing CRLF normalization warning only

## Risk / rollback
- Low API compatibility risk: `section_snippets` is additive and defaults to an empty list.
- Payload size is bounded by snippet count and total snippet chars.
- Rollback: revert this PR; clients will continue using bounded `markdown` as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Document uploads now intelligently extract and preserve important "section snippets," ensuring key sections remain available in chat context even when the full document is truncated for length limits. Each snippet includes source page references for easy identification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/305)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->