### PR TITLE
Fix product doc course research classification

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -548,9 +548,12 @@ def _resolve_doc_preview_lesson_id(state: AgentState | None) -> str:
     if isinstance(ctx, dict):
         candidates.extend([ctx.get("lesson_id"), ctx.get("lessonId")])
         for key in ("page_context", "host_context"):
-            value = ctx.get(key)
-            if isinstance(value, dict):
-                candidates.extend([value.get("lesson_id"), value.get("lessonId")])
+            _extend_doc_context_id_candidates(
+                candidates,
+                ctx.get(key),
+                snake_key="lesson_id",
+                camel_key="lessonId",
+            )
     for candidate in candidates:
         normalized = str(candidate or "").strip()
         if normalized:
@@ -566,14 +569,47 @@ def _resolve_doc_preview_course_id(state: AgentState | None) -> str:
     if isinstance(ctx, dict):
         candidates.extend([ctx.get("course_id"), ctx.get("courseId")])
         for key in ("page_context", "host_context"):
-            value = ctx.get(key)
-            if isinstance(value, dict):
-                candidates.extend([value.get("course_id"), value.get("courseId")])
+            _extend_doc_context_id_candidates(
+                candidates,
+                ctx.get(key),
+                snake_key="course_id",
+                camel_key="courseId",
+            )
     for candidate in candidates:
         normalized = str(candidate or "").strip()
         if normalized:
             return normalized
     return ""
+
+
+def _extend_doc_context_id_candidates(
+    candidates: list[Any],
+    value: Any,
+    *,
+    snake_key: str,
+    camel_key: str,
+    depth: int = 0,
+) -> None:
+    if not isinstance(value, dict) or depth > 3:
+        return
+    candidates.extend([value.get(snake_key), value.get(camel_key)])
+    for nested_key in (
+        "metadata",
+        "entity_refs",
+        "page",
+        "page_context",
+        "selection",
+        "editable_scope",
+    ):
+        nested = value.get(nested_key)
+        if isinstance(nested, dict):
+            _extend_doc_context_id_candidates(
+                candidates,
+                nested,
+                snake_key=snake_key,
+                camel_key=camel_key,
+                depth=depth + 1,
+            )
 
 
 def _extract_doc_course_title_from_query(query: str) -> str:
@@ -723,9 +759,6 @@ def _looks_holilihu_lms_manual_document(
     markdown: str,
     query: str = "",
 ) -> bool:
