### PR TITLE
Polish model selector Vietnamese label

### DIFF
--- a/wiii-desktop/src/__tests__/model-selector.test.tsx
+++ b/wiii-desktop/src/__tests__/model-selector.test.tsx
@@ -91,8 +91,11 @@ describe("ModelSelector", () => {
       expect(useModelStore.getState().providers.length).toBe(3);
     });
 
+    expect(screen.getByText("Tự động")).not.toBeNull();
+
     fireEvent.click(screen.getByTestId("model-selector-trigger"));
 
+    expect(screen.getAllByText("Tự động").length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText("OpenAI")).toBeNull();
     expect(screen.getByText("Provider tam thoi ban hoac da cham gioi han.")).not.toBeNull();
 

--- a/wiii-desktop/src/components/chat/ModelSelector.tsx
+++ b/wiii-desktop/src/components/chat/ModelSelector.tsx
@@ -16,7 +16,7 @@ const PROVIDER_ICONS: Record<string, typeof Cpu> = {
 };
 
 const PROVIDER_LABELS: Record<string, string> = {
-  auto: "Tu dong",
+  auto: "Tự động",
   google: "Gemini",
   zhipu: "Zhipu GLM",
   openai: "OpenAI",


### PR DESCRIPTION
Fixes #367.

## Summary
- Change the auto provider label from `Tu dong` to `Tự động` in the chat model selector.
- Add focused coverage so the label stays Vietnamese-first in the desktop/embed UI.

## Verification
- `cd wiii-desktop; npx vitest run src/__tests__/model-selector.test.tsx` -> 1 file, 2 tests passed
- `cd wiii-desktop; npm run build:embed` -> pass
- `git diff --check`

## Risk / rollback
- Very low risk: UI copy-only change plus test.
- Rollback: revert this PR if the product wants ASCII-only labels, though that would conflict with Vietnamese-first guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Vietnamese text display in the automatic model selection option to use proper diacritical marks and character formatting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/368)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->