### PR TITLE
Fix document course duration count

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -811,6 +811,8 @@ def _build_lms_manual_course_plan(
             }
         )
 
+    lesson_count = sum(len(chapter.get("lessons", [])) for chapter in chapters)
+
     return {
         "title": "Khai thác HoLiLiHu LMS từ tài liệu hướng dẫn",
         "description": (
@@ -819,7 +821,7 @@ def _build_lms_manual_course_plan(
             "kiểm tra chất lượng và citation để giáo viên xác minh trước khi áp dụng."
         ),
         "audience": "Giảng viên, trợ giảng, quản lý đào tạo và học viên cần sử dụng HoLiLiHu LMS.",
-        "duration": "5 chương, 16 bài, triển khai trong 3-5 buổi thực hành.",
+        "duration": f"{len(chapters)} chương, {lesson_count} bài, triển khai trong 3-5 buổi thực hành.",
         "chapters": chapters,
         "assessment_plan": [
             "Mỗi chương có câu hỏi kiểm tra nhanh gắn với thao tác thật.",

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -583,6 +583,7 @@ def test_uploaded_doc_course_plan_builder_creates_full_lms_architecture():
     assert any("Tác nghiệp giảng viên" in title for title in titles)
     assert any("Quản lý" in title for title in titles)
     assert plan["chapters"][2]["lessons"][0]["source_references"][0]["page_start"] == 23
+    assert f"{sum(len(chapter['lessons']) for chapter in plan['chapters'])} bài" in plan["duration"]
     assert "không publish tự động" in " ".join(plan["implementation_checklist"])
 
 


### PR DESCRIPTION
## Summary
- Derive the LMS manual course-plan duration from the generated lesson tree instead of a hardcoded lesson count.
- Add regression coverage so duration text matches the actual number of generated lessons.

## Verification
- cd maritime-ai-service; .\\.venv\\Scripts\\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_sprint222b_action_tools.py tests/unit/test_tool_collection_host_ui.py tests/unit/test_direct_node_provider_errors.py -q -> 102 passed
- cd maritime-ai-service; .\\.venv\\Scripts\\ruff.exe check app/ --select=E9,F63,F7 -> All checks passed
- git diff --check -> passed

## Risk / rollback
- Risk is minimal and display-only inside generated course_plan metadata. No host apply or mutation behavior changes.
- Rollback: revert this commit to restore the previous hardcoded duration text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Course plan generation now dynamically calculates and accurately displays the total number of chapters and lessons in the course duration. Previously, course plans used hardcoded placeholder values that showed a fixed course structure regardless of actual content. This update ensures users receive accurate course information reflecting real content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/311)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->