### PR TITLE
Prefer explicit document preview titles

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -318,6 +318,19 @@ def _extract_doc_preview_title_from_query(query: str) -> str:
     return ""
 
 
+def _is_low_value_doc_preview_title(value: str) -> bool:
+    normalized = _normalize_doc_preview_text(value)
+    if not normalized:
+        return True
+    return normalized in {
+        "parser provenance",
+        "document context",
+        "uploaded document context",
+        "uploaded source",
+        "tai lieu da tai len",
+    } or normalized.startswith("parser ")
+
+
 def _focus_doc_preview_markdown(query: str, markdown: str) -> str:
     normalized_query = _normalize_doc_preview_text(query)
     role_markers: tuple[str, ...] = ()
@@ -1709,10 +1722,16 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
     )
     first_attachment = attachments[0] if attachments else {}
     query_title = _extract_doc_preview_title_from_query(query)
+    attachment_title = str(first_attachment.get("title") or "").strip()
+    if _is_low_value_doc_preview_title(attachment_title):
+        attachment_title = ""
+    fallback_title = _first_nonempty_line(combined_markdown)
+    if _is_low_value_doc_preview_title(fallback_title):
+        fallback_title = ""
     title_source = (
-        str(first_attachment.get("title") or "").strip()
-        or query_title
-        or _first_nonempty_line(combined_markdown)
+        query_title
+        or attachment_title
+        or fallback_title
         or str(first_attachment.get("file_name") or "").strip()
         or "Tài liệu đã tải lên"
     )

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -882,6 +882,40 @@ def test_uploaded_doc_preview_preserves_labelled_non_wiii_marker_from_query():
     assert marker in params["content"]
 
 
+def test_uploaded_doc_preview_prefers_explicit_query_title_over_parser_metadata():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        _build_uploaded_doc_preview_params,
+    )
+
+    params = _build_uploaded_doc_preview_params(
+        (
+            'Tao preview_lesson_patch cho giao vien. '
+            'Trong preview gui source_references title la "Huong dan su dung HoLiLiHu LMS".'
+        ),
+        {
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "manual.docx",
+                            "title": "Parser provenance",
+                            "markdown": (
+                                "Parser provenance\n"
+                                "Muc tieu hoc tap: giao vien cap nhat bai hoc trong LMS.\n"
+                                "Checklist: kiem tra tieu de, noi dung va nguon truoc khi luu.\n"
+                            ),
+                        }
+                    ]
+                }
+            }
+        },
+    )
+
+    assert params["title"] == "Bản nháp: Huong dan su dung HoLiLiHu LMS"
+    assert params["source_references"][0]["title"] == "Huong dan su dung HoLiLiHu LMS"
+    assert "Parser provenance" not in params["title"]
+
+
 def test_uploaded_doc_preview_prefers_real_teacher_heading_over_smart_excerpt_outline():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (
         _build_uploaded_doc_preview_params,


### PR DESCRIPTION
## Summary
- Prefer explicit source titles requested by the teacher over parser metadata in deterministic document previews.
- Ignore low-value synthetic parser titles such as `Parser provenance` when choosing preview/source reference titles.
- Add regression coverage for the product E2E quality issue found after #329.

Closes #330.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py -q` -> 45 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/engine/multi_agent/direct_tool_rounds_runtime.py tests/unit/test_direct_tool_rounds_runtime.py --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk / rollback
- Low-risk deterministic preview text selection only; no schema, auth, or LMS mutation behavior changes.
- Rollback by reverting this commit; preview generation falls back to parser metadata precedence.