### PR TITLE
Filter label noise from document previews

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -49,6 +49,19 @@ _FORCED_WEB_SEARCH_TOOL_NAMES = (
 _RICH_SEARCH_RESULT_CHAR_FLOOR = 1200
 _DOC_PREVIEW_HOST_ACTION_TOOL = "host_action__authoring__preview_lesson_patch"
 _DOC_COURSE_HOST_ACTION_TOOL = "host_action__authoring__generate_course_from_document"
+_DOC_PREVIEW_LOW_VALUE_LABELS = {
+    "buoc",
+    "checkpoint",
+    "ket qua",
+    "ket qua dung",
+    "ket qua mong doi",
+    "muc tieu",
+    "muc tieu hoc tap",
+    "muc tieu sau khi doc",
+    "noi dung",
+    "thao tac",
+    "vai tro",
+}
 
 
 def _normalize_doc_preview_text(value: Any) -> str:
@@ -80,10 +93,19 @@ def _is_doc_preview_low_value_line(value: str) -> bool:
     line = str(value or "").strip()
     if not line:
         return True
-    normalized = _normalize_doc_preview_text(line).strip()
+    normalized = _normalize_doc_preview_text(line).strip(" #-:\t\r\n|")
+    if normalized in _DOC_PREVIEW_LOW_VALUE_LABELS:
+        return True
+    parts = [
+        part.strip(" #-:\t\r\n|")
+        for part in re.split(r"\s+-\s+|\s*[|:]\s*", normalized)
+        if part.strip(" #-:\t\r\n|")
+    ]
+    if parts and all(part in _DOC_PREVIEW_LOW_VALUE_LABELS for part in parts):
+        return True
     if normalized.startswith(("buoc - thao tac", "hinh ", "vai tro -")):
         return True
-    return bool(re.match(r"^\d+(?:\.\d+)*\.\s+\S+", line))
+    return bool(re.match(r"^\d+(?:\.\d+)*[.)]\s+\S+", line))
 
 
 def _uploaded_document_attachments_from_state(state: AgentState | None) -> list[dict[str, Any]]:
@@ -283,9 +305,19 @@ def _extract_marker(text: str) -> str:
 
 def _strip_doc_preview_goal_label(line: str) -> str:
     cleaned = str(line or "").strip()
-    if _normalize_doc_preview_text(cleaned).startswith("muc tieu "):
-        cleaned = re.sub(r"^(?:Mục tiêu|Muc tieu)\s*[-:–]?\s*", "", cleaned, flags=re.IGNORECASE)
-    return cleaned.strip() or str(line or "").strip()
+    if _is_doc_preview_low_value_line(cleaned):
+        return ""
+    if _normalize_doc_preview_text(cleaned).startswith("muc tieu"):
+        cleaned = re.sub(
+            r"^(?:Mục tiêu(?: học tập)?|Muc tieu(?: hoc tap)?)\s*[-:–]?\s*",
+            "",
+            cleaned,
+            flags=re.IGNORECASE,
+        )
+    cleaned = cleaned.strip()
+    if _is_doc_preview_low_value_line(cleaned):
+        return ""
+    return cleaned
 
 
 def _extract_relevant_lines(markdown: str, markers: tuple[str, ...], *, limit: int) -> list[str]:
@@ -1805,15 +1837,25 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
             "- Khi có nguy cơ va chạm, quy trình báo cáo và ghi log nên diễn ra như thế nào?",
         ]
     )
+    clean_goals = [
+        cleaned
+        for line in goals[:4]
+        if (cleaned := _strip_doc_preview_goal_label(line))
+    ]
+    clean_checklist = [
+        line
+        for line in checklist[:5]
+        if line and not _is_doc_preview_low_value_line(line)
+    ]
     content_lines = [
         f"# Bản nháp bài học từ tài liệu: {title_source}",
         "",
         *([f"Marker kiểm thử: {marker}", ""] if marker else []),
         "## Mục tiêu học tập",
-        *[f"- {_strip_doc_preview_goal_label(line)}" for line in goals[:4]],
+        *[f"- {line}" for line in clean_goals],
         "",
         checklist_heading,
-        *[f"- {line}" for line in checklist[:5]],
+        *[f"- {line}" for line in clean_checklist],
         "",
         "## Hoạt động thảo luận",
         *discussion_lines,

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -977,6 +977,43 @@ def test_doc_preview_clean_line_drops_checkbox_table_markers():
     ) == "Thong tin khoa hoan chinh. - Co tieu de va muc tieu hoc tap."
 
 
+def test_uploaded_doc_preview_filters_bare_table_labels_from_goals():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        _build_uploaded_doc_preview_params,
+    )
+
+    params = _build_uploaded_doc_preview_params(
+        "Tao preview_lesson_patch cho giao vien tu tai lieu vua upload.",
+        {
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "manual.docx",
+                            "markdown": (
+                                "Huong dan su dung HoLiLiHu LMS\n"
+                                "| **Muc tieu** |\n"
+                                "| **Muc tieu hoc tap** |\n"
+                                "| **Buoc** | **Thao tac** | **Ket qua dung** |\n"
+                                "Muc tieu hoc tap: giao vien cap nhat bai hoc va kiem tra nguon truoc khi luu.\n"
+                                "Checklist: xac nhan tieu de, noi dung, nguon va trang thai xuat ban.\n"
+                            ),
+                        }
+                    ]
+                }
+            }
+        },
+    )
+
+    content = params["content"]
+    assert "- Muc tieu\n" not in content
+    assert "- Muc tieu hoc tap\n" not in content
+    assert "- Buoc" not in content
+    assert "- Thao tac" not in content
+    assert "giao vien cap nhat bai hoc" in content
+    assert "xac nhan tieu de" in content
+
+
 @pytest.mark.asyncio
 async def test_execute_direct_tool_rounds_forwards_runtime_tier_to_failover_helper():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (


### PR DESCRIPTION
Closes #332.\n\n## Summary\n- Drop bare DOCX/PDF table labels such as Mục tiêu, Bước, Thao tác, and Kết quả đúng before rendering document preview bullets.\n- Preserve real objective/checklist content after stripping labels.\n- Add a regression test for table-label noise from uploaded document previews.\n\n## Verification\n- ./.venv/Scripts/python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py -q -> 46 passed.\n- ./.venv/Scripts/ruff.exe check app/ --select=E9,F63,F7 -> pass.\n- git diff --check -> pass.\n\n## Risk / rollback\n- Low risk: deterministic generator quality only. No host action permission, approval_token, parser mode, or LMS apply behavior changes.\n- Rollback: revert this commit to restore previous extraction behavior.\n\n## Product evidence\n- Follow-up from Wiii x LMS product E2E where the preview/apply contract worked, but generated content still showed bullets like - Mục tiêu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document preview text filtering to better exclude low-value content lines.
  * Enhanced lesson goal and checklist item sanitization for cleaner extracted content.
  * Added support for Vietnamese label handling in document previews.

* **Tests**
  * Added test coverage for document preview filtering with table labels.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/333)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->