### PR TITLE
Extend document parse upload timeout

### DIFF
--- a/wiii-desktop/src/__tests__/document-context-api.test.ts
+++ b/wiii-desktop/src/__tests__/document-context-api.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const postFormData = vi.fn();
+
+vi.mock("@/api/client", () => ({
+  getClient: () => ({ postFormData }),
+}));
+
+import {
+  getDocumentContextParseTimeoutMs,
+  parseDocumentContext,
+} from "@/api/document-context";
+
+function makeFile(name: string, sizeBytes: number, type = ""): File {
+  const file = new File(["x"], name, { type });
+  Object.defineProperty(file, "size", { value: sizeBytes });
+  return file;
+}
+
+describe("document context API", () => {
+  beforeEach(() => {
+    postFormData.mockReset();
+    postFormData.mockResolvedValue({ file_name: "ok.docx" });
+  });
+
+  it("uses a longer parse timeout for large documents", async () => {
+    const file = makeFile(
+      "maritime-research.docx",
+      Math.ceil(13.52 * 1024 * 1024),
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    );
+
+    await parseDocumentContext(file);
+
+    expect(getDocumentContextParseTimeoutMs(file)).toBe(330_000);
+    expect(postFormData).toHaveBeenCalledWith(
+      "/api/v1/document-context/parse",
+      expect.any(FormData),
+      330_000,
+    );
+  });
+
+  it("keeps small document parsing above the default API timeout", () => {
+    const file = makeFile("brief.pdf", 300 * 1024, "application/pdf");
+
+    expect(getDocumentContextParseTimeoutMs(file)).toBe(135_000);
+  });
+
+  it("allocates more time for video context extraction", () => {
+    const file = makeFile("training.mp4", 20 * 1024 * 1024, "video/mp4");
+
+    expect(getDocumentContextParseTimeoutMs(file)).toBe(840_000);
+  });
+});

--- a/wiii-desktop/src/api/client.ts
+++ b/wiii-desktop/src/api/client.ts
@@ -10,7 +10,7 @@ const isTauri =
   typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 
 /** Default request timeout in milliseconds (60 seconds) */
-const DEFAULT_TIMEOUT_MS = 60_000;
+export const DEFAULT_TIMEOUT_MS = 60_000;
 
 export class ApiHttpError extends Error {
   status: number;
@@ -378,7 +378,11 @@ export class WiiiClient {
   }
 
   /** POST request with multipart/form-data (e.g., file uploads) */
-  async postFormData<T>(path: string, formData: FormData): Promise<T> {
+  async postFormData<T>(
+    path: string,
+    formData: FormData,
+    timeoutMs: number = DEFAULT_TIMEOUT_MS,
+  ): Promise<T> {
     const url = new URL(path, this.baseUrl).toString();
 
     // Do NOT set Content-Type — browser sets it with boundary automatically
@@ -388,7 +392,7 @@ export class WiiiClient {
       method: "POST",
       headers: headersWithoutCT,
       body: formData,
-    });
+    }, timeoutMs);
 
     if (response.status === 401 && this.onUnauthorized) {
       const refreshed = await this.onUnauthorized();
@@ -398,7 +402,7 @@ export class WiiiClient {
           method: "POST",
           headers: retryHeaders,
           body: formData,
-        });
+        }, timeoutMs);
       }
     }
 

--- a/wiii-desktop/src/api/document-context.ts
+++ b/wiii-desktop/src/api/document-context.ts
@@ -1,5 +1,14 @@
 import { getClient } from "./client";
 
+const ONE_MIB = 1024 * 1024;
+const DOCUMENT_PARSE_BASE_TIMEOUT_MS = 120_000;
+const DOCUMENT_PARSE_PER_MIB_TIMEOUT_MS = 15_000;
+const DOCUMENT_PARSE_MAX_TIMEOUT_MS = 360_000;
+const VIDEO_PARSE_BASE_TIMEOUT_MS = 240_000;
+const VIDEO_PARSE_PER_MIB_TIMEOUT_MS = 30_000;
+const VIDEO_PARSE_MAX_TIMEOUT_MS = 900_000;
+const VIDEO_EXTENSIONS = new Set(["mp4", "m4v", "mov", "webm", "mkv"]);
+
 export interface DocumentContextExtractedImage {
   id: string;
   label?: string | null;
@@ -59,6 +68,29 @@ export interface DocumentContextParseResponse {
   table_count?: number;
 }
 
+function clampTimeout(value: number, max: number): number {
+  return Math.min(max, Math.max(DOCUMENT_PARSE_BASE_TIMEOUT_MS, value));
+}
+
+function isVideoFile(file: File): boolean {
+  const extension = file.name.split(".").pop()?.toLowerCase() || "";
+  return file.type.startsWith("video/") || VIDEO_EXTENSIONS.has(extension);
+}
+
+export function getDocumentContextParseTimeoutMs(file: File): number {
+  const sizeMiB = Math.max(1, Math.ceil((file.size || 0) / ONE_MIB));
+  if (isVideoFile(file)) {
+    return clampTimeout(
+      VIDEO_PARSE_BASE_TIMEOUT_MS + sizeMiB * VIDEO_PARSE_PER_MIB_TIMEOUT_MS,
+      VIDEO_PARSE_MAX_TIMEOUT_MS,
+    );
+  }
+  return clampTimeout(
+    DOCUMENT_PARSE_BASE_TIMEOUT_MS + sizeMiB * DOCUMENT_PARSE_PER_MIB_TIMEOUT_MS,
+    DOCUMENT_PARSE_MAX_TIMEOUT_MS,
+  );
+}
+
 export async function parseDocumentContext(
   file: File,
   options?: { parserMode?: "auto" | "fast" | "precision" },
@@ -71,5 +103,6 @@ export async function parseDocumentContext(
   return getClient().postFormData<DocumentContextParseResponse>(
     "/api/v1/document-context/parse",
     formData,
+    getDocumentContextParseTimeoutMs(file),
   );
 }


### PR DESCRIPTION
﻿## Summary
- Fixes #349.
- Lets multipart API calls use a caller-provided timeout instead of the global 60s default.
- Gives document-context parsing a timeout budget based on upload size and media type, so long DOCX/PDF/video parses do not abort prematurely on slower product VMs.
- Adds Vitest coverage for a 13.52MB DOCX, a small PDF, and a video upload timeout budget.

## Evidence
- Product smoke before fix: 13.52MB maritime DOCX showed `Wiii ch?a ??c ???c t?i li?u n?y`; network recorded `document-context/parse` as `net::ERR_ABORTED`.
- Local backend evidence: same DOCX parses with Docling in ~19.5s, 225459 chars, 64 section snippets, 166 assets.

## Verification
- `cd wiii-desktop && npx vitest run src/__tests__/document-context-api.test.ts src/__tests__/document-context.test.ts` -> 2 files, 12 tests passed.
- `cd wiii-desktop && npx tsc --noEmit` -> passed.
- `cd wiii-desktop && npm run build:embed` -> passed, existing chunk-size/dynamic-import warnings only.
- `git diff --check` -> passed.

## Risk / rollback
- Risk: Large uploads can keep one frontend request open longer; backend size limits still enforce 20MB document / 80MB video caps.
- Rollback: revert this PR to restore the previous 60s multipart timeout behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented adaptive timeout handling for document and video uploads
  * File parsing now automatically allocates extended processing time for larger files and video content
  * Configurable timeout parameters for upload operations

* **Tests**
  * Added test suite validating timeout behavior across different file types and sizes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/350)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->