### PR TITLE
Add precision document provenance pipeline

### DIFF
--- a/docs/integration/WIII_LMS_DOC_TO_COURSE_CONTRACT.md
+++ b/docs/integration/WIII_LMS_DOC_TO_COURSE_CONTRACT.md
@@ -87,6 +87,43 @@ The current Wiii status response emits references for:
 LMS may display these references as page chips, source rows, or citation links,
 but should preserve the page values verbatim.
 
+## Parser And Provenance Levels
+
+Wiii uses a hybrid parser policy:
+
+- `fast`: MarkItDown only. Best for quick LLM-ready Markdown from clean Office/PDF
+  files.
+- `auto`: MarkItDown first, then promote to Docling when the fast parse has weak
+  page/layout provenance.
+- `precision`: Docling first, MarkItDown fallback. Use this for teacher
+  doc-to-course flows where citations, embedded figures, tables, or page/layout
+  provenance matter.
+
+MarkItDown plugins such as OCR can recover text from embedded images, but that
+is still an inline text extraction lane. For teacher-facing citation UX, Docling
+or an equivalent structured document map should own page/figure/table
+provenance so LMS can show what Wiii relied on.
+
+The parse response should be treated as a source contract, not just text:
+
+- `parser`: final parser that produced the usable context.
+- `parser_chain`: parsers attempted/used, for example `["markitdown", "docling"]`.
+- `provenance_level`: one of `text_only`, `structured_text`, `page_marker`,
+  `page_layout`.
+- `embedded_asset_count`, `figure_count`, `table_count`: signals that the source
+  had visual/table material that may require citation or vision review.
+
+`page_layout` is the preferred level for LMS citations. `text_only` is usable for
+drafting, but LMS should avoid presenting exact page/figure claims as verified
+unless the preview carries source references that the teacher can inspect.
+
+Operational note: Docling is intentionally optional because it can add several GB
+of model/runtime footprint. Production deployments can enable it with
+`pip install -e ".[precision-docs]"` and `DOCUMENT_CONTEXT_PARSER_MODE=precision`
+or `USE_DOCLING_FOR_COURSE_GEN=true`. If Docling is unavailable, Wiii must fall
+back to MarkItDown and surface a parser warning rather than silently pretending
+the citation precision is higher than it is.
+
 ## LMS-Side Requirements
 
 The LMS host must implement the apply side in its own repository:

--- a/maritime-ai-service/app/adapters/docling_parser.py
+++ b/maritime-ai-service/app/adapters/docling_parser.py
@@ -1,20 +1,18 @@
+"""Docling-based document parser.
+
+Docling is the precision parser lane for documents where page/layout
+provenance matters. It complements MarkItDown rather than replacing it:
+MarkItDown remains the fast LLM-ready Markdown converter, while Docling gives
+Wiii stronger page, figure, table, and layout signals when available.
 """
-DoclingParserAdapter — Docling-based document parser.
 
