### PR TITLE
Accept visual patch lifecycle in production smoke

### DIFF
--- a/maritime-ai-service/scripts/deploy/smoke-test.sh
+++ b/maritime-ai-service/scripts/deploy/smoke-test.sh
@@ -108,7 +108,9 @@ if [ -n "$API_KEY" ]; then
         -d "$VISUAL_PAYLOAD" \
         --max-time 90 \
         2>/dev/null || true)
-    check "Structured visual SSE opens visual lifecycle" "$(echo "$STREAM_BODY" | grep -q '^event: visual_open$' && echo true || echo false)"
+    VISUAL_EVENTS="$(printf '%s\n' "$STREAM_BODY" | grep '^event:' | tr '\n' ' ' || true)"
+    echo "  [INFO] Structured visual SSE events: ${VISUAL_EVENTS:-none}"
+    check "Structured visual SSE opens or patches visual lifecycle" "$(printf '%s\n' "$STREAM_BODY" | grep -Eq '^event: visual_(open|patch)$' && echo true || echo false)"
     check "Structured visual SSE commits visual lifecycle" "$(echo "$STREAM_BODY" | grep -q '^event: visual_commit$' && echo true || echo false)"
     check "Structured visual stream hides raw widget fences" "$([ -n "$STREAM_BODY" ] && ! echo "$STREAM_BODY" | grep -q '```widget' && echo true || echo false)"
 else

--- a/maritime-ai-service/tests/unit/test_production_validation.py
+++ b/maritime-ai-service/tests/unit/test_production_validation.py
@@ -211,7 +211,8 @@ class TestProductionSmokeTestDocs:
         import pathlib
 
         script = pathlib.Path("scripts/deploy/smoke-test.sh").read_text(encoding="utf-8")
-        assert "event: visual_open" in script
+        assert "event: visual_(open|patch)" in script
+        assert "Structured visual SSE events" in script
         assert "event: visual_commit" in script
         assert 'VISUAL_SESSION_ID="smoke-test-visual-' in script
         assert 'session_id":"smoke-test-visual"' not in script


### PR DESCRIPTION
## Summary
- Treats either `visual_open` or `visual_patch` as a valid structured visual lifecycle start/upsert event in production smoke.
- Keeps `visual_commit` and raw-widget-fence checks strict.
- Prints a compact visual SSE event summary so future deploy smoke failures are diagnosable from the Actions log.

Fixes #359.

## Verification
- `bash -n maritime-ai-service/scripts/deploy/smoke-test.sh` -> pass (WSL config warnings only)
- `cd maritime-ai-service; .\.venv\Scripts\python.exe -m pytest tests/unit/test_production_validation.py -q` -> 49 passed
- `git diff --check` -> pass

## Risk / rollback
- Risk: smoke now accepts `visual_patch` as lifecycle start/upsert, matching frontend `patchVisualSession` behavior. It does not weaken commit or raw widget checks.
- Rollback: revert this PR to require only `visual_open`, but that can reintroduce false-negative deploys for valid patch lifecycle streams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated production validation tests to recognize expanded visual event patterns in SSE V3 responses.

* **Chores**
  * Enhanced deployment smoke-test script to accept both `visual_open` and `visual_patch` events, improving validation flexibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/360)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->