### PR TITLE
Align precision deploy guard defaults

### DIFF
--- a/maritime-ai-service/scripts/deploy/deploy.sh
+++ b/maritime-ai-service/scripts/deploy/deploy.sh
@@ -235,8 +235,10 @@ precision_docs_enabled() {
     local parser_mode
     local use_docling
 
-    parser_mode="$(clean_value "${DOCUMENT_CONTEXT_PARSER_MODE:-$(env_value DOCUMENT_CONTEXT_PARSER_MODE || true)}")"
-    use_docling="$(clean_value "${USE_DOCLING_FOR_COURSE_GEN:-$(env_value USE_DOCLING_FOR_COURSE_GEN || true)}")"
+    # Mirror docker-compose.prod.yml defaults. Production enables the precision
+    # parser lane unless the operator explicitly opts out in the environment.
+    parser_mode="$(clean_value "${DOCUMENT_CONTEXT_PARSER_MODE:-$(env_value DOCUMENT_CONTEXT_PARSER_MODE || echo precision)}")"
+    use_docling="$(clean_value "${USE_DOCLING_FOR_COURSE_GEN:-$(env_value USE_DOCLING_FOR_COURSE_GEN || echo true)}")"
     parser_mode="$(printf '%s' "${parser_mode:-}" | tr '[:upper:]' '[:lower:]')"
 
     [ "$parser_mode" = "precision" ] || is_truthy "$use_docling"

--- a/maritime-ai-service/tests/unit/test_production_validation.py
+++ b/maritime-ai-service/tests/unit/test_production_validation.py
@@ -291,6 +291,8 @@ class TestProductionOperationalScripts:
         assert "MIN_PRECISION_DOCKER_FREE_GIB" in script
         assert "ALLOW_LOW_MEMORY_PRECISION" in script
         assert "/proc/meminfo" in script
+        assert "echo precision" in script
+        assert "echo true" in script
         assert "DOCUMENT_CONTEXT_PARSER_MODE" in script
         assert "USE_DOCLING_FOR_COURSE_GEN" in script
 


### PR DESCRIPTION
## Summary
- closes #355
- makes `deploy.sh` precision-docs detection mirror `docker-compose.prod.yml` defaults
- keeps the capacity guard active when `.env.production` omits parser flags but compose defaults enable precision
- adds regression coverage in production validation tests

## Verification
- `bash -n maritime-ai-service/scripts/deploy/deploy.sh` -> pass
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_production_validation.py -q` -> 49 passed
- `git diff --check` -> pass

## Risk / rollback
- Deployment behavior: the guard now activates by default for the production precision lane. This is intended and matches compose runtime defaults.
- Emergency rollback remains the documented `ALLOW_LOW_MEMORY_PRECISION=true` override or explicit fast-parser env (`DOCUMENT_CONTEXT_PARSER_MODE=fast`, `USE_DOCLING_FOR_COURSE_GEN=false`).
- No app runtime, parser output, LMS contract, database, or secret changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved deployment configuration defaults for document parsing and course generation features.
  * Enhanced validation checks to ensure proper default behavior is maintained during deployments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/356)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->