### PR TITLE
Guard precision parser capacity by product capability

### DIFF
--- a/docs/integration/WIII_LMS_DOC_TO_COURSE_CONTRACT.md
+++ b/docs/integration/WIII_LMS_DOC_TO_COURSE_CONTRACT.md
@@ -135,7 +135,9 @@ LibreOffice and sets `DOCLING_LIBREOFFICE_CMD=/usr/bin/soffice` so Office files
 can expose richer layout/image signals where Docling supports them. If Docling or
 the Office converter is unavailable, Wiii must fall back or surface a parser
 warning rather than silently pretending the citation precision is higher than it
-is.
+is. Because the upload API can request `parser_mode=precision` per document, the
+production deploy capacity guard treats precision parsing as an installed
+product capability, not only as a global default setting.
 
 ## LMS-Side Requirements
 

--- a/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
+++ b/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
@@ -61,14 +61,15 @@ Important guardrail:
   headroom.
 - Docker defaults are tuned for single-node production: `APP_REPLICAS=1`,
   `GUNICORN_WORKERS=2`, `ASYNC_POOL_MAX_SIZE=20`, `APP_MEM_LIMIT=4G`.
-- Deploys with `DOCUMENT_CONTEXT_PARSER_MODE=precision` or
-  `USE_DOCLING_FOR_COURSE_GEN=true` fail early when the host has less than
-  `12GiB` physical RAM or less than `12GiB` free Docker/root disk. This is a
-  guardrail, not a performance target: the recommended product profile remains
-  `e2-standard-4` with an `80GB` boot disk. Use
+- Deploys fail early when the host has less than `12GiB` physical RAM or less
+  than `12GiB` free Docker/root disk because production images include the
+  precision document parser and teacher uploads can request precision parsing
+  per document. This is a guardrail, not a performance target: the recommended
+  product profile remains `e2-standard-4` with an `80GB` boot disk. Use
   `ALLOW_LOW_MEMORY_PRECISION=true` only for an explicit emergency deploy where
-  the operator accepts the risk, or temporarily switch to the fast parser lane
-  until the VM is resized.
+  the operator accepts the risk. Use
+  `SKIP_PRECISION_HOST_CAPACITY_CHECK=true` only for a verified fast-only host
+  that cannot accept per-request precision parsing.
 - Production app images are built with `INSTALL_PRECISION_DOCS=true`, which
   installs `maritime-ai-service/requirements-precision.txt` and enables the
   Docling parser without slowing every regular unit-test install. The production

--- a/maritime-ai-service/scripts/deploy/README.md
+++ b/maritime-ai-service/scripts/deploy/README.md
@@ -441,9 +441,13 @@ docker stats --no-stream
 # DOCUMENT_CONTEXT_PARSER_MODE=fast
 # USE_DOCLING_FOR_COURSE_GEN=false
 
-# Deploy has a precision-docs capacity guard. If it blocks a real emergency
-# rollback, either resize the VM or set ALLOW_LOW_MEMORY_PRECISION=true with an
-# explicit operator note. Do not treat the override as a steady-state fix.
+# Deploy has a precision-docs capacity guard because production images include
+# Docling and teacher uploads can request precision parsing per document. If it
+# blocks a real emergency rollback, either resize the VM or set
+# ALLOW_LOW_MEMORY_PRECISION=true with an explicit operator note. Only set
+# SKIP_PRECISION_HOST_CAPACITY_CHECK=true after verifying the host is fast-only
+# and cannot accept per-request precision parsing. Do not treat either override
+# as a steady-state fix.
 
 # If deploy pulls are slow or disk pressure appears, verify production images
 # are still CPU-only on the current non-GPU VM:

--- a/maritime-ai-service/scripts/deploy/deploy.sh
+++ b/maritime-ai-service/scripts/deploy/deploy.sh
@@ -48,6 +48,7 @@ SKIP_IMAGE_MANIFEST_CHECK="${SKIP_IMAGE_MANIFEST_CHECK:-false}"
 SKIP_PREDEPLOY_BACKUP="${SKIP_PREDEPLOY_BACKUP:-false}"
 RUN_EXTERNAL_SMOKE="${RUN_EXTERNAL_SMOKE:-false}"
 SKIP_PRE_PULL_DOCKER_CLEANUP="${SKIP_PRE_PULL_DOCKER_CLEANUP:-false}"
+SKIP_PRECISION_HOST_CAPACITY_CHECK="${SKIP_PRECISION_HOST_CAPACITY_CHECK:-false}"
 ALLOW_LOW_MEMORY_PRECISION="${ALLOW_LOW_MEMORY_PRECISION:-false}"
 MIN_PRECISION_HOST_MEM_GIB="${MIN_PRECISION_HOST_MEM_GIB:-12}"
 MIN_PRECISION_DOCKER_FREE_GIB="${MIN_PRECISION_DOCKER_FREE_GIB:-12}"
@@ -231,19 +232,6 @@ is_truthy() {
     esac
 }
 
