### PR TITLE
Use unique visual smoke sessions

### DIFF
--- a/maritime-ai-service/scripts/deploy/smoke-test.sh
+++ b/maritime-ai-service/scripts/deploy/smoke-test.sh
@@ -98,12 +98,14 @@ if [ -n "$API_KEY" ]; then
     check "Pointy voice status reports ElevenLabs provider" "$([ "$VOICE_HTTP" = "200" ] && grep -q '"provider":"elevenlabs"' "$VOICE_BODY" && echo true || echo false)"
     rm -f "$VOICE_BODY"
 
+    VISUAL_SESSION_ID="smoke-test-visual-$(date -u +%Y%m%d%H%M%S)-$$"
+    VISUAL_PAYLOAD=$(printf '{"user_id":"api-client","message":"Create a compact inline visual comparing soft attention and linear attention. Use structured visual lifecycle.","role":"student","session_id":"%s","domain_id":"maritime"}' "$VISUAL_SESSION_ID")
     STREAM_BODY=$(curl -sN \
         -X POST "${BASE_URL}/api/v1/chat/stream/v3" \
         -H "Content-Type: application/json" \
         -H "X-API-Key: ${API_KEY}" \
-        -H "X-Session-ID: smoke-test-visual" \
-        -d '{"user_id":"api-client","message":"Create a compact inline visual comparing soft attention and linear attention. Use structured visual lifecycle.","role":"student","session_id":"smoke-test-visual","domain_id":"maritime"}' \
+        -H "X-Session-ID: ${VISUAL_SESSION_ID}" \
+        -d "$VISUAL_PAYLOAD" \
         --max-time 90 \
         2>/dev/null || true)
     check "Structured visual SSE opens visual lifecycle" "$(echo "$STREAM_BODY" | grep -q '^event: visual_open$' && echo true || echo false)"

--- a/maritime-ai-service/tests/unit/test_production_validation.py
+++ b/maritime-ai-service/tests/unit/test_production_validation.py
@@ -213,6 +213,8 @@ class TestProductionSmokeTestDocs:
         script = pathlib.Path("scripts/deploy/smoke-test.sh").read_text(encoding="utf-8")
         assert "event: visual_open" in script
         assert "event: visual_commit" in script
+        assert 'VISUAL_SESSION_ID="smoke-test-visual-' in script
+        assert 'session_id":"smoke-test-visual"' not in script
         assert "```widget" in script
 
     def test_smoke_test_script_checks_llm_model_health_visibility(self):


### PR DESCRIPTION
﻿## Summary
- Fixes #351.
- Makes production visual SSE smoke use a fresh `VISUAL_SESSION_ID` per deploy run.
- Uses that id consistently in `X-Session-ID` and JSON payload, avoiding visual state leakage from previous deploy smokes.
- Adds a production validation guard so the fixed `smoke-test-visual` payload cannot silently return.

## Evidence
- Previous Deploy Production for #350 rolled out successfully but failed external smoke because `visual_commit` was present while `visual_open` was absent.
- The old smoke reused `session_id=smoke-test-visual`, which can make a repeated visual request behave as a follow-up/patch instead of a fresh open.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_production_validation.py -q` -> 46 passed.
- `bash -n maritime-ai-service/scripts/deploy/smoke-test.sh` -> passed.
- `git diff --check` -> passed.

## Risk / rollback
- Risk: Minimal; only changes deploy smoke request identity, not runtime behavior.
- Rollback: revert this PR to restore the fixed smoke session id.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation testing for chat streaming functionality with enhanced session tracking.
  * Updated test assertions to verify proper session ID handling in automated smoke test procedures.
  * Strengthened test infrastructure for structured visual chat streaming to ensure consistency and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/352)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->