### PR TITLE
[codex] Improve document preview objective quality

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -330,6 +330,19 @@ def _strip_doc_preview_ordered_action_prefix(value: str) -> str:
     return re.sub(r"^\s*\d+\s*[-.)]\s*", "", cleaned).strip()
 
 
+def _is_doc_preview_admonition_line(value: str) -> bool:
+    normalized = _normalize_doc_preview_text(value).strip(" -:\t\r\n")
+    return normalized.startswith(
+        (
+            "can luu y",
+            "khong duoc",
+            "khong nen",
+            "luu y",
+            "tranh ",
+        )
+    )
+
+
 def _extract_relevant_lines(markdown: str, markers: tuple[str, ...], *, limit: int) -> list[str]:
     normalized_markers = tuple(_normalize_doc_preview_text(marker) for marker in markers)
     selected: list[str] = []
@@ -1850,7 +1863,11 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
     clean_goals: list[str] = []
     for line in goals[:4]:
         cleaned = _strip_doc_preview_goal_label(line)
-        if not cleaned or _is_doc_preview_ordered_action_line(cleaned):
+        if (
+            not cleaned
+            or _is_doc_preview_ordered_action_line(cleaned)
+            or _is_doc_preview_admonition_line(cleaned)
+        ):
             continue
         clean_goals.append(cleaned)
 
@@ -1858,7 +1875,13 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
         fallback_goal = _strip_doc_preview_goal_label(
             _first_nonempty_line(focused_markdown) or _first_nonempty_line(combined_markdown)
         )
-        if fallback_goal and not _is_doc_preview_ordered_action_line(fallback_goal):
+        if (
+            fallback_goal
+            and not _is_doc_preview_ordered_action_line(fallback_goal)
+            and not _is_doc_preview_admonition_line(fallback_goal)
+            and _normalize_doc_preview_text(fallback_goal)
+            != _normalize_doc_preview_text(title_source)
+        ):
             clean_goals.append(fallback_goal)
     if not clean_goals:
         clean_goals = [

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -1051,6 +1051,39 @@ def test_uploaded_doc_preview_keeps_ordered_actions_out_of_learning_goals():
     assert "Them anh dai dien va nhap muc tieu bai hoc" in checklist_section
 
 
+def test_uploaded_doc_preview_excludes_admonitions_from_learning_goals():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        _build_uploaded_doc_preview_params,
+    )
+
+    params = _build_uploaded_doc_preview_params(
+        "Tao preview_lesson_patch cho giao vien tu tai lieu vua upload.",
+        {
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "manual.docx",
+                            "markdown": (
+                                "Huong dan su dung HoLiLiHu LMS\n"
+                                "Khong nen dan van ban qua dai mot doan. "
+                                "Chia thanh muc tieu, doi tuong, yeu cau dau vao.\n"
+                                "Luu y: giao vien kiem tra citation truoc khi luu.\n"
+                            ),
+                        }
+                    ]
+                }
+            }
+        },
+    )
+
+    content = params["content"]
+    objectives_section = content.split("## Checklist", 1)[0]
+    assert "Khong nen dan van ban qua dai" not in objectives_section
+    assert "Luu y: giao vien kiem tra citation" not in objectives_section
+    assert "Giáo viên xác định đúng thao tác cần làm trong LMS" in objectives_section
+
+
 @pytest.mark.asyncio
 async def test_execute_direct_tool_rounds_forwards_runtime_tier_to_failover_helper():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (


### PR DESCRIPTION
﻿## Summary
- exclude caution/admonition lines such as `Khong nen...` from document preview learning objectives
- avoid falling back to the document title as a learning objective when extracted objectives are weak
- add regression coverage for LMS manual previews where source guidance mentions `muc tieu` but is not itself an objective

## Why
Production E2E after #335 showed the remaining quality issue: Wiii no longer put ordered action rows under objectives, but it could still use a caution sentence as a learning objective. This keeps preview content closer to what a teacher would accept in an LMS lesson draft.

Closes #336.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py -q` -> 48 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk / rollback
Low risk: deterministic text selection cleanup for document preview payloads only. Roll back this PR to restore previous objective extraction behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Document previews now better filter out advisory and guidance text when extracting learning goals, providing cleaner and more focused learning objectives.

* **Tests**
  * Added test coverage to verify document preview properly excludes advisory text from learning goals.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/337)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->