### PR TITLE
[codex] Polish Vietnamese document preview titles

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -441,6 +441,26 @@ def _extract_doc_preview_title_from_query(query: str) -> str:
     return ""
 
 
+def _polish_doc_preview_vietnamese_title(value: str) -> str:
+    title = _clean_doc_preview_line(value)
+    if not title:
+        return ""
+    replacements = (
+        (r"\bHuong\s+dan\s+su\s+dung\b", "Hướng dẫn sử dụng"),
+        (r"\bcho\s+giao\s+vien\b", "cho giáo viên"),
+        (r"\bgiao\s+vien\b", "giáo viên"),
+        (r"\bgiang\s+vien\b", "giảng viên"),
+        (r"\bhoc\s+vien\b", "học viên"),
+        (r"\bquan\s+ly\b", "quản lý"),
+        (r"\bkhoa\s+hoc\b", "khóa học"),
+        (r"\bbai\s+hoc\b", "bài học"),
+    )
+    polished = title
+    for pattern, replacement in replacements:
+        polished = re.sub(pattern, replacement, polished, flags=re.IGNORECASE)
+    return polished
+
+
 def _is_low_value_doc_preview_title(value: str) -> bool:
     normalized = _normalize_doc_preview_text(value)
     if not normalized:
@@ -1858,6 +1878,7 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
         or str(first_attachment.get("file_name") or "").strip()
         or "Tài liệu đã tải lên"
     )
+    title_source = _polish_doc_preview_vietnamese_title(title_source)
     focused_markdown = _focus_doc_preview_markdown(query, combined_markdown)
     marker = _extract_marker(query) or _extract_marker(combined_markdown)
     goals = _extract_relevant_lines(

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -911,8 +911,9 @@ def test_uploaded_doc_preview_prefers_explicit_query_title_over_parser_metadata(
         },
     )
 
-    assert params["title"] == "Bản nháp: Huong dan su dung HoLiLiHu LMS"
-    assert params["source_references"][0]["title"] == "Huong dan su dung HoLiLiHu LMS"
+    assert params["title"] == "Bản nháp: Hướng dẫn sử dụng HoLiLiHu LMS"
+    assert params["source_references"][0]["title"] == "Hướng dẫn sử dụng HoLiLiHu LMS"
+    assert "# Bản nháp bài học từ tài liệu: Hướng dẫn sử dụng HoLiLiHu LMS" in params["content"]
     assert "Parser provenance" not in params["title"]
 
 


### PR DESCRIPTION
Closes #345.\n\n## Summary\n- Normalize conservative ASCII Vietnamese title phrases in document lesson previews.\n- Apply the polished title consistently to preview title, content heading, and source references.\n- Extend regression coverage for ASCII HoLiLiHu LMS title prompts.\n\n## Safety\n- Preview text generation only.\n- No change to host action authorization, approval_token gating, apply, publish, delete, enroll, grade, or payment behavior.\n\n## Verification\n- ./.venv/Scripts/python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py -q -> 51 passed.\n- ./.venv/Scripts/ruff.exe check app/ --select=E9,F63,F7 -> passed.\n- git diff --check -> passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vietnamese title formatting in document preview lessons. Titles now display with proper diacritics and normalized terminology, enhancing text presentation and consistency across the platform.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/346)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->