### PR TITLE
Fix manifest retry under strict shell mode

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -91,21 +91,34 @@ jobs:
             local max_attempts=4
             local delay_seconds=5
             local attempt=1
+            local inspect_output=""
+            local inspect_status=0
 
             while [ "$attempt" -le "$max_attempts" ]; do
-              if docker manifest inspect "$image" >/dev/null; then
+              set +e
+              inspect_output="$(docker manifest inspect "$image" 2>&1 >/dev/null)"
+              inspect_status=$?
+              set -e
+
+              if [ "$inspect_status" -eq 0 ]; then
                 echo "Validated image manifest: ${image}"
                 return 0
               fi
 
+              if [ -n "$inspect_output" ]; then
+                inspect_output="$(printf '%s\n' "$inspect_output" | tail -n 1)"
+              else
+                inspect_output="unknown image manifest failure"
+              fi
+
               if [ "$attempt" -lt "$max_attempts" ]; then
-                echo "::warning::Image manifest check failed for ${image} (attempt ${attempt}/${max_attempts}); retrying in ${delay_seconds}s."
+                echo "::warning::Image manifest check failed for ${image} (attempt ${attempt}/${max_attempts}); retrying in ${delay_seconds}s. Last error: ${inspect_output}"
                 sleep "$delay_seconds"
               fi
               attempt=$((attempt + 1))
             done
 
-            echo "::error::Image manifest check failed after ${max_attempts} attempts: ${image}"
+            echo "::error::Image manifest check failed after ${max_attempts} attempts: ${image}. Last error: ${inspect_output}"
             return 1
           }
 

--- a/maritime-ai-service/scripts/deploy/deploy.sh
+++ b/maritime-ai-service/scripts/deploy/deploy.sh
@@ -226,21 +226,34 @@ validate_compose_config() {
 inspect_image_manifest_with_retry() {
     local image="$1"
     local attempt=1
+    local inspect_output=""
+    local inspect_status=0
 
     while [ "$attempt" -le "$IMAGE_MANIFEST_RETRIES" ]; do
-        if docker manifest inspect "$image" >/dev/null; then
+        set +e
+        inspect_output="$(docker manifest inspect "$image" 2>&1 >/dev/null)"
+        inspect_status=$?
+        set -e
+
+        if [ "$inspect_status" -eq 0 ]; then
             info "Validated image manifest: ${image}"
             return 0
         fi
 
+        if [ -n "$inspect_output" ]; then
+            inspect_output="$(printf '%s\n' "$inspect_output" | tail -n 1)"
+        else
+            inspect_output="unknown image manifest failure"
+        fi
+
         if [ "$attempt" -lt "$IMAGE_MANIFEST_RETRIES" ]; then
-            warn "Image manifest check failed for ${image} (attempt ${attempt}/${IMAGE_MANIFEST_RETRIES}); retrying in ${IMAGE_MANIFEST_RETRY_DELAY_SECONDS}s."
+            warn "Image manifest check failed for ${image} (attempt ${attempt}/${IMAGE_MANIFEST_RETRIES}); retrying in ${IMAGE_MANIFEST_RETRY_DELAY_SECONDS}s. Last error: ${inspect_output}"
             sleep "$IMAGE_MANIFEST_RETRY_DELAY_SECONDS"
         fi
         attempt=$((attempt + 1))
     done
 
-    error "Image manifest check failed after ${IMAGE_MANIFEST_RETRIES} attempts: ${image}"
+    error "Image manifest check failed after ${IMAGE_MANIFEST_RETRIES} attempts: ${image}. Last error: ${inspect_output}"
     return 1
 }
 

--- a/maritime-ai-service/tests/unit/test_production_validation.py
+++ b/maritime-ai-service/tests/unit/test_production_validation.py
@@ -308,12 +308,18 @@ class TestProductionOperationalScripts:
 
         assert "inspect_image_manifest_with_retry" in deploy_script
         assert "IMAGE_MANIFEST_RETRIES" in deploy_script
+        assert "inspect_output=\"$(docker manifest inspect" in deploy_script
+        assert "inspect_status=$?" in deploy_script
         assert "Image manifest check failed after" in deploy_script
+        assert "Last error:" in deploy_script
         assert deploy_script.count("docker manifest inspect") == 1
 
         assert "inspect_manifest_with_retry" in deploy_workflow
         assert "max_attempts=4" in deploy_workflow
+        assert "inspect_output=\"$(docker manifest inspect" in deploy_workflow
+        assert "inspect_status=$?" in deploy_workflow
         assert "::warning::Image manifest check failed" in deploy_workflow
+        assert "Last error:" in deploy_workflow
         assert deploy_workflow.count("docker manifest inspect") == 1
 
     def test_status_dashboard_surfaces_docker_disk_usage(self):


### PR DESCRIPTION
Fixes #365.

## Summary
- Capture `docker manifest inspect` failures under `set +e` inside the bounded retry loop so `errexit` cannot short-circuit retries.
- Surface the last manifest-inspect error in retry warnings and final failure messages.
- Extend production validation coverage for the stricter retry helper in both GitHub Actions and server deploy script.

## Verification
- `bash -n maritime-ai-service/scripts/deploy/deploy.sh`
- `cd maritime-ai-service; .\.venv\Scripts\python.exe -m pytest tests/unit/test_production_validation.py -q` -> 50 passed
- `git diff --check`

## Risk / rollback
- Low runtime risk: deploy remains fail-closed if all manifest attempts fail.
- Rollback: revert this PR; the previous behavior only affects pre-deploy manifest validation, not application runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error diagnostics and messaging during deployment validation, capturing detailed failure information from manifest inspection attempts and including context in retry warnings and final error reports.

* **Tests**
  * Expanded deployment validation tests to verify the enhanced error reporting and retry behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/366)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->