### PR TITLE
Generalize document-to-course architect pipeline

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -451,6 +451,18 @@ def _extract_doc_section_references(markdown: str, fallback_title: str) -> list[
                 stripped,
                 flags=re.IGNORECASE,
             )
+        if not source_match:
+            source_match = re.search(
+                r"Nguồn section:\s*(.+?)\s*\(trang\s*(\d{1,4})(?:\s*[-–]\s*(\d{1,4}))?\)",
+                stripped,
+                flags=re.IGNORECASE,
+            )
+        if not source_match:
+            source_match = re.search(
+                r"Ngu.n section:\s*(.+?)\s*\(trang\s*(\d{1,4})(?:\s*[-–]\s*(\d{1,4}))?\)",
+                stripped,
+                flags=re.IGNORECASE,
+            )
         if source_match:
             title = _clean_doc_preview_line(source_match.group(1)) or current_heading or fallback_title
             page_start = int(source_match.group(2))
@@ -464,7 +476,7 @@ def _extract_doc_section_references(markdown: str, fallback_title: str) -> list[
                 )
             )
     if refs:
-        return refs[:16]
+        return refs[:96]
 
     heading_refs: list[dict[str, Any]] = []
     for heading in _extract_doc_headings(markdown)[:80]:
@@ -1162,65 +1174,409 @@ def _extract_doc_headings(markdown: str) -> list[str]:
     return headings
 
 
