### PR TITLE
Optimize production Docker image size

### DIFF
--- a/.github/workflows/build-production-images.yml
+++ b/.github/workflows/build-production-images.yml
@@ -64,7 +64,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Validate precision Dockerfile profile
-        run: docker buildx build --check --build-arg INSTALL_PRECISION_DOCS=true -f maritime-ai-service/Dockerfile.prod .
+        run: docker buildx build --check --build-arg INSTALL_PRECISION_DOCS=true --build-arg UV_TORCH_BACKEND=cpu -f maritime-ai-service/Dockerfile.prod .
 
       - name: Build app image
         uses: docker/build-push-action@v7
@@ -74,6 +74,8 @@ jobs:
           push: false
           tags: |
             ghcr.io/${{ steps.owner.outputs.value }}/wiii-app:pr-${{ github.sha }}
+          build-args: |
+            UV_TORCH_BACKEND=cpu
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -147,6 +149,7 @@ jobs:
           push: true
           build-args: |
             INSTALL_PRECISION_DOCS=true
+            UV_TORCH_BACKEND=cpu
           tags: |
             ghcr.io/${{ steps.owner.outputs.value }}/wiii-app:main
             ghcr.io/${{ steps.owner.outputs.value }}/wiii-app:sha-${{ github.sha }}

--- a/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
+++ b/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
@@ -66,6 +66,11 @@ Important guardrail:
   Docling parser without slowing every regular unit-test install. The production
   runtime image also includes LibreOffice for Office layout conversion and
   `ffmpeg`/`ffprobe` for bounded video upload context.
+- Production app images intentionally build PyTorch with `UV_TORCH_BACKEND=cpu`
+  on the current `e2-standard-4` CPU-only VM. Do not switch to a CUDA backend
+  unless the target host, budget, and rollback plan explicitly include GPU
+  capacity; otherwise unused CUDA wheels add several GB to the image and slow
+  deploys without improving parsing quality.
 
 Production `.env.production` is secret-bearing and must stay on the VM. For the current NVIDIA-backed product lane, apply these non-secret shape requirements there rather than committing a changed `.env` template:
 

--- a/maritime-ai-service/Dockerfile.prod
+++ b/maritime-ai-service/Dockerfile.prod
@@ -1,29 +1,31 @@
 # syntax=docker/dockerfile:1.7
 # =============================================================================
-# Wiii backend — Multi-stage build với uv (SOTA 4/5/2026).
+# Wiii backend - production multi-stage build with uv.
 #
 # Stage 1 (builder): full python:3.11 + build tools, install all deps to /venv.
-# Stage 2 (runtime): python:3.11-slim, copy ONLY /venv + /app + browser cache.
+# Stage 2 (runtime): python:3.11-slim, copy only /venv, app, web assets,
+# and the shared Playwright browser cache.
 #
 # References:
-# - https://docs.astral.sh/uv/guides/integration/docker/  (uv multi-stage canonical)
-# - https://hynek.me/articles/docker-uv/                  (Hynek's "lean" pattern)
-# - Anthropic / Astral best practices Q1 2026
+# - https://docs.astral.sh/uv/guides/integration/docker/
+# - https://docs.astral.sh/uv/guides/integration/pytorch/
+# - https://docs.docker.com/build/cache/optimize/
 #
-# Expected savings: ~40% (5.54GB → ~3.3GB) — main wins:
-#   - No build-essential / gcc in runtime stage (-200MB)
-#   - No pip cache, wheel cache, __pycache__ in final layer (-150MB)
-#   - --compile-bytecode at install (no runtime .pyc generation, faster cold-start)
+# Production is currently a CPU-only GCP VM. Keep UV_TORCH_BACKEND=cpu unless
+# the target host has an explicit GPU plan; otherwise Linux resolves CUDA wheels
+# and bakes several GB of unused nvidia/cu* runtime packages into /venv.
+# Local measurement with INSTALL_PRECISION_DOCS=true: ~13GB -> ~5.4GB image.
 # =============================================================================
 
 # -----------------------------------------------------------------------------
-# Stage 1 — builder: install all dependencies into /venv
+# Stage 1 - builder: install all dependencies into /venv
 # -----------------------------------------------------------------------------
 FROM python:3.11-slim AS builder
 
 ARG INSTALL_PRECISION_DOCS=false
+ARG UV_TORCH_BACKEND=cpu
 
-# uv binary (Astral package manager — 10-100x faster than pip).
+# uv binary (Astral package manager).
 COPY --from=ghcr.io/astral-sh/uv:0.9.7 /uv /uvx /usr/local/bin/
 
 ENV UV_COMPILE_BYTECODE=1 \
@@ -31,9 +33,10 @@ ENV UV_COMPILE_BYTECODE=1 \
     UV_PROJECT_ENVIRONMENT=/venv \
     UV_PYTHON=/usr/local/bin/python3.11 \
     UV_PYTHON_DOWNLOADS=0 \
+    UV_TORCH_BACKEND=${UV_TORCH_BACKEND} \
     PYTHONDONTWRITEBYTECODE=1
 
-# Build deps (only in builder stage — NOT in runtime).
+# Build deps (only in builder stage, not runtime).
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         libpq-dev \
@@ -42,7 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Layer 1: deps only (rarely changes → maximizes Docker layer cache hits).
+# Layer 1: deps only (rarely changes, maximizes Docker layer cache hits).
 COPY maritime-ai-service/requirements.txt ./
 COPY maritime-ai-service/requirements-precision.txt ./
 
@@ -54,7 +57,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         uv pip install --python /venv/bin/python --requirement requirements.txt; \
     fi
 
