### PR TITLE
fix(rag): persist text ingestion domain ids

### DIFF
--- a/maritime-ai-service/app/repositories/dense_search_repository_runtime.py
+++ b/maritime-ai-service/app/repositories/dense_search_repository_runtime.py
@@ -411,111 +411,105 @@ async def store_document_chunk_impl(
             inline_embedding_str = (
                 _embedding_to_pgvector(inline_embedding) if inline_embedding else None
             )
-            if eff_org_id and await repo._has_column(conn, "knowledge_embeddings", "organization_id"):
-                storage_id = await conn.fetchval(
-                    f"""
-                    INSERT INTO knowledge_embeddings (
-                        {key_column}, content, embedding, document_id, page_number,
-                        chunk_index, content_type, confidence_score, image_url, metadata,
-                        organization_id, bounding_boxes
-                    )
-                    VALUES ($1, $2, {('$3::vector' if inline_embedding_str else 'NULL')}, $4, $5, $6, $7, $8, $9, ${10 if inline_embedding_str else 9}::jsonb, ${11 if inline_embedding_str else 10}, ${12 if inline_embedding_str else 11}::jsonb)
-                    ON CONFLICT ({key_column})
-                    DO UPDATE SET
-                        content = EXCLUDED.content,
-                        embedding = COALESCE(EXCLUDED.embedding, knowledge_embeddings.embedding),
-                        document_id = EXCLUDED.document_id,
-                        page_number = EXCLUDED.page_number,
-                        chunk_index = EXCLUDED.chunk_index,
-                        content_type = EXCLUDED.content_type,
-                        confidence_score = EXCLUDED.confidence_score,
-                        image_url = EXCLUDED.image_url,
-                        metadata = EXCLUDED.metadata,
-                        organization_id = COALESCE(EXCLUDED.organization_id, knowledge_embeddings.organization_id),
-                        bounding_boxes = EXCLUDED.bounding_boxes,
-                        updated_at = NOW()
-                    RETURNING id::text
-                    """,
-                    key_value,
-                    content[:2000],
-                    *(
-                        (
-                            inline_embedding_str,
-                            document_id,
-                            page_number,
-                            chunk_index,
-                            content_type,
-                            confidence_score,
-                            image_url,
-                            metadata_json,
-                            eff_org_id,
-                            bounding_boxes_json,
-                        )
-                        if inline_embedding_str
-                        else (
-                            document_id,
-                            page_number,
-                            chunk_index,
-                            content_type,
-                            confidence_score,
-                            image_url,
-                            metadata_json,
-                            eff_org_id,
-                            bounding_boxes_json,
-                        )
-                    ),
-                )
+            has_org_column = bool(
+                eff_org_id
+                and await repo._has_column(conn, "knowledge_embeddings", "organization_id")
+            )
+            has_domain_column = await repo._has_column(
+                conn,
+                "knowledge_embeddings",
+                "domain_id",
+            )
+            domain_id = metadata.get("domain_id") if isinstance(metadata, dict) else None
+
+            columns = [
+                key_column,
+                "content",
+                "embedding",
+                "document_id",
+                "page_number",
+                "chunk_index",
+                "content_type",
+                "confidence_score",
+                "image_url",
+                "metadata",
+            ]
+            params: list[object] = [key_value, content[:2000]]
+            values = ["$1", "$2"]
+            if inline_embedding_str:
+                params.append(inline_embedding_str)
+                values.append("$3::vector")
             else:
-                storage_id = await conn.fetchval(
-                    f"""
-                    INSERT INTO knowledge_embeddings (
-                        {key_column}, content, embedding, document_id, page_number,
-                        chunk_index, content_type, confidence_score, image_url, metadata,
-                        bounding_boxes
-                    )
-                    VALUES ($1, $2, {('$3::vector' if inline_embedding_str else 'NULL')}, $4, $5, $6, $7, $8, $9, ${10 if inline_embedding_str else 9}::jsonb, ${11 if inline_embedding_str else 10}::jsonb)
-                    ON CONFLICT ({key_column})
-                    DO UPDATE SET
-                        content = EXCLUDED.content,
-                        embedding = COALESCE(EXCLUDED.embedding, knowledge_embeddings.embedding),
-                        document_id = EXCLUDED.document_id,
-                        page_number = EXCLUDED.page_number,
-                        chunk_index = EXCLUDED.chunk_index,
-                        content_type = EXCLUDED.content_type,
-                        confidence_score = EXCLUDED.confidence_score,
-                        image_url = EXCLUDED.image_url,
-                        metadata = EXCLUDED.metadata,
-                        bounding_boxes = EXCLUDED.bounding_boxes,
-                        updated_at = NOW()
-                    RETURNING id::text
-                    """,
-                    key_value,
-                    content[:2000],
-                    *(
-                        (
-                            inline_embedding_str,
-                            document_id,
-                            page_number,
-                            chunk_index,
-                            content_type,
-                            confidence_score,
-                            image_url,
-                            metadata_json,
-                            bounding_boxes_json,
-                        )
-                        if inline_embedding_str
-                        else (
-                            document_id,
-                            page_number,
-                            chunk_index,
-                            content_type,
-                            confidence_score,
-                            image_url,
-                            metadata_json,
-                            bounding_boxes_json,
-                        )
-                    ),
+                values.append("NULL")
+
+            for value, cast_jsonb in (
+                (document_id, False),
+                (page_number, False),
+                (chunk_index, False),
+                (content_type, False),
+                (confidence_score, False),
+                (image_url, False),
+                (metadata_json, True),
+            ):
+                params.append(value)
+                placeholder = f"${len(params)}"
+                if cast_jsonb:
+                    placeholder += "::jsonb"
+                values.append(placeholder)
+
+            if has_org_column:
+                columns.append("organization_id")
+                params.append(eff_org_id)
+                values.append(f"${len(params)}")
+
+            if has_domain_column:
+                columns.append("domain_id")
+                params.append(domain_id)
+                values.append(f"${len(params)}")
+
+            columns.append("bounding_boxes")
+            params.append(bounding_boxes_json)
+            values.append(f"${len(params)}::jsonb")
+
+            update_lines = [
+                "content = EXCLUDED.content",
+                "embedding = COALESCE(EXCLUDED.embedding, knowledge_embeddings.embedding)",
+                "document_id = EXCLUDED.document_id",
+                "page_number = EXCLUDED.page_number",
+                "chunk_index = EXCLUDED.chunk_index",
+                "content_type = EXCLUDED.content_type",
+                "confidence_score = EXCLUDED.confidence_score",
+                "image_url = EXCLUDED.image_url",
+                "metadata = EXCLUDED.metadata",
+            ]
+            if has_org_column:
+                update_lines.append(
+                    "organization_id = COALESCE(EXCLUDED.organization_id, knowledge_embeddings.organization_id)"
                 )
+            if has_domain_column:
+                update_lines.append(
+                    "domain_id = COALESCE(EXCLUDED.domain_id, knowledge_embeddings.domain_id)"
+                )
+            update_lines.extend(
+                [
+                    "bounding_boxes = EXCLUDED.bounding_boxes",
+                    "updated_at = NOW()",
+                ]
+            )
+
+            storage_id = await conn.fetchval(
+                f"""
+                INSERT INTO knowledge_embeddings (
+                    {", ".join(columns)}
+                )
+                VALUES ({", ".join(values)})
+                ON CONFLICT ({key_column})
+                DO UPDATE SET
+                    {", ".join(update_lines)}
+                RETURNING id::text
+                """,
+                *params,
+            )
 
             if storage_id:
                 await _write_shadow_vectors_async(

--- a/maritime-ai-service/tests/unit/test_dense_search_repository_runtime.py
+++ b/maritime-ai-service/tests/unit/test_dense_search_repository_runtime.py
@@ -44,10 +44,11 @@ class _FakeConn:
 
 
 class _FakeRepo:
-    def __init__(self, *, has_node_id: bool):
+    def __init__(self, *, has_node_id: bool, has_domain_id: bool = False):
         self._available = True
         self._pool = None
         self._has_node_id = has_node_id
+        self._has_domain_id = has_domain_id
         self.conn = _FakeConn()
 
     async def _get_pool(self):
@@ -58,7 +59,18 @@ class _FakeRepo:
             return self._has_node_id
         if column == "organization_id":
             return True
+        if column == "domain_id":
+            return self._has_domain_id
         return False
+
+
+def _metadata_payload_from_params(params: tuple[object, ...]) -> dict:
+    for param in params:
+        if isinstance(param, str) and param.startswith("{"):
+            parsed = json.loads(param)
+            if "legacy_node_id" in parsed:
+                return parsed
+    raise AssertionError("Metadata JSON param was not captured")
 
 
 @pytest.mark.asyncio
@@ -83,15 +95,43 @@ async def test_store_document_chunk_uses_uuid_id_when_schema_lacks_node_id():
 
     assert ok is True
     query, params = repo.conn.calls[0]
-    assert "INSERT INTO knowledge_embeddings (\n                        id," in query
+    assert "INSERT INTO knowledge_embeddings" in query
+    assert "id, content, embedding, document_id" in query
     assert "ON CONFLICT (id)" in query
     assert params[0] == _derive_storage_uuid("legacy-node-123")
-    metadata_payload = json.loads(params[9])
+    metadata_payload = _metadata_payload_from_params(params)
     assert metadata_payload["legacy_node_id"] == "legacy-node-123"
     assert (
         metadata_payload["embedding_space_fingerprint"]
         == metadata_payload["_embedding_space"]["fingerprint"]
     )
+
+
+@pytest.mark.asyncio
+async def test_store_document_chunk_persists_domain_column_when_available():
+    repo = _FakeRepo(has_node_id=True, has_domain_id=True)
+
+    ok = await store_document_chunk_impl(
+        repo,
+        node_id="domain-node-123",
+        content="Rule 15 crossing situation chunk",
+        embedding=[0.1] * 768,
+        document_id="doc-1",
+        page_number=1,
+        chunk_index=0,
+        content_type="text",
+        confidence_score=0.9,
+        image_url="",
+        metadata={"domain_id": "maritime"},
+        organization_id=None,
+        bounding_boxes=None,
+    )
+
+    assert ok is True
+    query, params = repo.conn.calls[0]
+    assert "domain_id" in query
+    assert "domain_id = COALESCE(EXCLUDED.domain_id, knowledge_embeddings.domain_id)" in query
+    assert "maritime" in params
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- persist `metadata.domain_id` into the `knowledge_embeddings.domain_id` column when that schema column exists
- keep organization and bounding-box upsert behavior intact while simplifying placeholder generation
- add coverage so text KB ingestion no longer shows as `untagged` in production stats

Refs #385.

## Verification
- `E:\Sach\Sua\AI_v1\maritime-ai-service\.venv\Scripts\python.exe -m pytest tests/unit/test_document_context_api.py tests/unit/test_seed_maritime_text_kb.py tests/unit/test_knowledge_api.py tests/unit/test_sprint136_universal_kb.py tests/unit/test_dense_search_repository_runtime.py -q` -> 56 passed
- `E:\Sach\Sua\AI_v1\maritime-ai-service\.venv\Scripts\ruff.exe check app\repositories\dense_search_repository_runtime.py --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk / rollback
- Risk: repository SQL generation changed for document chunk upsert. Covered by runtime repository tests and existing ingestion tests.
- Rollback: revert this commit; existing rows remain inserted but domain stats may fall back to `untagged` for text-ingested chunks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal database query handling for document storage operations to be more maintainable and flexible.

* **Tests**
  * Enhanced unit tests to better validate query generation and storage logic.

**Note:** These changes are internal improvements with no user-facing feature updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/393)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->