### PR TITLE
Harden sync chat, Pointy voice, and KB seeding

### DIFF
--- a/maritime-ai-service/app/api/v1/voice.py
+++ b/maritime-ai-service/app/api/v1/voice.py
@@ -233,10 +233,10 @@ def _clean_pointy_speech_text(text: str) -> str:
     return cleaned
 
 
-def _build_elevenlabs_payload(text: str) -> dict[str, Any]:
+def _build_elevenlabs_payload(text: str, *, model_id: str | None = None) -> dict[str, Any]:
     return {
         "text": text,
-        "model_id": getattr(settings, "elevenlabs_model_id", "eleven_flash_v2_5"),
+        "model_id": model_id or getattr(settings, "elevenlabs_model_id", "eleven_flash_v2_5"),
         "voice_settings": {
             "stability": 0.42,
             "similarity_boost": 0.82,
@@ -358,7 +358,7 @@ async def synthesize_pointy_speech(
                     "Content-Type": "application/json",
                     "Accept": "audio/mpeg",
                 },
-                json=_build_elevenlabs_payload(text),
+                json=_build_elevenlabs_payload(text, model_id=config.model_id),
             )
     except httpx.HTTPError as exc:
         logger.warning("ElevenLabs Pointy TTS request failed: %s", exc)

--- a/maritime-ai-service/app/services/chat_orchestrator.py
+++ b/maritime-ai-service/app/services/chat_orchestrator.py
@@ -95,6 +95,55 @@ _AGENT_TYPE_MAP = {
 }
 
 
+def _has_sync_fast_path_blocking_context(context: ChatContext | None) -> bool:
+    """Keep deterministic sync replies away from tool/file/action turns."""
+    if context is None:
+        return True
+    return any(
+        bool(getattr(context, field_name, None))
+        for field_name in (
+            "images",
+            "image_input_error",
+            "document_context",
+            "force_skills",
+            "pointy_mode",
+            "host_action_feedback",
+        )
+    )
+
+
+def _build_sync_social_chatter_answer(message: str, shape: str) -> tuple[str, str]:
+    from app.engine.multi_agent.supervisor_hint_runtime import (
+        _normalize_router_text_impl,
+    )
+
+    normalized = _normalize_router_text_impl(message)
+    if shape == "reaction":
+        return (
+            "Mình nghe thấy rồi. Nếu cậu muốn, cứ ném phần tiếp theo qua đây, mình bắt nhịp cùng cậu.",
+            "Đây chỉ là một phản ứng ngắn, không phải lượt cần tra cứu hay dùng tool. Mình nên đáp lại có mặt, gọn, và mở đường để cậu nói tiếp.",
+        )
+    if any(marker in normalized for marker in ("cam on", "thanks", "thank you", "thank")):
+        return (
+            "Không có gì đâu, mình ở đây mà. Cần mình phụ tiếp đoạn nào thì cứ nói nhé.",
+            "Cậu đang cảm ơn, nên câu trả lời tốt nhất là ấm, ngắn, không kéo pipeline LLM chỉ để tạo thêm chữ.",
+        )
+    if any(marker in normalized for marker in ("tam biet", "bye", "goodbye", "hen gap lai")):
+        return (
+            "Ừ, mình tạm gác ở đây nha. Khi cậu quay lại, mình tiếp tục cùng cậu từ mạch đang làm.",
+            "Đây là lượt kết thúc nhẹ, nên Wiii nên giữ cảm giác liên tục thay vì route sang RAG hoặc tool.",
+        )
+    if "alo" in normalized:
+        return (
+            "Mình nghe đây. Cậu cần mình phụ phần nào trước?",
+            "Câu này là tín hiệu gọi Wiii, không có yêu cầu tri thức hay hành động. Mình đáp nhanh để cuộc trò chuyện không bị khựng.",
+        )
+    return (
+        "Chào cậu, mình đây. Cậu muốn mình cùng xử lý phần nào trước?",
+        "Đây là lời chào rất rõ, không cần RAG, web hay tool. Mình nên phản hồi ngay để tạo nhịp tự nhiên rồi chờ yêu cầu thật sự của cậu.",
+    )
+
+
 @dataclass(frozen=True)
 class RequestScope:
     """Resolved organization and domain for a chat request."""
@@ -239,6 +288,64 @@ class ChatOrchestrator:
             domain_id=domain_id,
             title=title,
             organization_id=organization_id,
+        )
+
+    def _build_sync_fast_chatter_result(
+        self,
+        context: ChatContext | None,
+    ) -> ProcessingResult | None:
+        """Return a deterministic result for obvious sync-only chatter."""
+        if _has_sync_fast_path_blocking_context(context):
+            return None
+
+        message = getattr(context, "message", "") or ""
+        from app.engine.multi_agent.supervisor_hint_runtime import (
+            classify_fast_chatter_turn_impl,
+        )
+
+        classification = classify_fast_chatter_turn_impl(message)
+        if not classification:
+            return None
+
+        intent, shape = classification
+        if intent != "social":
+            return None
+
+        if shape == "hunger_chatter":
+            from app.engine.multi_agent.direct_node_runtime import (
+                _build_hunger_chatter_answer,
+                _build_hunger_chatter_thinking,
+            )
+
+            answer = _build_hunger_chatter_answer(message)
+            thinking = _build_hunger_chatter_thinking(message)
+        elif shape in {"social", "reaction"}:
+            answer, thinking = _build_sync_social_chatter_answer(message, shape)
+        else:
+            return None
+
+        return ProcessingResult(
+            message=answer,
+            agent_type=AgentType.DIRECT,
+            sources=None,
+            metadata={
+                "multi_agent": False,
+                "provider": "deterministic",
+                "model": "wiii-sync-fast-chatter-v1",
+                "runtime_authoritative": True,
+                "current_agent": "direct",
+                "tools_used": [],
+                "reasoning_trace": None,
+                "thinking": thinking,
+                "thinking_content": thinking,
+                "routing_metadata": {
+                    "method": "sync_fast_chatter",
+                    "intent": intent,
+                    "shape": shape,
+                    "reason": "obvious_short_social_turn_without_tool_context",
+                },
+            },
+            thinking=thinking,
         )
 
     def finalize_response_turn(
@@ -474,8 +581,14 @@ class ChatOrchestrator:
         # STAGE 4: AGENT PROCESSING
         # ================================================================
         
-        # Option A: Multi-Agent System (SOTA 2025)
-        if self._use_multi_agent:
+        fast_result = self._build_sync_fast_chatter_result(context)
+
+        # Option A: Deterministic fast path for obvious sync-only chatter.
+        if fast_result is not None:
+            result = fast_result
+
+        # Option B: Multi-Agent System (SOTA 2025)
+        elif self._use_multi_agent:
             result = await self._process_with_multi_agent(
                 context,
                 session,
@@ -485,7 +598,7 @@ class ChatOrchestrator:
                 model,
             )
 
-        # Option B: Fallback to direct RAG mode
+        # Option C: Fallback to direct RAG mode
         else:
             result = await self.process_without_multi_agent(context)
         

--- a/maritime-ai-service/docs/deploy/KNOWLEDGE_INGESTION.md
+++ b/maritime-ai-service/docs/deploy/KNOWLEDGE_INGESTION.md
@@ -20,6 +20,24 @@
 6. Check stats: `curl localhost:8000/api/v1/knowledge/stats -H "X-API-Key: your-key"`
 7. Test RAG: Ask a maritime question → should cite ingested documents
 
+## Fast Seed For Empty KB
+
+If production stats show `total_chunks=0`, seed the small COLREGs teaching
+corpus first so source-backed RAG is not silently empty while larger PDFs are
+being prepared:
+
+```bash
+cd maritime-ai-service
+WIII_BASE_URL=https://wiii.holilihu.online \
+WIII_ADMIN_JWT=<platform-admin-jwt> \
+python scripts/seed_maritime_text_kb.py
+```
+
+The seed is idempotent. It writes `document_id=maritime-colregs-teaching-seed-v1`
+through `POST /api/v1/knowledge/ingest-text`, then prints before/after stats
+without printing credentials. Use `--dry-run` to inspect the target and payload
+size without writing.
+
 ## Alternative: Admin UI Upload
 
 The Org Admin panel has drag-drop PDF upload at:

--- a/maritime-ai-service/scripts/data/maritime_seed_corpus/colregs_teaching_seed_v1.md
+++ b/maritime-ai-service/scripts/data/maritime_seed_corpus/colregs_teaching_seed_v1.md
@@ -1,0 +1,121 @@
+# COLREGs Teaching Seed Corpus v1
+
+Source note: Teaching summary derived from the International Regulations for Preventing Collisions at Sea (COLREGs), 1972, as amended. This corpus is an instructional summary for retrieval grounding; teachers should verify exact legal wording against the official publication before assessment or operational use.
+
+## Rule 5 - Look-out
+
+Every vessel must maintain a proper look-out at all times. The look-out uses sight, hearing, radar, AIS when available, and any other means suitable for the conditions. The goal is to understand the traffic situation early enough to assess collision risk.
+
+Teaching points:
+- A look-out is continuous, not occasional.
+- Sight and hearing both matter.
+- Electronic aids support judgment but do not replace watchkeeping.
+- The practical question is whether the officer has enough information to make a full appraisal of the situation.
+
+## Rule 6 - Safe Speed
+
+A vessel must proceed at a safe speed so she can take proper and effective action to avoid collision and stop within an appropriate distance. Safe speed depends on visibility, traffic density, maneuverability, background light, weather, sea state, current, hazards, draft, radar limitations, and the quality of available information.
+
+Teaching points:
+- Safe speed is contextual, not a fixed number.
+- Restricted visibility usually requires extra caution.
+- The vessel must still be able to act effectively after detecting risk.
+
+## Rule 7 - Risk of Collision
+
+Every vessel must use all available means to determine whether risk of collision exists. If there is doubt, risk must be treated as existing. Radar plotting, systematic observation, and compass bearings are common methods. A steady bearing with decreasing range is a strong warning sign.
+
+Teaching points:
+- Doubt is resolved on the side of safety.
+- A changing bearing does not always mean no risk, especially with large vessels, towage, or close-range encounters.
+- Assessment should be systematic, not based on a single glance.
+
+## Rule 8 - Action to Avoid Collision
+
+Action to avoid collision must be positive, made in ample time, and consistent with good seamanship. Course or speed changes should be large enough to be readily apparent to another vessel. The action should result in passing at a safe distance, and the vessel should check that the action is working.
+
+Teaching points:
+- Early and obvious action is safer than late minor changes.
+- Altering course alone can be effective when there is enough sea room.
+- If needed, slow down, stop, or reverse propulsion.
+
+## Rule 9 - Narrow Channels
+
+In a narrow channel or fairway, a vessel should keep as near as safe and practicable to the outer limit of the channel on her starboard side. Small vessels, sailing vessels, and fishing vessels must not impede vessels that can safely navigate only within the channel.
+
+Teaching points:
+- Starboard-side discipline reduces ambiguity.
+- Crossing or fishing activity must not block constrained traffic.
+- Overtaking in a narrow channel requires extra agreement and signaling.
+
+## Rule 10 - Traffic Separation Schemes
+
+When using a traffic separation scheme, vessels should proceed in the appropriate traffic lane in the general direction of traffic flow, keep clear of separation zones, and cross lanes as nearly as practicable at right angles when crossing is necessary.
+
+Teaching points:
+- Use the lane direction correctly.
+- Avoid unnecessary crossing.
+- Keep clear of separation lines and zones unless the rule permits otherwise.
+
+## Rule 13 - Overtaking
+
+An overtaking vessel must keep out of the way of the vessel being overtaken. A vessel is overtaking when coming from more than 22.5 degrees abaft the other vessel's beam. At night, this usually means seeing only the sternlight and not the sidelights. If in doubt, assume the situation is overtaking.
+
+Teaching points:
+- The overtaking vessel remains responsible until finally past and clear.
+- Later changes in bearing do not convert the overtaking vessel into a crossing vessel.
+- Doubt should not be used to avoid give-way responsibility.
+
+## Rule 14 - Head-on Situation
+
+When two power-driven vessels meet on reciprocal or nearly reciprocal courses with risk of collision, each should alter course to starboard so they pass port side to port side. At night, seeing both masthead lights in line or nearly in line and both sidelights is a common indicator.
+
+Teaching points:
+- Both vessels act.
+- The expected avoiding action is to starboard.
+- If there is doubt whether the situation is head-on, assume it exists and act safely.
+
+## Rule 15 - Crossing Situation
+
+When two power-driven vessels are crossing with risk of collision, the vessel that has the other vessel on her own starboard side must keep out of the way. If circumstances allow, the give-way vessel should avoid crossing ahead of the stand-on vessel.
+
+Teaching points:
+- The vessel seeing the other on her starboard side is the give-way vessel.
+- The stand-on vessel is the one seeing the other on her port side.
+- Passing astern is usually safer than crossing ahead.
+
+## Rule 16 - Action by Give-way Vessel
+
+The give-way vessel must take early and substantial action to keep well clear. The action should not be hesitant or too small to be understood by the other vessel.
+
+Teaching points:
+- Early means before the situation becomes urgent.
+- Substantial means visible enough to be recognized.
+- The aim is to keep well clear, not merely avoid contact at the last moment.
+
+## Rule 17 - Action by Stand-on Vessel
+
+The stand-on vessel should keep her course and speed at first. If it becomes clear that the give-way vessel is not taking appropriate action, the stand-on vessel may act to avoid collision. If collision cannot be avoided by the give-way vessel alone, the stand-on vessel must take the best action available to help avoid collision.
+
+Teaching points:
+- Stand-on does not mean passive forever.
+- Maintaining course and speed preserves predictability early in the encounter.
+- Later action may become necessary if the give-way vessel fails to act.
+
+## Rule 18 - Responsibilities Between Vessels
+
+Except where other rules change the situation, power-driven vessels usually keep out of the way of sailing vessels, fishing vessels, vessels restricted in their ability to maneuver, and vessels not under command. Sailing vessels and fishing vessels also have responsibilities toward more constrained vessels.
+
+Teaching points:
+- Vessel status matters.
+- More maneuverable vessels usually keep clear of less maneuverable or constrained vessels.
+- The hierarchy does not remove the duty to keep a proper look-out and act safely.
+
+## Rule 19 - Conduct in Restricted Visibility
+
+Rule 19 applies when vessels are not in sight of one another in or near restricted visibility. Vessels should proceed at a safe speed, have engines ready for immediate maneuver, and navigate with extreme caution until danger of collision is over.
+
+Teaching points:
+- Restricted visibility changes the operating assumptions.
+- Radar information must be interpreted carefully.
+- Avoid bold alterations toward a vessel forward of the beam unless the situation is clearly understood and safe.

--- a/maritime-ai-service/scripts/seed_maritime_text_kb.py
+++ b/maritime-ai-service/scripts/seed_maritime_text_kb.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Seed a small maritime text corpus into the Wiii pgvector knowledge base.
+
+The script is intentionally idempotent: the API writes deterministic chunk
+node IDs from document_id + chunk_index, so re-running updates the same corpus.
+Secrets are read from environment variables and never printed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
+
+
+DEFAULT_CORPUS = (
+    Path(__file__).resolve().parent
+    / "data"
+    / "maritime_seed_corpus"
+    / "colregs_teaching_seed_v1.md"
+)
+DEFAULT_DOCUMENT_ID = "maritime-colregs-teaching-seed-v1"
+DEFAULT_TITLE = "COLREGs teaching seed corpus v1"
+
+
+def _json_request(
+    url: str,
+    *,
+    method: str = "GET",
+    payload: dict[str, Any] | None = None,
+    api_key: str | None = None,
+    bearer_token: str | None = None,
+    timeout: float = 60.0,
+) -> tuple[int, dict[str, Any]]:
+    body = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+    elif api_key:
+        headers["X-API-Key"] = api_key
+
+    request = Request(url, data=body, headers=headers, method=method)
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8", errors="replace")
+            parsed = json.loads(raw) if raw else {}
+            return response.status, parsed
+    except HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        try:
+            parsed = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            parsed = {"detail": raw[:500]}
+        return exc.code, parsed
+    except URLError as exc:
+        raise RuntimeError(f"Could not reach {url}: {exc}") from exc
+
+
+def _read_secret_env(name: str | None) -> str | None:
+    if not name:
+        return None
+    value = os.getenv(name)
+    if value and value.strip():
+        return value.strip()
+    return None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Seed the Wiii knowledge base with a small COLREGs teaching corpus."
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("WIII_BASE_URL", "http://localhost:8000"),
+        help="Wiii API base URL, for example https://wiii.holilihu.online",
+    )
+    parser.add_argument("--corpus", default=str(DEFAULT_CORPUS), help="Markdown corpus path.")
+    parser.add_argument("--document-id", default=DEFAULT_DOCUMENT_ID)
+    parser.add_argument("--title", default=DEFAULT_TITLE)
+    parser.add_argument("--domain-id", default="maritime")
+    parser.add_argument("--organization-id", default=None)
+    parser.add_argument(
+        "--api-key-env",
+        default="WIII_API_KEY",
+        help="Environment variable that contains X-API-Key. Fallback: API_KEY.",
+    )
+    parser.add_argument(
+        "--bearer-token-env",
+        default="WIII_ADMIN_JWT",
+        help="Environment variable that contains a platform-admin JWT.",
+    )
+    parser.add_argument("--stats-only", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--timeout", type=float, default=90.0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    base_url = args.base_url.rstrip("/") + "/"
+    stats_url = urljoin(base_url, "api/v1/knowledge/stats")
+    ingest_url = urljoin(base_url, "api/v1/knowledge/ingest-text")
+
+    api_key = _read_secret_env(args.api_key_env) or _read_secret_env("API_KEY")
+    bearer_token = _read_secret_env(args.bearer_token_env)
+
+    print(f"Target: {base_url.rstrip('/')}")
+    before_status, before = _json_request(
+        stats_url,
+        api_key=api_key,
+        bearer_token=bearer_token,
+        timeout=args.timeout,
+    )
+    print(
+        "Before stats: "
+        f"http={before_status}, chunks={before.get('total_chunks')}, "
+        f"documents={before.get('total_documents')}, warning={before.get('warning')!r}"
+    )
+    if args.stats_only:
+        return 0 if before_status < 400 else 1
+
+    corpus_path = Path(args.corpus)
+    content = corpus_path.read_text(encoding="utf-8").strip()
+    if not content:
+        print(f"Corpus is empty: {corpus_path}", file=sys.stderr)
+        return 2
+
+    payload = {
+        "content": content,
+        "document_id": args.document_id,
+        "domain_id": args.domain_id,
+        "title": args.title,
+        "organization_id": args.organization_id,
+    }
+
+    if args.dry_run:
+        print(
+            "Dry run: "
+            f"document_id={args.document_id}, domain_id={args.domain_id}, "
+            f"bytes={len(content.encode('utf-8'))}"
+        )
+        return 0
+
+    if not api_key and not bearer_token:
+        print(
+            "Missing credentials. Set WIII_ADMIN_JWT for platform-admin JWT "
+            "or WIII_API_KEY/API_KEY when the target environment permits admin API-key ingestion.",
+            file=sys.stderr,
+        )
+        return 2
+
+    ingest_status, ingest = _json_request(
+        ingest_url,
+        method="POST",
+        payload=payload,
+        api_key=api_key,
+        bearer_token=bearer_token,
+        timeout=args.timeout,
+    )
+    print(
+        "Ingest result: "
+        f"http={ingest_status}, status={ingest.get('status')!r}, "
+        f"document_id={ingest.get('document_id')!r}, chunks={ingest.get('total_chunks')}, "
+        f"detail={ingest.get('detail')!r}"
+    )
+    if ingest_status >= 400:
+        return 1
+
+    after_status, after = _json_request(
+        stats_url,
+        api_key=api_key,
+        bearer_token=bearer_token,
+        timeout=args.timeout,
+    )
+    print(
+        "After stats: "
+        f"http={after_status}, chunks={after.get('total_chunks')}, "
+        f"documents={after.get('total_documents')}, domain_breakdown={after.get('domain_breakdown')}"
+    )
+    return 0 if after_status < 400 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/maritime-ai-service/tests/unit/test_chat_request_flow.py
+++ b/maritime-ai-service/tests/unit/test_chat_request_flow.py
@@ -136,6 +136,86 @@ def test_normalize_thread_id_treats_new_as_none():
     assert ChatOrchestrator.normalize_thread_id(request) == "session-1"
 
 
+def test_sync_fast_chatter_handles_unicode_hunger_without_llm():
+    orchestrator = _make_orchestrator()
+    context = _make_chat_context()
+    context.message = "\u0111\u00f3i ph\u1ebft"
+    context.images = None
+
+    result = orchestrator._build_sync_fast_chatter_result(context)
+
+    assert result is not None
+    assert result.agent_type.value == "direct"
+    assert "\u0110\u00f3i ph\u1ebft" in result.message
+    assert result.metadata["provider"] == "deterministic"
+    assert result.metadata["routing_metadata"] == {
+        "method": "sync_fast_chatter",
+        "intent": "social",
+        "shape": "hunger_chatter",
+        "reason": "obvious_short_social_turn_without_tool_context",
+    }
+
+
+def test_sync_fast_chatter_handles_plain_greeting_without_llm():
+    orchestrator = _make_orchestrator()
+    context = _make_chat_context()
+    context.message = "chao"
+    context.images = None
+
+    result = orchestrator._build_sync_fast_chatter_result(context)
+
+    assert result is not None
+    assert "Ch\u00e0o c\u1eadu" in result.message
+    assert result.metadata["routing_metadata"]["shape"] == "social"
+
+
+def test_sync_fast_chatter_does_not_bypass_document_context():
+    orchestrator = _make_orchestrator()
+    context = _make_chat_context()
+    context.message = "chao"
+    context.images = None
+    context.document_context = {"file_name": "manual.docx"}
+
+    assert orchestrator._build_sync_fast_chatter_result(context) is None
+
+
+@pytest.mark.asyncio
+async def test_process_uses_sync_fast_chatter_before_multi_agent():
+    orchestrator = _make_orchestrator()
+    request = _make_request(message="\u0111\u00f3i ph\u1ebft")
+    context = _make_chat_context()
+    context.message = request.message
+    context.images = None
+    session = _make_session()
+    session.session_id = context.session_id
+    prepared_turn = SimpleNamespace(
+        request_scope=RequestScope(organization_id="org-1", domain_id="maritime"),
+        session=session,
+        session_id=context.session_id,
+        validation=SimpleNamespace(blocked=False, blocked_response=None),
+        chat_context=context,
+    )
+    orchestrator.prepare_turn = AsyncMock(return_value=prepared_turn)
+    orchestrator._process_with_multi_agent = AsyncMock(
+        side_effect=AssertionError("multi-agent should not run for fast chatter")
+    )
+    orchestrator._output_processor.validate_and_format = AsyncMock(
+        side_effect=lambda *, result, session_id, user_name, user_role: SimpleNamespace(
+            message=result.message,
+            metadata=result.metadata,
+            agent_type=result.agent_type,
+            sources=result.sources,
+        )
+    )
+    orchestrator.finalize_response_turn = MagicMock()
+
+    response = await orchestrator.process(request)
+
+    assert "\u0110\u00f3i ph\u1ebft" in response.message
+    assert response.metadata["routing_metadata"]["method"] == "sync_fast_chatter"
+    orchestrator._process_with_multi_agent.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_resolve_request_scope_uses_request_and_router():
     orchestrator = _make_orchestrator()

--- a/maritime-ai-service/tests/unit/test_voice_api.py
+++ b/maritime-ai-service/tests/unit/test_voice_api.py
@@ -180,3 +180,55 @@ def test_synthesize_pointy_speech_proxies_to_elevenlabs(monkeypatch):
     assert captured["params"] == {"output_format": "mp3_22050_32"}
     assert captured["headers"]["xi-api-key"] == "test-key"
     assert captured["json"]["model_id"] == "eleven_flash_v2_5"
+
+
+def test_synthesize_pointy_speech_uses_persisted_model_config(monkeypatch):
+    from app.api.v1 import voice as module
+
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+        content = b"mp3-bytes"
+        text = ""
+        headers = {"content-type": "audio/mpeg"}
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, **kwargs):
+            captured.update(kwargs)
+            return FakeResponse()
+
+    _install_voice_repo(
+        monkeypatch,
+        module,
+        {
+            "enabled": True,
+            "elevenlabs_api_key": "test-key",
+            "voice_id": "voice-id",
+            "model_id": "eleven_multilingual_v2",
+            "output_format": "mp3_44100_128",
+        },
+    )
+    monkeypatch.setattr(module.settings, "elevenlabs_model_id", "eleven_flash_v2_5", raising=False)
+    monkeypatch.setattr(module.httpx, "AsyncClient", FakeClient)
+
+    response = asyncio.run(
+        module.synthesize_pointy_speech(
+            SimpleNamespace(client=SimpleNamespace(host="127.0.0.1")),
+            module.PointySpeechRequest(text="Xin chao"),
+            SimpleNamespace(user_id="u"),
+        )
+    )
+
+    assert response.body == b"mp3-bytes"
+    assert captured["params"] == {"output_format": "mp3_44100_128"}
+    assert captured["json"]["model_id"] == "eleven_multilingual_v2"

