### PR TITLE
Improve doc course cover title extraction

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -256,8 +256,98 @@ def _first_nonempty_line(text: str) -> str:
             and not _is_doc_preview_scaffold_line(line)
             and not _is_doc_preview_low_value_line(line)
         ):
-            return line[:140]
+            selected = _select_doc_preview_title_line(text)
+            return selected or line[:140]
     return "Tài liệu đã tải lên"
+
+
+def _select_doc_preview_title_line(text: str) -> str:
+    fallback = ""
+    best_line = ""
+    best_score = -10_000
+    for raw_line in str(text or "").replace("\\_", "_").splitlines()[:120]:
+        line = _clean_doc_preview_line(raw_line)
+        if (
+            not line
+            or _is_doc_preview_scaffold_line(line)
+            or _is_doc_preview_low_value_line(line)
+            or _is_low_value_doc_preview_title(line)
+            or _is_doc_preview_cover_metadata_line(line)
+        ):
+            continue
+        if not fallback:
+            fallback = line[:140]
+        score = _score_doc_preview_title_candidate(line)
+        if score > best_score:
+            best_score = score
+            best_line = line[:140]
+        if best_score >= 150:
+            break
+    if best_line and best_score >= 120:
+        return best_line
+    return fallback
+
+
+def _score_doc_preview_title_candidate(value: str) -> int:
+    cleaned = _clean_doc_preview_line(value)
+    normalized = _normalize_doc_preview_text(cleaned)
+    if not cleaned or _is_doc_preview_cover_metadata_line(cleaned):
+        return -10_000
+    score = min(len(cleaned), 160) // 4
+    word_count = len(re.findall(r"\w+", cleaned, flags=re.IGNORECASE))
+    if word_count >= 6:
+        score += 25
+    if word_count >= 12:
+        score += 25
+    for marker in (
+        "nghien cuu",
+        "xay dung he thong",
+        "thiet ke he thong",
+        "quan ly van hanh",
+        "ho so tau",
+        "tau thuy",
+        "van tai bien",
+        "nghiep vu chuyen mon",
+        "thuy thu",
+    ):
+        if marker in normalized:
+            score += 40
+    if normalized in {"loi cam on", "muc luc", "danh muc bang", "danh muc hinh"}:
+        score -= 100
+    return score
+
+
+def _is_doc_preview_cover_metadata_line(value: str) -> bool:
+    normalized = _normalize_doc_preview_text(value).strip(" #-:\t\r\n|")
+    if not normalized:
+        return True
+    if normalized in {
+        "bo xay dung",
+        "bo giao duc va dao tao",
+        "bo xay dung - bo giao duc va dao tao",
+        "truong dai hoc hang hai viet nam",
+        "truong dai hoc",
+        "thuc tap tot nghiep",
+        "do an tot nghiep",
+        "khoa luan tot nghiep",
+        "bao cao thuc tap",
+        "hai phong - 2026",
+        "hai phong 2026",
+    }:
+        return True
+    if any(
+        marker in normalized
+        for marker in (
+            "giang vien huong dan",
+            "sinh vien thuc hien",
+            "nguoi huong dan",
+            "giao vien huong dan",
+        )
+    ):
+        return True
+    if re.search(r"\b\d{5,}\b", normalized) and re.search(r"\b[a-z]{2,}\d{2}", normalized):
+        return True
+    return bool(re.fullmatch(r"(?:hai phong|ha noi|tp\.? ho chi minh)\s*[-–]?\s*\d{4}", normalized))
 
 
 def _clean_doc_preview_line(value: str) -> str:

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -766,6 +766,61 @@ def test_uploaded_doc_course_plan_research_title_overrides_manual_markers_in_bod
     assert "khai thac holilihu lms" not in normalized_title
 
 