-Converts PDF, DOCX, PPTX, HTML, LaTeX, images into structured Markdown.
-- Digital pages: local AI models (DocLayNet + TableFormer), 0 API cost
-- Scanned pages: VLM provider (Gemini, Ollama, etc.), configurable
-
-Maritime-specific: detects Điều, Khoản, Chương, Rule, Section headings
-for chapter-to-page mapping used by EXPAND node.
-
-Design spec v2.0 (2026-03-22).
-"""
+from __future__ import annotations
 
 import asyncio
 import logging
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 from app.ports.document_parser import DocumentParserPort, ParsedDocument
@@ -24,49 +22,41 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class DoclingConfig:
-    """Configuration for Docling document converter."""
+    """Configuration for Docling document conversion."""
 
     vlm_backend: str = "none"  # "gemini" | "ollama" | "granite_local" | "none"
     vlm_api_url: str = ""
     vlm_api_key: str = ""
     vlm_model: str = "gemini-3.1-flash-lite"
     vlm_concurrency: int = 3
-    standard_pipeline: bool = True  # DocLayNet + TableFormer for digital pages
+    standard_pipeline: bool = True
 
 
 class DoclingParserAdapter(DocumentParserPort):
-    """Parse documents using IBM Docling (Apache 2.0, 55K+ stars).
-
-    Requires: pip install docling
-    Or use Docling Serve: docker pull doclingproject/docling-serve
-
-    Falls back gracefully if Docling is not installed.
-    """
+    """Parse documents using Docling when the optional dependency exists."""
 
     def __init__(self, config: Optional[DoclingConfig] = None):
         self._config = config or DoclingConfig()
         self._converter = None
         self._init_converter()
 
-    def _init_converter(self):
-        """Initialize Docling DocumentConverter with configured pipeline."""
+    def _init_converter(self) -> None:
         try:
-            from docling.document_converter import DocumentConverter, PdfFormatOption
             from docling.datamodel.base_models import InputFormat
+            from docling.document_converter import DocumentConverter, PdfFormatOption
 
             format_options = {}
-
             if self._config.vlm_backend != "none" and self._config.vlm_api_url:
                 try:
-                    from docling.pipeline.vlm_pipeline import VlmPipeline
                     from docling.datamodel.pipeline_options import (
-                        VlmPipelineOptions,
                         VlmConvertOptions,
+                        VlmPipelineOptions,
                     )
                     from docling.datamodel.vlm_engine_options import (
                         ApiVlmEngineOptions,
                         VlmEngineType,
                     )
+                    from docling.pipeline.vlm_pipeline import VlmPipeline
 
                     vlm_engine = ApiVlmEngineOptions(
                         runtime_type=VlmEngineType.API,
@@ -84,13 +74,17 @@ class DoclingParserAdapter(DocumentParserPort):
                         pipeline_cls=VlmPipeline,
                         pipeline_options=VlmPipelineOptions(vlm_options=vlm_options),
                     )
-                    logger.info("Docling: VLM pipeline enabled (backend=%s)", self._config.vlm_backend)
+                    logger.info(
+                        "Docling: VLM pipeline enabled (backend=%s)",
+                        self._config.vlm_backend,
+                    )
                 except ImportError:
-                    logger.warning("Docling VLM pipeline not available, using standard pipeline only")
+                    logger.warning(
+                        "Docling VLM pipeline not available, using standard pipeline only"
+                    )
 
             self._converter = DocumentConverter(format_options=format_options)
             logger.info("Docling DocumentConverter initialized")
-
         except ImportError:
             logger.warning(
                 "Docling not installed (pip install docling). "
@@ -103,32 +97,48 @@ class DoclingParserAdapter(DocumentParserPort):
         return self._converter is not None
 
     async def parse(self, file_path: str, options: dict | None = None) -> ParsedDocument:
-        """Convert document to structured Markdown via Docling."""
+        """Convert a document to Markdown plus page-grounded metadata."""
         if self._converter is None:
             raise NotImplementedError(
                 "Docling is not installed. Install with: pip install docling"
             )
 
         logger.info("Docling: parsing %s", file_path)
+
         def _convert() -> ParsedDocument:
             result = self._converter.convert(file_path)
             doc = result.document
 
-            markdown = doc.export_to_markdown()
+            raw_markdown = doc.export_to_markdown()
             section_map = self._extract_section_map(doc)
-            images = self._extract_images(doc)
+            assets = self._extract_assets(doc)
+            images = [
+                asset
+                for asset in assets
+                if asset.get("kind") in {"image", "figure", "picture"}
+            ]
             page_count = len(doc.pages) if hasattr(doc, "pages") else 0
+            markdown = self._inject_page_markers(raw_markdown, section_map)
 
             metadata = {
-                "title": doc.name if hasattr(doc, "name") else "",
+                "title": getattr(doc, "name", "") or Path(file_path).name,
                 "language": self._detect_language(markdown),
+                "parser": "docling",
+                "parser_chain": ["docling"],
+                "provenance_level": "page_layout" if page_count > 0 else "structured_text",
+                "source_extension": Path(file_path).suffix.lower().lstrip("."),
+                "embedded_asset_count": len(assets),
+                "figure_count": sum(
+                    1 for item in assets if item.get("kind") in {"image", "figure", "picture"}
+                ),
+                "table_count": sum(1 for item in assets if item.get("kind") == "table"),
             }
 
             logger.info(
-                "Docling: parsed %d pages, %d sections, %d images, %d chars markdown",
+                "Docling: parsed %d pages, %d sections, %d assets, %d chars markdown",
                 page_count,
                 len(section_map),
-                len(images),
+                len(assets),
                 len(markdown),
             )
 
@@ -138,71 +148,153 @@ class DoclingParserAdapter(DocumentParserPort):
                 metadata=metadata,
                 section_map=section_map,
                 images=images,
+                assets=assets,
             )
 
         return await asyncio.to_thread(_convert)
 
     def _extract_section_map(self, doc) -> dict[str, list[int]]:
-        """Map headings to page numbers — maritime-specific patterns."""
+        """Map generic headings and maritime aliases to page numbers."""
         section_map: dict[str, list[int]] = {}
         try:
             for item in doc.iterate_items():
-                if hasattr(item, "label") and item.label in (
-                    "section_header",
-                    "title",
+                label = self._label_name(item)
+                if label not in {"section_header", "title"}:
+                    continue
+                text = self._item_text(item)
+                if not text:
+                    continue
+                page = self._first_page(item)
+                self._append_section_page(section_map, text, page)
+                for pattern in (
+                    r"Ch\u01b0\u01a1ng\s+(\S+)",
+                    r"\u0110i\u1ec1u\s+(\d+)",
+                    r"Kho\u1ea3n\s+(\d+)",
+                    r"Ph\u1ea7n\s+(\S+)",
+                    r"Chapter\s+(\S+)",
+                    r"Section\s+(\d+)",
+                    r"Rule\s+(\d+)",
+                    r"Part\s+(\S+)",
                 ):
-                    text = item.text if hasattr(item, "text") else str(item)
-                    # Vietnamese maritime document patterns
-                    for pattern in [
-                        r"Chương\s+(\S+)",
-                        r"Điều\s+(\d+)",
-                        r"Khoản\s+(\d+)",
-                        r"Phần\s+(\S+)",
-                        r"Chapter\s+(\S+)",
-                        r"Section\s+(\d+)",
-                        r"Rule\s+(\d+)",
-                        r"Part\s+(\S+)",
-                    ]:
-                        match = re.search(pattern, text)
-                        if match:
-                            key = match.group(0)
-                            page = (
-                                item.prov[0].page_no
-                                if hasattr(item, "prov") and item.prov
-                                else 0
-                            )
-                            section_map.setdefault(key, []).append(page)
-        except Exception as e:
-            logger.warning("Docling: section_map extraction failed: %s", e)
+                    match = re.search(pattern, text, re.IGNORECASE)
+                    if match:
+                        self._append_section_page(section_map, match.group(0), page)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Docling: section_map extraction failed: %s", exc)
         return section_map
 
-    def _extract_images(self, doc) -> list[dict]:
-        """Extract image metadata from parsed document."""
-        images = []
+    def _extract_assets(self, doc) -> list[dict]:
+        """Extract page-grounded figure/table metadata from a Docling document."""
+        assets: list[dict] = []
         try:
+            index = 1
             for item in doc.iterate_items():
-                if hasattr(item, "label") and item.label in ("picture", "figure"):
-                    page = (
-                        item.prov[0].page_no
-                        if hasattr(item, "prov") and item.prov
-                        else 0
-                    )
-                    images.append(
-                        {
-                            "page": page,
-                            "label": item.label,
-                            "text": item.text[:200] if hasattr(item, "text") else "",
-                        }
-                    )
-        except Exception as e:
-            logger.warning("Docling: image extraction failed: %s", e)
-        return images
+                label = self._label_name(item)
+                if label not in {"picture", "figure", "table"}:
+                    continue
+                kind = "image" if label in {"picture", "figure"} else "table"
+                page = self._first_page(item)
+                assets.append(
+                    {
+                        "id": f"docling-{kind}-{index}",
+                        "kind": kind,
+                        "page": page if page > 0 else None,
+                        "label": label,
+                        "text": self._item_text(item)[:500],
+                        "bbox": self._first_bbox(item),
+                        "source": "docling",
+                    }
+                )
+                index += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Docling: asset extraction failed: %s", exc)
+        return assets
+
+    @staticmethod
+    def _label_name(item) -> str:
+        label = getattr(item, "label", "")
+        value = getattr(label, "value", label)
+        return str(value or "").split(".")[-1].lower()
+
+    @staticmethod
+    def _item_text(item) -> str:
+        text = getattr(item, "text", "")
+        if not text:
+            text = getattr(item, "caption", "")
+        return re.sub(r"\s+", " ", str(text or "")).strip()
+
+    @staticmethod
+    def _first_page(item) -> int:
+        prov = getattr(item, "prov", None)
+        if not prov:
+            return 0
+        try:
+            return int(getattr(prov[0], "page_no", 0) or 0)
+        except (TypeError, ValueError, IndexError):
+            return 0
+
+    @staticmethod
+    def _first_bbox(item) -> dict | None:
+        prov = getattr(item, "prov", None)
+        if not prov:
+            return None
+        bbox = getattr(prov[0], "bbox", None)
+        if bbox is None:
+            return None
+        out: dict[str, float] = {}
+        for key in ("l", "t", "r", "b", "x0", "y0", "x1", "y1"):
+            value = getattr(bbox, key, None)
+            if value is not None:
+                try:
+                    out[key] = float(value)
+                except (TypeError, ValueError):
+                    pass
+        return out or None
+
+    @staticmethod
+    def _append_section_page(
+        section_map: dict[str, list[int]],
+        title: str,
+        page: int,
+    ) -> None:
+        clean = re.sub(r"\s+", " ", str(title or "").strip(" #\t\r\n"))[:180]
+        if not clean:
+            return
+        pages = section_map.setdefault(clean, [])
+        if page > 0 and page not in pages:
+            pages.append(page)
+
+    @staticmethod
+    def _inject_page_markers(markdown: str, section_map: dict[str, list[int]]) -> str:
+        if not markdown or "<!-- page " in markdown.lower():
+            return markdown
+        heading_to_page = {
+            title.strip().lower(): min(pages)
+            for title, pages in section_map.items()
+            if title and pages
+        }
+        if not heading_to_page:
+            return markdown
+        lines: list[str] = []
+        last_page = 0
+        for line in markdown.splitlines():
+            match = re.match(r"^(\s{0,3}#{1,6}\s+)(.+?)\s*$", line)
+            if match:
+                page = heading_to_page.get(match.group(2).strip().lower())
+                if page and page != last_page:
+                    lines.append(f"<!-- page {page} -->")
+                    last_page = page
+            lines.append(line)
+        return "\n".join(lines)
 
     def _detect_language(self, text: str) -> str:
         """Simple Vietnamese detection based on diacritics."""
-        vi_chars = set("àáảãạăắằẳẵặâấầẩẫậèéẻẽẹêếềểễệìíỉĩịòóỏõọôốồổỗộơớờởỡợùúủũụưứừửữựỳýỷỹỵđ")
+        vi_chars = set(
+            "àáảãạăắằẳẵặâấầẩẫậèéẻẽẹêếềểễệ"
+            "ìíỉĩịòóỏõọôốồổỗộơớờởỡợùúủũụưứừửữựỳýỷỹỵđ"
+        )
         sample = text[:2000].lower()
-        vi_count = sum(1 for c in sample if c in vi_chars)
+        vi_count = sum(1 for char in sample if char in vi_chars)
         return "vi" if vi_count > 20 else "en"
 
     def supported_formats(self) -> list[str]:

--- a/maritime-ai-service/app/adapters/document_parser_router.py
+++ b/maritime-ai-service/app/adapters/document_parser_router.py
@@ -1,0 +1,187 @@
+"""Hybrid document parser router for fast and precision parsing lanes."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from app.ports.document_parser import DocumentParserPort, ParsedDocument
+
+ParserMode = Literal["auto", "fast", "precision"]
+
+PRECISION_EXTENSIONS = {".pdf", ".docx", ".pptx"}
+PROVENANCE_RANK = {
+    "none": 0,
+    "text_only": 1,
+    "structured_text": 2,
+    "page_marker": 3,
+    "page_layout": 4,
+}
+
+
+@dataclass(frozen=True)
+class RoutedParseResult:
+    parsed: ParsedDocument
+    warning: str = ""
+
+
+class DocumentParserRouter(DocumentParserPort):
+    """Route document parsing between MarkItDown and Docling.
+
+    - fast: MarkItDown only.
+    - precision: Docling first, MarkItDown fallback.
+    - auto: MarkItDown first, then promote to Docling if provenance is weak.
+    """
+
+    def __init__(
+        self,
+        *,
+        markitdown_parser: DocumentParserPort | None,
+        docling_parser: DocumentParserPort | None,
+        mode: ParserMode = "auto",
+        logger_obj: logging.Logger | None = None,
+    ):
+        self._markitdown_parser = markitdown_parser
+        self._docling_parser = docling_parser
+        self._mode = mode
+        self._logger = logger_obj or logging.getLogger(__name__)
+
+    @property
+    def is_available(self) -> bool:
+        return self._markitdown_parser is not None or self._docling_parser is not None
+
+    async def parse(self, file_path: str, options: dict | None = None) -> ParsedDocument:
+        ext = Path(file_path).suffix.lower()
+        result = await self._parse_routed(file_path, ext, options or {})
+        if result.warning:
+            metadata = dict(result.parsed.metadata or {})
+            metadata["parser_warning"] = result.warning
+            result.parsed.metadata = metadata
+        return result.parsed
+
+    async def _parse_routed(
+        self,
+        file_path: str,
+        ext: str,
+        options: dict,
+    ) -> RoutedParseResult:
+        if self._mode == "fast":
+            return RoutedParseResult(await self._parse_markitdown_required(file_path, options))
+
+        if self._mode == "precision":
+            docling = await self._try_parse_docling(file_path, options)
+            if docling is not None:
+                return RoutedParseResult(docling)
+            warning = "Docling precision parser unavailable; fell back to MarkItDown."
+            return RoutedParseResult(
+                await self._parse_markitdown_required(file_path, options),
+                warning=warning,
+            )
+
+        markitdown = await self._try_parse_markitdown(file_path, options)
+        if markitdown is None:
+            docling = await self._try_parse_docling(file_path, options)
+            if docling is not None:
+                return RoutedParseResult(docling)
+            raise RuntimeError("No document parser is available on this backend.")
+
+        if ext in PRECISION_EXTENSIONS and self._should_promote_to_docling(markitdown):
+            docling = await self._try_parse_docling(file_path, options)
+            if docling is not None and self._is_precision_upgrade(docling, markitdown):
+                metadata = dict(docling.metadata or {})
+                metadata["parser_chain"] = ["markitdown", "docling"]
+                metadata["parser_warning"] = (
+                    "Auto mode promoted this document from MarkItDown to Docling "
+                    "because the fast parse had weak page/layout provenance."
+                )
+                docling.metadata = metadata
+                return RoutedParseResult(docling)
+            return RoutedParseResult(
+                markitdown,
+                warning=(
+                    "Auto mode detected weak page/layout provenance, but Docling "
+                    "precision parsing was unavailable or did not improve the result."
+                ),
+            )
+
+        return RoutedParseResult(markitdown)
+
+    async def _parse_markitdown_required(
+        self,
+        file_path: str,
+        options: dict,
+    ) -> ParsedDocument:
+        parsed = await self._try_parse_markitdown(file_path, options)
+        if parsed is None:
+            raise RuntimeError("MarkItDown parser is not available on this backend.")
+        return parsed
+
+    async def _try_parse_markitdown(
+        self,
+        file_path: str,
+        options: dict,
+    ) -> ParsedDocument | None:
+        if self._markitdown_parser is None:
+            return None
+        try:
+            return await self._markitdown_parser.parse(file_path, options=options)
+        except Exception as exc:  # noqa: BLE001
+            self._logger.warning("MarkItDown parse failed: %s", exc)
+            return None
+
+    async def _try_parse_docling(
+        self,
+        file_path: str,
+        options: dict,
+    ) -> ParsedDocument | None:
+        if self._docling_parser is None:
+            return None
+        try:
+            return await self._docling_parser.parse(file_path, options=options)
+        except Exception as exc:  # noqa: BLE001
+            self._logger.warning("Docling parse failed: %s", exc)
+            return None
+
+    def _should_promote_to_docling(self, parsed: ParsedDocument) -> bool:
+        metadata = parsed.metadata or {}
+        provenance = str(metadata.get("provenance_level") or "text_only")
+        if PROVENANCE_RANK.get(provenance, 0) <= PROVENANCE_RANK["text_only"]:
+            return True
+        return bool(parsed.markdown) and not parsed.section_map and not parsed.images
+
+    def _is_precision_upgrade(
+        self,
+        candidate: ParsedDocument,
+        baseline: ParsedDocument,
+    ) -> bool:
+        candidate_rank = PROVENANCE_RANK.get(
+            str((candidate.metadata or {}).get("provenance_level") or "none"),
+            0,
+        )
+        baseline_rank = PROVENANCE_RANK.get(
+            str((baseline.metadata or {}).get("provenance_level") or "none"),
+            0,
+        )
+        if candidate_rank > baseline_rank:
+            return True
+        if len(candidate.section_map or {}) > len(baseline.section_map or {}):
+            return True
+        return len(candidate.images or []) > len(baseline.images or [])
+
+    def supported_formats(self) -> list[str]:
+        formats: set[str] = set()
+        for parser in (self._markitdown_parser, self._docling_parser):
+            if parser is not None:
+                formats.update(parser.supported_formats())
+        return sorted(formats)
+
+
+def normalize_parser_mode(value: str | None) -> ParserMode:
+    normalized = str(value or "auto").strip().lower()
+    if normalized in {"fast", "markitdown"}:
+        return "fast"
+    if normalized in {"precision", "docling"}:
+        return "precision"
+    return "auto"

