### PR TITLE
Remove duplicated course plan preview caution

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -1837,8 +1837,7 @@ def _build_uploaded_doc_course_params(query: str, state: AgentState | None) -> d
         "title": course_plan.get("title") or title_source,
         "summary": (
             f"Wiii đã dựng cây khóa học nháp gồm {len(chapters)} chương và "
-            f"{lesson_count} bài từ tài liệu upload. Giáo viên cần xem nguồn trích dẫn "
-            "trước khi áp dụng vào LMS."
+            f"{lesson_count} bài từ tài liệu upload."
         ),
         "course_plan": course_plan,
         "changed_fields": ["course_structure"],

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -577,6 +577,9 @@ def test_uploaded_doc_course_plan_builder_creates_full_lms_architecture():
     plan = params["course_plan"]
     assert params["course_id"] == "course-1"
     assert params["changed_fields"] == ["course_structure"]
+    assert params["summary"].endswith("tài liệu upload.")
+    assert "trích dẫn" not in params["summary"]
+    assert "LMS" not in params["summary"]
     assert len(plan["chapters"]) == 5
     titles = [chapter["title"] for chapter in plan["chapters"]]
     assert any("Hành trình học viên" in title for title in titles)


### PR DESCRIPTION
## Summary
- Removes the redundant citation/LMS caution from Wiii course-plan preview summary.
- Leaves the LMS preview dialog responsible for the approval/citation warning exactly once.
- Adds regression coverage so the Wiii course-plan host-action summary stays focused on generated chapter/lesson structure.

Fixes #361.

## Verification
- `cd maritime-ai-service; .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py::test_uploaded_document_course_plan_runs_host_action_without_planner_llm tests/unit/test_direct_tool_rounds_runtime.py::test_uploaded_doc_course_plan_builder_creates_full_lms_architecture tests/unit/test_direct_tool_rounds_runtime.py::test_uploaded_doc_course_plan_builder_keeps_maritime_research_out_of_lms_manual -q` -> 3 passed
- `git diff --check` -> pass

## Risk / rollback
- Risk: copy-only backend host-action summary change; lesson preview safety copy is unchanged and LMS still displays the approval/citation warning.
- Rollback: revert this PR to restore the previous longer summary, accepting duplicated warning copy in the LMS preview panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated course summary generation to display only course structure details (chapters and lessons), removing supplementary instructions about source review before application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/362)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->