### PR TITLE
fix(rag): route source-backed maritime questions to RAG

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/supervisor.py
+++ b/maritime-ai-service/app/engine/multi_agent/supervisor.py
@@ -55,6 +55,7 @@ from app.engine.multi_agent.supervisor_runtime_support import (
     is_complex_query_impl,
     rule_based_route_impl,
     resolve_house_routing_provider_impl,
+    _looks_source_backed_domain_lookup_turn,
     validate_domain_routing_impl,
 )
 from app.engine.multi_agent.direct_search_synthesis_fallback import (
@@ -290,6 +291,30 @@ class SupervisorAgent:
             return agent
 
         _apply_routing_hint(state, query)
+
+        normalized_query = _normalize_router_text(query)
+        if _looks_source_backed_domain_lookup_turn(normalized_query):
+            agent = AgentType.RAG.value
+            intent = "lookup"
+            method = "deterministic_source_backed_lookup_guard"
+            state["routing_metadata"] = {
+                "intent": intent,
+                "confidence": 1.0,
+                "reasoning": _finalize_routing_reasoning(
+                    raw_reasoning=(
+                        "user asked for a source-backed domain answer; use RAG "
+                        "before direct model synthesis so citations can surface"
+                    ),
+                    method=method,
+                    chosen_agent=agent,
+                    intent=intent,
+                    query=query,
+                ),
+                "llm_reasoning": "",
+                "method": method,
+                "final_agent": agent,
+            }
+            return agent
 
         routing_hint = state.get("_routing_hint") or {}
         if (

--- a/maritime-ai-service/app/engine/multi_agent/supervisor_runtime_support.py
+++ b/maritime-ai-service/app/engine/multi_agent/supervisor_runtime_support.py
@@ -121,6 +121,29 @@ _OBVIOUS_MARITIME_LOOKUP_BLOCKERS = (
     "web search",
 )
 
+_SOURCE_BACKED_LOOKUP_MARKERS = (
+    "according to",
+    "can cu",
+    "cite",
+    "citation",
+    "citations",
+    "co dan nguon",
+    "co nguon",
+    "dan nguon",
+    "dua tren tai lieu",
+    "knowledge source",
+    "nguon",
+    "reference",
+    "references",
+    "source",
+    "sources",
+    "source-backed",
+    "tai lieu noi gi",
+    "theo nguon",
+    "theo tai lieu",
+    "trich dan",
+)
+
 _EXPLICIT_WEB_SEARCH_MARKERS = (
     "@web-search",
     "@web_search",
@@ -195,6 +218,34 @@ def _looks_colreg_rule_explanation_turn(normalized_query: str) -> bool:
         query,
     ) is not None
     return has_colreg and has_rule_number
+
+
+def _looks_source_backed_domain_lookup_turn(normalized_query: str) -> bool:
+    """Route citation/source-backed domain questions to RAG before LLM routing.
+
+    This guard is intentionally narrower than the generic maritime lookup
+    heuristic: it only catches prompts that explicitly ask Wiii to ground the
+    answer in a source/citation and that contain a maritime regulation marker.
+    Web/latest requests stay out so the web-search lane can handle them.
+    """
+    query = normalized_query or ""
+    if not query:
+        return False
+    if _looks_explicit_web_search_turn(query):
+        return False
+    if _contains_any_marker(query, ("latest", "moi nhat", "news", "tin moi", "tin tuc")):
+        return False
+
+    has_domain_marker = _contains_any_marker(
+        query,
+        _OBVIOUS_MARITIME_LOOKUP_MARKERS,
+    ) or re.search(r"\brule\s+\d+[a-z]?\b", query) is not None or re.search(
+        r"\bquy\s*tac\s+\d+[a-z]?\b",
+        query,
+    ) is not None
+    if not has_domain_marker:
+        return False
+    return _contains_any_marker(query, _SOURCE_BACKED_LOOKUP_MARKERS)
 
 
 def _looks_explicit_web_search_turn(normalized_query: str) -> bool:

--- a/maritime-ai-service/tests/unit/test_conservative_evolution.py
+++ b/maritime-ai-service/tests/unit/test_conservative_evolution.py
@@ -1257,6 +1257,45 @@ class TestConservativeFastRouting:
         mock_llm.with_structured_output.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_source_backed_colregs_lookup_routes_rag_without_fast_flag(self):
+        from app.engine.multi_agent import supervisor as supervisor_module
+
+        mock_llm = MagicMock()
+        mock_llm.with_structured_output = MagicMock()
+        supervisor = _make_supervisor(mock_llm)
+        state = {
+            "query": (
+                "According to COLREGs, in a crossing situation between two "
+                "power-driven vessels with risk of collision, which vessel "
+                "should give way? Cite the knowledge source if available."
+            ),
+            "context": {},
+            "domain_config": {"routing_keywords": ["colregs", "solas", "rule"]},
+        }
+
+        with patch.object(supervisor_module.settings, "enable_conservative_fast_routing", False):
+            result = await supervisor.route(state)
+
+        assert result == "rag_agent"
+        assert state["routing_metadata"]["method"] == "deterministic_source_backed_lookup_guard"
+        assert state["routing_metadata"]["intent"] == "lookup"
+        mock_llm.with_structured_output.assert_not_called()
+
+    def test_source_backed_guard_does_not_steal_web_or_latest_requests(self):
+        from app.engine.multi_agent.supervisor_runtime_support import (
+            _looks_source_backed_domain_lookup_turn,
+        )
+        from app.engine.multi_agent.supervisor_hint_runtime import (
+            _normalize_router_text_impl,
+        )
+
+        normalized = _normalize_router_text_impl(
+            "Search the web for latest COLREGs amendments and cite sources."
+        )
+
+        assert _looks_source_backed_domain_lookup_turn(normalized) is False
+
+    @pytest.mark.asyncio
     async def test_codebase_schema_jwt_skips_llm_and_routes_direct(self):
         from app.engine.multi_agent import supervisor as supervisor_module
 


### PR DESCRIPTION
## Summary
- Link #385.
- Force explicitly source-backed maritime regulation questions (COLREG/Rule/Quy tac + cite/source/theo tai lieu markers) into `rag_agent` before the LLM router.
- Keep web/latest/source requests out of the guard so web-search/direct routing can still handle them.
- Add regression tests for the exact production smoke prompt shape and web/latest exclusion.

## In scope
- Backend supervisor routing only.
- Production RAG citation smoke blocker from #385.

## Out of scope
- KB ingestion workflow, domain persistence, document parsing, UI, or provider changes.

## Verification
- `E:\Sach\Sua\AI_v1\maritime-ai-service\.venv\Scripts\python.exe -m pytest tests/unit/test_conservative_evolution.py::TestConservativeFastRouting::test_source_backed_colregs_lookup_routes_rag_without_fast_flag tests/unit/test_conservative_evolution.py::TestConservativeFastRouting::test_source_backed_guard_does_not_steal_web_or_latest_requests tests/unit/test_conservative_evolution.py::TestConservativeFastRouting::test_clear_maritime_lookup_skips_llm_and_routes_rag -q` -> 3 passed.
- `E:\Sach\Sua\AI_v1\maritime-ai-service\.venv\Scripts\python.exe -m pytest tests/unit/test_conservative_evolution.py tests/unit/test_supervisor_routing.py tests/unit/test_supervisor_agent.py tests/unit/test_supervisor_route_timeout.py -q` -> 165 passed.
- `E:\Sach\Sua\AI_v1\maritime-ai-service\.venv\Scripts\ruff.exe check app/engine/multi_agent/supervisor.py app/engine/multi_agent/supervisor_runtime_support.py --select=E9,F63,F7` -> pass.
- `git diff --check` -> pass.

## Risk / rollback
- Risk: source/citation prompts for maritime regulation now prefer RAG over direct synthesis, which is intended for source-backed answers but may expose retrieval gaps more honestly.
- Rollback: revert this PR to restore previous LLM-router behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added intelligent detection for maritime domain queries requesting citation-grounded answers
  * Queries matching source-backed lookup patterns now route directly to the retrieval agent, bypassing intermediate routing steps and improving response speed

* **Tests**
  * Added unit tests to validate source-backed domain lookup routing behavior and verify web search requests are handled separately

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/395)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->