### PR TITLE
fix: prefer teacher authoring sections in document context

### DIFF
--- a/wiii-desktop/src/__tests__/document-context.test.ts
+++ b/wiii-desktop/src/__tests__/document-context.test.ts
@@ -100,6 +100,7 @@ describe("document context helpers", () => {
 
   it("prioritizes teacher authoring sections over incidental admin teacher mentions", () => {
     const snippets = [
+      ["3.7. Hoc video tuong tac", "Hoc vien tra loi khi video tam dung."],
       ["4. Huong Dan Cho Giang Vien", "Tong quan quy trinh tao va van hanh khoa hoc."],
       ["4.2. Tao khoa hoc moi", "Nhap thong tin khoa hoc, muc tieu va mo ta cho hoc vien."],
       ["4.4. Soan cau truc chuong va bai", "Sap xep chuong, bai, tai lieu va thu tu hoc."],
@@ -130,6 +131,7 @@ describe("document context helpers", () => {
     expect(bounded).toContain("Nguồn section: 4.4. Soan cau truc chuong va bai");
     expect(bounded).toContain("Nguồn section: 4.5. Them bai video va video tuong tac");
     expect(bounded).toContain("Nguồn section: 4.6. Tao cau hoi trong ngan hang");
+    expect(bounded).not.toContain("Nguồn section: 3.7. Hoc video tuong tac");
     expect(bounded).not.toContain("Nguồn section: 6.2. Quan ly giang vien");
     expect(bounded).not.toContain("Nguồn section: 4.9. Doc phan tich giang vien");
   });

--- a/wiii-desktop/src/lib/document-context.ts
+++ b/wiii-desktop/src/lib/document-context.ts
@@ -13,6 +13,22 @@ export const MAX_DOCUMENT_CONTEXT_CHARS = 8_000;
 const SECTION_CONTEXT_TITLE_LIMIT = 28;
 const PRIORITY_SECTION_LIMIT = 6;
 const PRIORITY_SECTION_CHARS = 1_050;
+const TEACHER_AUTHORING_TOKENS = [
+  "tao khoa",
+  "hoan thien thong tin khoa",
+  "soan",
+  "chuong va bai",
+  "them bai video",
+  "thiet ke diem dung",
+  "tao noi dung tuong tac",
+  "kiem tra truoc khi xuat ban",
+  "tao cau hoi",
+  "ngan hang cau hoi",
+  "bai tap",
+  "cai dat khoa",
+  "gui duyet",
+  "xuat ban",
+];
 
 interface MarkdownSection {
   title: string;
@@ -260,7 +276,7 @@ function scoreSectionTitle(title: string): number {
   if (/(huong dan cho giang vien|danh cho giang vien|teacher guide)/.test(normalized)) return 100;
   if (
     !isStudentLearningSection
-    && /(tao khoa|hoan thien thong tin khoa|soan|chuong va bai|them bai video|thiet ke diem dung|tao noi dung tuong tac|kiem tra truoc khi xuat ban|tao cau hoi|ngan hang cau hoi|bai tap|cai dat khoa|gui duyet|xuat ban)/.test(normalized)
+    && TEACHER_AUTHORING_TOKENS.some((token) => normalized.includes(token))
   ) {
     return 95;
   }

--- a/wiii-desktop/src/lib/document-context.ts
+++ b/wiii-desktop/src/lib/document-context.ts
@@ -256,9 +256,11 @@ function scoreSectionTitle(title: string): number {
   const normalized = stripVietnameseDiacritics(title).toLowerCase();
   const isTeacher = /\b(giang vien|giao vien|teacher|instructor)\b/.test(normalized);
   const isAdminManagement = /\b(quan ly|org_admin|admin|manager)\b/.test(normalized);
+  const isStudentLearningSection = /^\s*3\./.test(normalized) || /(hoc video|xem bai|ket qua hoc tap)/.test(normalized);
   if (/(huong dan cho giang vien|danh cho giang vien|teacher guide)/.test(normalized)) return 100;
   if (
-    /(tao khoa|hoan thien thong tin khoa|soan|chuong va bai|them bai video|video tuong tac|tao cau hoi|ngan hang cau hoi|bai tap|cai dat khoa|gui duyet|xuat ban)/.test(normalized)
+    !isStudentLearningSection
+    && /(tao khoa|hoan thien thong tin khoa|soan|chuong va bai|them bai video|thiet ke diem dung|tao noi dung tuong tac|kiem tra truoc khi xuat ban|tao cau hoi|ngan hang cau hoi|bai tap|cai dat khoa|gui duyet|xuat ban)/.test(normalized)
   ) {
     return 95;
   }


### PR DESCRIPTION
﻿## Summary
- Prevent student learn-interactive-video sections from outranking teacher authoring sections just because they mention interactive video.
- Add a regression assertion so teacher context keeps create/structure/video/question snippets while excluding the student video snippet.

## Verification
- `cd wiii-desktop && npx vitest run src/__tests__/document-context.test.ts` -> 7 passed
- `cd wiii-desktop && npx tsc --noEmit` -> passed
- `cd wiii-desktop && npm run build:embed` -> passed, existing bundle-size warnings only
- `git diff --check` -> passed

## Risk / rollback
- Very low risk: frontend-only deterministic scoring change for per-turn document excerpt selection.
- Rollback: revert this PR; #305/#306 functionality remains intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering logic to better distinguish between different types of course content sections in document context.
  * Enhanced prioritization of relevant content sections for course materials.

* **Tests**
  * Extended test coverage for section filtering scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/307)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->