-# Layer 2: scrape extras — separate RUN bypasses pip resolver lxml conflict.
+# Layer 2: scrape extras. Separate RUN bypasses pip resolver lxml conflict.
 # crawl4ai 0.8.6 pins lxml~=5.3, ours needs >=6.1. With deps already installed,
 # uv emits a warning instead of failing (same behavior as pip --no-deps).
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -69,14 +72,14 @@ RUN --mount=type=cache,target=/root/.cache/uv \
             huggingface-hub tokenizers fsspec patchright)
 
 # Strip __pycache__ + .pyc to slim the venv (keeping compile=1 above means
-# bytecode is regenerated on first import in runtime — but .pyc is small;
+# bytecode is regenerated on first import in runtime, but .pyc is small;
 # we strip *.dist-info and tests instead which are larger and useless at runtime).
 RUN find /venv -type d -name "tests" -prune -exec rm -rf {} + 2>/dev/null || true && \
     find /venv -type d -name "test" -prune -exec rm -rf {} + 2>/dev/null || true && \
     find /venv -type f -name "*.pyc" -delete 2>/dev/null || true
 
 # -----------------------------------------------------------------------------
-# Stage 2 — runtime: minimal slim image with only what's needed at run time
+# Stage 2 - runtime: minimal slim image with only what's needed at run time
 # -----------------------------------------------------------------------------
 FROM python:3.11-slim AS runtime
 
@@ -121,23 +124,23 @@ ENV PATH="/venv/bin:$PATH" \
     PYTHONPATH="/venv/lib/python3.11/site-packages" \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    DOCLING_LIBREOFFICE_CMD=/usr/bin/soffice
+    DOCLING_LIBREOFFICE_CMD=/usr/bin/soffice \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 WORKDIR /app
 
-# Install Playwright Chromium (uses already-built playwright in /venv).
-RUN /venv/bin/python -m playwright install chromium 2>/dev/null || true
-
-# App code (changes most frequently → put last for layer cache).
-COPY maritime-ai-service/ ./
-COPY wiii-desktop/dist-embed /app-embed
-COPY wiii-desktop/dist-web /app-web
-
-# Non-root user + relocate Chromium cache to user home (keeps /root clean).
+# Non-root user and shared Playwright cache. Installing directly into
+# /ms-playwright avoids baking a second browser copy under /root/.cache.
 RUN useradd --create-home --shell /bin/bash appuser && \
-    mkdir -p /home/appuser/.cache && \
-    cp -r /root/.cache/ms-playwright /home/appuser/.cache/ms-playwright 2>/dev/null || true && \
-    chown -R appuser:appuser /home/appuser/.cache /app
+    mkdir -p /app /app-embed /app-web /ms-playwright && \
+    chown -R appuser:appuser /app /app-embed /app-web /ms-playwright && \
+    (/venv/bin/python -m playwright install chromium 2>/dev/null || true) && \
+    chown -R appuser:appuser /ms-playwright
+
+# App code (changes most frequently, put last for layer cache).
+COPY --chown=appuser:appuser maritime-ai-service/ ./
+COPY --chown=appuser:appuser wiii-desktop/dist-embed /app-embed
+COPY --chown=appuser:appuser wiii-desktop/dist-web /app-web
 
 USER appuser
 

--- a/maritime-ai-service/scripts/deploy/README.md
+++ b/maritime-ai-service/scripts/deploy/README.md
@@ -440,6 +440,10 @@ docker stats --no-stream
 # GUNICORN_WORKERS=2
 # DOCUMENT_CONTEXT_PARSER_MODE=fast
 # USE_DOCLING_FOR_COURSE_GEN=false
+
+# If deploy pulls are slow or disk pressure appears, verify production images
+# are still CPU-only on the current non-GPU VM:
+# docker compose exec app python -c "import torch; print(torch.__version__, torch.cuda.is_available())"
 ```
 
 ---


### PR DESCRIPTION
## Summary
- closes #324
- forces production Docker builds to use CPU-only PyTorch via `UV_TORCH_BACKEND=cpu`
- installs Playwright browsers into a single shared `/ms-playwright` path instead of duplicating root/user caches
- documents the CPU-only guardrail for the current `e2-standard-4` production VM

## Evidence
- Local precision build: `docker buildx build --load --build-arg INSTALL_PRECISION_DOCS=true --build-arg UV_TORCH_BACKEND=cpu -t wiii-app-prod-cpu-test -f maritime-ai-service/Dockerfile.prod .` -> success, ~22m52s
- Image size: previous production app image ~13GB; optimized local image `wiii-app-prod-cpu-test:latest 5.41GB`
- Runtime smoke: `torch 2.11.0+cpu`, `torch.cuda.is_available() == False`, no `nvidia` site-packages, `docling` present, `soffice` present, `ffmpeg` present
- Docling DOCX parse smoke inside image -> parser `docling`, table extraction OK, LibreOffice path detected
- `docker buildx build --check --build-arg INSTALL_PRECISION_DOCS=true --build-arg UV_TORCH_BACKEND=cpu -f maritime-ai-service/Dockerfile.prod .` -> pass
- `git diff --check` -> pass

## Risk / rollback
- Risk: if production later moves to a GPU VM, this build arg must be changed intentionally as part of a GPU rollout plan.
- Rollback: revert this PR or build with a GPU torch backend only after host capacity and cost are approved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated production Docker image build configuration to use CPU-only PyTorch backend.
  * Optimized Docker image layers and browser cache handling.

* **Documentation**
  * Added production build guardrails documentation.
  * Enhanced deployment troubleshooting guide with configuration verification steps.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/325)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->