--- a/maritime-ai-service/app/adapters/markitdown_parser.py
+++ b/maritime-ai-service/app/adapters/markitdown_parser.py
@@ -107,17 +107,26 @@ class MarkItDownParserAdapter(DocumentParserPort):
             )
             title = getattr(result, "title", None) or os.path.basename(file_path)
             section_map = self._extract_section_map(markdown)
+            page_count = self._estimate_page_count(markdown)
+            provenance_level = (
+                "page_marker"
+                if re.search(r"<!--\s*page\s+\d+\s*-->", markdown, re.IGNORECASE)
+                else "text_only"
+            )
 
             return ParsedDocument(
                 markdown=markdown,
-                page_count=self._estimate_page_count(markdown),
+                page_count=page_count,
                 metadata={
                     "title": title,
                     "parser": "markitdown",
+                    "parser_chain": ["markitdown"],
+                    "provenance_level": provenance_level,
                     "source_extension": ext,
                 },
                 section_map=section_map,
                 images=[],
+                assets=[],
             )
 
         return await asyncio.to_thread(_convert)

--- a/maritime-ai-service/app/api/v1/course_generation_parsers.py
+++ b/maritime-ai-service/app/api/v1/course_generation_parsers.py
@@ -86,9 +86,15 @@ class BasicPdfParser:
                 return ParsedDocument(
                     markdown=markdown,
                     page_count=len(pages),
-                    metadata={"title": os.path.basename(file_path)},
+                    metadata={
+                        "title": os.path.basename(file_path),
+                        "parser": "pymupdf_basic",
+                        "parser_chain": ["pymupdf_basic"],
+                        "provenance_level": "page_marker",
+                    },
                     section_map={},
                     images=[],
+                    assets=[],
                 )
             except ImportError:
                 with open(file_path, "r", errors="ignore", encoding="utf-8") as handle:
@@ -96,9 +102,15 @@ class BasicPdfParser:
                 return ParsedDocument(
                     markdown=text,
                     page_count=1,
-                    metadata={"title": os.path.basename(file_path)},
+                    metadata={
+                        "title": os.path.basename(file_path),
+                        "parser": "text_fallback",
+                        "parser_chain": ["text_fallback"],
+                        "provenance_level": "text_only",
+                    },
                     section_map={},
                     images=[],
+                    assets=[],
                 )
 
         return await asyncio.to_thread(_extract)
@@ -116,6 +128,11 @@ def get_parser(file_path: str, *, settings_obj, logger):
         ".xlsx",
     }
     if should_use_rich_parser:
