### PR TITLE
Preserve LMS approval tokens in preview flow

### DIFF
--- a/docs/integration/WIII_LMS_DOC_TO_COURSE_CONTRACT.md
+++ b/docs/integration/WIII_LMS_DOC_TO_COURSE_CONTRACT.md
@@ -27,6 +27,10 @@ Use the host action preview/apply lane for LMS authoring:
 - Apply action: `authoring.apply_lesson_patch`
 - Preview kind: `lesson_patch`
 - Apply input must include the preview token returned by the preview action.
+- If the LMS preview dialog performs the teacher confirmation itself, the
+  preview response may also return an opaque, short-lived `approval_token`.
+  Wiii may forward that token with `preview_token` to the apply action, but
+  should not log it in audit metadata.
 - The preview payload must carry source references from the uploaded document.
 - The apply action must fail closed when the preview token is missing, expired, or
   does not match the patch being applied.
@@ -38,6 +42,7 @@ Expected preview metadata:
   "preview_kind": "lesson_patch",
   "apply_action": "authoring.apply_lesson_patch",
   "preview_token": "opaque-host-token",
+  "approval_token": "opaque-teacher-approval-token",
   "source_references": [
     {
       "kind": "chapter",

--- a/wiii-desktop/src/__tests__/host-action-sse.test.ts
+++ b/wiii-desktop/src/__tests__/host-action-sse.test.ts
@@ -108,4 +108,31 @@ describe("Host Action SSE + PostMessage Integration (Sprint 222b)", () => {
       "Xem bản xem trước rồi xác nhận rõ ràng nếu bạn muốn Wiii áp dụng thay đổi này vào LMS.",
     );
   });
+
+  it("preserves LMS approval tokens from host preview responses", () => {
+    const hostContext = {
+      host_type: "lms",
+      page: { type: "course_editor", title: "Course editor" },
+      workflow_stage: "editing",
+    } satisfies HostContext;
+
+    const item = buildHostActionPreviewItem(
+      "authoring.preview_lesson_patch",
+      "req-approval-1",
+      {},
+      {
+        preview_token: "lesson-preview-123",
+        approval_token: "approval-from-lms-dialog",
+        preview_kind: "lesson_patch",
+        apply_action: "authoring.apply_lesson_patch",
+        summary: "Teacher approved the LMS preview dialog.",
+        lesson_title: "Bài học đã duyệt",
+      },
+      hostContext,
+    );
+
+    expect(item?.metadata?.preview_token).toBe("lesson-preview-123");
+    expect(item?.metadata?.approval_token).toBe("approval-from-lms-dialog");
+    expect(item?.metadata?.apply_action).toBe("authoring.apply_lesson_patch");
+  });
 });

--- a/wiii-desktop/src/__tests__/preview-panel-ui.test.tsx
+++ b/wiii-desktop/src/__tests__/preview-panel-ui.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PreviewPanel } from "@/components/layout/PreviewPanel";
+import { buildHostActionPreviewItem } from "@/hooks/useSSEStream";
 import { useChatStore } from "@/stores/chat-store";
 import { useUIStore } from "@/stores/ui-store";
 import { useHostContextStore } from "@/stores/host-context-store";
@@ -333,6 +334,85 @@ describe("PreviewPanel host action operator flow", () => {
       );
     });
     expect(await screen.findByText("Applied with LMS approval.")).toBeTruthy();