-precision_docs_enabled() {
-    local parser_mode
-    local use_docling
-
-    # Mirror docker-compose.prod.yml defaults. Production enables the precision
-    # parser lane unless the operator explicitly opts out in the environment.
-    parser_mode="$(clean_value "${DOCUMENT_CONTEXT_PARSER_MODE:-$(env_value DOCUMENT_CONTEXT_PARSER_MODE || echo precision)}")"
-    use_docling="$(clean_value "${USE_DOCLING_FOR_COURSE_GEN:-$(env_value USE_DOCLING_FOR_COURSE_GEN || echo true)}")"
-    parser_mode="$(printf '%s' "${parser_mode:-}" | tr '[:upper:]' '[:lower:]')"
-
-    [ "$parser_mode" = "precision" ] || is_truthy "$use_docling"
-}
-
 capacity_failure() {
     local message="$1"
     if is_truthy "$ALLOW_LOW_MEMORY_PRECISION"; then
@@ -258,10 +246,17 @@ capacity_failure() {
 }
 
 validate_host_capacity() {
-    info "Step 4/11: Validating host capacity for the selected parser profile..."
+    info "Step 4/11: Validating host capacity for precision document parsing..."
 
-    if ! precision_docs_enabled; then
-        info "Precision document parsing is disabled; skipping precision-docs capacity guard."
+    local parser_mode
+    local use_docling
+    parser_mode="$(clean_value "${DOCUMENT_CONTEXT_PARSER_MODE:-$(env_value DOCUMENT_CONTEXT_PARSER_MODE || echo precision)}")"
+    use_docling="$(clean_value "${USE_DOCLING_FOR_COURSE_GEN:-$(env_value USE_DOCLING_FOR_COURSE_GEN || echo true)}")"
+    info "Configured parser profile: DOCUMENT_CONTEXT_PARSER_MODE=${parser_mode:-unset}, USE_DOCLING_FOR_COURSE_GEN=${use_docling:-unset}."
+
+    if is_truthy "$SKIP_PRECISION_HOST_CAPACITY_CHECK"; then
+        warn "Skipping precision-docs capacity guard because SKIP_PRECISION_HOST_CAPACITY_CHECK=true."
+        warn "Use this only for an emergency deploy or a verified fast-only host that cannot accept per-request precision parsing."
         return 0
     fi
 

--- a/maritime-ai-service/tests/unit/test_production_validation.py
+++ b/maritime-ai-service/tests/unit/test_production_validation.py
@@ -280,13 +280,13 @@ class TestProductionOperationalScripts:
         assert "maritime-ai-service/logs/" in dockerignore
 
     def test_deploy_script_guards_precision_docs_host_capacity(self):
-        """Precision-docs deploys should fail early on undersized hosts."""
+        """Precision-docs capability should fail early on undersized hosts."""
         import pathlib
 
         script = pathlib.Path("scripts/deploy/deploy.sh").read_text(encoding="utf-8")
 
         assert "validate_host_capacity" in script
-        assert "precision_docs_enabled" in script
+        assert "SKIP_PRECISION_HOST_CAPACITY_CHECK" in script
         assert "MIN_PRECISION_HOST_MEM_GIB" in script
         assert "MIN_PRECISION_DOCKER_FREE_GIB" in script
         assert "ALLOW_LOW_MEMORY_PRECISION" in script
@@ -295,6 +295,8 @@ class TestProductionOperationalScripts:
         assert "echo true" in script
         assert "DOCUMENT_CONTEXT_PARSER_MODE" in script
         assert "USE_DOCLING_FOR_COURSE_GEN" in script
+        assert "Configured parser profile:" in script
+        assert "Precision document parsing is disabled; skipping" not in script
 
     def test_status_dashboard_surfaces_docker_disk_usage(self):
         """Production status should show Docker disk pressure next to RAM/disk."""


### PR DESCRIPTION
## Summary
- Runs the precision-docs host capacity guard by default because product uploads can request `parser_mode=precision` per document even when global parser defaults are fast/false.
- Adds explicit `SKIP_PRECISION_HOST_CAPACITY_CHECK=true` override for verified fast-only/emergency hosts, separate from `ALLOW_LOW_MEMORY_PRECISION=true`.
- Updates deployment docs and validation coverage so operators do not mistake global parser settings for capability safety.

Fixes #357.

## Verification
- `bash -n maritime-ai-service/scripts/deploy/deploy.sh` -> pass (WSL config warnings only)
- `cd maritime-ai-service; .\.venv\Scripts\python.exe -m pytest tests/unit/test_production_validation.py -q` -> 49 passed
- `cd maritime-ai-service; docker compose --env-file .env.production -f docker-compose.prod.yml config --quiet` -> pass (existing `CF_TUNNEL_TOKEN` blank warning)
- `git diff --check` -> pass

## Risk / rollback
- Risk: undersized production hosts now fail earlier unless an operator sets an explicit override. This is intentional for teacher document uploads that can invoke Docling per request.
- Rollback: revert this PR or set `SKIP_PRECISION_HOST_CAPACITY_CHECK=true` only for a verified emergency/fast-only deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified precision document parsing as a deployment capacity requirement with updated system resource guidance (12GiB RAM/disk minimum).
  * Enhanced troubleshooting documentation with clearer out-of-memory guidance and recovery options.
  * Added environment variable references for emergency deployment scenarios and host capacity validation overrides.

* **Tests**
  * Updated production deployment validation tests to reflect new capacity-check behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/358)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->