+        if getattr(settings_obj, "use_docling_for_course_gen", False):
+            parser = try_build_docling_parser(settings_obj=settings_obj, logger=logger)
+            if parser is not None:
+                return parser
+
         markitdown_parser = try_build_markitdown_parser(
             settings_obj=settings_obj,
             logger=logger,

--- a/maritime-ai-service/app/api/v1/document_context.py
+++ b/maritime-ai-service/app/api/v1/document_context.py
@@ -15,7 +15,7 @@ import unicodedata
 from pathlib import Path
 from typing import Any, Literal
 
-from fastapi import APIRouter, File, HTTPException, UploadFile, status
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile, status
 from pydantic import BaseModel, Field
 
 from app.api.deps import RequireAuth
@@ -34,6 +34,7 @@ MAX_SECTION_SNIPPETS = 80
 MAX_SECTION_SNIPPET_CHARS = 1_500
 MAX_SECTION_SNIPPET_TOTAL_CHARS = 80_000
 MAX_EXTRACTED_IMAGES = 5
+MAX_EMBEDDED_ASSETS = 20
 
 DOCUMENT_EXTENSIONS = {
     ".pdf",
@@ -66,6 +67,16 @@ class DocumentContextExtractedImage(BaseModel):
     detail: Literal["auto", "low", "high"] = "low"
 
 
+class DocumentContextEmbeddedAsset(BaseModel):
+    id: str
+    kind: Literal["image", "figure", "picture", "table"] = "image"
+    label: str | None = None
+    page: int | None = None
+    text: str | None = None
+    bbox: dict[str, float] | None = None
+    has_data: bool = False
+
+
 class DocumentContextSectionSnippet(BaseModel):
     title: str
     markdown: str
@@ -82,6 +93,14 @@ class DocumentContextParseResponse(BaseModel):
     media_kind: Literal["document", "video"] = "document"
     size_bytes: int
     parser: str = "markitdown"
+    parser_chain: list[str] = Field(default_factory=list)
+    parser_warning: str | None = None
+    provenance_level: Literal[
+        "text_only",
+        "structured_text",
+        "page_marker",
+        "page_layout",
+    ] = "text_only"
     title: str | None = None
     page_count: int | None = None
     section_titles: list[str] = Field(default_factory=list)
@@ -91,6 +110,10 @@ class DocumentContextParseResponse(BaseModel):
     truncated: bool = False
     extracted_images: list[DocumentContextExtractedImage] = Field(default_factory=list)
     extracted_image_count: int = 0
+    embedded_assets: list[DocumentContextEmbeddedAsset] = Field(default_factory=list)
+    embedded_asset_count: int = 0
+    figure_count: int = 0
+    table_count: int = 0
 
 
 def _safe_upload_name(file: UploadFile) -> str:
@@ -113,17 +136,15 @@ def _validate_extension(file_name: str) -> str:
     return ext
 
 
-def _build_parser():
+def _build_markitdown_parser():
     try:
         from app.adapters.markitdown_parser import (
             MarkItDownConfig,
             MarkItDownParserAdapter,
         )
     except ImportError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="MarkItDown is not installed on this backend.",
-        ) from exc
+        logger.warning("MarkItDown import failed: %s", exc)
+        return None
 
     parser = MarkItDownParserAdapter(
         MarkItDownConfig(
@@ -131,9 +152,48 @@ def _build_parser():
         )
     )
     if not getattr(parser, "is_available", False):
+        return None
+    return parser
+
+
+def _build_docling_parser():
+    try:
+        from app.adapters.docling_parser import DoclingConfig, DoclingParserAdapter
+    except ImportError as exc:
+        logger.warning("Docling import failed: %s", exc)
+        return None
+
+    parser = DoclingParserAdapter(
+        DoclingConfig(
+            vlm_backend=getattr(settings, "docling_vlm_backend", "none"),
+            vlm_api_url=getattr(settings, "docling_vlm_api_url", "") or "",
+            vlm_api_key=getattr(settings, "docling_vlm_api_key", "") or "",
+            vlm_model=getattr(settings, "docling_vlm_model", "gemini-3.1-flash-lite"),
+        )
+    )
+    if not getattr(parser, "is_available", False):
+        return None
+    return parser
+
+
+def _build_parser(parser_mode: str | None = None):
+    from app.adapters.document_parser_router import (
+        DocumentParserRouter,
+        normalize_parser_mode,
+    )
+
+    configured_mode = parser_mode or getattr(settings, "document_context_parser_mode", "auto")
+    mode = normalize_parser_mode(configured_mode)
+    parser = DocumentParserRouter(
+        markitdown_parser=_build_markitdown_parser(),
+        docling_parser=_build_docling_parser(),
+        mode=mode,
+        logger_obj=logger,
+    )
+    if not parser.is_available:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="MarkItDown parser is not available on this backend.",
+            detail="No document parser is available on this backend.",
         )
     return parser
 
