### PR TITLE
Preserve explicit markers in doc previews

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -262,8 +262,23 @@ def _clean_doc_preview_line(value: str) -> str:
 
 def _extract_marker(text: str) -> str:
     cleaned = str(text or "").replace("\\_", "_")
-    match = re.search(r"\bWIII_DOC_GOAL_[0-9A-Za-z_-]+\b", cleaned)
-    return match.group(0) if match else ""
+    direct_match = re.search(r"\bWIII_[0-9A-Za-z][0-9A-Za-z_-]{2,140}\b", cleaned)
+    if direct_match:
+        return direct_match.group(0)
+
+    label_match = re.search(
+        r"(?:marker|test marker|exact marker|ma kiem thu|chuoi kiem thu)"
+        r"[^0-9A-Za-z_]{0,60}"
+        r"([0-9A-Za-z][0-9A-Za-z_.:-]{2,140})",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    if not label_match:
+        return ""
+    marker = label_match.group(1).strip("`'\".,;:()[]{}<>")
+    if len(marker) < 3 or re.fullmatch(r"(?:kiem|thu|chinh|xac|exact|marker|test)", marker, flags=re.IGNORECASE):
+        return ""
+    return marker
 
 
 def _strip_doc_preview_goal_label(line: str) -> str:

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -816,6 +816,72 @@ def test_uploaded_doc_preview_skips_logo_data_uri_and_focuses_teacher_manual():
     assert "WIII_DOC_GOAL_REAL_MANUAL" in content
 
 
+def test_uploaded_doc_preview_preserves_general_wiii_marker_from_query():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        _build_uploaded_doc_preview_params,
+    )
+
+    marker = "WIII_PRODUCT_E2E_20260512024500"
+    params = _build_uploaded_doc_preview_params(
+        (
+            "Tao preview_lesson_patch cho giao vien tu tai lieu vua upload. "
+            f"Noi dung bai hoc moi phai chua marker kiem thu chinh xac: {marker}."
+        ),
+        {
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "manual.docx",
+                            "markdown": (
+                                "Huong dan su dung HoLiLiHu LMS\n"
+                                "Muc tieu hoc tap: giao vien tao khoa hoc va kiem tra noi dung.\n"
+                                "Quy trinh thao tac: mo khoa hoc, cap nhat bai hoc, kiem tra quiz.\n"
+                            ),
+                        }
+                    ]
+                },
+                "page_context": {"lesson_id": "lesson-e2e"},
+            }
+        },
+    )
+
+    assert params["lesson_id"] == "lesson-e2e"
+    assert marker in params["content"]
+
+
+def test_uploaded_doc_preview_preserves_labelled_non_wiii_marker_from_query():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        _build_uploaded_doc_preview_params,
+    )
+
+    marker = "COURSE_PATCH_MARKER_42"
+    params = _build_uploaded_doc_preview_params(
+        (
+            "Create a safe LMS preview from the uploaded document. "
+            f"Exact marker: {marker}."
+        ),
+        {
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "manual.docx",
+                            "markdown": (
+                                "Bridge resource management guide\n"
+                                "Learning objective: verify the checklist before saving.\n"
+                                "Checklist: title, lesson content, source references, preview approval.\n"
+                            ),
+                        }
+                    ]
+                }
+            }
+        },
+    )
+
+    assert marker in params["content"]
+
+
 def test_uploaded_doc_preview_prefers_real_teacher_heading_over_smart_excerpt_outline():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (
         _build_uploaded_doc_preview_params,


### PR DESCRIPTION
## Summary
- Preserve explicit user-requested markers in deterministic document preview payloads beyond the old hard-coded `WIII_DOC_GOAL_*` prefix.
- Support bounded `WIII_*` markers and labelled marker tokens such as `Exact marker: COURSE_PATCH_MARKER_42`.
- Add regression coverage for the product E2E case found on LMS/Wiii doc-to-course smoke.

Closes #328.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py -q` -> 44 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/engine/multi_agent/direct_tool_rounds_runtime.py tests/unit/test_direct_tool_rounds_runtime.py --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk / rollback
- Low-risk backend deterministic-preview change only; no schema or auth changes.
- Rollback by reverting this commit; preview flow falls back to previous marker behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced marker extraction to recognize both formal identifier formats and natural language label-style phrases, improving flexibility in how markers are referenced.

* **Tests**
  * Added test coverage for marker preservation functionality in document preview generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/329)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->