### PR TITLE
[codex] Supplement document preview objectives

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -360,6 +360,37 @@ def _shape_doc_preview_learning_goal(value: str, *, is_lms_manual: bool) -> str:
     return cleaned
 
 
+def _supplement_doc_preview_learning_goals(
+    goals: list[str],
+    *,
+    is_lms_manual: bool,
+) -> list[str]:
+    supplements = (
+        [
+            "Giáo viên kiểm tra diff, citation và nguồn tài liệu trước khi áp dụng thay đổi vào LMS.",
+            "Giáo viên tạo hoặc cập nhật bài học ở trạng thái nháp, không xuất bản khi chưa rà soát nội dung.",
+            "Giáo viên xác nhận nội dung, tài liệu, video hoặc câu hỏi liên quan trước khi bấm Apply.",
+        ]
+        if is_lms_manual
+        else [
+            "Người học xác định ý chính, bằng chứng nguồn và tình huống áp dụng từ tài liệu.",
+            "Người học chuyển nội dung nguồn thành checklist thực hành có thể kiểm chứng.",
+            "Người học trả lời câu hỏi nhanh dựa trên citation thay vì ghi nhớ rời rạc.",
+        ]
+    )
+    normalized_seen = {_normalize_doc_preview_text(goal) for goal in goals}
+    completed = list(goals)
+    for supplement in supplements:
+        if len(completed) >= 3:
+            break
+        normalized = _normalize_doc_preview_text(supplement)
+        if normalized in normalized_seen:
+            continue
+        completed.append(supplement)
+        normalized_seen.add(normalized)
+    return completed
+
+
 def _extract_relevant_lines(markdown: str, markers: tuple[str, ...], *, limit: int) -> list[str]:
     normalized_markers = tuple(_normalize_doc_preview_text(marker) for marker in markers)
     selected: list[str] = []
@@ -1912,6 +1943,10 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
                 else "Người học xác định nội dung trọng tâm, bằng chứng nguồn và bước thực hành an toàn."
             )
         ]
+    clean_goals = _supplement_doc_preview_learning_goals(
+        clean_goals,
+        is_lms_manual=is_lms_manual,
+    )
 
     clean_checklist: list[str] = []
     for line in checklist[:5]:

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -1117,6 +1117,40 @@ def test_uploaded_doc_preview_shapes_descriptive_excerpt_into_learning_goal():
     )
 
 
+def test_uploaded_doc_preview_supplements_sparse_lms_learning_goals():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        _build_uploaded_doc_preview_params,
+    )
+
+    params = _build_uploaded_doc_preview_params(
+        "Tao preview_lesson_patch cho giao vien tu tai lieu vua upload.",
+        {
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "manual.docx",
+                            "markdown": (
+                                "Huong dan su dung HoLiLiHu LMS\n"
+                                "Muc tieu hoc tap: giao vien tao khoa hoc dung quy trinh.\n"
+                            ),
+                        }
+                    ]
+                }
+            }
+        },
+    )
+
+    objectives_section = params["content"].split("## Checklist", 1)[0]
+    objective_lines = [
+        line for line in objectives_section.splitlines() if line.startswith("- ")
+    ]
+    assert len(objective_lines) >= 3
+    assert "giao vien tao khoa hoc dung quy trinh" in objectives_section
+    assert "diff, citation" in objectives_section
+    assert "trạng thái nháp" in objectives_section
+
+
 @pytest.mark.asyncio
 async def test_execute_direct_tool_rounds_forwards_runtime_tier_to_failover_helper():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (


### PR DESCRIPTION
﻿## Summary
- add domain-aware supplemental learning objectives when document previews extract too few strong goals
- include safe LMS objectives around diff/citation review, draft state, and teacher Apply confirmation
- add regression coverage for sparse LMS manual objective extraction

## Why
Teacher-facing LMS lesson drafts should usually show 2-3 useful objectives. After #339 the primary objective is clean and teacher-ready, but some documents still yield only one good objective. This fills the gap with safe, product-specific objectives instead of leaving the lesson thin.

Closes #341.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py -q` -> 50 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk / rollback
Low risk: deterministic text supplementation for document preview objectives only. Roll back this PR to return to extracted/fallback single-goal behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Learning goals in document previews are now automatically supplemented with additional instructional guidance, deduplicated for clarity, and limited to 3 items to provide comprehensive yet concise objectives.

* **Tests**
  * Added test coverage validating that learning goals are properly supplemented even when documents have minimal goal content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/342)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->