### PR TITLE
fix(rag): warn when production knowledge base is empty

### DIFF
--- a/maritime-ai-service/app/api/v1/knowledge.py
+++ b/maritime-ai-service/app/api/v1/knowledge.py
@@ -196,6 +196,18 @@ class KnowledgeStatsResponse(BaseModel):
     warning: Optional[str] = None
 
 
+EMPTY_KNOWLEDGE_BASE_WARNING = (
+    "Knowledge base is empty; ingest documents before relying on source-backed RAG."
+)
+
+
+def build_knowledge_stats_warning(total_chunks: int, total_documents: int) -> Optional[str]:
+    """Surface empty-KB readiness gaps without treating DB connectivity as failed."""
+    if total_chunks <= 0 or total_documents <= 0:
+        return EMPTY_KNOWLEDGE_BASE_WARNING
+    return None
+
+
 @router.get("/stats", response_model=KnowledgeStatsResponse)
 @limiter.limit("60/minute")
 async def get_statistics(request: Request) -> KnowledgeStatsResponse:
@@ -252,7 +264,10 @@ async def get_statistics(request: Request) -> KnowledgeStatsResponse:
                 content_types=content_types,
                 avg_confidence=round(float(avg_confidence), 3),
                 domain_breakdown=domain_breakdown,
-                warning=None
+                warning=build_knowledge_stats_warning(
+                    total_chunks=total_chunks or 0,
+                    total_documents=total_documents or 0,
+                )
             )
         finally:
             await conn.close()

--- a/maritime-ai-service/tests/unit/test_sprint136_universal_kb.py
+++ b/maritime-ai-service/tests/unit/test_sprint136_universal_kb.py
@@ -398,3 +398,19 @@ class TestTextIngestionEndpoint:
         )
         assert resp.domain_breakdown["maritime"] == 70
         assert resp.domain_breakdown["traffic_law"] == 30
+
+    def test_knowledge_stats_warning_for_empty_kb(self):
+        """Empty KB should be visible as degraded for source-backed RAG readiness."""
+        from app.api.v1.knowledge import (
+            EMPTY_KNOWLEDGE_BASE_WARNING,
+            build_knowledge_stats_warning,
+        )
+
+        assert build_knowledge_stats_warning(0, 0) == EMPTY_KNOWLEDGE_BASE_WARNING
+        assert build_knowledge_stats_warning(10, 0) == EMPTY_KNOWLEDGE_BASE_WARNING
+
+    def test_knowledge_stats_no_warning_for_indexed_kb(self):
+        """Non-empty indexed KB should not emit the empty-KB warning."""
+        from app.api.v1.knowledge import build_knowledge_stats_warning
+
+        assert build_knowledge_stats_warning(10, 2) is None


### PR DESCRIPTION
## Summary
- Link #385.
- Surface an explicit warning from /api/v1/knowledge/stats when the indexed KB has zero chunks or zero documents.
- Keep DB connectivity healthy while making source-backed RAG readiness visibly degraded.

## Verification
- cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests\unit\test_sprint136_universal_kb.py -q -> 24 passed
- cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app\api\v1\knowledge.py tests\unit\test_sprint136_universal_kb.py --select=E9,F63,F7 -> pass
- git diff --check -> pass

## Risk and rollback
- Low runtime risk: response schema already has optional warning; clients that ignore warning remain compatible.
- Rollback: revert commit 45f62bae if an integration incorrectly assumes warning is null for empty DB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The knowledge statistics endpoint now displays a warning when the knowledge base is empty.

* **Tests**
  * Added tests validating warning behavior for empty and non-empty knowledge bases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/386)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->