### PR TITLE
Install ffmpeg for production video context

### DIFF
--- a/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
+++ b/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
@@ -63,7 +63,9 @@ Important guardrail:
   `GUNICORN_WORKERS=2`, `ASYNC_POOL_MAX_SIZE=20`, `APP_MEM_LIMIT=4G`.
 - Production app images are built with `INSTALL_PRECISION_DOCS=true`, which
   installs `maritime-ai-service/requirements-precision.txt` and enables the
-  Docling parser without slowing every regular unit-test install.
+  Docling parser without slowing every regular unit-test install. The production
+  runtime image also includes LibreOffice for Office layout conversion and
+  `ffmpeg`/`ffprobe` for bounded video upload context.
 
 Production `.env.production` is secret-bearing and must stay on the VM. For the current NVIDIA-backed product lane, apply these non-secret shape requirements there rather than committing a changed `.env` template:
 

--- a/maritime-ai-service/Dockerfile.prod
+++ b/maritime-ai-service/Dockerfile.prod
@@ -85,6 +85,7 @@ ARG INSTALL_PRECISION_DOCS=false
 # Runtime libs for Playwright Chromium (no build tools needed).
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
+        ffmpeg \
         libgomp1 \
         libgl1 \
         libpq5 \

--- a/maritime-ai-service/scripts/deploy/README.md
+++ b/maritime-ai-service/scripts/deploy/README.md
@@ -95,7 +95,9 @@ Prefer the provision helper above so the VM, static IP, firewall tags, and SSH s
 The setup script assumes this single-node profile by default: 4G swap,
 conservative Docker resource limits, one app replica until Postgres/cache/object
 storage move off-host, and enough RAM headroom for the Docling precision parser
-plus LibreOffice-based Office layout/image conversion.
+plus LibreOffice-based Office layout/image conversion. Production images also
+include `ffmpeg`/`ffprobe` so bounded video upload context can extract metadata
+and representative keyframes.
 
 ---
 


### PR DESCRIPTION
## Summary
- install `ffmpeg`/`ffprobe` in the production runtime image
- update production runbook/deploy docs so video upload context is covered by the runtime profile

Closes #320.

## Verification
- `docker buildx build --check --build-arg INSTALL_PRECISION_DOCS=true -f maritime-ai-service/Dockerfile.prod .` -> pass
- `git diff --check` -> pass

## Risk and rollback
- Risk: image size increases slightly from the ffmpeg package.
- Mitigation: package is installed in the existing runtime apt layer and directly satisfies `VideoContextParserAdapter.is_available`.
- Rollback: revert this PR or deploy the previous pinned image if the larger runtime layer causes an operational issue.