### PR TITLE
ci(rag): add production RAG chat smoke

### DIFF
--- a/.github/workflows/seed-production-kb.yml
+++ b/.github/workflows/seed-production-kb.yml
@@ -33,6 +33,16 @@ on:
         required: true
         default: false
         type: boolean
+      run_rag_smoke:
+        description: "After ingest, run an authenticated chat query that must return source evidence."
+        required: true
+        default: false
+        type: boolean
+      smoke_query:
+        description: "RAG smoke query to send to /api/v1/chat when run_rag_smoke is true."
+        required: true
+        default: "According to COLREGs, in a crossing situation between two power-driven vessels with risk of collision, which vessel should give way? Cite the knowledge source if available."
+        type: string
 
 permissions:
   contents: read
@@ -90,6 +100,8 @@ jobs:
           TITLE: ${{ inputs.title }}
           CORPUS_PATH: ${{ inputs.corpus_path }}
           DRY_RUN: ${{ inputs.dry_run }}
+          RUN_RAG_SMOKE: ${{ inputs.run_rag_smoke }}
+          SMOKE_QUERY: ${{ inputs.smoke_query }}
         run: |
           set -euo pipefail
 
@@ -103,9 +115,10 @@ jobs:
           DOMAIN_ID_B64="$(encode "$DOMAIN_ID")"
           TITLE_B64="$(encode "$TITLE")"
           CORPUS_PATH_B64="$(encode "$CORPUS_PATH")"
+          SMOKE_QUERY_B64="$(encode "$SMOKE_QUERY")"
 
           ssh -i ~/.ssh/wiii_production_key -p "$SSH_PORT" "$SSH_TARGET" \
-            "APP_DIR='$APP_DIR' BASE_URL_B64='$BASE_URL_B64' DOCUMENT_ID_B64='$DOCUMENT_ID_B64' DOMAIN_ID_B64='$DOMAIN_ID_B64' TITLE_B64='$TITLE_B64' CORPUS_PATH_B64='$CORPUS_PATH_B64' DRY_RUN='$DRY_RUN' bash -s" <<'REMOTE'
+            "APP_DIR='$APP_DIR' BASE_URL_B64='$BASE_URL_B64' DOCUMENT_ID_B64='$DOCUMENT_ID_B64' DOMAIN_ID_B64='$DOMAIN_ID_B64' TITLE_B64='$TITLE_B64' CORPUS_PATH_B64='$CORPUS_PATH_B64' SMOKE_QUERY_B64='$SMOKE_QUERY_B64' DRY_RUN='$DRY_RUN' RUN_RAG_SMOKE='$RUN_RAG_SMOKE' bash -s" <<'REMOTE'
           set -euo pipefail
 
           decode() { printf '%s' "$1" | base64 -d; }
@@ -136,6 +149,7 @@ jobs:
           DOMAIN_ID="$(decode "$DOMAIN_ID_B64")"
           TITLE="$(decode "$TITLE_B64")"
           CORPUS_PATH="$(decode "$CORPUS_PATH_B64")"
+          SMOKE_QUERY="$(decode "$SMOKE_QUERY_B64")"
 
           cd "$APP_DIR"
           git fetch --prune origin main
@@ -240,4 +254,12 @@ jobs:
           fi
 
           WIII_ADMIN_JWT="$ADMIN_JWT" "$PYTHON_BIN" "${args[@]}"
+          if [ "$RUN_RAG_SMOKE" = "true" ]; then
+            WIII_ADMIN_JWT="$ADMIN_JWT" "$PYTHON_BIN" scripts/smoke_production_rag_chat.py \
+              --base-url "$BASE_URL" \
+              --query "$SMOKE_QUERY" \
+              --domain-id "$DOMAIN_ID" \
+              --bearer-token-env WIII_ADMIN_JWT \
+              --require-source
+          fi
           REMOTE

