### PR TITLE
[codex] Shape document preview learning goals

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -343,6 +343,23 @@ def _is_doc_preview_admonition_line(value: str) -> bool:
     )
 
 
+def _shape_doc_preview_learning_goal(value: str, *, is_lms_manual: bool) -> str:
+    cleaned = str(value or "").strip()
+    if not cleaned or not is_lms_manual:
+        return cleaned
+    normalized = _normalize_doc_preview_text(cleaned)
+    if normalized.startswith("phan nay tap trung vao"):
+        detail = re.sub(
+            r"^(?:Phần|Phan)\s+(?:này|nay)\s+(?:tập trung|tap trung)\s+(?:vào|vao)\s*",
+            "",
+            cleaned,
+            flags=re.IGNORECASE,
+        ).strip(" .")
+        if detail:
+            return f"Giáo viên thực hiện được {detail} trong LMS."
+    return cleaned
+
+
 def _extract_relevant_lines(markdown: str, markers: tuple[str, ...], *, limit: int) -> list[str]:
     normalized_markers = tuple(_normalize_doc_preview_text(marker) for marker in markers)
     selected: list[str] = []
@@ -1869,7 +1886,9 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
             or _is_doc_preview_admonition_line(cleaned)
         ):
             continue
-        clean_goals.append(cleaned)
+        clean_goals.append(
+            _shape_doc_preview_learning_goal(cleaned, is_lms_manual=is_lms_manual)
+        )
 
     if not clean_goals:
         fallback_goal = _strip_doc_preview_goal_label(
@@ -1882,7 +1901,9 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
             and _normalize_doc_preview_text(fallback_goal)
             != _normalize_doc_preview_text(title_source)
         ):
-            clean_goals.append(fallback_goal)
+            clean_goals.append(
+                _shape_doc_preview_learning_goal(fallback_goal, is_lms_manual=is_lms_manual)
+            )
     if not clean_goals:
         clean_goals = [
             (

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -1084,6 +1084,39 @@ def test_uploaded_doc_preview_excludes_admonitions_from_learning_goals():
     assert "Giáo viên xác định đúng thao tác cần làm trong LMS" in objectives_section
 
 
+def test_uploaded_doc_preview_shapes_descriptive_excerpt_into_learning_goal():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        _build_uploaded_doc_preview_params,
+    )
+
+    params = _build_uploaded_doc_preview_params(
+        "Tao preview_lesson_patch cho giao vien tu tai lieu vua upload.",
+        {
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "manual.docx",
+                            "markdown": (
+                                "Huong dan su dung HoLiLiHu LMS\n"
+                                "Phan nay tap trung vao tac vu tao va van hanh khoa hoc: "
+                                "lap khoa, soan noi dung, tao cau hoi va cau hinh video.\n"
+                            ),
+                        }
+                    ]
+                }
+            }
+        },
+    )
+
+    objectives_section = params["content"].split("## Checklist", 1)[0]
+    assert "Phan nay tap trung vao" not in objectives_section
+    assert (
+        "Giáo viên thực hiện được tac vu tao va van hanh khoa hoc"
+        in objectives_section
+    )
+
+
 @pytest.mark.asyncio
 async def test_execute_direct_tool_rounds_forwards_runtime_tier_to_failover_helper():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (


### PR DESCRIPTION
﻿## Summary
- shape LMS manual descriptive objective excerpts into teacher-ready learning goals
- keep the transformation scoped to deterministic document preview payloads
- add regression coverage for `Phan nay tap trung vao...` objective candidates

## Why
Production E2E after #337 showed objectives were safe but still a little excerpt-like. This makes Wiii's preview read more like an LMS lesson draft a teacher can accept: `Giáo viên thực hiện được ... trong LMS.` rather than raw `Phan nay tap trung vao...` text.

Closes #338.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py -q` -> 49 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk / rollback
Low risk: display/text shaping only for deterministic document preview learning objectives. Roll back this PR to restore verbatim objective rendering.
