### PR TITLE
[codex] Refine document preview objectives

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -320,6 +320,16 @@ def _strip_doc_preview_goal_label(line: str) -> str:
     return cleaned
 
 
+def _is_doc_preview_ordered_action_line(value: str) -> bool:
+    normalized = _normalize_doc_preview_text(value).strip()
+    return bool(re.match(r"^\d+\s*[-.)]\s+\S+", normalized))
+
+
+def _strip_doc_preview_ordered_action_prefix(value: str) -> str:
+    cleaned = str(value or "").strip()
+    return re.sub(r"^\s*\d+\s*[-.)]\s*", "", cleaned).strip()
+
+
 def _extract_relevant_lines(markdown: str, markers: tuple[str, ...], *, limit: int) -> list[str]:
     normalized_markers = tuple(_normalize_doc_preview_text(marker) for marker in markers)
     selected: list[str] = []
@@ -1837,16 +1847,35 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
             "- Khi có nguy cơ va chạm, quy trình báo cáo và ghi log nên diễn ra như thế nào?",
         ]
     )
-    clean_goals = [
-        cleaned
-        for line in goals[:4]
-        if (cleaned := _strip_doc_preview_goal_label(line))
-    ]
-    clean_checklist = [
-        line
-        for line in checklist[:5]
-        if line and not _is_doc_preview_low_value_line(line)
-    ]
+    clean_goals: list[str] = []
+    for line in goals[:4]:
+        cleaned = _strip_doc_preview_goal_label(line)
+        if not cleaned or _is_doc_preview_ordered_action_line(cleaned):
+            continue
+        clean_goals.append(cleaned)
+
+    if not clean_goals:
+        fallback_goal = _strip_doc_preview_goal_label(
+            _first_nonempty_line(focused_markdown) or _first_nonempty_line(combined_markdown)
+        )
+        if fallback_goal and not _is_doc_preview_ordered_action_line(fallback_goal):
+            clean_goals.append(fallback_goal)
+    if not clean_goals:
+        clean_goals = [
+            (
+                "Giáo viên xác định đúng thao tác cần làm trong LMS và kiểm tra nguồn trước khi lưu."
+                if is_lms_manual
+                else "Người học xác định nội dung trọng tâm, bằng chứng nguồn và bước thực hành an toàn."
+            )
+        ]
+
+    clean_checklist: list[str] = []
+    for line in checklist[:5]:
+        if not line or _is_doc_preview_low_value_line(line):
+            continue
+        cleaned = _strip_doc_preview_ordered_action_prefix(line)
+        if cleaned and not _is_doc_preview_low_value_line(cleaned):
+            clean_checklist.append(cleaned)
     content_lines = [
         f"# Bản nháp bài học từ tài liệu: {title_source}",
         "",

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -1014,6 +1014,43 @@ def test_uploaded_doc_preview_filters_bare_table_labels_from_goals():
     assert "xac nhan tieu de" in content
 
 
+def test_uploaded_doc_preview_keeps_ordered_actions_out_of_learning_goals():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        _build_uploaded_doc_preview_params,
+    )
+
+    params = _build_uploaded_doc_preview_params(
+        "Tao preview_lesson_patch cho giao vien tu tai lieu vua upload.",
+        {
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "manual.docx",
+                            "markdown": (
+                                "Huong dan su dung HoLiLiHu LMS\n"
+                                "Muc tieu hoc tap: giao vien hieu cach chuan bi bai hoc truoc khi luu.\n"
+                                "| **Buoc** | **Thao tac** | **Ket qua dung** |\n"
+                                "| **3** | Them anh dai dien va nhap muc tieu bai hoc khi soan bai. |"
+                                "Noi dung duoc hien thi dung cho hoc vien. |\n"
+                                "Checklist: xac nhan source references va preview approval.\n"
+                            ),
+                        }
+                    ]
+                }
+            }
+        },
+    )
+
+    content = params["content"]
+    objectives_section = content.split("## Checklist", 1)[0]
+    checklist_section = content.split("## Checklist", 1)[1]
+    assert "giao vien hieu cach chuan bi bai hoc" in objectives_section
+    assert "Them anh dai dien" not in objectives_section
+    assert "- 3 - Them anh" not in content
+    assert "Them anh dai dien va nhap muc tieu bai hoc" in checklist_section
+
+
 @pytest.mark.asyncio
 async def test_execute_direct_tool_rounds_forwards_runtime_tier_to_failover_helper():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (


### PR DESCRIPTION
﻿## Summary
- keep ordered action/checklist rows out of document preview learning objectives
- strip ordered prefixes when checklist rows are rendered so procedural rows read naturally
- add regression coverage for DOCX-style table rows that mention objectives but represent actions

## Why
Production E2E showed the Wiii x LMS safe preview flow is working, but a procedural row like `3 - Them anh dai dien...` could still land under `Muc tieu hoc tap` when the row text mentioned objectives. This keeps the generated lesson preview pedagogically cleaner without special-casing one document.

Closes #334.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py -q` -> 47 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk / rollback
Low risk: deterministic formatting-only cleanup in document preview payload generation. Roll back this PR to restore previous objective/checklist rendering.
