### PR TITLE
fix(rag): harden upload smoke tooling

### DIFF
--- a/.github/workflows/seed-production-kb.yml
+++ b/.github/workflows/seed-production-kb.yml
@@ -1,0 +1,185 @@
+name: Seed Production Knowledge Base
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Public Wiii API base URL."
+        required: true
+        default: "https://wiii.holilihu.online"
+        type: string
+      document_id:
+        description: "Idempotent document_id to upsert into RAG."
+        required: true
+        default: "maritime-colregs-teaching-seed-v1"
+        type: string
+      domain_id:
+        description: "Domain tag for the ingested chunks."
+        required: true
+        default: "maritime"
+        type: string
+      title:
+        description: "Human-readable document title."
+        required: true
+        default: "COLREGs teaching seed corpus v1"
+        type: string
+      corpus_path:
+        description: "Path under maritime-ai-service/ on the production checkout."
+        required: true
+        default: "scripts/data/maritime_seed_corpus/colregs_teaching_seed_v1.md"
+        type: string
+      dry_run:
+        description: "Check stats and print planned ingest without writing."
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-kb-seed
+  cancel-in-progress: false
+
+jobs:
+  seed:
+    name: Seed production RAG via VM API key
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ inputs.base_url }}
+    timeout-minutes: 20
+
+    steps:
+      - name: Configure SSH
+        shell: bash
+        env:
+          PROD_HOST: ${{ secrets.WIII_PRODUCTION_HOST }}
+          PROD_USER: ${{ secrets.WIII_PRODUCTION_USER }}
+          PROD_SSH_KEY: ${{ secrets.WIII_PRODUCTION_SSH_KEY }}
+          PROD_KNOWN_HOSTS: ${{ secrets.WIII_PRODUCTION_KNOWN_HOSTS }}
+          PROD_SSH_PORT: ${{ vars.WIII_PRODUCTION_SSH_PORT }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PROD_HOST:-}" ] || [ -z "${PROD_USER:-}" ] || [ -z "${PROD_SSH_KEY:-}" ]; then
+            echo "Missing required production SSH secrets: WIII_PRODUCTION_HOST, WIII_PRODUCTION_USER, WIII_PRODUCTION_SSH_KEY." >&2
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$PROD_SSH_KEY" > ~/.ssh/wiii_production_key
+          chmod 600 ~/.ssh/wiii_production_key
+          if [ -n "${PROD_KNOWN_HOSTS:-}" ]; then
+            printf '%s\n' "$PROD_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          else
+            ssh-keyscan -p "${PROD_SSH_PORT:-22}" "$PROD_HOST" >> ~/.ssh/known_hosts
+          fi
+
+      - name: Seed production knowledge base
+        shell: bash
+        env:
+          PROD_HOST: ${{ secrets.WIII_PRODUCTION_HOST }}
+          PROD_USER: ${{ secrets.WIII_PRODUCTION_USER }}
+          PROD_SSH_PORT: ${{ vars.WIII_PRODUCTION_SSH_PORT }}
+          PROD_APP_DIR: ${{ vars.WIII_PRODUCTION_APP_DIR }}
+          BASE_URL: ${{ inputs.base_url }}
+          DOCUMENT_ID: ${{ inputs.document_id }}
+          DOMAIN_ID: ${{ inputs.domain_id }}
+          TITLE: ${{ inputs.title }}
+          CORPUS_PATH: ${{ inputs.corpus_path }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          encode() { printf '%s' "$1" | base64 -w0; }
+
+          APP_DIR="${PROD_APP_DIR:-/opt/wiii}"
+          SSH_TARGET="${PROD_USER}@${PROD_HOST}"
+          SSH_PORT="${PROD_SSH_PORT:-22}"
+          BASE_URL_B64="$(encode "$BASE_URL")"
+          DOCUMENT_ID_B64="$(encode "$DOCUMENT_ID")"
+          DOMAIN_ID_B64="$(encode "$DOMAIN_ID")"
+          TITLE_B64="$(encode "$TITLE")"
+          CORPUS_PATH_B64="$(encode "$CORPUS_PATH")"
+
+          ssh -i ~/.ssh/wiii_production_key -p "$SSH_PORT" "$SSH_TARGET" \
+            "APP_DIR='$APP_DIR' BASE_URL_B64='$BASE_URL_B64' DOCUMENT_ID_B64='$DOCUMENT_ID_B64' DOMAIN_ID_B64='$DOMAIN_ID_B64' TITLE_B64='$TITLE_B64' CORPUS_PATH_B64='$CORPUS_PATH_B64' DRY_RUN='$DRY_RUN' bash -s" <<'REMOTE'
+          set -euo pipefail
+
+          decode() { printf '%s' "$1" | base64 -d; }
+          clean_value() {
+            local value="${1:-}"
+            value="${value%$'\r'}"
+            value="${value#\"}"
+            value="${value%\"}"
+            value="${value#\'}"
+            value="${value%\'}"
+            printf '%s' "$value"
+          }
+          env_value() {
+            local key="$1"
+            awk -v key="$key" '
+              BEGIN { FS = "="; found = 0 }
+              $0 !~ /^[[:space:]]*#/ && $1 == key {
+                sub(/^[^=]*=/, "")
+                print
+                found = 1
+              }
+              END { exit found ? 0 : 1 }
+            ' "$ENV_PATH" | tail -n 1
+          }
+
+          BASE_URL="$(decode "$BASE_URL_B64")"
+          DOCUMENT_ID="$(decode "$DOCUMENT_ID_B64")"
+          DOMAIN_ID="$(decode "$DOMAIN_ID_B64")"
+          TITLE="$(decode "$TITLE_B64")"
+          CORPUS_PATH="$(decode "$CORPUS_PATH_B64")"
+
+          cd "$APP_DIR"
+          git fetch --prune origin main
+          git switch main
+          git pull --ff-only origin main
+
+          SERVICE_DIR="${APP_DIR}/maritime-ai-service"
+          ENV_PATH="${SERVICE_DIR}/.env.production"
+          if [ ! -f "$ENV_PATH" ]; then
+            echo "Missing production env file: $ENV_PATH" >&2
+            exit 1
+          fi
+
+          API_KEY_VALUE="$(clean_value "$(env_value API_KEY || true)")"
+          if [ -z "$API_KEY_VALUE" ]; then
+            echo "Missing API_KEY in production env file." >&2
+            exit 1
+          fi
+
+          cd "$SERVICE_DIR"
+          if [ ! -f "$CORPUS_PATH" ]; then
+            echo "Corpus path not found under maritime-ai-service: $CORPUS_PATH" >&2
+            exit 1
+          fi
+
+          args=(
+            scripts/seed_maritime_text_kb.py
+            --base-url "$BASE_URL"
+            --corpus "$CORPUS_PATH"
+            --document-id "$DOCUMENT_ID"
+            --domain-id "$DOMAIN_ID"
+            --title "$TITLE"
+            --api-key-env API_KEY
+          )
+          if [ "$DRY_RUN" = "true" ]; then
+            args+=(--dry-run)
+          fi
+
+          if command -v python3 >/dev/null 2>&1; then
+            API_KEY="$API_KEY_VALUE" python3 "${args[@]}"
+          elif command -v python >/dev/null 2>&1; then
+            API_KEY="$API_KEY_VALUE" python "${args[@]}"
+          else
+            echo "Python is not available on the production VM host." >&2
+            exit 1
+          fi
+          REMOTE