--- a/wiii-desktop/src/pointy-host/__tests__/voice.test.ts
+++ b/wiii-desktop/src/pointy-host/__tests__/voice.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { synthesizePointySpeech } from "@/api/voice";
+import { useSettingsStore } from "@/stores/settings-store";
+import { ensurePointyVoiceBridge, stopPointyVoice } from "../voice";
+
+vi.mock("@/api/voice", () => ({
+  synthesizePointySpeech: vi.fn(),
+}));
+
+describe("Pointy voice bridge", () => {
+  type MockAudioInstance = {
+    pause: ReturnType<typeof vi.fn>;
+    play: ReturnType<typeof vi.fn>;
+    src: string;
+    preload: string;
+    volume: number;
+    onended: (() => void) | null;
+  };
+
+  const audioInstances: MockAudioInstance[] = [];
+  let originalCreateObjectURL: PropertyDescriptor | undefined;
+  let originalRevokeObjectURL: PropertyDescriptor | undefined;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    audioInstances.length = 0;
+    await useSettingsStore.getState().updateSettings({
+      pointy_mode: true,
+      pointy_voice_enabled: true,
+    });
+
+    originalCreateObjectURL = Object.getOwnPropertyDescriptor(URL, "createObjectURL");
+    originalRevokeObjectURL = Object.getOwnPropertyDescriptor(URL, "revokeObjectURL");
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:wiii-pointy-voice"),
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+    });
+
+    class MockAudio implements MockAudioInstance {
+      pause = vi.fn();
+      play = vi.fn().mockResolvedValue(undefined);
+      src: string;
+      preload = "";
+      volume = 1;
+      onended: (() => void) | null = null;
+
+      constructor(src: string) {
+        this.src = src;
+        audioInstances.push(this);
+      }
+    }
+
+    vi.stubGlobal("Audio", MockAudio);
+  });
+
+  afterEach(async () => {
+    stopPointyVoice();
+    vi.unstubAllGlobals();
+    if (originalCreateObjectURL) {
+      Object.defineProperty(URL, "createObjectURL", originalCreateObjectURL);
+    } else {
+      Reflect.deleteProperty(URL, "createObjectURL");
+    }
+    if (originalRevokeObjectURL) {
+      Object.defineProperty(URL, "revokeObjectURL", originalRevokeObjectURL);
+    } else {
+      Reflect.deleteProperty(URL, "revokeObjectURL");
+    }
+    await useSettingsStore.getState().updateSettings({
+      pointy_mode: false,
+      pointy_voice_enabled: false,
+    });
+  });
+
+  it("synthesizes a caption and starts browser audio playback", async () => {
+    vi.mocked(synthesizePointySpeech).mockResolvedValue(
+      new Blob([new Uint8Array([1, 2, 3, 4])], { type: "audio/mpeg" }),
+    );
+
+    ensurePointyVoiceBridge();
+    window.dispatchEvent(
+      new CustomEvent("wiii:pointy:target", {
+        detail: {
+          selector: "#send-message",
+          caption: "Đây là nút gửi tin nhắn.",
+        },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(synthesizePointySpeech).toHaveBeenCalledWith("Đây là nút gửi tin nhắn.");
+      expect(audioInstances).toHaveLength(1);
+      expect(audioInstances[0].play).toHaveBeenCalledTimes(1);
+    });
+    expect(audioInstances[0].src).toBe("blob:wiii-pointy-voice");
+    expect(audioInstances[0].preload).toBe("auto");
+    expect(audioInstances[0].volume).toBe(0.92);
+  });
+
+  it("skips playback when Pointy voice is disabled", async () => {
+    await useSettingsStore.getState().updateSettings({
+      pointy_mode: true,
+      pointy_voice_enabled: false,
+    });
+
+    ensurePointyVoiceBridge();
+    window.dispatchEvent(
+      new CustomEvent("wiii:pointy:target", {
+        detail: {
+          selector: "#send-message",
+          caption: "Đây là nút gửi tin nhắn.",
+        },
+      }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(synthesizePointySpeech).not.toHaveBeenCalled();
+    expect(audioInstances).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #389 by adding a deterministic sync fast path for obvious Vietnamese social/hunger chatter while refusing to bypass document, image, Pointy, host-action, or forced-skill context.
- Moves #385 forward with an idempotent COLREG maritime seed corpus and `scripts/seed_maritime_text_kb.py` so production KB can be populated with admin credentials without printing secrets.
- Improves Pointy TTS by honoring persisted ElevenLabs `model_id` and adding frontend playback regression coverage for `Audio.play()`.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_knowledge_api.py tests/unit/test_voice_api.py tests/unit/test_chat_request_flow.py -q` -> 45 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> pass
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m py_compile scripts\seed_maritime_text_kb.py` -> pass
- `cd maritime-ai-service && .\.venv\Scripts\python.exe scripts\seed_maritime_text_kb.py --dry-run --base-url https://wiii.holilihu.online` -> dry run OK; unauth stats returns 403 as expected
- `cd wiii-desktop && npx vitest run src/pointy-host/__tests__/voice.test.ts src/__tests__/pointy-voice-toggle.test.tsx` -> 2 files, 5 tests passed
- `cd wiii-desktop && npx tsc --noEmit` -> pass
- `cd wiii-desktop && npm run build:embed` -> pass with existing large chunk warnings
- `git diff --check` -> pass

## Risk / rollback
- Sync fast path is intentionally narrow and blocked for file/image/tool/Pointy/action contexts; rollback is reverting `chat_orchestrator.py` and the related tests.
- KB seed script mutates nothing unless run with `WIII_ADMIN_JWT` or permitted API key; production KB still needs an authorized seed run to fully close #385.
- TTS model config change only makes persisted runtime settings authoritative for ElevenLabs requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat now responds instantly to social greetings and reactions without invoking the multi-agent pipeline
  * Voice synthesis now respects persisted per-runtime model configuration for TTS requests
  * Knowledge base seeding is now fully documented and can be automated via CLI script

* **Documentation**
  * Added production deployment checklist for seeding empty knowledge bases from a teaching corpus

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/390)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->