### PR TITLE
[codex] Fix truncated document preview copy

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -343,10 +343,28 @@ def _is_doc_preview_admonition_line(value: str) -> bool:
     )
 
 
+def _repair_doc_preview_common_truncations(value: str) -> str:
+    cleaned = str(value or "").strip()
+    if not cleaned:
+        return ""
+    return re.sub(r"(?:xuất|xuat)\s+b[ảa]\s*$", "xuất bản", cleaned, flags=re.IGNORECASE)
+
+
+def _clip_doc_preview_line(value: str, *, limit: int = 260) -> str:
+    cleaned = str(value or "").strip()
+    if len(cleaned) <= limit:
+        return _repair_doc_preview_common_truncations(cleaned)
+    clipped = cleaned[:limit].rstrip()
+    boundary = max(clipped.rfind(" "), clipped.rfind("\t"))
+    if boundary >= int(limit * 0.72):
+        clipped = clipped[:boundary].rstrip()
+    return _repair_doc_preview_common_truncations(clipped.rstrip(" ,;:-"))
+
+
 def _shape_doc_preview_learning_goal(value: str, *, is_lms_manual: bool) -> str:
     cleaned = str(value or "").strip()
     if not cleaned or not is_lms_manual:
-        return cleaned
+        return _repair_doc_preview_common_truncations(cleaned)
     normalized = _normalize_doc_preview_text(cleaned)
     if normalized.startswith("phan nay tap trung vao"):
         detail = re.sub(
@@ -356,8 +374,10 @@ def _shape_doc_preview_learning_goal(value: str, *, is_lms_manual: bool) -> str:
             flags=re.IGNORECASE,
         ).strip(" .")
         if detail:
-            return f"Giáo viên thực hiện được {detail} trong LMS."
-    return cleaned
+            repaired = _repair_doc_preview_common_truncations(detail)
+            return f"Giáo viên thực hiện được {repaired} trong LMS."
+    return _repair_doc_preview_common_truncations(cleaned)
+
 
 
 def _supplement_doc_preview_learning_goals(
@@ -404,7 +424,7 @@ def _extract_relevant_lines(markdown: str, markers: tuple[str, ...], *, limit: i
             continue
         normalized_line = _normalize_doc_preview_text(line)
         if any(marker in normalized_line for marker in normalized_markers):
-            selected.append(line[:220])
+            selected.append(_clip_doc_preview_line(line))
         if len(selected) >= limit:
             break
     return selected

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -1117,6 +1117,37 @@ def test_uploaded_doc_preview_shapes_descriptive_excerpt_into_learning_goal():
     )
 
 
+def test_uploaded_doc_preview_repairs_truncated_publish_word_in_learning_goal():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        _build_uploaded_doc_preview_params,
+    )
+
+    params = _build_uploaded_doc_preview_params(
+        "Tao preview_lesson_patch cho giao vien tu tai lieu vua upload.",
+        {
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "manual.docx",
+                            "markdown": (
+                                "Huong dan su dung HoLiLiHu LMS\n"
+                                "Phan nay tap trung vao tac vu tao va van hanh khoa hoc: "
+                                "lap khoa, soan noi dung, tao cau hoi, cau hinh video, "
+                                "kiem tra roi xuat ba\n"
+                            ),
+                        }
+                    ]
+                }
+            }
+        },
+    )
+
+    objectives_section = params["content"].split("## Checklist", 1)[0]
+    assert "xuat ba trong LMS" not in objectives_section
+    assert "xuất bản trong LMS" in objectives_section
+
+
 def test_uploaded_doc_preview_supplements_sparse_lms_learning_goals():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (
         _build_uploaded_doc_preview_params,


### PR DESCRIPTION
Closes #343.\n\n## Summary\n- Clip document preview lines at word boundaries instead of raw character slicing.\n- Repair common truncated Vietnamese publish wording before shaping LMS learning objectives.\n- Add regression coverage for the product-observed xuat ba trong LMS copy issue.\n\n## Safety\n- Preview text generation only.\n- Does not change host action authorization, approval_token gating, apply, publish, delete, enroll, grade, or payment behavior.\n\n## Verification\n- ./.venv/Scripts/python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py -q -> 51 passed.\n- ./.venv/Scripts/ruff.exe check app/ --select=E9,F63,F7 -> passed.\n- git diff --check -> passed.