--- a/maritime-ai-service/app/api/v1/document_context.py
+++ b/maritime-ai-service/app/api/v1/document_context.py
@@ -300,6 +300,19 @@ def _safe_int(value: Any, default: int = 0) -> int:
         return default
 
 
+def _document_title_from_metadata(metadata: dict[str, Any], file_name: str) -> str:
+    """Prefer the user's upload name when parsers only saw a temp file path."""
+    title = str(metadata.get("title") or "").strip()
+    if not title:
+        return file_name
+
+    stem = Path(title).stem
+    suffix = Path(title).suffix
+    if re.fullmatch(r"tmp[a-zA-Z0-9_-]{6,}", stem) and not suffix:
+        return file_name
+    return title
+
+
 def _build_section_snippets(
     *,
     raw_markdown: str,
@@ -455,7 +468,7 @@ def _response_from_parsed(
         parser_chain=parser_chain,
         parser_warning=str(metadata.get("parser_warning") or "") or None,
         provenance_level=provenance_level,
-        title=str(metadata.get("title") or file_name),
+        title=_document_title_from_metadata(metadata, file_name),
         page_count=parsed.page_count,
         section_titles=section_titles,
         section_snippets=section_snippets,

--- a/maritime-ai-service/scripts/seed_maritime_text_kb.py
+++ b/maritime-ai-service/scripts/seed_maritime_text_kb.py
@@ -27,6 +27,7 @@ DEFAULT_CORPUS = (
 )
 DEFAULT_DOCUMENT_ID = "maritime-colregs-teaching-seed-v1"
 DEFAULT_TITLE = "COLREGs teaching seed corpus v1"
+DEFAULT_USER_AGENT = "Wiii-KB-Seed/1.0"
 
 
 def _json_request(
@@ -39,7 +40,13 @@ def _json_request(
     timeout: float = 60.0,
 ) -> tuple[int, dict[str, Any]]:
     body = None
-    headers = {"Accept": "application/json"}
+    headers = {
+        "Accept": "application/json",
+        # Cloudflare can block Python's default urllib user agent with 1010.
+        # Keep this explicit so production dry-runs behave like curl/browser
+        # probes without weakening auth on write endpoints.
+        "User-Agent": DEFAULT_USER_AGENT,
+    }
     if payload is not None:
         body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
         headers["Content-Type"] = "application/json"

--- a/maritime-ai-service/tests/unit/test_document_context_api.py
+++ b/maritime-ai-service/tests/unit/test_document_context_api.py
@@ -89,6 +89,19 @@ class FakeDoclingAssetParser:
         )
 
 
+class FakeTempTitleParser:
+    is_available = True
+
+    async def parse(self, file_path: str, options=None):
+        return ParsedDocument(
+            markdown="# Uploaded Research\n\nNội dung tài liệu.",
+            page_count=1,
+            metadata={"title": "tmpabcdef123", "parser": "docling"},
+            section_map={"Uploaded Research": [1]},
+            images=[],
+        )
+
+
 class FakeVideoParser:
     is_available = True
 
@@ -227,6 +240,21 @@ def test_parse_document_context_surfaces_docling_assets(monkeypatch):
     assert response.table_count == 1
     assert response.embedded_assets[0].page == 2
     assert response.embedded_assets[0].bbox == {"l": 1.0, "t": 2.0, "r": 3.0, "b": 4.0}
+
+
+def test_parse_document_context_uses_upload_name_for_temp_parser_title(monkeypatch):
+    from app.api.v1 import document_context as module
+
+    monkeypatch.setattr(module, "_build_parser", lambda parser_mode=None: FakeTempTitleParser())
+
+    response = asyncio.run(
+        module.parse_document_context(
+            SimpleNamespace(user_id="u"),
+            _upload_file("research-proposal.docx", b"docx-bytes"),
+        )
+    )
+
+    assert response.title == "research-proposal.docx"
 
 
 def test_document_context_prompt_block_bounds_and_labels():

--- a/maritime-ai-service/tests/unit/test_seed_maritime_text_kb.py
+++ b/maritime-ai-service/tests/unit/test_seed_maritime_text_kb.py
@@ -1,0 +1,42 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_seed_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "seed_maritime_text_kb.py"
+    spec = importlib.util.spec_from_file_location("seed_maritime_text_kb", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_json_request_sets_user_agent_for_cloudflare_compat(monkeypatch):
+    module = _load_seed_module()
+    captured = {}
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps({"ok": True}).encode("utf-8")
+
+    def fake_urlopen(request, timeout):
+        captured["timeout"] = timeout
+        captured["headers"] = dict(request.header_items())
+        return FakeResponse()
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+
+    status, payload = module._json_request("https://wiii.example/api/v1/knowledge/stats")
+
+    assert status == 200
+    assert payload == {"ok": True}
+    assert captured["headers"]["User-agent"] == module.DEFAULT_USER_AGENT


### PR DESCRIPTION
## Summary
- Make the KB seed script send an explicit `User-Agent` so production dry-runs are not blocked by Cloudflare 1010.
- Keep uploaded document titles user-facing by falling back to the original upload name when parsers report temp-file titles.
- Add an audited `Seed Production Knowledge Base` workflow that SSHes to the production VM, reads `API_KEY` from `.env.production` without printing it, and runs the idempotent seed script.
- Add regression coverage for seed request headers and document-context title fallback.

## Test evidence
- `E:\Sach\Sua\AI_v1\maritime-ai-service\.venv\Scripts\python.exe -m pytest tests/unit/test_document_context_api.py tests/unit/test_seed_maritime_text_kb.py tests/unit/test_knowledge_api.py tests/unit/test_sprint136_universal_kb.py tests/unit/test_tool_collection_host_ui.py -q` -> 66 passed
- `E:\Sach\Sua\AI_v1\maritime-ai-service\.venv\Scripts\ruff.exe check app\api\v1\document_context.py --select=E9,F63,F7` -> pass
- `E:\Sach\Sua\AI_v1\maritime-ai-service\.venv\Scripts\python.exe -m py_compile scripts\seed_maritime_text_kb.py` -> pass
- YAML parse for `.github/workflows/seed-production-kb.yml` -> pass
- `git diff --check` -> pass
- `python scripts\seed_maritime_text_kb.py --dry-run --base-url https://wiii.holilihu.online` -> HTTP 200 stats, still 0 chunks/docs as expected until authorized seed

## Product smoke notes
- Production `/api/v1/knowledge/stats` still reports empty KB: `total_chunks=0`, `total_documents=0`.
- Production `/api/v1/knowledge/ingest-text` correctly rejects unauthenticated writes with HTTP 401.
- Local document-context parse succeeds for real DOCX uploads; Docling extracted figure/table counts and bounded snippets.

## Operational path after merge
1. Dispatch `Seed Production Knowledge Base` with `dry_run=true` if we want one more no-write check.
2. Dispatch it with `dry_run=false` to insert `maritime-colregs-teaching-seed-v1` into production RAG.
3. Verify `/api/v1/knowledge/stats` reports non-zero chunks/documents and run a COLREG RAG smoke.

## Risk / rollback
- Low runtime risk: operational workflow, script header, and response-title normalization only.
- Seed workflow is manual-only and uses existing production environment SSH secrets.
- Rollback code path: revert this PR.
- Rollback data path: remove the seeded `document_id` rows from `knowledge_embeddings` if needed.

Refs #385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Document titles now prefer user-provided upload names when metadata titles are missing or appear to be temporary placeholders
  * API requests include a stable User-Agent header to improve compatibility with cloud services

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/391)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->