--- a/maritime-ai-service/scripts/smoke_production_rag_chat.py
+++ b/maritime-ai-service/scripts/smoke_production_rag_chat.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Smoke test production RAG chat against an already-ingested corpus.
+
+The script intentionally avoids printing secrets. It reports only response
+shape, source/document evidence, and a short answer preview for operator QA.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
+
+
+DEFAULT_QUERY = (
+    "According to COLREGs, in a crossing situation between two power-driven "
+    "vessels with risk of collision, which vessel should give way? Cite the "
+    "knowledge source if available."
+)
+DEFAULT_USER_AGENT = "Wiii-RAG-Chat-Smoke/1.0"
+
+
+def _read_secret_env(name: str | None) -> str | None:
+    if not name:
+        return None
+    value = os.getenv(name)
+    if value and value.strip():
+        return value.strip()
+    return None
+
+
+def _json_post(
+    url: str,
+    *,
+    payload: dict[str, Any],
+    bearer_token: str,
+    timeout: float,
+) -> tuple[int, dict[str, Any]]:
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    request = Request(
+        url,
+        data=body,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {bearer_token}",
+            "Content-Type": "application/json",
+            "User-Agent": DEFAULT_USER_AGENT,
+        },
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8", errors="replace")
+            parsed = json.loads(raw) if raw else {}
+            return response.status, parsed
+    except HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        try:
+            parsed = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            parsed = {"detail": raw[:500]}
+        return exc.code, parsed
+    except URLError as exc:
+        raise RuntimeError(f"Could not reach {url}: {exc}") from exc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a production RAG chat smoke query using a platform-admin JWT."
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("WIII_BASE_URL", "https://wiii.holilihu.online"),
+        help="Wiii API base URL.",
+    )
+    parser.add_argument("--query", default=DEFAULT_QUERY)
+    parser.add_argument("--domain-id", default="maritime")
+    parser.add_argument("--bearer-token-env", default="WIII_ADMIN_JWT")
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--require-source", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    bearer_token = _read_secret_env(args.bearer_token_env)
+    if not bearer_token:
+        print(f"Missing bearer token env: {args.bearer_token_env}", file=sys.stderr)
+        return 2
+
+    base_url = args.base_url.rstrip("/") + "/"
+    chat_url = urljoin(base_url, "api/v1/chat")
+    session_id = f"production-rag-smoke-{int(time.time())}"
+    payload = {
+        "user_id": "github-actions-rag-smoke",
+        "message": args.query,
+        "role": "teacher",
+        "session_id": session_id,
+        "domain_id": args.domain_id,
+        "thinking_effort": "medium",
+    }
+
+    status_code, response = _json_post(
+        chat_url,
+        payload=payload,
+        bearer_token=bearer_token,
+        timeout=args.timeout,
+    )
+    data = response.get("data") if isinstance(response, dict) else {}
+    metadata = response.get("metadata") if isinstance(response, dict) else {}
+    answer = (data or {}).get("answer") or ""
+    sources = (data or {}).get("sources") or []
+    document_ids = (metadata or {}).get("document_ids_used") or []
+    tools_used = (metadata or {}).get("tools_used") or []
+    agent_type = (metadata or {}).get("agent_type")
+    query_type = (metadata or {}).get("query_type")
+    provider = (metadata or {}).get("provider")
+    model = (metadata or {}).get("model")
+    preview = " ".join(answer.split())[:500]
+
+    print(
+        "RAG chat smoke: "
+        f"http={status_code}, status={response.get('status')!r}, "
+        f"answer_chars={len(answer)}, sources={len(sources)}, "
+        f"document_ids={document_ids}, tools={tools_used}, "
+        f"agent_type={agent_type!r}, query_type={query_type!r}, "
+        f"provider={provider!r}, model={model!r}"
+    )
+    if preview:
+        print(f"Answer preview: {preview}")
+
+    if status_code >= 400:
+        detail = response.get("detail") or response.get("message") or response
+        print(f"RAG chat smoke failed: {detail}", file=sys.stderr)
+        return 1
+    if response.get("status") != "success" or not answer.strip():
+        print("RAG chat smoke failed: response did not contain a successful answer.", file=sys.stderr)
+        return 1
+    if args.require_source and not sources and not document_ids:
+        print(
+            "RAG chat smoke failed: no source citations or document_ids_used returned.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an optional `run_rag_smoke` step to the production KB seed workflow
- add `scripts/smoke_production_rag_chat.py` to call `/api/v1/chat` with the same short-lived admin JWT and require source/document evidence
- keep the smoke disabled by default so ordinary seed runs do not depend on LLM latency

Refs #385.

## Verification
- `E:\Sach\Sua\AI_v1\maritime-ai-service\.venv\Scripts\python.exe -m py_compile scripts\smoke_production_rag_chat.py scripts\seed_maritime_text_kb.py` -> pass
- Parsed `.github/workflows/seed-production-kb.yml` with PyYAML and confirmed smoke step is wired.
- `bash -n` on the extracted workflow run block -> pass
- `git diff --check` -> pass

## Risk / rollback
- Risk: optional workflow-only smoke may fail on transient LLM latency when explicitly enabled; default remains false.
- Rollback: revert this commit; seed/ingest remains available, only the extra chat evidence smoke disappears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added optional smoke-testing capability for production RAG functionality to validate deployments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/394)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->