### PR TITLE
Fix inline visual route timeout fallback

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/visual_intent_resolver.py
+++ b/maritime-ai-service/app/engine/multi_agent/visual_intent_resolver.py
@@ -413,6 +413,48 @@ def _resolve_visual_intent_core(query: str) -> VisualIntentDecision:
             critic_policy="premium",
         )
 
+    explicit_inline_visual = _contains_any(
+        normalized,
+        (
+            "article figure",
+            "comparison visual",
+            "compare visually",
+            "explain visually",
+            "inline diagram",
+            "inline figure",
+            "inline visual",
+            "minh hoa",
+            "minh hoa truc quan",
+            "structured visual",
+            "truc quan hoa",
+            "visual comparison",
+            "visual explanation",
+            "visual inline",
+            "with an inline visual",
+            "with visual",
+        ),
+    )
+    if explicit_inline_visual:
+        is_comparison = _contains_any(
+            normalized,
+            (
+                "compare",
+                "comparing",
+                "comparison",
+                "khac nhau",
+                "so sanh",
+                "trade off",
+                "vs ",
+            ),
+        )
+        return build_article_figure_decision_impl(
+            decision_cls=VisualIntentDecision,
+            visual_type="comparison" if is_comparison else "concept",
+            reason="explicit-inline-visual",
+            figure_budget=2,
+            living_expression_mode="expressive",
+        )
+
     if _contains_any(
         normalized,
         (
@@ -453,7 +495,18 @@ def _resolve_visual_intent_core(query: str) -> VisualIntentDecision:
             living_expression_mode="subtle",
         )
 
-    if _contains_any(normalized, ("so sanh", "compare", "vs ", "khac nhau", "uu nhuoc diem")):
+    if _contains_any(
+        normalized,
+        (
+            "comparison",
+            "compare",
+            "comparing",
+            "so sanh",
+            "vs ",
+            "khac nhau",
+            "uu nhuoc diem",
+        ),
+    ):
         return build_article_figure_decision_impl(
             decision_cls=VisualIntentDecision,
             visual_type="comparison",

--- a/maritime-ai-service/scripts/deploy/smoke-test.sh
+++ b/maritime-ai-service/scripts/deploy/smoke-test.sh
@@ -103,7 +103,7 @@ if [ -n "$API_KEY" ]; then
         -H "Content-Type: application/json" \
         -H "X-API-Key: ${API_KEY}" \
         -H "X-Session-ID: smoke-test-visual" \
-        -d '{"user_id":"api-client","message":"So sánh attention mềm và linear attention bằng visual inline","role":"student","session_id":"smoke-test-visual","domain_id":"maritime"}' \
+        -d '{"user_id":"api-client","message":"Create a compact inline visual comparing soft attention and linear attention. Use structured visual lifecycle.","role":"student","session_id":"smoke-test-visual","domain_id":"maritime"}' \
         --max-time 90 \
         2>/dev/null || true)
     check "Structured visual SSE opens visual lifecycle" "$(echo "$STREAM_BODY" | grep -q '^event: visual_open$' && echo true || echo false)"

--- a/maritime-ai-service/tests/unit/test_visual_intent_resolver.py
+++ b/maritime-ai-service/tests/unit/test_visual_intent_resolver.py
@@ -23,6 +23,29 @@ def test_resolves_comparison_visual():
     assert decision.critic_policy == "standard"
 
 
+def test_resolves_explicit_inline_visual_comparison_request():
+    decision = resolve_visual_intent(
+        "Create a compact inline visual comparing soft attention and linear attention. "
+        "Use structured visual lifecycle."
+    )
+    assert decision.mode == "inline_html"
+    assert decision.force_tool is True
+    assert decision.visual_type == "comparison"
+    assert decision.reason == "explicit-inline-visual"
+    assert decision.presentation_intent == "article_figure"
+    assert decision.preferred_tool == "tool_generate_visual"
+
+
+def test_resolves_mojibake_smoke_prompt_from_deploy_script():
+    decision = resolve_visual_intent(
+        "So sÃ¡nh attention má»m vÃ  linear attention báº±ng visual inline"
+    )
+    assert decision.mode == "inline_html"
+    assert decision.force_tool is True
+    assert decision.presentation_intent == "article_figure"
+    assert decision.preferred_tool == "tool_generate_visual"
+
+
 def test_resolves_process_visual():
     decision = resolve_visual_intent("Giai thich quy trinh docking step by step")
     assert decision.mode == "inline_html"


### PR DESCRIPTION
## Summary
- Recognize explicit inline/structured visual prompts as article-figure requests.
- Keep those prompts bound to `tool_generate_visual` instead of falling through as plain text on route timeout.
- Make the deploy visual SSE smoke prompt ASCII-stable.

## Linked Issue
- Closes #322

## Verification
- `uv pip install --python .\.venv\Scripts\python.exe openai~=2.32.0` (local venv repair only; test dependency already exists in `requirements.txt`)
- `set PYTHONIOENCODING=utf-8 && .\.venv\Scripts\python.exe -m pytest tests/unit/test_visual_intent_resolver.py tests/unit/test_supervisor_agent.py tests/unit/test_supervisor_routing.py tests/unit/test_supervisor_route_timeout.py -q` -> 137 passed
- `set PYTHONIOENCODING=utf-8 && .\.venv\Scripts\ruff.exe check app/engine/multi_agent/visual_intent_resolver.py --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk / rollback
- Risk is low and scoped to visual intent classification plus the smoke prompt.
- Rollback by reverting this commit; the only behavior loss would be explicit `inline visual` prompts returning to plain text under route-timeout fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced system's ability to detect and process requests for inline visual content, including diagrams and structured visuals.
  * Improved keyword recognition for visual requests across English and Vietnamese inputs.

* **Tests**
  * Added test coverage for inline visual comparison scenarios and language variant cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/323)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->