### PR TITLE
fix: improve document preview content quality

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -170,6 +170,8 @@ def _clean_doc_preview_line(value: str) -> str:
             for cell in cells
             if cell.strip()
         ]
+        while cells and _normalize_doc_preview_text(cells[0]) in {"□", "☐", "☑", "✓", "x"}:
+            cells = cells[1:]
         if not cells or all(set(cell) <= {"-", " ", ":"} for cell in cells):
             return ""
         line = " - ".join(cells)
@@ -383,6 +385,7 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
     content_lines = [
         f"# Bản nháp bài học từ tài liệu: {title_source}",
         "",
+        *([f"Marker kiểm thử: {marker}", ""] if marker else []),
         "## Mục tiêu học tập",
         *[f"- {_strip_doc_preview_goal_label(line)}" for line in goals[:4]],
         "",
@@ -395,11 +398,18 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
         "## Câu hỏi kiểm tra nhanh",
         *quick_questions,
     ]
-    if marker:
-        content_lines.extend(["", f"Marker kiểm thử: {marker}"])
+    description = (
+        "Bài học giúp giảng viên chuyển tài liệu hướng dẫn HoLiLiHu LMS thành "
+        "các thao tác tạo khóa, soạn chương/bài, thêm video/tài liệu/quiz, "
+        "kiểm tra và gửi duyệt một cách an toàn."
+        if is_lms_manual
+        else "Bài học giúp người học chuyển tài liệu nguồn thành checklist thao tác, "
+        "tình huống thực hành và câu hỏi kiểm tra nhanh."
+    )
 
     params: dict[str, Any] = {
         "title": f"Bản nháp: {title_source[:90]}",
+        "description": description,
         "content": "\n".join(content_lines),
         "source_references": [
             {

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -526,6 +526,16 @@ def test_uploaded_doc_preview_prefers_real_teacher_heading_over_smart_excerpt_ou
     assert "- 4. Huong Dan Cho Giang Vien" not in content
     assert "Nhap thong tin khoa" in content
     assert "Checklist trien khai" in content
+    assert "HoLiLiHu LMS" in params["description"]
+    assert "OOW" not in params["description"]
+
+
+def test_doc_preview_clean_line_drops_checkbox_table_markers():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import _clean_doc_preview_line
+
+    assert _clean_doc_preview_line(
+        "| **□** | Thong tin khoa hoan chinh. | Co tieu de va muc tieu hoc tap. |"
+    ) == "Thong tin khoa hoan chinh. - Co tieu de va muc tieu hoc tap."
 
 
 @pytest.mark.asyncio

--- a/wiii-desktop/src/__tests__/document-context.test.ts
+++ b/wiii-desktop/src/__tests__/document-context.test.ts
@@ -98,6 +98,42 @@ describe("document context helpers", () => {
     expect(bounded).toContain("thêm video tương tác");
   });
 
+  it("prioritizes teacher authoring sections over incidental admin teacher mentions", () => {
+    const snippets = [
+      ["4. Huong Dan Cho Giang Vien", "Tong quan quy trinh tao va van hanh khoa hoc."],
+      ["4.2. Tao khoa hoc moi", "Nhap thong tin khoa hoc, muc tieu va mo ta cho hoc vien."],
+      ["4.4. Soan cau truc chuong va bai", "Sap xep chuong, bai, tai lieu va thu tu hoc."],
+      ["4.5. Them bai video va video tuong tac", "Them video, diem dung, cau hoi va phan hoi."],
+      ["4.6. Tao cau hoi trong ngan hang", "Tao cau hoi, dap an, giai thich va gan vao quiz."],
+      ["4.9. Doc phan tich giang vien", "Theo doi hieu qua khoa va noi dung hoc vien dang vuong."],
+      ["6.2. Quan ly giang vien", "Admin tim va ho tro tai khoan giang vien."],
+      ["9.2. Checklist giang vien truoc khi gui duyet", "Kiem tra thong tin, video, cau hoi va trang thai gui duyet."],
+    ].map(([title, body], index) => ({
+      title,
+      markdown: `# ${title}\n\n${body}`,
+      char_start: 10_000 + index * 1000,
+      char_end: 10_800 + index * 1000,
+      source_pages: [index + 1],
+    }));
+
+    const context = buildChatDocumentContext([
+      makeDoc({
+        markdown: "# Manual\n\n" + "Mo dau tai lieu ".repeat(900),
+        char_count: 80_000,
+        truncated: true,
+        section_snippets: snippets,
+      }),
+    ], 5_200);
+    const bounded = context?.attachments[0].markdown || "";
+
+    expect(bounded).toContain("Nguồn section: 4.2. Tao khoa hoc moi");
+    expect(bounded).toContain("Nguồn section: 4.4. Soan cau truc chuong va bai");
+    expect(bounded).toContain("Nguồn section: 4.5. Them bai video va video tuong tac");
+    expect(bounded).toContain("Nguồn section: 4.6. Tao cau hoi trong ngan hang");
+    expect(bounded).not.toContain("Nguồn section: 6.2. Quan ly giang vien");
+    expect(bounded).not.toContain("Nguồn section: 4.9. Doc phan tich giang vien");
+  });
+
   it("strips markdown from display attachments", () => {
     const display = toDisplayDocumentAttachment(makeDoc());
 

--- a/wiii-desktop/src/lib/document-context.ts
+++ b/wiii-desktop/src/lib/document-context.ts
@@ -11,8 +11,8 @@ import type {
 
 export const MAX_DOCUMENT_CONTEXT_CHARS = 8_000;
 const SECTION_CONTEXT_TITLE_LIMIT = 28;
-const PRIORITY_SECTION_LIMIT = 4;
-const PRIORITY_SECTION_CHARS = 1_300;
+const PRIORITY_SECTION_LIMIT = 6;
+const PRIORITY_SECTION_CHARS = 1_050;
 
 interface MarkdownSection {
   title: string;
@@ -122,9 +122,12 @@ function buildBoundedDocumentMarkdown(
     return markdown.slice(0, maxChars).trim();
   }
 
+  const hasSectionSnippets = Boolean(doc.section_snippets?.length);
   const title = `# Tài liệu upload: ${doc.file_name}`;
   const outline = renderSectionOutline(sections);
-  const headBudget = Math.min(1_500, Math.max(700, Math.floor(maxChars * 0.22)));
+  const headBudget = hasSectionSnippets
+    ? Math.min(900, Math.max(520, Math.floor(maxChars * 0.12)))
+    : Math.min(1_500, Math.max(700, Math.floor(maxChars * 0.22)));
   const chunks: string[] = [
     title,
     outline,
@@ -152,7 +155,9 @@ function buildBoundedDocumentMarkdown(
     }
   }
 
-  const tailBudget = Math.min(900, Math.max(350, Math.floor(maxChars * 0.12)));
+  const tailBudget = hasSectionSnippets
+    ? Math.min(520, Math.max(260, Math.floor(maxChars * 0.07)))
+    : Math.min(900, Math.max(350, Math.floor(maxChars * 0.12)));
   chunks.push("## Trích đoạn cuối tài liệu", markdown.slice(-tailBudget).trim());
 
   return compactToBudget(chunks.join("\n\n"), maxChars);
@@ -249,10 +254,17 @@ function formatSectionSourceLine(section: ContextSection): string {
 
 function scoreSectionTitle(title: string): number {
   const normalized = stripVietnameseDiacritics(title).toLowerCase();
-  if (/\b(giang vien|giao vien|teacher|instructor)\b/.test(normalized)) return 100;
-  if (/(tao khoa|soan|chuong va bai|cau hoi|bai tap|xuat ban|phan tich giang vien)/.test(normalized)) {
-    return 85;
+  const isTeacher = /\b(giang vien|giao vien|teacher|instructor)\b/.test(normalized);
+  const isAdminManagement = /\b(quan ly|org_admin|admin|manager)\b/.test(normalized);
+  if (/(huong dan cho giang vien|danh cho giang vien|teacher guide)/.test(normalized)) return 100;
+  if (
+    /(tao khoa|hoan thien thong tin khoa|soan|chuong va bai|them bai video|video tuong tac|tao cau hoi|ngan hang cau hoi|bai tap|cai dat khoa|gui duyet|xuat ban)/.test(normalized)
+  ) {
+    return 95;
   }
+  if (/(checklist.*giang vien|giang vien.*checklist|kiem tra truoc khi xuat ban)/.test(normalized)) return 90;
+  if (/phan tich giang vien/.test(normalized)) return 60;
+  if (isTeacher && !isAdminManagement) return 80;
   if (/\b(hoc vien|student|learner)\b/.test(normalized)) return 65;
   if (/\b(quan ly|org_admin|admin|manager)\b/.test(normalized)) return 55;
   if (/(checklist|quy trinh|video tuong tac|van hanh)/.test(normalized)) return 45;


### PR DESCRIPTION
## Summary
- Tune document section scoring so teacher authoring sections (create course, structure chapters, add video/interactions, create questions) outrank incidental admin mentions of teachers.
- Add LMS-specific preview descriptions so generated lesson previews do not retain unrelated maritime/OOW descriptions from the current lesson.
- Clean checkbox table markers before building goals/checklists and keep smoke markers near the top of test previews.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_document_context_api.py -q` -> 49 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> passed
- `cd wiii-desktop && npx vitest run src/__tests__/document-context.test.ts` -> 7 passed
- `cd wiii-desktop && npx tsc --noEmit` -> passed
- `cd wiii-desktop && npm run build:embed` -> passed, existing bundle-size warnings only
- `git diff --check` -> passed

## Risk / rollback
- Low runtime risk: content selection changes are deterministic and covered by targeted tests.
- API contract is unchanged in this PR.
- Rollback: revert this PR; long-document section snippets from #305 continue to work with prior scoring.