+  });
+
+  it("forwards approval tokens that arrive through the host-action SSE preview item", async () => {
+    const preview = buildHostActionPreviewItem(
+      "authoring.preview_lesson_patch",
+      "req-preview-from-lms-dialog",
+      {},
+      {
+        preview_token: "preview-lesson-from-sse",
+        approval_token: "approval-from-lms-dialog",
+        preview_kind: "lesson_patch",
+        apply_action: "authoring.apply_lesson_patch",
+        summary: "LMS preview dialog approved.",
+        lesson_id: "lesson-1",
+        lesson_title: "Bài học đã duyệt",
+      },
+      {
+        host_type: "lms",
+        page: { type: "course_editor", title: "Course editor" },
+        workflow_stage: "editing",
+      },
+    );
+    expect(preview).not.toBeNull();
+
+    const requestAction = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        summary: "Applied with LMS approval from SSE.",
+      },
+    });
+    useHostContextStore.setState({
+      capabilities: {
+        host_type: "lms",
+        host_name: "LMS",
+        version: "1",
+        resources: ["course"],
+        surfaces: ["right_sidebar"],
+        tools: [
+          {
+            name: "authoring.apply_lesson_patch",
+            description: "Apply a teacher-approved lesson patch.",
+            input_schema: {
+              type: "object",
+              properties: {
+                preview_token: { type: "string" },
+                approval_token: { type: "string" },
+              },
+              required: ["preview_token", "approval_token"],
+            },
+            requires_confirmation: true,
+            mutates_state: true,
+          },
+        ],
+      },
+      requestAction,
+    } as never);
+
+    seedConversation([preview as PreviewItemData]);
+    useUIStore.getState().openPreview("host-action-req-preview-from-lms-dialog");
+
+    render(<PreviewPanel inline />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Xác nhận áp dụng vào bài học" }),
+    );
+
+    await waitFor(() => {
+      expect(requestAction).toHaveBeenCalledWith(
+        "authoring.apply_lesson_patch",
+        {
+          preview_token: "preview-lesson-from-sse",
+          approval_token: "approval-from-lms-dialog",
+        },
+        expect.stringMatching(/^req-preview-apply-/),
+      );
+    });
+    expect(
+      await screen.findByText("Applied with LMS approval from SSE."),
+    ).toBeTruthy();
   });
 
   it("treats host_preview_approval_required as the expected LMS safety gate", async () => {

--- a/wiii-desktop/src/hooks/useSSEStream.ts
+++ b/wiii-desktop/src/hooks/useSSEStream.ts
@@ -255,6 +255,8 @@ export function buildHostActionPreviewItem(
 ): PreviewItemData | null {
   const previewToken = typeof data.preview_token === "string" ? data.preview_token.trim() : "";
   if (!previewToken) return null;
+  const approvalToken =
+    typeof data.approval_token === "string" ? data.approval_token.trim() : "";
 
   const previewKind = typeof data.preview_kind === "string" ? data.preview_kind : "";
   const summary = typeof data.summary === "string" ? data.summary.trim() : "Preview is ready.";
@@ -301,6 +303,7 @@ export function buildHostActionPreviewItem(
       summary,
       preview_kind: previewKind || undefined,
       preview_token: previewToken,
+      approval_token: approvalToken || undefined,
       apply_action: typeof data.apply_action === "string" ? data.apply_action : undefined,
       target_label: targetLabel,
       lesson_id: typeof data.lesson_id === "string" ? data.lesson_id : undefined,


### PR DESCRIPTION
## Summary
- closes #326
- preserve non-empty LMS `approval_token` values when building host-action preview items from SSE responses
- add regression coverage for SSE preview preservation and the PreviewPanel apply path
- clarify the doc-to-course contract: LMS may return a short-lived teacher approval token, Wiii forwards it but should not log it in audit metadata

## Why
The product goal requires:

Wiii upload/parse document -> LMS preview/diff/citation dialog -> teacher confirms -> apply only with LMS approval token.

`PreviewPanel` already knew how to forward `metadata.approval_token`, but the SSE preview builder dropped the token before it reached the panel.

## Verification
- `cd wiii-desktop && npx vitest run src/__tests__/host-action-sse.test.ts src/__tests__/preview-panel-ui.test.tsx` -> 2 files, 11 tests passed
- `cd wiii-desktop && npx tsc --noEmit` -> pass
- `cd wiii-desktop && npm run build:embed` -> pass, existing chunk/dynamic-import warnings only
- `git diff --check` -> pass

## Risk / rollback
- Risk is low and scoped to host-action preview metadata. The token is only copied when the host explicitly returns a string `approval_token`.
- Rollback is reverting this PR; the previous behavior remains safe but can block the final teacher-approved apply step.