### PR TITLE
Retry GHCR manifest checks in deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -86,8 +86,31 @@ jobs:
           set -euo pipefail
 
           echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin >/dev/null
-          docker manifest inspect "${{ steps.release.outputs.app_image }}" >/dev/null
-          docker manifest inspect "${{ steps.release.outputs.nginx_image }}" >/dev/null
+          inspect_manifest_with_retry() {
+            local image="$1"
+            local max_attempts=4
+            local delay_seconds=5
+            local attempt=1
+
+            while [ "$attempt" -le "$max_attempts" ]; do
+              if docker manifest inspect "$image" >/dev/null; then
+                echo "Validated image manifest: ${image}"
+                return 0
+              fi
+
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                echo "::warning::Image manifest check failed for ${image} (attempt ${attempt}/${max_attempts}); retrying in ${delay_seconds}s."
+                sleep "$delay_seconds"
+              fi
+              attempt=$((attempt + 1))
+            done
+
+            echo "::error::Image manifest check failed after ${max_attempts} attempts: ${image}"
+            return 1
+          }
+
+          inspect_manifest_with_retry "${{ steps.release.outputs.app_image }}"
+          inspect_manifest_with_retry "${{ steps.release.outputs.nginx_image }}"
 
       - name: Configure SSH
         shell: bash

--- a/maritime-ai-service/scripts/deploy/deploy.sh
+++ b/maritime-ai-service/scripts/deploy/deploy.sh
@@ -45,6 +45,8 @@ DEPLOY_SHA="${DEPLOY_SHA:-}"
 ALLOW_PLACEHOLDERS="${ALLOW_PLACEHOLDERS:-false}"
 REQUIRE_PINNED_IMAGES="${REQUIRE_PINNED_IMAGES:-false}"
 SKIP_IMAGE_MANIFEST_CHECK="${SKIP_IMAGE_MANIFEST_CHECK:-false}"
+IMAGE_MANIFEST_RETRIES="${IMAGE_MANIFEST_RETRIES:-4}"
+IMAGE_MANIFEST_RETRY_DELAY_SECONDS="${IMAGE_MANIFEST_RETRY_DELAY_SECONDS:-5}"
 SKIP_PREDEPLOY_BACKUP="${SKIP_PREDEPLOY_BACKUP:-false}"
 RUN_EXTERNAL_SMOKE="${RUN_EXTERNAL_SMOKE:-false}"
 SKIP_PRE_PULL_DOCKER_CLEANUP="${SKIP_PRE_PULL_DOCKER_CLEANUP:-false}"
@@ -206,8 +208,8 @@ validate_images() {
     fi
 
     if [ "$SKIP_IMAGE_MANIFEST_CHECK" != "true" ]; then
-        docker manifest inspect "$APP_IMAGE" >/dev/null
-        docker manifest inspect "$NGINX_IMAGE" >/dev/null
+        inspect_image_manifest_with_retry "$APP_IMAGE"
+        inspect_image_manifest_with_retry "$NGINX_IMAGE"
     else
         warn "Skipping docker manifest validation."
     fi
@@ -219,6 +221,27 @@ validate_images() {
 validate_compose_config() {
     info "Step 3/11: Validating docker compose configuration..."
     compose config --quiet
+}
+
+inspect_image_manifest_with_retry() {
+    local image="$1"
+    local attempt=1
+
+    while [ "$attempt" -le "$IMAGE_MANIFEST_RETRIES" ]; do
+        if docker manifest inspect "$image" >/dev/null; then
+            info "Validated image manifest: ${image}"
+            return 0
+        fi
+
+        if [ "$attempt" -lt "$IMAGE_MANIFEST_RETRIES" ]; then
+            warn "Image manifest check failed for ${image} (attempt ${attempt}/${IMAGE_MANIFEST_RETRIES}); retrying in ${IMAGE_MANIFEST_RETRY_DELAY_SECONDS}s."
+            sleep "$IMAGE_MANIFEST_RETRY_DELAY_SECONDS"
+        fi
+        attempt=$((attempt + 1))
+    done
+
+    error "Image manifest check failed after ${IMAGE_MANIFEST_RETRIES} attempts: ${image}"
+    return 1
 }
 
 is_truthy() {

--- a/maritime-ai-service/tests/unit/test_production_validation.py
+++ b/maritime-ai-service/tests/unit/test_production_validation.py
@@ -299,6 +299,23 @@ class TestProductionOperationalScripts:
         assert "Configured parser profile:" in script
         assert "Precision document parsing is disabled; skipping" not in script
 
+    def test_deploy_manifest_checks_retry_transient_ghcr_errors(self):
+        """Pinned image validation should tolerate short GHCR token timeouts."""
+        import pathlib
+
+        deploy_script = pathlib.Path("scripts/deploy/deploy.sh").read_text(encoding="utf-8")
+        deploy_workflow = pathlib.Path("../.github/workflows/deploy-production.yml").read_text(encoding="utf-8")
+
+        assert "inspect_image_manifest_with_retry" in deploy_script
+        assert "IMAGE_MANIFEST_RETRIES" in deploy_script
+        assert "Image manifest check failed after" in deploy_script
+        assert deploy_script.count("docker manifest inspect") == 1
+
+        assert "inspect_manifest_with_retry" in deploy_workflow
+        assert "max_attempts=4" in deploy_workflow
+        assert "::warning::Image manifest check failed" in deploy_workflow
+        assert deploy_workflow.count("docker manifest inspect") == 1
+
     def test_status_dashboard_surfaces_docker_disk_usage(self):
         """Production status should show Docker disk pressure next to RAM/disk."""
         import pathlib


### PR DESCRIPTION
## Summary
- Adds bounded retries around pinned image manifest inspection in the GitHub Actions production deploy workflow.
- Adds the same retry behavior to the server-side deploy script so manual/pinned deploys are resilient too.
- Keeps validation fail-closed after retries and adds unit validation coverage.

Fixes #363.

## Verification
- `bash -n maritime-ai-service/scripts/deploy/deploy.sh` -> pass (WSL config warnings only)
- `cd maritime-ai-service; .\.venv\Scripts\python.exe -m pytest tests/unit/test_production_validation.py -q` -> 50 passed
- `git diff --check` -> pass

## Risk / rollback
- Risk: deploy validation can take up to ~15s longer per image if GHCR is transiently unavailable. It still fails if the image remains missing/unreachable.
- Rollback: revert this PR to restore single-attempt manifest inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment workflows now include retry logic for Docker image manifest validation with configurable retry parameters to improve resilience during production deployments.

* **Tests**
  * Added unit tests to validate retry behavior and transient error handling in deployment validation processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/364)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->