+def _section_candidate_markers(title: str) -> tuple[str, ...]:
+    normalized = _normalize_doc_preview_text(title)
+    compact = re.sub(r"^\d+(?:\.\d+)*\.?\s*", "", normalized).strip()
+    markers = [marker for marker in (normalized, compact) if marker]
+    return tuple(dict.fromkeys(markers))
+
+
+def _copy_doc_refs_with_indices(
+    refs: list[dict[str, Any]],
+    *,
+    chapter_index: int | None = None,
+    lesson_index: int | None = None,
+) -> list[dict[str, Any]]:
+    copied: list[dict[str, Any]] = []
+    for ref in refs[:3]:
+        next_ref = dict(ref)
+        if chapter_index is not None:
+            next_ref["chapter_index"] = chapter_index
+        if lesson_index is not None:
+            next_ref["lesson_index"] = lesson_index
+        copied.append(next_ref)
+    return copied
+
+
+def _document_course_section_candidates(
+    *,
+    markdown: str,
+    refs: list[dict[str, Any]],
+    fallback_title: str,
+) -> list[dict[str, Any]]:
+    """Build a stable document map from source references plus headings.
+
+    The previous generic builder used the first six headings, which is brittle
+    for long manuals/research reports. This map keeps the source order and then
+    clusters the whole document into course chapters.
+    """
+
+    candidates: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def add_candidate(title: str, source_refs: list[dict[str, Any]]) -> None:
+        clean_title = _clean_doc_preview_line(title)
+        if not clean_title or _is_doc_preview_scaffold_line(clean_title):
+            return
+        normalized = _normalize_doc_preview_text(clean_title)
+        if not normalized or normalized in seen:
+            return
+        seen.add(normalized)
+        candidates.append(
+            {
+                "title": clean_title[:140],
+                "markers": _section_candidate_markers(clean_title),
+                "source_refs": source_refs,
+                "source_index": len(candidates) + 1,
+            }
+        )
+
+    for ref in refs:
+        title = str(ref.get("title") or ref.get("excerpt") or "").strip()
+        if not title:
+            continue
+        add_candidate(title, [ref])
+        if len(candidates) >= 96:
+            break
+
+    for heading in _extract_doc_headings(markdown):
+        if len(candidates) >= 96:
+            break
+        if refs:
+            heading_refs = _match_doc_refs(
+                refs,
+                _section_candidate_markers(heading),
+                fallback_title=fallback_title,
+            )
+        else:
+            heading_refs = [
+                _doc_source_reference(
+                    title=heading,
+                    excerpt=heading,
+                )
+            ]
+        add_candidate(heading, heading_refs)
+
+    if candidates:
+        return candidates
+
+    fallback_refs = refs[:1] or [_doc_source_reference(title=fallback_title)]
+    return [
+        {
+            "title": fallback_title,
+            "markers": _section_candidate_markers(fallback_title),
+            "source_refs": fallback_refs,
+            "source_index": 1,
+        }
+    ]
+
+
+def _cluster_document_course_sections(
+    candidates: list[dict[str, Any]],
+) -> list[list[dict[str, Any]]]:
+    if not candidates:
+        return []
+    section_count = len(candidates)
+    if section_count >= 18:
+        chapter_count = 6
+    elif section_count >= 12:
+        chapter_count = 5
+    elif section_count >= 6:
+        chapter_count = 4
+    else:
+        chapter_count = max(1, section_count)
+
+    clusters: list[list[dict[str, Any]]] = []
+    base_size = section_count // chapter_count
+    remainder = section_count % chapter_count
+    cursor = 0
+    for index in range(chapter_count):
+        size = base_size + (1 if index < remainder else 0)
+        cluster = candidates[cursor : cursor + size]
+        if cluster:
+            clusters.append(cluster)
+        cursor += size
+    return clusters
+
+
+def _select_lesson_section_candidates(
+    cluster: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    if len(cluster) <= 3:
+        return cluster
+    indexes = [0, len(cluster) // 2, len(cluster) - 1]
+    selected: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for index in indexes:
+        if index in seen:
+            continue
+        seen.add(index)
+        selected.append(cluster[index])
+    return selected
+
+
+def _cluster_title(cluster: list[dict[str, Any]], *, chapter_index: int) -> str:
+    primary = str((cluster[0] if cluster else {}).get("title") or "").strip()
+    if not primary:
+        return f"Chương {chapter_index}: Nền tảng tài liệu"
+    normalized = _normalize_doc_preview_text(primary)
+    if normalized.startswith(("tong quan", "gioi thieu", "mo dau")):
+        return f"Bối cảnh và mục tiêu: {primary}"
+    if any(marker in normalized for marker in ("ket luan", "tong ket", "danh gia")):
+        return f"Tổng kết và đánh giá: {primary}"
+    return f"Trục nội dung {chapter_index}: {primary}"
+
+
+def _lesson_refs_for_candidate(
+    candidate: dict[str, Any],
+    refs: list[dict[str, Any]],
+    *,
+    fallback_title: str,
+    chapter_index: int,
+    lesson_index: int,
+) -> list[dict[str, Any]]:
+    direct_refs = candidate.get("source_refs")
+    if isinstance(direct_refs, list) and direct_refs:
+        return _copy_doc_refs_with_indices(
+            [ref for ref in direct_refs if isinstance(ref, dict)],
+            chapter_index=chapter_index,
+            lesson_index=lesson_index,
+        )
+    return _match_doc_refs(
+        refs,
+        tuple(candidate.get("markers") or (candidate.get("title") or "",)),
+        fallback_title=fallback_title,
+        chapter_index=chapter_index,
+        lesson_index=lesson_index,
+    )
+
+
+def _classify_uploaded_document_course_domain(
+    *,
+    query: str,
+    title_source: str,
+    markdown: str,
+    refs: list[dict[str, Any]],
+) -> dict[str, Any]:
+    lms_manual = _looks_holilihu_lms_manual_document(
+        title_source=title_source,
+        markdown=markdown,
+        query=query,
+    )
+    maritime_vessel = _looks_maritime_vessel_management_document(
+        title_source=title_source,
+        markdown=markdown,
+    )
+    if lms_manual:
+        domain_id = "holilihu_lms_manual"
+        confidence = 0.86
+    elif maritime_vessel:
+        domain_id = "maritime_vessel_management"
+        confidence = 0.82
+    else:
+        domain_id = "generic_document_course"
+        confidence = 0.64
+
+    headings = _extract_doc_headings(markdown)
+    return {
+        "domain_id": domain_id,
+        "confidence": confidence,
+        "evidence": {
+            "heading_count": len(headings),
+            "source_reference_count": len(refs),
+            "document_chars": len(markdown or ""),
+            "query_lms_mention": bool(
+                re.search(
+                    r"(^|[^a-z0-9])(lms|holilihu)([^a-z0-9]|$)",
+                    _normalize_doc_preview_text(query),
+                )
+            ),
+        },
+    }
+
+
+def _build_document_course_quality_report(
+    *,
+    course_plan: dict[str, Any],
+    classification: dict[str, Any],
+    refs: list[dict[str, Any]],
+) -> dict[str, Any]:
+    chapters = course_plan.get("chapters") if isinstance(course_plan, dict) else []
+    chapter_count = len(chapters) if isinstance(chapters, list) else 0
+    lesson_count = 0
+    lessons_missing_refs = 0
+    lessons_missing_activity = 0
+    iterable_chapters = chapters if isinstance(chapters, list) else []
+    for chapter in iterable_chapters:
+        lessons = chapter.get("lessons") if isinstance(chapter, dict) else []
+        if not isinstance(lessons, list):
+            continue
+        for lesson in lessons:
+            if not isinstance(lesson, dict):
+                continue
+            lesson_count += 1
+            if not lesson.get("source_references"):
+                lessons_missing_refs += 1
+            if not str(lesson.get("activity") or "").strip():
+                lessons_missing_activity += 1
+
+    warnings: list[str] = []
+    if chapter_count < 3:
+        warnings.append("course_has_too_few_chapters")
+    if lesson_count < 6:
+        warnings.append("course_has_too_few_lessons")
+    if lessons_missing_refs:
+        warnings.append("lesson_missing_source_references")
+    if lessons_missing_activity:
+        warnings.append("lesson_missing_activity")
+    if not refs:
+        warnings.append("document_has_no_extractable_source_references")
+
+    return {
+        "status": "pass" if not warnings else "warn",
+        "domain_id": classification.get("domain_id"),
+        "domain_confidence": classification.get("confidence"),
+        "chapter_count": chapter_count,
+        "lesson_count": lesson_count,
+        "source_reference_count": len(refs),
+        "lessons_missing_source_references": lessons_missing_refs,
+        "lessons_missing_activity": lessons_missing_activity,
+        "warnings": warnings,
+    }
+
+
 def _build_generic_document_course_plan(
     *,
     title_source: str,
     markdown: str,
     refs: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    headings = _extract_doc_headings(markdown)
-    if not headings:
-        headings = [
-            "Tổng quan tài liệu và mục tiêu học tập",
-            "Quy trình chính và khái niệm nền tảng",
-            "Thực hành theo tình huống",
-            "Kiểm tra, phản hồi và cải tiến",
-        ]
-    chapter_titles = headings[:6]
+    candidates = _document_course_section_candidates(
+        markdown=markdown,
+        refs=refs,
+        fallback_title=title_source,
+    )
+    clusters = _cluster_document_course_sections(candidates)
     chapters: list[dict[str, Any]] = []
-    for chapter_index, heading in enumerate(chapter_titles, start=1):
-        chapter_refs = _match_doc_refs(
-            refs,
-            (heading,),
-            fallback_title=title_source,
+    for chapter_index, cluster in enumerate(clusters, start=1):
+        chapter_refs = _copy_doc_refs_with_indices(
+            [
+                ref
+                for candidate in cluster
+                for ref in candidate.get("source_refs", [])
+                if isinstance(ref, dict)
+            ],
             chapter_index=chapter_index,
         )
-        lessons = [
-            _lms_manual_lesson(
-                title=f"Nắm bối cảnh: {heading}",
-                summary=f"Rút ra khái niệm, mục tiêu và phạm vi cần học từ phần {heading}.",
-                activity="Người học đánh dấu 3 ý chính và 1 điểm còn mơ hồ cần hỏi lại.",
-                quick_check="Ý nào trong tài liệu là bằng chứng mạnh nhất cho phần này?",
-                refs=chapter_refs,
-                duration_minutes=15,
-            ),
-            _lms_manual_lesson(
-                title=f"Thực hành áp dụng: {heading}",
-                summary=f"Chuyển nội dung {heading} thành thao tác, checklist hoặc quyết định thực tế.",
-                activity="Làm một tình huống ngắn, ghi quyết định và nguồn đối chiếu.",
-                quick_check="Nếu áp dụng sai phần này, rủi ro rõ nhất là gì?",
-                refs=chapter_refs,
-                duration_minutes=20,
-            ),
-        ]
+        if not chapter_refs:
+            chapter_refs = _match_doc_refs(
+                refs,
+                tuple(
+                    marker
+                    for candidate in cluster
+                    for marker in candidate.get("markers", ())
+                ),
+                fallback_title=title_source,
+                chapter_index=chapter_index,
+            )
+        lesson_candidates = _select_lesson_section_candidates(cluster)
+        lessons: list[dict[str, Any]] = []
+        for lesson_index, candidate in enumerate(lesson_candidates, start=1):
+            section_title = str(candidate.get("title") or title_source).strip()
+            lesson_refs = _lesson_refs_for_candidate(
+                candidate,
+                refs,
+                fallback_title=title_source,
+                chapter_index=chapter_index,
+                lesson_index=lesson_index,
+            )
+            if lesson_index == 1:
+                title = f"Đọc hiểu trọng tâm: {section_title}"
+                summary = (
+                    f"Xác định vấn đề, mục tiêu và khái niệm cốt lõi trong phần {section_title}."
+                )
+                activity = (
+                    "Người học ghi lại 3 ý chính, 1 giả định cần kiểm chứng và nguồn trích dẫn tương ứng."
+                )
+                quick_check = "Điểm nào trong nguồn là căn cứ quan trọng nhất cho phần này?"
+                duration = 18
+            elif lesson_index == len(lesson_candidates):
+                title = f"Vận dụng và kiểm chứng: {section_title}"
+                summary = (
+                    f"Chuyển nội dung {section_title} thành bài tập, checklist hoặc quyết định có thể đánh giá."
+                )
+                activity = (
+                    "Làm một tình huống ngắn, nộp câu trả lời kèm citation chứng minh lựa chọn."
+                )
+                quick_check = "Nếu áp dụng sai phần này, rủi ro hoặc hệ quả dễ thấy nhất là gì?"
+                duration = 24
+            else:
+                title = f"Thiết kế hoạt động học từ: {section_title}"
+                summary = (
+                    f"Biến phần {section_title} thành hoạt động học giúp người học tự thao tác thay vì chỉ đọc."
+                )
+                activity = (
+                    "Theo nhóm, dựng một sơ đồ/quy trình nhỏ rồi đối chiếu lại với nguồn tài liệu."
+                )
+                quick_check = "Hoạt động này đo được năng lực nào, và citation nào hỗ trợ?"
+                duration = 22
+            lessons.append(
+                _lms_manual_lesson(
+                    title=title,
+                    summary=summary,
+                    activity=activity,
+                    quick_check=quick_check,
+                    refs=lesson_refs,
+                    duration_minutes=duration,
+                )
+            )
+        if len(lessons) == 1:
+            only_candidate = lesson_candidates[0]
+            section_title = str(only_candidate.get("title") or title_source).strip()
+            lessons.append(
+                _lms_manual_lesson(
+                    title=f"Thực hành tổng hợp: {section_title}",
+                    summary=(
+                        f"Áp dụng phần {section_title} vào một tình huống hoặc sản phẩm học tập cụ thể."
+                    ),
+                    activity="Hoàn thiện một sản phẩm nhỏ và ghi rõ nguồn đã dùng để kiểm chứng.",
+                    quick_check="Sản phẩm này có thể được giáo viên đánh giá bằng tiêu chí nào?",
+                    refs=_lesson_refs_for_candidate(
+                        only_candidate,
+                        refs,
+                        fallback_title=title_source,
+                        chapter_index=chapter_index,
+                        lesson_index=2,
+                    ),
+                    duration_minutes=24,
+                )
+            )
+        focus_titles = [str(item.get("title") or "").strip() for item in cluster[:4]]
         chapters.append(
             {
-                "title": heading,
-                "summary": f"Chương này biến phần {heading} thành nội dung học có mục tiêu, hoạt động và kiểm tra.",
+                "title": _cluster_title(cluster, chapter_index=chapter_index),
+                "summary": (
+                    "Chương này gom các phần liên tiếp của tài liệu thành một nhịp học có mục tiêu, "
+                    "hoạt động và kiểm tra dựa trên nguồn."
+                ),
                 "learning_objectives": [
-                    f"Giải thích được ý chính của {heading}.",
-                    "Đối chiếu thao tác với nguồn tài liệu thay vì học thuộc rời rạc.",
-                    "Hoàn thành một kiểm tra nhanh dựa trên bằng chứng trong tài liệu.",
+                    f"Giải thích được trọng tâm của {focus_titles[0] if focus_titles else title_source}.",
+                    "Kết nối các mục liên quan trong tài liệu thành một luồng học có thứ tự.",
+                    "Hoàn thành hoạt động/kiểm tra nhanh có citation để giáo viên xác minh.",
                 ],
                 "lessons": lessons,
                 "source_references": chapter_refs,
             }
         )
+    lesson_count = sum(len(ch.get("lessons", [])) for ch in chapters)
     return {
         "title": f"Khóa học từ tài liệu: {title_source[:90]}",
-        "description": "Bản thiết kế khóa học được tạo từ tài liệu upload, có cấu trúc chương/bài và nguồn để giáo viên kiểm chứng trước khi áp dụng.",
+        "description": (
+            "Bản thiết kế khóa học được tạo từ tài liệu upload, có cấu trúc chương/bài, "
+            "hoạt động học và citation để giáo viên kiểm chứng trước khi áp dụng."
+        ),
         "audience": "Người học cần chuyển tài liệu nguồn thành năng lực thực hành.",
-        "duration": f"{len(chapters)} chương, {sum(len(ch.get('lessons', [])) for ch in chapters)} bài.",
+        "duration": f"{len(chapters)} chương, {lesson_count} bài.",
         "chapters": chapters,
         "assessment_plan": [
             "Mỗi chương có kiểm tra nhanh gắn với citation.",
@@ -1231,6 +1587,12 @@ def _build_generic_document_course_plan(
             "Không publish tự động; mọi nội dung sinh ra ở trạng thái draft.",
         ],
         "source_document_title": title_source,
+        "document_map_summary": {
+            "strategy": "cluster_full_document_map",
+            "candidate_section_count": len(candidates),
+            "chapter_count": len(chapters),
+            "lesson_count": lesson_count,
+        },
     }
 
 
@@ -1251,16 +1613,17 @@ def _build_uploaded_doc_course_params(query: str, state: AgentState | None) -> d
         or "Tài liệu đã tải lên"
     )
     refs = _extract_doc_section_references(combined_markdown, title_source)
-    is_lms_manual = _looks_holilihu_lms_manual_document(
+    classification = _classify_uploaded_document_course_domain(
+        query=query,
         title_source=title_source,
         markdown=combined_markdown,
+        refs=refs,
     )
-    if is_lms_manual:
+    domain_id = str(classification.get("domain_id") or "generic_document_course")
+    is_lms_manual = domain_id == "holilihu_lms_manual"
+    if domain_id == "holilihu_lms_manual":
         course_plan = _build_lms_manual_course_plan(title_source=title_source, refs=refs)
-    elif _looks_maritime_vessel_management_document(
-        title_source=title_source,
-        markdown=combined_markdown,
-    ):
+    elif domain_id == "maritime_vessel_management":
         course_plan = _build_maritime_vessel_management_course_plan(
             title_source=title_source,
             refs=refs,
@@ -1271,6 +1634,19 @@ def _build_uploaded_doc_course_params(query: str, state: AgentState | None) -> d
             markdown=combined_markdown,
             refs=refs,
         )
+    if isinstance(course_plan, dict):
+        course_plan["document_domain"] = {
+            "id": domain_id,
+            "confidence": classification.get("confidence"),
+            "evidence": classification.get("evidence"),
+        }
+        course_plan.setdefault(
+            "document_map_summary",
+            {
+                "strategy": "domain_pack",
+                "source_reference_count": len(refs),
+            },
+        )
 
     chapters = course_plan.get("chapters") if isinstance(course_plan, dict) else []
     lesson_count = sum(
@@ -1278,6 +1654,13 @@ def _build_uploaded_doc_course_params(query: str, state: AgentState | None) -> d
         for chapter in chapters
         if isinstance(chapter, dict)
     )
+    quality_report = _build_document_course_quality_report(
+        course_plan=course_plan if isinstance(course_plan, dict) else {},
+        classification=classification,
+        refs=refs,
+    )
+    if isinstance(course_plan, dict):
+        course_plan["quality_report"] = quality_report
     params: dict[str, Any] = {
         "action": "preview_course_plan_from_document",
         "title": course_plan.get("title") or title_source,
@@ -1293,6 +1676,8 @@ def _build_uploaded_doc_course_params(query: str, state: AgentState | None) -> d
             title_source=title_source,
             is_lms_manual=is_lms_manual,
         ),
+        "document_domain": course_plan.get("document_domain"),
+        "quality_report": quality_report,
     }
     course_id = _resolve_doc_preview_course_id(state)
     if course_id:

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -657,6 +657,99 @@ def test_uploaded_doc_course_plan_builder_keeps_maritime_research_out_of_lms_man
     )
 
 
+def test_generic_uploaded_doc_course_clusters_full_long_document_map():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        _build_uploaded_doc_course_params,
+        _normalize_doc_preview_text,
+    )
+
+    sections = []
+    for index in range(1, 25):
+        sections.append(
+            "\n".join(
+                [
+                    f"# Section {index}: Operational capability {index}",
+                    f"This section explains capability {index}, constraints, evidence, and practical decisions.",
+                    f"Nguon section: Section {index}: Operational capability {index} (trang {index}-{index})",
+                ]
+            )
+        )
+    markdown = "# Complex operations handbook\n" + "\n\n".join(sections)
+
+    params = _build_uploaded_doc_course_params(
+        "Turn this uploaded handbook into a complete course plan with citations.",
+        {
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "complex-operations-handbook.docx",
+                            "title": "Complex operations handbook",
+                            "markdown": markdown,
+                        }
+                    ]
+                },
+                "page_context": {"course_id": "course-generic"},
+            }
+        },
+    )
+
+    plan = params["course_plan"]
+    normalized_plan = _normalize_doc_preview_text(json.dumps(plan, ensure_ascii=False))
+
+    assert params["course_id"] == "course-generic"
+    assert plan["document_domain"]["id"] == "generic_document_course"
+    assert len(plan["chapters"]) == 6
+    assert sum(len(chapter["lessons"]) for chapter in plan["chapters"]) == 18
+    assert plan["document_map_summary"]["strategy"] == "cluster_full_document_map"
+    assert plan["document_map_summary"]["candidate_section_count"] >= 24
+    assert params["quality_report"]["status"] == "pass"
+    assert params["quality_report"]["source_reference_count"] >= 24
+    assert "section 24" in normalized_plan
+    assert "section 1" in normalized_plan
+    assert all(
+        lesson.get("source_references")
+        for chapter in plan["chapters"]
+        for lesson in chapter["lessons"]
+    )
+
+
+def test_uploaded_doc_course_parses_unicode_vietnamese_source_lines():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        _build_uploaded_doc_course_params,
+    )
+
+    markdown = (
+        "# Báo cáo vận hành\n"
+        "Nguồn section: Tổng quan vận hành (trang 7-9)\n"
+        "# Quy trình kiểm tra\n"
+        "Nguồn section: Quy trình kiểm tra (trang 12)\n"
+        "# Đánh giá sau triển khai\n"
+        "Nguồn section: Đánh giá sau triển khai (trang 18-20)\n"
+    )
+
+    params = _build_uploaded_doc_course_params(
+        "Tạo khóa học từ báo cáo này với citation.",
+        {
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "bao-cao-van-hanh.docx",
+                            "title": "Báo cáo vận hành",
+                            "markdown": markdown,
+                        }
+                    ]
+                },
+            }
+        },
+    )
+
+    assert params["quality_report"]["source_reference_count"] == 3
+    assert params["source_references"][0]["page_start"] == 7
+    assert params["source_references"][0]["page_end"] == 9
+
+
 def test_uploaded_doc_course_request_matches_real_teacher_curriculum_wording():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (
         _looks_uploaded_doc_course_request,

--- a/wiii-desktop/src/__tests__/document-context.test.ts
+++ b/wiii-desktop/src/__tests__/document-context.test.ts
@@ -131,9 +131,9 @@ describe("document context helpers", () => {
     expect(bounded).toContain("Nguồn section: 4.4. Soan cau truc chuong va bai");
     expect(bounded).toContain("Nguồn section: 4.5. Them bai video va video tuong tac");
     expect(bounded).toContain("Nguồn section: 4.6. Tao cau hoi trong ngan hang");
-    expect(bounded).not.toContain("Nguồn section: 3.7. Hoc video tuong tac");
-    expect(bounded).not.toContain("Nguồn section: 6.2. Quan ly giang vien");
-    expect(bounded).not.toContain("Nguồn section: 4.9. Doc phan tich giang vien");
+    expect(bounded).not.toContain("Hoc vien tra loi khi video tam dung");
+    expect(bounded).not.toContain("Admin tim va ho tro tai khoan giang vien");
+    expect(bounded).not.toContain("Theo doi hieu qua khoa va noi dung hoc vien dang vuong");
   });
 
   it("strips markdown from display attachments", () => {
@@ -141,6 +141,35 @@ describe("document context helpers", () => {
 
     expect(display.file_name).toBe("brief.docx");
     expect("markdown" in display).toBe(false);
+  });
+
+  it("keeps outline source lines for long non-priority documents", () => {
+    const sectionSnippets = Array.from({ length: 35 }, (_, index) => {
+      const sectionNumber = index + 1;
+      return {
+        title: `Section ${sectionNumber}: Operational topic ${sectionNumber}`,
+        markdown: `# Section ${sectionNumber}: Operational topic ${sectionNumber}\n\nNeutral operational content ${sectionNumber}.`,
+        char_start: sectionNumber * 1000,
+        char_end: sectionNumber * 1000 + 800,
+        source_pages: [sectionNumber],
+      };
+    });
+
+    const context = buildChatDocumentContext([
+      makeDoc({
+        file_name: "long-neutral-report.docx",
+        markdown: "# Long neutral report\n\n" + "Opening context ".repeat(1200),
+        char_count: 90_000,
+        truncated: true,
+        section_snippets: sectionSnippets,
+      }),
+    ], 9_000);
+    const bounded = context?.attachments[0].markdown || "";
+
+    expect(bounded.length).toBeLessThanOrEqual(9_000);
+    expect(bounded).toContain("Nguồn section: Section 1: Operational topic 1 (trang 1)");
+    expect(bounded).toContain("Nguồn section: Section 35: Operational topic 35 (trang 35)");
+    expect(bounded).not.toContain("còn 1 mục khác");
   });
 
   it("preserves video frame metadata without putting frame bytes in document context", () => {

--- a/wiii-desktop/src/lib/document-context.ts
+++ b/wiii-desktop/src/lib/document-context.ts
@@ -9,10 +9,10 @@ import type {
   DocumentContextSectionSnippet,
 } from "@/api/document-context";
 
-export const MAX_DOCUMENT_CONTEXT_CHARS = 8_000;
-const SECTION_CONTEXT_TITLE_LIMIT = 28;
+export const MAX_DOCUMENT_CONTEXT_CHARS = 24_000;
+const SECTION_CONTEXT_TITLE_LIMIT = 80;
 const PRIORITY_SECTION_LIMIT = 6;
-const PRIORITY_SECTION_CHARS = 1_050;
+const PRIORITY_SECTION_CHARS = 1_400;
 const TEACHER_AUTHORING_TOKENS = [
   "tao khoa",
   "hoan thien thong tin khoa",
@@ -297,12 +297,17 @@ function stripVietnameseDiacritics(value: string): string {
     .replace(/Đ/g, "D");
 }
 
-function renderSectionOutline(sections: Array<{ title: string }>): string {
-  const titles = sections
+function renderSectionOutline(sections: ContextSection[]): string {
+  const lines = sections
     .slice(0, SECTION_CONTEXT_TITLE_LIMIT)
-    .map((section) => `- ${section.title}`)
-    .join("\n");
-  return `## Mục lục phát hiện\n${titles}`;
+    .flatMap((section) => {
+      const sourceLine = formatSectionSourceLine(section);
+      return sourceLine ? [`- ${section.title}`, sourceLine] : [`- ${section.title}`];
+    });
+  if (sections.length > SECTION_CONTEXT_TITLE_LIMIT) {
+    lines.push(`- ... còn ${sections.length - SECTION_CONTEXT_TITLE_LIMIT} mục khác trong tài liệu`);
+  }
+  return `## Mục lục phát hiện\n${lines.join("\n")}`;
 }
 
 function compactToBudget(text: string, maxChars: number): string {


### PR DESCRIPTION
## Summary

Closes #314.

This PR moves Wiii's document-to-course path closer to a general course architect instead of a per-DOCX heuristic:

- Expands desktop upload context from 8k to 24k chars and keeps up to 80 section provenance lines so long Word/PDF manuals preserve citation anchors.
- Adds deterministic document-domain metadata and a course quality report before LMS preview/apply.
- Reworks the generic document course builder to cluster the whole document map into chapters instead of taking the first 6 headings.
- Fixes citation parsing for proper Vietnamese `Nguồn section` lines, existing no-accent `Nguon section`, and malformed Windows fallback text.
- Adds regression coverage for long generic docs, Unicode Vietnamese citation markers, and document-context outline provenance.

## Research notes

Implementation direction was cross-checked against current public/open-source patterns:

- UI-TARS / UI-TARS-desktop: observe -> structured action contract -> post-process/normalize, avoiding blind action.
- Open Design: skill-driven workflow, artifact-first contract, prompt budget guards, critique/quality gates before shipping.
- Microsoft MarkItDown: good LLM-oriented markdown conversion, but not high-fidelity provenance by itself.
- Docling: stronger future direction for structured document maps and layout/page provenance.

## Verification

- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_sprint222b_action_tools.py tests/unit/test_tool_collection_host_ui.py tests/unit/test_direct_node_provider_errors.py -q` -> `105 passed`
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> pass
- `cd wiii-desktop && npx vitest run src/__tests__/document-context.test.ts` -> `8 passed`
- `cd wiii-desktop && npx tsc --noEmit` -> pass
- `git diff --check` -> pass

Manual/product-like smoke with the 14MB maritime vessel-management DOCX:

- Parse: ~17s, 177,522 raw markdown chars, 64 section snippets.
- Bounded context: ~13.5k chars.
- Deterministic builder: ~0.05s.
- Result: `maritime_vessel_management`, 6 chapters, 18 lessons, 70 source refs, 0 lessons missing citations/activity, no HoLiLiHu leakage.

## Risk / rollback

Risk is mostly payload size and generic-course wording. The desktop context cap is still bounded at 24k and the backend path remains preview-only with LMS approval gates. Rollback is reverting this PR; no migration or persistent data shape change.