+def test_uploaded_doc_course_title_skips_cover_metadata_for_long_thesis_doc():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        _build_uploaded_doc_course_params,
+        _normalize_doc_preview_text,
+    )
+
+    title = (
+        "NGHIEN CUU XAY DUNG HE THONG QUAN LY VAN HANH VA HO SO TAU THUY "
+        "PHUC VU DOANH NGHIEP VAN TAI BIEN"
+    )
+    markdown = (
+        "| BO XAY DUNG | BO GIAO DUC VA DAO TAO |\n"
+        "|-------------|-------------------------|\n\n"
+        "**TRUONG DAI HOC HANG HAI VIET NAM**\n\n"
+        "<!-- image -->\n\n"
+        "**VU DUC TINH - 97658 - CNT63CL**\n\n"
+        "**BUI TRUNG HIEU - 95457 - CNT63CL**\n\n"
+        "**THUC TAP TOT NGHIEP**\n\n"
+        f"**{title}**\n\n"
+        "HAI PHONG - 2026\n\n"
+        "# MO DAU\n"
+        "Tai lieu trinh bay bai toan quan ly van hanh, ho so tau thuy va doanh nghiep van tai bien.\n"
+        "Nguon section: Mo dau bai toan quan ly ho so tau (trang 1-4)\n"
+        "# PHAN TICH HE THONG\n"
+        "Mo ta chuc nang quan ly tau, ho so, thuyen vien, bao tri va van hanh.\n"
+        "Nguon section: Phan tich he thong quan ly tau (trang 5-20)\n"
+    )
+
+    params = _build_uploaded_doc_course_params(
+        "Tao bai giang di.",
+        {
+            "context": {
+                "document_context": {
+                    "attachments": [
+                        {
+                            "file_name": "40 - GV.25-26.01.31.docx",
+                            "markdown": markdown,
+                        }
+                    ]
+                },
+                "page_context": {"course_id": "course-thesis"},
+            }
+        },
+    )
+
+    plan = params["course_plan"]
+    normalized_source = _normalize_doc_preview_text(plan["source_document_title"])
+    assert params["course_id"] == "course-thesis"
+    assert plan["document_domain"]["id"] == "maritime_vessel_management"
+    assert "bo xay dung" not in normalized_source
+    assert "truong dai hoc" not in normalized_source
+    assert "nghien cuu xay dung he thong quan ly van hanh" in normalized_source
+    assert "doanh nghiep van tai bien" in normalized_source
+
+
 def test_generic_uploaded_doc_course_clusters_full_long_document_map():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (
         _build_uploaded_doc_course_params,


### PR DESCRIPTION
## Summary
- Fixes #381.
- Skips cover metadata such as ministry/school labels, student ID/class lines, and generic graduation-report labels when selecting uploaded document source titles.
- Scores meaningful research/title candidates so long thesis DOCX files use the actual project title in `source_document_title` while short/manual preview behavior stays stable.

## Product evidence before fix
- Tested `40 - GV.25-26.01.31 - Nghiên cứu xây dựng hệ thống quản lý vận hành và hồ sơ tàu thủy phục vụ doanh nghiệp vận tải biển.docx` on production.
- Parse: 200, docling, ~53.2s, 225,491 source chars, 29,999 markdown chars, `truncated=true`, `embeddedAssets=168`.
- Stream: 200, ~1.7s, emitted `tool_call`, `tool_result`, `host_action`, `answer`, `done`.
- Course preview was otherwise correct (`maritime_vessel_management`, 6 chapters / 18 lessons, 12 source refs), but `sourceDocumentTitle` was incorrectly `BỘ XÂY DỰNG - BỘ GIÁO DỤC VÀ ĐÀO TẠO`.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py -q` -> 54 passed
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_node_provider_errors.py -q` -> 35 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk / rollback
- Risk is limited to deterministic title/source metadata selection for uploaded document previews.
- No LMS mutation behavior changes; doc-to-course remains preview-only.
- Roll back by reverting this commit if source titles regress for short/manual documents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document title detection for uploaded files. The system now intelligently skips cover pages, institutional metadata, and other non-essential information to select the most meaningful titles from actual document content.

* **Tests**
  * Added comprehensive test validation for document title extraction in thesis-style and academic documents, ensuring institutional metadata and cover page information are properly excluded from titles.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/382)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->