-    document_text = _normalize_doc_preview_text(
-        f"{title_source}\n{str(markdown or '')[:8000]}"
-    )
     manual_markers = (
         "huong dan su dung",
         "huong dan cho hoc vien",
@@ -745,12 +778,56 @@ def _looks_holilihu_lms_manual_document(
         "manual",
         "user guide",
     )
+    title_text = _normalize_doc_preview_text(title_source)
+    query_text = _normalize_doc_preview_text(query)
+    title_has_guide_frame = any(marker in title_text for marker in guide_markers)
+    title_has_holilihu = "holilihu" in title_text
+    query_explicitly_requests_holilihu_manual = (
+        "holilihu" in query_text and any(marker in query_text for marker in guide_markers)
+    )
+    research_title_markers = (
+        "nghien cuu",
+        "cong trinh",
+        "de tai",
+        "bao cao",
+        "luan van",
+        "khoa luan",
+        "xay dung he thong",
+        "thiet ke he thong",
+    )
+    maritime_training_title_markers = (
+        "thuy thu",
+        "hang hai",
+        "nghiep vu chuyen mon",
+        "van tai bien",
+        "tau thuy",
+    )
+    title_is_research_lms = bool(
+        title_text
+        and re.search(r"(^|[^a-z0-9])lms([^a-z0-9]|$)", title_text)
+        and any(marker in title_text for marker in research_title_markers)
+    )
+    title_is_maritime_training_research = bool(
+        title_text
+        and any(marker in title_text for marker in research_title_markers)
+        and any(marker in title_text for marker in maritime_training_title_markers)
+    )
+    if (
+        (title_is_research_lms or title_is_maritime_training_research)
+        and not title_has_holilihu
+        and not title_has_guide_frame
+        and not query_explicitly_requests_holilihu_manual
+    ):
+        return False
+
+    document_text = _normalize_doc_preview_text(
+        f"{title_source}\n{str(markdown or '')[:8000]}"
+    )
     if "holilihu" in document_text:
         return any(marker in document_text for marker in guide_markers + manual_markers)
     has_manual_frame = any(marker in document_text for marker in guide_markers)
     if re.search(r"(^|[^a-z0-9])lms([^a-z0-9]|$)", document_text):
         return has_manual_frame and any(marker in document_text for marker in manual_markers)
-    query_text = _normalize_doc_preview_text(query)
     query_says_lms = "holilihu" in query_text or re.search(r"(^|[^a-z0-9])lms([^a-z0-9]|$)", query_text)
     if query_says_lms and has_manual_frame and any(marker in document_text for marker in manual_markers):
         return True

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -714,6 +714,58 @@ def test_uploaded_doc_course_plan_builder_keeps_maritime_lms_research_out_of_hol
     assert "thuy thu" in normalized_plan
 
 
+def test_uploaded_doc_course_plan_research_title_overrides_manual_markers_in_body():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        _build_uploaded_doc_course_params,
+        _normalize_doc_preview_text,
+    )
+
+    markdown = (
+        "CONG TRINH\n\n"
+        "**NGHIEN CUU XAY DUNG HE THONG LMS NANG CAO NGHIEP VU CHUYEN MON CHO CAC THUY THU**\n"
+        "# GIOI THIEU\n"
+        "Tai lieu phan tich nhu cau boi duong nghiep vu chuyen mon cho thuy thu bang he thong LMS.\n"
+        "Nguon section: Gioi thieu nhu cau dao tao thuy thu (trang 1-5)\n"
+        "# HUONG DAN SU DUNG HE THONG LMS\n"
+        "Noi dung minh hoa co cac marker dang nhap, tao khoa hoc, them video va quiz.\n"
+        "HoLiLiHu LMS duoc nhac den nhu mot vi du san pham trong qua trinh nghien cuu.\n"
+        "Nguon section: Phan tich chuc nang LMS va quy trinh su dung (trang 19-36)\n"
+        "# THU NGHIEM VA DANH GIA\n"
+        "Danh gia kha nang ung dung he thong trong dao tao nghiep vu chuyen mon cho thuy thu.\n"
+        "Nguon section: Thu nghiem va danh gia (trang 37-48)\n"
+    )
+
+    params = _build_uploaded_doc_course_params(
+        "Tao bai giang di.",
+        {
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "SV25-26.43_KH-KT.docx",
+                            "title": "tmpg98c_ocp",
+                            "markdown": markdown,
+                        }
+                    ]
+                },
+                "host_context": {
+                    "page": {
+                        "metadata": {
+                            "course_id": "course-from-nested-host-metadata",
+                        }
+                    }
+                },
+            }
+        },
+    )
+
+    plan = params["course_plan"]
+    normalized_title = _normalize_doc_preview_text(plan["title"])
+    assert params["course_id"] == "course-from-nested-host-metadata"
+    assert plan["document_domain"]["id"] != "holilihu_lms_manual"
+    assert "khai thac holilihu lms" not in normalized_title
+
+
 def test_generic_uploaded_doc_course_clusters_full_long_document_map():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (
         _build_uploaded_doc_course_params,


### PR DESCRIPTION
## Summary
- Fixes #379.
- Prevents research/công trình/đề tài LMS hàng hải source titles from being forced into the HoLiLiHu manual course template just because body excerpts contain guide/manual markers.
- Resolves doc preview/course ids from nested LMS host context metadata/entity refs, not only legacy flat `page_context`.

## Product evidence before fix
- Product parse for `SV25-26.43_KH-KT.docx`: 200, parser `docling`, ~37.2s, `truncated=false`.
- Product stream emitted the right `authoring.generate_course_from_document` host action, but payload still had `document_domain.id=holilihu_lms_manual`, title `Khai thác HoLiLiHu LMS từ tài liệu hướng dẫn`, and missing `course_id` in the direct API smoke.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py -q` -> 53 passed
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_node_provider_errors.py -q` -> 35 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk / rollback
- Risk is limited to deterministic doc-to-course classification and ID extraction. The flow remains preview-only; this does not add any direct LMS mutation.
- Rollback by reverting this commit if HoLiLiHu manual documents stop selecting the manual template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved extraction of course and lesson identifiers from uploaded documents with enhanced support for nested metadata structures
  * Refined document classification logic to better recognize research-oriented documents and accurately distinguish between manual materials and LMS content

* **Tests**
  * Expanded test coverage for document classification scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/380)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->