@@ -233,6 +293,13 @@ def _select_section_indices(candidates: list[dict[str, Any]]) -> list[int]:
     return sorted(selected)
 
 
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _build_section_snippets(
     *,
     raw_markdown: str,
@@ -306,6 +373,19 @@ def _response_from_parsed(
 
     metadata: dict[str, Any] = parsed.metadata or {}
     media_kind = "video" if str(metadata.get("media_kind") or "").lower() == "video" else "document"
+    parser = str(metadata.get("parser") or "markitdown")
+    parser_chain = metadata.get("parser_chain")
+    if not isinstance(parser_chain, list) or not parser_chain:
+        parser_chain = [parser]
+    parser_chain = [str(item) for item in parser_chain if str(item).strip()]
+    provenance_level = str(metadata.get("provenance_level") or "text_only")
+    if provenance_level not in {
+        "text_only",
+        "structured_text",
+        "page_marker",
+        "page_layout",
+    }:
+        provenance_level = "text_only"
     section_titles = [
         str(title).strip()
         for title in (parsed.section_map or {}).keys()
@@ -332,13 +412,49 @@ def _response_from_parsed(
                 detail=image.get("detail") if image.get("detail") in {"auto", "low", "high"} else "low",
             )
         )
+    embedded_assets: list[DocumentContextEmbeddedAsset] = []
+    raw_assets = parsed.assets or parsed.images or []
+    for index, asset in enumerate(raw_assets[:MAX_EMBEDDED_ASSETS], start=1):
+        if not isinstance(asset, dict):
+            continue
+        kind = str(asset.get("kind") or asset.get("label") or "image").lower()
+        if kind == "picture":
+            kind = "image"
+        if kind not in {"image", "figure", "picture", "table"}:
+            kind = "image"
+        page_value = asset.get("page")
+        try:
+            page = int(page_value) if page_value is not None else None
+        except (TypeError, ValueError):
+            page = None
+        bbox = asset.get("bbox")
+        embedded_assets.append(
+            DocumentContextEmbeddedAsset(
+                id=str(asset.get("id") or f"embedded-asset-{index}"),
+                kind=kind,
+                label=str(asset.get("label") or kind),
+                page=page if page and page > 0 else None,
+                text=str(asset.get("text") or "")[:500] or None,
+                bbox=bbox if isinstance(bbox, dict) else None,
+                has_data=bool(str(asset.get("data") or "").strip()),
+            )
+        )
+    figure_count = _safe_int(metadata.get("figure_count"))
+    table_count = _safe_int(metadata.get("table_count"))
+    if figure_count <= 0:
+        figure_count = sum(1 for asset in embedded_assets if asset.kind in {"image", "figure", "picture"})
+    if table_count <= 0:
+        table_count = sum(1 for asset in embedded_assets if asset.kind == "table")
 
     return DocumentContextParseResponse(
         file_name=file_name,
         mime_type=mime_type,
         media_kind=media_kind,
         size_bytes=size_bytes,
-        parser=str(metadata.get("parser") or "markitdown"),
+        parser=parser,
+        parser_chain=parser_chain,
+        parser_warning=str(metadata.get("parser_warning") or "") or None,
+        provenance_level=provenance_level,
         title=str(metadata.get("title") or file_name),
         page_count=parsed.page_count,
         section_titles=section_titles,
@@ -348,6 +464,13 @@ def _response_from_parsed(
         truncated=truncated,
         extracted_images=extracted_images,
         extracted_image_count=len(extracted_images),
+        embedded_assets=embedded_assets,
+        embedded_asset_count=_safe_int(
+            metadata.get("embedded_asset_count"),
+            len(embedded_assets),
+        ),
+        figure_count=figure_count,
+        table_count=table_count,
     )
 
 
@@ -355,6 +478,7 @@ def _response_from_parsed(
 async def parse_document_context(
     auth: RequireAuth,
     file: UploadFile = File(..., description="PDF, Word, PowerPoint, Excel, CSV, TXT, Markdown, or video file"),
+    parser_mode: str = Form("auto", description="auto, fast, or precision"),
 ) -> DocumentContextParseResponse:
     """Parse an uploaded document into Markdown for the next chat turn."""
     file_name = _safe_upload_name(file)
@@ -374,7 +498,8 @@ async def parse_document_context(
             detail=f"File too large. Maximum size is {max_upload_bytes // 1024 // 1024}MB.",
         )
 
-    parser = _build_video_parser() if ext in VIDEO_EXTENSIONS else _build_parser()
+    parser_mode_value = parser_mode if isinstance(parser_mode, str) else "auto"
+    parser = _build_video_parser() if ext in VIDEO_EXTENSIONS else _build_parser(parser_mode_value)
     tmp_path = ""
     try:
         with tempfile.NamedTemporaryFile(delete=False, suffix=ext) as tmp_file:

--- a/maritime-ai-service/app/core/config/_settings_base_fields.py
+++ b/maritime-ai-service/app/core/config/_settings_base_fields.py
@@ -144,6 +144,7 @@ class BaseSettingsFieldsMixin:
 
     # Course Generation (design spec v2.0, 2026-03-22)
     use_docling_for_course_gen: bool = Field(default=False, description="Use Docling for document conversion (requires pip install docling)")
+    document_context_parser_mode: str = Field(default="auto", description="Document upload parser mode: auto, fast, or precision")
     markitdown_enable_plugins: bool = Field(default=False, description="Enable MarkItDown third-party plugins for document conversion")
     docling_vlm_backend: str = Field(default="none", description="VLM backend for scanned pages: 'gemini', 'ollama', 'none'")
     docling_vlm_api_url: Optional[str] = Field(default=None, description="VLM API URL for Docling scanned page extraction")

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -1218,13 +1218,21 @@ def _build_uploaded_document_context_fallback_answer(
         file_name = str(item.get("file_name") or f"file-{index}")
         media_kind = str(item.get("media_kind") or "document")
         parser = str(item.get("parser") or "markitdown")
+        provenance_level = str(item.get("provenance_level") or "")
         char_count = item.get("char_count")
         extracted_image_count = item.get("extracted_image_count")
+        embedded_asset_count = item.get("embedded_asset_count")
 
         lines.append("")
-        lines.append(f"- File: `{file_name}` ({media_kind}, parser={parser})")
+        provenance_text = f", provenance={provenance_level}" if provenance_level else ""
+        lines.append(f"- File: `{file_name}` ({media_kind}, parser={parser}{provenance_text})")
         if isinstance(char_count, int):
             lines.append(f"- Nội dung parse được: khoảng {char_count} ký tự.")
+        if isinstance(embedded_asset_count, int) and embedded_asset_count > 0:
+            lines.append(
+                f"- Parser phát hiện {embedded_asset_count} asset nhúng (hình/bảng); "
+                "cần citation/vision rõ ràng trước khi mô tả chi tiết hình ảnh."
+            )
 
         if media_kind == "video":
             duration = _first_markdown_line(markdown, "Duration")

--- a/maritime-ai-service/app/ports/document_parser.py
+++ b/maritime-ai-service/app/ports/document_parser.py
@@ -31,6 +31,9 @@ class ParsedDocument:
     images: list[dict] = field(default_factory=list)
     """Extracted images with metadata (page, bounding box, URL)."""
 
+    assets: list[dict] = field(default_factory=list)
+    """Structured embedded assets such as figures, pictures, and tables."""
+
 
 class DocumentParserPort(ABC):
     """Parse any document format into structured markdown.

--- a/maritime-ai-service/app/services/input_processor_context_runtime.py
+++ b/maritime-ai-service/app/services/input_processor_context_runtime.py
@@ -110,8 +110,11 @@ def _render_document_context_for_prompt(document_context: Any) -> str:
             continue
         file_name = str(_document_context_attr(item, "file_name", f"document-{idx}") or f"document-{idx}")
         parser = str(_document_context_attr(item, "parser", "markitdown") or "markitdown")
+        provenance_level = str(_document_context_attr(item, "provenance_level", "") or "")
+        parser_chain = _document_context_attr(item, "parser_chain", None)
         media_kind = str(_document_context_attr(item, "media_kind", "document") or "document")
         extracted_image_count = _document_context_attr(item, "extracted_image_count", None)
+        embedded_asset_count = _document_context_attr(item, "embedded_asset_count", None)
         char_count = _document_context_attr(item, "char_count", len(markdown))
         truncated = bool(_document_context_attr(item, "truncated", False))
         excerpt = markdown[:remaining].rstrip()
@@ -121,10 +124,25 @@ def _render_document_context_for_prompt(document_context: Any) -> str:
             if isinstance(extracted_image_count, int) and extracted_image_count > 0
             else ""
         )
+        asset_suffix = (
+            f" | embedded_assets={embedded_asset_count}"
+            if isinstance(embedded_asset_count, int) and embedded_asset_count > 0
+            else ""
+        )
+        chain_suffix = (
+            f" | parser_chain={' -> '.join(str(item) for item in parser_chain)}"
+            if isinstance(parser_chain, list) and parser_chain
+            else ""
+        )
+        provenance_suffix = (
+            f" | provenance={provenance_level}"
+            if provenance_level
+            else ""
+        )
         sections.extend(
             [
                 "",
-                f"[Tai lieu {idx}] {file_name} | kind={media_kind} | parser={parser} | chars={char_count} | truncated={truncated}{image_suffix}",
+                f"[Tai lieu {idx}] {file_name} | kind={media_kind} | parser={parser}{chain_suffix}{provenance_suffix} | chars={char_count} | truncated={truncated}{image_suffix}{asset_suffix}",
                 excerpt,
             ]
         )

--- a/maritime-ai-service/pyproject.toml
+++ b/maritime-ai-service/pyproject.toml
@@ -58,6 +58,9 @@ dev = [
     "mypy>=1.8.0",
     "pre-commit>=3.6.0",
 ]
+precision-docs = [
+    "docling>=2.30.0",
+]
 
 [tool.setuptools.packages.find]
 include = ["app*"]

--- a/maritime-ai-service/requirements.txt
+++ b/maritime-ai-service/requirements.txt
@@ -65,7 +65,8 @@ Pillow>=10.0.0  # CHỈ THỊ 26: Image processing
 # Document Conversion (Course Generation — design spec v2.0, optional)
 # Install: pip install docling  (requires 3-4GB for DocLayNet + TableFormer models)
 # Or use Docling Serve: docker pull doclingproject/docling-serve
-# Feature-gated: USE_DOCLING_FOR_COURSE_GEN=true
+# Feature-gated: USE_DOCLING_FOR_COURSE_GEN=true or DOCUMENT_CONTEXT_PARSER_MODE=precision
+# Optional package extra: pip install -e ".[precision-docs]"
 # docling>=2.30.0  # Uncomment when ready to deploy Docling
 markitdown[pdf,docx,pptx,xlsx,audio-transcription]>=0.1.5  # Lightweight Office/PDF/audio-to-Markdown parser
 

--- a/maritime-ai-service/tests/unit/test_document_context_api.py
+++ b/maritime-ai-service/tests/unit/test_document_context_api.py
@@ -50,6 +50,45 @@ class FakeLongManualParser:
         )
 
 
+class FakeDoclingAssetParser:
+    is_available = True
+
+    async def parse(self, file_path: str, options=None):
+        return ParsedDocument(
+            markdown="# Lesson\n\n![figure](ignored)\n\n| A | B |\n|---|---|",
+            page_count=4,
+            metadata={
+                "title": "Asset Manual",
+                "parser": "docling",
+                "parser_chain": ["markitdown", "docling"],
+                "parser_warning": "Auto mode promoted to Docling.",
+                "provenance_level": "page_layout",
+                "embedded_asset_count": 2,
+                "figure_count": 1,
+                "table_count": 1,
+            },
+            section_map={"Lesson": [2]},
+            images=[],
+            assets=[
+                {
+                    "id": "fig-1",
+                    "kind": "image",
+                    "page": 2,
+                    "label": "picture",
+                    "text": "Bridge diagram",
+                    "bbox": {"l": 1.0, "t": 2.0, "r": 3.0, "b": 4.0},
+                },
+                {
+                    "id": "table-1",
+                    "kind": "table",
+                    "page": 3,
+                    "label": "table",
+                    "text": "Checklist",
+                },
+            ],
+        )
+
+
 class FakeVideoParser:
     is_available = True
 
@@ -121,7 +160,7 @@ def test_parse_document_context_accepts_video_with_keyframes(monkeypatch):
 def test_parse_document_context_uses_markitdown(monkeypatch):
     from app.api.v1 import document_context as module
 
-    monkeypatch.setattr(module, "_build_parser", lambda: FakeMarkItDownParser())
+    monkeypatch.setattr(module, "_build_parser", lambda parser_mode=None: FakeMarkItDownParser())
 
     response = asyncio.run(
         module.parse_document_context(
@@ -136,13 +175,15 @@ def test_parse_document_context_uses_markitdown(monkeypatch):
     assert response.page_count == 2
     assert response.section_titles == ["Safety Brief"]
     assert "Rule 5" in response.markdown
+    assert response.provenance_level == "text_only"
+    assert response.parser_chain == ["markitdown"]
     assert response.char_count == len("# Safety Brief\n\nRule 5: keep a proper lookout.")
 
 
 def test_parse_document_context_keeps_late_sections_as_snippets(monkeypatch):
     from app.api.v1 import document_context as module
 
-    monkeypatch.setattr(module, "_build_parser", lambda: FakeLongManualParser())
+    monkeypatch.setattr(module, "_build_parser", lambda parser_mode=None: FakeLongManualParser())
 
     response = asyncio.run(
         module.parse_document_context(
@@ -162,6 +203,30 @@ def test_parse_document_context_keeps_late_sections_as_snippets(monkeypatch):
     assert late_snippet.page_start == 9
     assert late_snippet.page_end == 10
     assert "them video tuong tac" in late_snippet.markdown
+
+
+def test_parse_document_context_surfaces_docling_assets(monkeypatch):
+    from app.api.v1 import document_context as module
+
+    monkeypatch.setattr(module, "_build_parser", lambda parser_mode=None: FakeDoclingAssetParser())
+
+    response = asyncio.run(
+        module.parse_document_context(
+            SimpleNamespace(user_id="u"),
+            _upload_file("asset-manual.docx", b"docx-bytes"),
+            parser_mode="precision",
+        )
+    )
+
+    assert response.parser == "docling"
+    assert response.parser_chain == ["markitdown", "docling"]
+    assert response.provenance_level == "page_layout"
+    assert response.parser_warning == "Auto mode promoted to Docling."
+    assert response.embedded_asset_count == 2
+    assert response.figure_count == 1
+    assert response.table_count == 1
+    assert response.embedded_assets[0].page == 2
+    assert response.embedded_assets[0].bbox == {"l": 1.0, "t": 2.0, "r": 3.0, "b": 4.0}
 
 
 def test_document_context_prompt_block_bounds_and_labels():

--- a/maritime-ai-service/tests/unit/test_document_parser_router.py
+++ b/maritime-ai-service/tests/unit/test_document_parser_router.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.adapters.document_parser_router import DocumentParserRouter
+from app.ports.document_parser import ParsedDocument
+
+
+class FakeParser:
+    def __init__(self, parsed: ParsedDocument | None = None, error: Exception | None = None):
+        self.parsed = parsed
+        self.error = error
+        self.calls = 0
+
+    async def parse(self, file_path: str, options: dict | None = None):
+        self.calls += 1
+        if self.error:
+            raise self.error
+        return self.parsed
+
+    def supported_formats(self):
+        return ["docx", "pdf"]
+
+
+def _parsed(parser: str, provenance: str, *, sections: int = 0, assets: int = 0):
+    return ParsedDocument(
+        markdown="# Section\n\nBody",
+        page_count=1 if provenance == "text_only" else 3,
+        metadata={
+            "parser": parser,
+            "parser_chain": [parser],
+            "provenance_level": provenance,
+        },
+        section_map={f"Section {idx}": [idx] for idx in range(1, sections + 1)},
+        images=[{"kind": "image", "page": 2}] * assets,
+        assets=[{"kind": "image", "page": 2}] * assets,
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_promotes_weak_markitdown_parse_to_docling():
+    markitdown = FakeParser(_parsed("markitdown", "text_only"))
+    docling = FakeParser(_parsed("docling", "page_layout", sections=3, assets=1))
+    router = DocumentParserRouter(
+        markitdown_parser=markitdown,
+        docling_parser=docling,
+        mode="auto",
+    )
+
+    parsed = await router.parse("manual.docx")
+
+    assert parsed.metadata["parser"] == "docling"
+    assert parsed.metadata["parser_chain"] == ["markitdown", "docling"]
+    assert parsed.metadata["provenance_level"] == "page_layout"
+    assert "promoted" in parsed.metadata["parser_warning"]
+    assert markitdown.calls == 1
+    assert docling.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_keeps_markitdown_when_page_markers_are_available():
+    markitdown = FakeParser(_parsed("markitdown", "page_marker", sections=2))
+    docling = FakeParser(_parsed("docling", "page_layout", sections=3))
+    router = DocumentParserRouter(
+        markitdown_parser=markitdown,
+        docling_parser=docling,
+        mode="auto",
+    )
+
+    parsed = await router.parse("manual.docx")
+
+    assert parsed.metadata["parser"] == "markitdown"
+    assert docling.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_marks_warning_when_precision_upgrade_is_unavailable():
+    markitdown = FakeParser(_parsed("markitdown", "text_only"))
+    router = DocumentParserRouter(
+        markitdown_parser=markitdown,
+        docling_parser=None,
+        mode="auto",
+    )
+
+    parsed = await router.parse("manual.docx")
+
+    assert parsed.metadata["parser"] == "markitdown"
+    assert "weak page/layout provenance" in parsed.metadata["parser_warning"]
+
+
+@pytest.mark.asyncio
+async def test_precision_falls_back_to_markitdown_with_warning():
+    markitdown = FakeParser(_parsed("markitdown", "text_only"))
+    docling = FakeParser(error=RuntimeError("docling unavailable"))
+    router = DocumentParserRouter(
+        markitdown_parser=markitdown,
+        docling_parser=docling,
+        mode="precision",
+    )
+
+    parsed = await router.parse("manual.docx")
+
+    assert parsed.metadata["parser"] == "markitdown"
+    assert "fell back to MarkItDown" in parsed.metadata["parser_warning"]
+
+
+@pytest.mark.asyncio
+async def test_docling_adapter_extracts_generic_sections_and_assets(monkeypatch, tmp_path):
+    import sys
+    import types
+
+    from app.adapters.docling_parser import DoclingParserAdapter
+
+    class FakeProv:
+        page_no = 2
+        bbox = SimpleNamespace(l=1, t=2, r=3, b=4)
+
+    class FakeItem:
+        def __init__(self, label: str, text: str, page_no: int = 2):
+            self.label = label
+            self.text = text
+            self.prov = [SimpleNamespace(page_no=page_no, bbox=FakeProv.bbox)]
+
+    class FakeDoc:
+        name = "manual.docx"
+        pages = {1: object(), 2: object()}
+
+        def export_to_markdown(self):
+            return "# Bridge manual\n\n## Chuong 2\n\nSee figure and table."
+
+        def iterate_items(self):
+            return iter(
+                [
+                    FakeItem("title", "Bridge manual", 1),
+                    FakeItem("section_header", "Chuong 2", 2),
+                    FakeItem("picture", "Bridge console diagram", 2),
+                    FakeItem("table", "Watchkeeping checklist", 2),
+                ]
+            )
+
+    class FakeDocumentConverter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def convert(self, file_path: str):
+            return SimpleNamespace(document=FakeDoc())
+
+    fake_converter_module = types.ModuleType("docling.document_converter")
+    fake_converter_module.DocumentConverter = FakeDocumentConverter
+    fake_converter_module.PdfFormatOption = object
+    fake_base_models = types.ModuleType("docling.datamodel.base_models")
+    fake_base_models.InputFormat = SimpleNamespace(PDF="pdf")
+    monkeypatch.setitem(sys.modules, "docling", types.ModuleType("docling"))
+    monkeypatch.setitem(sys.modules, "docling.datamodel", types.ModuleType("docling.datamodel"))
+    monkeypatch.setitem(sys.modules, "docling.document_converter", fake_converter_module)
+    monkeypatch.setitem(sys.modules, "docling.datamodel.base_models", fake_base_models)
+
+    source = tmp_path / "manual.docx"
+    source.write_bytes(b"fake")
+
+    parser = DoclingParserAdapter()
+    parsed = await parser.parse(str(source))
+
+    assert parsed.metadata["parser"] == "docling"
+    assert parsed.metadata["provenance_level"] == "page_layout"
+    assert parsed.section_map["Bridge manual"] == [1]
+    assert parsed.section_map["Chuong 2"] == [2]
+    assert "<!-- page 1 -->" in parsed.markdown
+    assert "<!-- page 2 -->" in parsed.markdown
+    assert parsed.metadata["embedded_asset_count"] == 2
+    assert parsed.metadata["figure_count"] == 1
+    assert parsed.metadata["table_count"] == 1
+    assert parsed.assets[0]["bbox"]["l"] == 1

--- a/maritime-ai-service/tests/unit/test_markitdown_parser.py
+++ b/maritime-ai-service/tests/unit/test_markitdown_parser.py
@@ -42,6 +42,8 @@ async def test_markitdown_parser_converts_local_file(monkeypatch, tmp_path):
     assert parsed.section_map == {"Radar plotting": [2]}
     assert parsed.metadata["title"] == "Radar lesson"
     assert parsed.metadata["parser"] == "markitdown"
+    assert parsed.metadata["parser_chain"] == ["markitdown"]
+    assert parsed.metadata["provenance_level"] == "page_marker"
     assert FakeMarkItDown.instances[0].enable_plugins is True
     assert FakeMarkItDown.instances[0].converted_paths == [str(source)]
 
@@ -63,6 +65,29 @@ def test_course_generation_prefers_markitdown_for_office(monkeypatch):
     parser = parsers.get_parser(
         "demo.xlsx",
         settings_obj=SimpleNamespace(use_docling_for_course_gen=False),
+        logger=MagicMock(),
+    )
+
+    assert parser is sentinel
+
+
+def test_course_generation_prefers_docling_when_precision_enabled(monkeypatch):
+    import app.api.v1.course_generation_parsers as parsers
+
+    sentinel = object()
+
+    def fake_docling(*, settings_obj, logger):
+        return sentinel
+
+    def fail_markitdown(*, settings_obj, logger):
+        raise AssertionError("MarkItDown should not be called when Docling precision is enabled")
+
+    monkeypatch.setattr(parsers, "try_build_docling_parser", fake_docling)
+    monkeypatch.setattr(parsers, "try_build_markitdown_parser", fail_markitdown)
+
+    parser = parsers.get_parser(
+        "demo.docx",
+        settings_obj=SimpleNamespace(use_docling_for_course_gen=True),
         logger=MagicMock(),
     )
 

--- a/wiii-desktop/src/__tests__/document-context.test.ts
+++ b/wiii-desktop/src/__tests__/document-context.test.ts
@@ -201,6 +201,37 @@ describe("document context helpers", () => {
     expect(frames[0].media_type).toBe("image/jpeg");
   });
 
+  it("carries parser provenance and embedded asset counts into bounded context", () => {
+    const markdown = [
+      "# Maritime report",
+      "Opening ".repeat(900),
+      "# Findings",
+      "Operational findings ".repeat(200),
+    ].join("\n\n");
+
+    const context = buildChatDocumentContext([
+      makeDoc({
+        file_name: "asset-report.docx",
+        parser: "docling",
+        parser_chain: ["markitdown", "docling"],
+        provenance_level: "page_layout",
+        embedded_asset_count: 3,
+        figure_count: 2,
+        table_count: 1,
+        markdown,
+        char_count: markdown.length,
+        truncated: true,
+      }),
+    ], 2_400);
+    const bounded = context?.attachments[0].markdown || "";
+
+    expect(context?.attachments[0].provenance_level).toBe("page_layout");
+    expect(context?.attachments[0].embedded_asset_count).toBe(3);
+    expect(bounded).toContain("Parser provenance");
+    expect(bounded).toContain("parser_chain: markitdown -> docling");
+    expect(bounded).toContain("Embedded asset signals");
+  });
+
   it("formats attachment sizes compactly", () => {
     expect(formatBytes(512)).toBe("512 B");
     expect(formatBytes(2048)).toBe("2.0 KB");

--- a/wiii-desktop/src/api/document-context.ts
+++ b/wiii-desktop/src/api/document-context.ts
@@ -9,6 +9,22 @@ export interface DocumentContextExtractedImage {
   detail?: "auto" | "low" | "high";
 }
 
+export type DocumentContextProvenanceLevel =
+  | "text_only"
+  | "structured_text"
+  | "page_marker"
+  | "page_layout";
+
+export interface DocumentContextEmbeddedAsset {
+  id: string;
+  kind: "image" | "figure" | "picture" | "table";
+  label?: string | null;
+  page?: number | null;
+  text?: string | null;
+  bbox?: Record<string, number> | null;
+  has_data?: boolean;
+}
+
 export interface DocumentContextSectionSnippet {
   title: string;
   markdown: string;
@@ -25,6 +41,9 @@ export interface DocumentContextParseResponse {
   media_kind?: "document" | "video";
   size_bytes: number;
   parser: string;
+  parser_chain?: string[];
+  parser_warning?: string | null;
+  provenance_level?: DocumentContextProvenanceLevel;
   title?: string | null;
   page_count?: number | null;
   section_titles: string[];
@@ -34,13 +53,21 @@ export interface DocumentContextParseResponse {
   truncated: boolean;
   extracted_images?: DocumentContextExtractedImage[];
   extracted_image_count?: number;
+  embedded_assets?: DocumentContextEmbeddedAsset[];
+  embedded_asset_count?: number;
+  figure_count?: number;
+  table_count?: number;
 }
 
 export async function parseDocumentContext(
   file: File,
+  options?: { parserMode?: "auto" | "fast" | "precision" },
 ): Promise<DocumentContextParseResponse> {
   const formData = new FormData();
   formData.append("file", file);
+  if (options?.parserMode) {
+    formData.append("parser_mode", options.parserMode);
+  }
   return getClient().postFormData<DocumentContextParseResponse>(
     "/api/v1/document-context/parse",
     formData,

--- a/wiii-desktop/src/api/types.ts
+++ b/wiii-desktop/src/api/types.ts
@@ -23,9 +23,15 @@ export interface ChatDocumentAttachment {
   media_kind?: "document" | "video";
   size_bytes: number;
   parser?: string;
+  parser_chain?: string[];
+  parser_warning?: string | null;
+  provenance_level?: "text_only" | "structured_text" | "page_marker" | "page_layout";
   char_count?: number;
   truncated?: boolean;
   extracted_image_count?: number;
+  embedded_asset_count?: number;
+  figure_count?: number;
+  table_count?: number;
 }
 
 export interface ChatDocumentContextAttachment extends ChatDocumentAttachment {

--- a/wiii-desktop/src/components/chat/ChatInput.tsx
+++ b/wiii-desktop/src/components/chat/ChatInput.tsx
@@ -17,7 +17,12 @@ import {
   toDisplayDocumentAttachment,
   type ParsedDocumentForContext,
 } from "@/lib/document-context";
-import type { DocumentContextExtractedImage, DocumentContextSectionSnippet } from "@/api/document-context";
+import type {
+  DocumentContextEmbeddedAsset,
+  DocumentContextExtractedImage,
+  DocumentContextProvenanceLevel,
+  DocumentContextSectionSnippet,
+} from "@/api/document-context";
 import {
   parseSkillMentions,
   detectMentionTyping,
@@ -89,10 +94,17 @@ interface AttachedDocument {
   media_kind?: "document" | "video";
   size_bytes: number;
   parser?: string;
+  parser_chain?: string[];
+  parser_warning?: string | null;
+  provenance_level?: DocumentContextProvenanceLevel;
   char_count?: number;
   truncated?: boolean;
   extracted_images?: DocumentContextExtractedImage[];
   extracted_image_count?: number;
+  embedded_assets?: DocumentContextEmbeddedAsset[];
+  embedded_asset_count?: number;
+  figure_count?: number;
+  table_count?: number;
   section_snippets?: DocumentContextSectionSnippet[];
   markdown?: string;
   status: "parsing" | "ready" | "error";
@@ -157,9 +169,16 @@ function toParsedDocumentForContext(doc: AttachedDocument): ParsedDocumentForCon
     media_kind: doc.media_kind,
     size_bytes: doc.size_bytes,
     parser: doc.parser || "markitdown",
+    parser_chain: doc.parser_chain,
+    parser_warning: doc.parser_warning,
+    provenance_level: doc.provenance_level,
     char_count: doc.char_count,
     extracted_images: doc.extracted_images,
     extracted_image_count: doc.extracted_image_count,
+    embedded_assets: doc.embedded_assets,
+    embedded_asset_count: doc.embedded_asset_count,
+    figure_count: doc.figure_count,
+    table_count: doc.table_count,
     section_snippets: doc.section_snippets,
     truncated: doc.truncated,
     markdown: doc.markdown,
@@ -183,13 +202,21 @@ function DocumentAttachmentStrip({
         const frameLabel = doc.extracted_image_count
           ? ` · ${doc.extracted_image_count} khung hình`
           : "";
+        const assetLabel = doc.embedded_asset_count
+          ? ` · ${doc.embedded_asset_count} asset`
+          : "";
+        const provenanceLabel = doc.provenance_level === "page_layout"
+          ? " · layout"
+          : doc.provenance_level === "page_marker"
+            ? " · page"
+            : "";
         const label = isParsing
           ? isVideo
             ? "Wiii đang đọc video..."
             : "Wiii đang đọc..."
           : isError
             ? doc.error || "Chưa đọc được"
-            : `${doc.parser || "MarkItDown"} · ${formatBytes(doc.size_bytes)} · ${doc.char_count ?? 0} ký tự${frameLabel}${doc.truncated ? " · đã rút gọn" : ""}`;
+            : `${doc.parser || "MarkItDown"}${provenanceLabel} · ${formatBytes(doc.size_bytes)} · ${doc.char_count ?? 0} ký tự${frameLabel}${assetLabel}${doc.truncated ? " · đã rút gọn" : ""}`;
         return (
           <div
             key={doc.id}
@@ -483,9 +510,16 @@ export function ChatInput({ onSend, onCancel, editingMessage, onClearEdit, cente
                   media_kind: parsed.media_kind || mediaKind,
                   size_bytes: parsed.size_bytes,
                   parser: parsed.parser,
+                  parser_chain: parsed.parser_chain || [],
+                  parser_warning: parsed.parser_warning || null,
+                  provenance_level: parsed.provenance_level,
                   char_count: parsed.char_count,
                   extracted_images: parsed.extracted_images || [],
                   extracted_image_count: parsed.extracted_image_count || 0,
+                  embedded_assets: parsed.embedded_assets || [],
+                  embedded_asset_count: parsed.embedded_asset_count || 0,
+                  figure_count: parsed.figure_count || 0,
+                  table_count: parsed.table_count || 0,
                   section_snippets: parsed.section_snippets || [],
                   truncated: parsed.truncated,
                   markdown: parsed.markdown,

--- a/wiii-desktop/src/lib/document-context.ts
+++ b/wiii-desktop/src/lib/document-context.ts
@@ -5,6 +5,7 @@ import type {
   ImageInput,
 } from "@/api/types";
 import type {
+  DocumentContextEmbeddedAsset,
   DocumentContextExtractedImage,
   DocumentContextSectionSnippet,
 } from "@/api/document-context";
@@ -48,6 +49,7 @@ interface ContextSection {
 export interface ParsedDocumentForContext extends ChatDocumentContextAttachment {
   id: string;
   extracted_images?: DocumentContextExtractedImage[];
+  embedded_assets?: DocumentContextEmbeddedAsset[];
   section_snippets?: DocumentContextSectionSnippet[];
 }
 
@@ -60,10 +62,16 @@ export function toDisplayDocumentAttachment(
     mime_type: doc.mime_type,
     size_bytes: doc.size_bytes,
     parser: doc.parser,
+    parser_chain: doc.parser_chain,
+    parser_warning: doc.parser_warning,
+    provenance_level: doc.provenance_level,
     char_count: doc.char_count,
     truncated: doc.truncated,
     media_kind: doc.media_kind,
     extracted_image_count: doc.extracted_image_count,
+    embedded_asset_count: doc.embedded_asset_count,
+    figure_count: doc.figure_count,
+    table_count: doc.table_count,
   };
 }
 
@@ -111,9 +119,15 @@ export function buildChatDocumentContext(
       mime_type: doc.mime_type,
       size_bytes: doc.size_bytes,
       parser: doc.parser || "markitdown",
+      parser_chain: doc.parser_chain,
+      parser_warning: doc.parser_warning,
+      provenance_level: doc.provenance_level,
       char_count: doc.char_count,
       media_kind: doc.media_kind,
       extracted_image_count: doc.extracted_image_count,
+      embedded_asset_count: doc.embedded_asset_count,
+      figure_count: doc.figure_count,
+      table_count: doc.table_count,
       truncated: Boolean(doc.truncated || doc.markdown.length > markdown.length),
       markdown,
     });
@@ -146,10 +160,12 @@ function buildBoundedDocumentMarkdown(
     : Math.min(1_500, Math.max(700, Math.floor(maxChars * 0.22)));
   const chunks: string[] = [
     title,
+    renderParserProvenanceSummary(doc),
+    renderEmbeddedAssetSummary(doc),
     outline,
     "## Trích đoạn đầu tài liệu",
     markdown.slice(0, headBudget).trim(),
-  ];
+  ].filter(Boolean);
 
   const prioritySections = sections
     .filter((section) => section.priority > 0)
@@ -177,6 +193,37 @@ function buildBoundedDocumentMarkdown(
   chunks.push("## Trích đoạn cuối tài liệu", markdown.slice(-tailBudget).trim());
 
   return compactToBudget(chunks.join("\n\n"), maxChars);
+}
+
+function renderParserProvenanceSummary(doc: ParsedDocumentForContext): string {
+  const provenance = doc.provenance_level;
+  const parserChain = doc.parser_chain?.length ? doc.parser_chain.join(" -> ") : doc.parser;
+  if (!provenance && !parserChain) return "";
+  return [
+    "## Parser provenance",
+    `- parser_chain: ${parserChain || "unknown"}`,
+    `- provenance_level: ${provenance || "unknown"}`,
+    doc.parser_warning ? `- parser_warning: ${doc.parser_warning}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function renderEmbeddedAssetSummary(doc: ParsedDocumentForContext): string {
+  const assetCount = doc.embedded_asset_count || 0;
+  if (assetCount <= 0 && !doc.figure_count && !doc.table_count) return "";
+  const parts = [
+    doc.figure_count ? `${doc.figure_count} figure/image` : "",
+    doc.table_count ? `${doc.table_count} table` : "",
+  ].filter(Boolean);
+  return [
+    "## Embedded asset signals",
+    `- detected_assets: ${assetCount}`,
+    parts.length ? `- asset_types: ${parts.join(", ")}` : "",
+    "Use these as extraction signals only; inspect source references before relying on visual details.",
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 function normalizeDocumentMarkdown(markdown: string): string {


### PR DESCRIPTION
## Summary
- Adds a hybrid document parser router with `auto`, `fast`, and `precision` modes so MarkItDown remains the fast lane and Docling becomes the optional high-fidelity provenance lane.
- Surfaces `parser_chain`, `provenance_level`, `parser_warning`, and embedded asset counts through `/document-context/parse`, prompt context, deterministic uploaded-file fallback, and desktop attachment metadata.
- Upgrades Docling extraction to map generic headings to pages, inject page markers before headings, and preserve figure/table metadata for LMS citation UX.
- Documents the LMS doc-to-course parser/provenance contract and keeps Docling as an optional `precision-docs` extra to avoid production OOM risk.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_document_parser_router.py tests/unit/test_markitdown_parser.py tests/unit/test_document_context_api.py tests/unit/test_course_generation_flow.py tests/unit/test_course_generation_source_preparation.py -q` -> 52 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> passed
- `cd wiii-desktop && npx vitest run src/__tests__/document-context.test.ts` -> 9 passed
- `cd wiii-desktop && npx tsc --noEmit` -> passed
- `cd wiii-desktop && npm run build:embed` -> passed with existing Vite chunk/dynamic-import warnings
- `git diff --check` -> passed, with CRLF normalization warning for ChatInput.tsx

## Product Smoke
- `Huong_dan_su_dung_HoLiLiHu_LMS_Chi_tiet_2026-05-10.docx`: MarkItDown auto parse, ~3.94s, 42,784 chars, 56 section snippets, `provenance_level=text_only` because local Docling is not installed.
- Long maritime vessel management DOCX: MarkItDown auto parse, ~12.07s, 177,522 chars, 64 section snippets, warning surfaced: weak page/layout provenance and Docling precision unavailable.

## Risk / Rollback
- Docling remains optional; default production behavior falls back to MarkItDown instead of hard-failing or expanding image/model memory footprint.
- New response fields are additive and backward-compatible.
- Rollback is safe by reverting this PR; MarkItDown-only upload parsing is restored.

Closes #316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configurable document parsing modes (`auto`, `fast`, `precision`) for flexible document upload behavior
  * Enhanced extraction of structured document elements including figures, tables, and page layouts
  * Parser provenance metadata and warnings about citation precision for uploaded documents
  * Embedded asset detection and reporting with page references and extraction counts

* **Documentation**
  * Added parsing policy documentation describing hybrid document parsing approach and citation-handling guidance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/317)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->