### PR TITLE
docs: add Wiii codebase recovery harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,8 @@ wiii-desktop/dist-embed/
 wiii-desktop/dist-web/
 wiii-desktop/dist-pointy/
 pytest-cache-files-*
-# Keep local nested agent configs ignored, but track root Codex review guidance.
+# Keep local nested agent configs ignored, but track approved Codex review and
+# subsystem guidance files.
 .agents/*
 !.agents/skills/
 .agents/skills/*
@@ -117,3 +118,5 @@ pytest-cache-files-*
 !.agents/skills/speckit-*/SKILL.md
 **/AGENTS.md
 !/AGENTS.md
+!/maritime-ai-service/AGENTS.md
+!/wiii-desktop/AGENTS.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,10 @@ Use this folder for repository-level documentation that explains the product, th
 
 - `../README.md`: repository overview and deployment model
 - `WIII_PROJECT_MENTAL_MODEL.md`: one-page product and system mental model
+- `architecture/WIII_CODEBASE_MAP.md`: concise codebase map for maintainers and coding agents
 - `WIII_ARCHITECTURE_AUDIT.md`: opinionated audit of architectural center, strengths, and risk areas
 - `WIII_TECHNICAL_SIMPLIFICATION_ROADMAP.md`: phased simplification plan and first landed slice
+- `operations/WIII_AGENTIC_CODEBASE_HARNESS.md`: large-codebase agent workflow, context layering, and WIP recovery pattern
 - `plans/2026-04-27-wiii-native-orchestration-rfc.md`: phased RFC for replacing remaining LangGraph assumptions with Wiii-owned runtime contracts
 - `plans/2026-04-28-wiii-pipeline-simplification-plan.md`: current request/auth/memory/router/agent/tool/RAG/stream lifecycle and safe LangGraph/history/compat cleanup plan
 - `operations/WIII_DOCUMENTATION_GOVERNANCE.md`: documentation lifecycle, cleanup controls, and issue/PR standards
@@ -27,7 +29,12 @@ Use this folder for repository-level documentation that explains the product, th
 
 - `plans/`: reviewed design notes and active implementation plans
 - `operations/`: reviewed governance, release, auth, and runtime operation documents
+- `architecture/`: current maps and contracts for navigating the system
 - `assets/`: committed documentation assets that are referenced by canonical docs
+
+## Archive / Audit Log
+
+- `operations/WIII_REPO_RECOVERY_AUDIT_2026-05-19.md`: temporary/history recovery record for issue #397; durable process guidance lives in `operations/WIII_AGENTIC_CODEBASE_HARNESS.md`.
 
 ## Rules
 

--- a/docs/architecture/WIII_CODEBASE_MAP.md
+++ b/docs/architecture/WIII_CODEBASE_MAP.md
@@ -1,0 +1,112 @@
+# Wiii Codebase Map
+
+Status: Active
+
+Owner: Architecture Maintainers (CODEOWNERS; track drift through `area:docs` GitHub issues)
+
+Last updated: 2026-05-19
+
+This is the short navigational map for humans and coding agents working in the
+Wiii repository. It complements `AGENTS.md`, the operation docs, and deeper
+architecture references.
+
+## One Sentence
+
+Wiii is a multi-surface agentic AI platform with a FastAPI backend, a React/Tauri
+desktop and embed frontend, organization-aware data boundaries, retrieval and
+memory, LMS host actions, visual artifacts, and voice.
+
+## Top-Level Folders
+
+| Path | Purpose | Notes |
+|---|---|---|
+| `maritime-ai-service/` | FastAPI backend, orchestration, RAG, tools, memory, LMS, deploy assets | Highest-risk runtime surface |
+| `wiii-desktop/` | React 18, Tauri v2, embed app, chat UX, Pointy, voice controls | User-visible behavior and stream rendering |
+| `docs/` | Architecture, operations, integration, release, governance | Durable knowledge belongs here |
+| `specs/` | Spec Kit artifacts for architecture-sensitive work | Use for multi-phase or contract changes |
+| `.github/` | GitHub Actions, templates, CodeRabbit, CODEOWNERS | Merge safety and review automation |
+| `.agents/skills/` | Repo-local Codex skills | Skills should be focused and loaded on demand |
+| `memory/` | Historical handoffs and field notes | Useful context, not canonical governance |
+| `scripts/` | Repository-level helper scripts | Avoid adding one-off local probes here |
+| `chaos/`, `loadtest/` | Stress and load tooling | Run only when task requires it |
+
+## Five-Layer Product Model
+
+| Layer | Meaning | Main code areas |
+|---|---|---|
+| Core | Decide and execute the current turn | chat services, multi-agent runtime, tool loop |
+| Living | Maintain continuity and identity over time | memory, emotion, reflection, post-turn hooks |
+| Host | Understand where Wiii is operating | desktop, embed, LMS, Pointy, host actions |
+| Org | Enforce ownership and tenant boundaries | auth, org middleware, settings, repositories |
+| Data | Preserve durable state and retrieval substrate | PostgreSQL, pgvector, repositories, migrations |
+
+## Main Runtime Flow
+
+The normal chat turn should be read in this order:
+
+1. FastAPI route receives request and auth context.
+2. `ChatOrchestrator` prepares the turn.
+3. Context, org, host, history, document, and memory state are assembled.
+4. Multi-agent runtime chooses direct, RAG, tool, visual, LMS, or other lanes.
+5. Tools and retrieval execute with tenant and host constraints.
+6. Backend emits sync response or SSE V3 events.
+7. Frontend assembles visible answer, previews, sources, and artifacts.
+8. Post-turn hooks update continuity outside the critical response path.
+
+## Backend Navigation
+
+| Need | Start here |
+|---|---|
+| Sync chat behavior | `maritime-ai-service/app/api/v1/chat.py`, then `maritime-ai-service/app/services/chat_orchestrator.py` |
+| Streaming behavior | `maritime-ai-service/app/api/v1/chat_stream.py`, then `maritime-ai-service/app/services/chat_stream_coordinator.py` |
+| Direct tool loop | `maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py` |
+| Native stream/provider quirks | `maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py` |
+| Routing and supervisor behavior | `maritime-ai-service/app/engine/multi_agent/supervisor*.py` |
+| Tool registry | `maritime-ai-service/app/engine/tools/registry.py` and `maritime-ai-service/app/engine/multi_agent/tool_collection.py` |
+| LMS host actions | `maritime-ai-service/app/engine/context/action_tools.py`, `maritime-ai-service/app/engine/tools/lms_tools.py` |
+| Document context | `maritime-ai-service/app/api/v1/document_context.py`, document runtime helpers |
+| Config | `maritime-ai-service/app/core/config/_settings*.py` |
+| Voice | `maritime-ai-service/app/api/v1/voice.py` |
+
+## Frontend Navigation
+
+| Need | Start here |
+|---|---|
+| Chat UI | `wiii-desktop/src/EmbedApp.tsx` |
+| User input | `wiii-desktop/src/components/chat/ChatInput.tsx` |
+| SSE assembly | `wiii-desktop/src/hooks/useSSEStream.ts` |
+| Markdown | `wiii-desktop/src/components/common/MarkdownRenderer.tsx`, `wiii-desktop/src/styles/markdown.css` |
+| Preview/apply UI | `wiii-desktop/src/components/layout/PreviewPanel.tsx` |
+| Source references | `wiii-desktop/src/lib/source-references.ts` |
+| Host bridge | `wiii-desktop/src/lib/embed-bridge.ts`, `wiii-desktop/src/lib/context-bridge.ts` |
+| Pointy | `wiii-desktop/src/pointy-host/**` and `wiii-desktop/src/components/chat/PointyModeToggle.tsx` |
+| Voice | `wiii-desktop/src/api/voice.ts`, voice mode/toggle components |
+| Visual artifacts | `wiii-desktop/src/components/chat/VisualArtifactCard.tsx`, `wiii-desktop/src/components/common/InlineVisualFrame.tsx` |
+
+## Canonical Contracts
+
+Keep these contracts explicit and tested:
+
+- agent turn lifecycle
+- native provider stream lifecycle
+- tool call dispatch and result handling
+- document context provenance and source references
+- host action preview/apply approval
+- SSE V3 event names and order
+- frontend Markdown repair and rendering
+- voice listening/speaking state
+- visual artifact sandbox and frame sizing
+
+## Where Not To Put Durable Knowledge
+
+Avoid using these as canonical documentation:
+
+- chat transcripts
+- temporary local screenshots
+- one-off script output
+- stale branch names
+- provider-specific debugging notes without date or owner
+- untracked local scratch files
+
+Promote durable findings into `docs/`, `specs/`, or an approved path-specific
+`AGENTS.md`.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -18,6 +18,8 @@ Operational docs are different from exploratory reports:
 - `WIII_PRODUCTION_AUTH_RUNBOOK.md`: production Magic Link and Google OAuth enablement, fail-closed behavior, smoke tests, and rollback.
 - `WIII_PRODUCT_RELEASE_RUNBOOK.md`: production deploy lane, pinned-image rollout, smoke gates, rollback, and parallel-team safety.
 - `WIII_MULTI_AGENT_MAINTAINER_PROTOCOL.md`: multi-agent ownership, maintainer review, CodeRabbit, conflict, and merge protocol.
+- `WIII_AGENTIC_CODEBASE_HARNESS.md`: layered context, scoped exploration, WIP recovery, and deterministic checks for large-codebase agent work.
+- `WIII_REPO_RECOVERY_AUDIT_2026-05-19.md`: temporary/history recovery record for the large WIP snapshot preserved before repository cleanup; durable guidance lives in `WIII_AGENTIC_CODEBASE_HARNESS.md` and follow-up tracking lives in issue #397.
 - `BYPASS_LOG.md`: audited record of branch-protection bypasses, rationale, and restored controls.
 
 ## Promotion Rule

--- a/docs/operations/WIII_AGENTIC_CODEBASE_HARNESS.md
+++ b/docs/operations/WIII_AGENTIC_CODEBASE_HARNESS.md
@@ -1,0 +1,167 @@
+# Wiii Agentic Codebase Harness
+
+Status: Active
+
+Owner: Project leadership
+
+Last updated: 2026-05-19
+
+This document translates large-codebase agent practices into Wiii's repository
+workflow. The goal is not to add ceremony. The goal is to make Wiii easier to
+navigate, safer to edit, and less dependent on tribal memory.
+
+## Principles
+
+1. Load broad context once, specialized context only when needed.
+2. Start from a scoped subsystem when the task is scoped.
+3. Prefer live code search over stale mental models.
+4. Separate exploration from editing for broad changes.
+5. Keep WIP reviewable by contract, not by enthusiasm.
+6. Put durable learnings in docs, not chat.
+7. Let deterministic checks enforce what prompts should not have to remember.
+
+## Layered Context
+
+Wiii uses layered agent guidance:
+
+| Layer | File | Purpose |
+|---|---|---|
+| Repository | `AGENTS.md` | global rules, governance, risk surfaces |
+| Backend | `maritime-ai-service/AGENTS.md` | backend runtime navigation and tests |
+| Frontend | `wiii-desktop/AGENTS.md` | chat/embed/voice/visual UI navigation and tests |
+| Skills | `.agents/skills/**/SKILL.md` | on-demand workflows |
+| Operations | `docs/operations/**` | governance, deploy, recovery, release |
+| Architecture | `docs/architecture/**` | system maps and contracts |
+| Specs | `specs/**` | feature-specific plans and tasks |
+
+Root guidance should stay compact. Path-specific guidance should carry the local
+details.
+
+## Exploration Protocol
+
+For broad or unclear tasks:
+
+1. Read root `AGENTS.md`.
+2. Read the path-specific `AGENTS.md` for the subsystem.
+3. Read the relevant architecture or operation doc.
+4. Use `rg` and focused file reads to map the exact path.
+5. Write a short finding or plan before editing.
+6. Edit only the scoped files.
+7. Run the smallest meaningful checks.
+8. Update docs if the contract changed.
+
+For narrow bugs, skip broad architecture reading once the relevant subsystem is
+known, but still obey the local `AGENTS.md`.
+
+## PR Slicing Rules
+
+Split work by contract:
+
+- tool call parsing and dispatch
+- streaming lifecycle
+- Markdown rendering
+- LMS preview/apply approval
+- document memory and provenance
+- voice transport and provider config
+- visual artifact runtime
+- deployment config
+- docs and harness
+
+Do not mix deploy changes with runtime changes unless the issue is specifically
+about production rollout.
+
+## Reviewability Budget
+
+Default governance limits remain:
+
+- maximum 150 changed files
+- maximum 20,000 total changed lines
+
+Wiii should normally aim much smaller:
+
+- backend runtime PR: 3 to 12 files
+- frontend UI PR: 3 to 15 files
+- docs-only PR: 1 to 8 files
+- deploy PR: as small as possible, with rollback notes
+
+If a branch grows beyond that, split before opening ready-for-review.
+
+## Deterministic Checks
+
+Use checks to enforce basics:
+
+```powershell
+git status --short
+git diff --check
+```
+
+Backend focused checks:
+
+```powershell
+cd maritime-ai-service
+python -m ruff check app/ tests/unit/ --select=E9,F63,F7
+python -m pytest tests/unit/<focused-test>.py -q --tb=short
+```
+
+Frontend focused checks:
+
+```powershell
+cd wiii-desktop
+npx vitest run src/__tests__/<focused-test>.test.tsx
+npx tsc --noEmit
+```
+
+Run broader suites only after focused checks are green or when the PR touches a
+shared contract.
+
+## Repository Hygiene Rules
+
+Never commit:
+
+- `.env*`
+- provider keys or tokens
+- local logs
+- screenshots from temporary runs
+- generated `dist`, `dist-embed`, coverage, cache, or dependency folders
+- one-off scratch scripts without ownership
+
+When a session produces useful but mixed WIP, preserve it with a named stash or
+branch before cleanup. Do not hide it inside an unrelated PR.
+
+## WIP Recovery Pattern
+
+Use this pattern when work has become too broad:
+
+```powershell
+git status -sb
+git diff --shortstat
+git stash push -u -m "<clear-wip-name>"
+git switch -c codex/<narrow-cleanup-or-fix>
+```
+
+Then recover slices with:
+
+```powershell
+git stash list --format="%H %gd %s"
+git stash show --stat <stash-commit-hash>
+git checkout <stash-commit-hash> -- path/to/file
+```
+
+Use the stash message to select the right entry, then use its commit hash.
+Avoid `stash@{0}` in durable docs because stash positions change as new entries
+are created or dropped.
+
+Only restore files for the PR slice being prepared.
+
+## Maintenance Cadence
+
+Every 3 to 6 months, review:
+
+- root and path-specific `AGENTS.md`
+- active skills
+- stale local branches
+- feature flags and tiers
+- docs that describe runtime paths
+- scripts used by deploy or local startup
+
+Remove or archive docs that no longer match code. Keep the codebase map current.

--- a/docs/operations/WIII_REPO_RECOVERY_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_REPO_RECOVERY_AUDIT_2026-05-19.md
@@ -1,0 +1,122 @@
+# Wiii Repository Recovery Audit - 2026-05-19
+
+Status: Active local recovery record
+
+Owner: Project leadership
+
+Purpose: document how the large local WIP was preserved and how the repository
+was returned to a clean, reviewable state.
+
+Tracking issue: https://github.com/meiiie/wiii/issues/397
+
+## Decision
+
+The large WIP branch was not pushed to `main`.
+
+Reason: the work touched backend runtime, frontend UX, voice, visual artifacts,
+LMS contracts, deploy files, tests, and docs at the same time. That is not a
+reviewable or safely deployable unit.
+
+## Main Sync
+
+`main` was synchronized in a separate product worktree:
+
+- Worktree label: `product-main-worktree`
+- Branch: `main`
+- Current commit: `181e43c4`
+- Status: clean against `origin/main`
+
+Verify the concrete local path with:
+
+```powershell
+git worktree list
+git -C <product-main-worktree-path> status -sb
+```
+
+No WIP was merged into `main`.
+
+## WIP Preservation
+
+The full dirty investigation worktree was preserved with:
+
+```powershell
+git stash push -u -m "wiii-full-surface-wip-before-repo-cleanup-2026-05-19"
+```
+
+Verified stash entry:
+
+```text
+0f88ba8632984b450c7157817756245ccc766ebb On codex/full-surface-test-2026-05-13: wiii-full-surface-wip-before-repo-cleanup-2026-05-19
+```
+
+The positional ref was `stash@{0}` at capture time, but future recovery should
+use the commit hash or re-resolve the entry by message because stash positions
+can change.
+
+Snapshot scale before stashing:
+
+- 161 modified tracked files
+- 35 untracked paths
+- 8,584 insertions
+- 1,603 deletions
+
+The stash is the recovery source for future focused PRs.
+
+## What Was Cleaned
+
+The working tree was returned to a clean state without deleting the WIP:
+
+- no tracked WIP remains in the active cleanup branch
+- no untracked WIP remains in the active cleanup branch
+- the large mixed change set is isolated in a named stash
+- local `main` is synced in the product worktree
+
+## Current Cleanup Branch
+
+The active cleanup branch is:
+
+```text
+codex/repo-harness-cleanup-2026-05-19
+```
+
+This branch should contain only documentation and codebase-harness work unless a
+maintainer explicitly expands its scope.
+
+## How To Recover A Slice
+
+Inspect the stash:
+
+```powershell
+git stash list --format="%H %gd %s"
+git stash show --stat 0f88ba8632984b450c7157817756245ccc766ebb
+```
+
+Restore one file or folder into a new focused branch:
+
+```powershell
+git switch -c codex/<focused-slice>
+git checkout 0f88ba8632984b450c7157817756245ccc766ebb -- path/to/file
+```
+
+Do not apply the whole stash into a PR branch unless the goal is explicitly to
+recreate the full investigation state.
+
+## Recommended Slice Order
+
+1. Raw provider tool-call JSON guard.
+2. Markdown and chat presentation repair.
+3. LMS document authoring approval contract.
+4. Voice mode stabilization.
+5. Visual and Code Studio quality contracts.
+6. Deploy and production config.
+7. Additional docs and cleanup.
+
+Each slice should have focused tests, risk notes, and rollback notes.
+
+## Safety Notes
+
+- No deploy was performed.
+- No merge was performed.
+- No WIP changes were deleted.
+- No known provider secret was committed.
+- Future PRs must still run their own secret and diff hygiene checks.

--- a/maritime-ai-service/AGENTS.md
+++ b/maritime-ai-service/AGENTS.md
@@ -1,0 +1,94 @@
+# AGENTS.md - Backend
+
+Status: Active
+
+Owner: Backend maintainers
+
+Applies to: `maritime-ai-service/**`
+
+This file narrows the repository-level guidance for backend work. Read the root
+`AGENTS.md` first, then use this file for backend-specific navigation,
+boundaries, and verification.
+
+## Backend Mental Model
+
+The backend owns Wiii Core, Wiii Org, Wiii Data, and most cross-surface runtime
+contracts.
+
+The safest way to read backend behavior is by runtime lane:
+
+| Lane | Primary paths | What to protect |
+|---|---|---|
+| Chat transport | `app/api/v1/chat*.py`, `app/services/chat_*` | sync/stream parity, auth, session state, SSE shape |
+| Agent runtime | `app/engine/multi_agent/**` | routing, tool loop, provider behavior, source propagation |
+| RAG and memory | `app/repositories/**`, `app/services/**memory**`, ingestion paths | tenant filters, citations, provenance, durable state |
+| Host and LMS | `app/engine/context/**`, `app/engine/tools/lms_tools.py`, document context API | preview before mutation, approval tokens, host capability checks |
+| Voice and media | `app/api/v1/voice.py`, voice requirements/config | server-side secrets, feature flags, graceful fallback |
+| Config and deploy | `app/core/config/**`, Docker, nginx, deploy scripts | production defaults, fail-closed behavior, rollback clarity |
+
+## High-Risk Surfaces
+
+Treat these as high-risk and keep changes narrow:
+
+- auth, JWT, OAuth, refresh tokens, LMS token exchange
+- organization and tenant filtering
+- memory writes and retrieval query scope
+- provider selection and model routing
+- native tool calling and host actions
+- SSE event names, ordering, and finalization
+- production Docker, nginx, and deploy scripts
+- secret handling and runtime settings persistence
+
+For high-risk work, include rollback notes in the PR body.
+
+## Runtime Contracts
+
+Backend changes should preserve these contracts unless the PR explicitly changes
+them:
+
+- A chat turn must not expose raw provider tool-call JSON to the user.
+- Tool calls must either execute through the tool loop or fail visibly.
+- LMS mutating actions must require preview plus approval evidence.
+- Source-backed answers must preserve source references and citations.
+- Streaming and non-streaming paths should produce compatible final answers.
+- Voice and media features must degrade gracefully when provider config is absent.
+- Tenant/org context must be applied before retrieval, memory, or host action work.
+
+## Where To Start
+
+Use these entry points before editing:
+
+- Chat request setup: `app/services/chat_orchestrator.py`
+- SSE coordination: `app/services/chat_stream_coordinator.py`
+- Direct/runtime tool loop: `app/engine/multi_agent/direct_tool_rounds_runtime.py`
+- Native OpenAI-compatible stream handling: `app/engine/multi_agent/openai_stream_runtime.py`
+- Tool registry and inventory: `app/engine/tools/registry.py`
+- Host action helpers: `app/engine/context/action_tools.py`
+- LMS tools: `app/engine/tools/lms_tools.py`
+- Settings: `app/core/config/_settings*.py`
+
+## Verification
+
+Choose the smallest meaningful test set for the changed paths.
+
+Common backend checks:
+
+```powershell
+cd maritime-ai-service
+python -m pytest tests/unit/test_openai_stream_runtime.py tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short
+python -m pytest tests/unit/test_chat_stream_coordinator.py tests/unit/test_chat_request_flow.py -q --tb=short
+python -m ruff check app/ tests/unit/ --select=E9,F63,F7
+```
+
+For config, auth, memory, LMS, or deploy changes, add focused tests and explicit
+risk notes. Do not rely on manual localhost testing alone.
+
+## Editing Guidance
+
+- Prefer typed helper modules for stable contracts instead of spreading JSON
+  shape assumptions across runtime and API code.
+- Keep provider-specific quirks near provider adapters or stream parsers.
+- Avoid adding broad feature flags without a tier, owner, and test.
+- Do not commit `.env*`, local logs, generated output, or provider secrets.
+- Do not mix deployment changes with chat/runtime behavior unless the issue
+  explicitly requires it.

--- a/wiii-desktop/AGENTS.md
+++ b/wiii-desktop/AGENTS.md
@@ -1,0 +1,97 @@
+# AGENTS.md - Desktop And Embed
+
+Status: Active
+
+Owner: Frontend maintainers
+
+Applies to: `wiii-desktop/**`
+
+Read the root `AGENTS.md` first. This file narrows guidance for the Tauri,
+React, embed, chat, Pointy, voice, and visual-artifact frontend surfaces.
+
+## Frontend Mental Model
+
+The desktop project owns the user-visible shape of Wiii:
+
+- chat input and message rendering
+- SSE V3 stream consumption
+- preview and source-reference panels
+- LMS embed behavior
+- Pointy host control
+- voice controls and audio UX
+- visual/code-studio artifact display
+- persisted local settings and session state
+
+Frontend changes are product changes. Even small CSS or Markdown edits can alter
+teacher trust, LMS safety, and perceived intelligence.
+
+## High-Risk Surfaces
+
+Treat these as high-risk:
+
+- SSE event handling and final answer assembly
+- persisted Zustand stores
+- auth token storage and refresh behavior
+- embed auth and host bridge messages
+- preview/apply UI for LMS host actions
+- source references and citation display
+- Pointy dispatch and DOM targeting
+- microphone, voice, and hotkey behavior
+- sandboxed visual/code artifact rendering
+
+## User Experience Contracts
+
+Preserve these contracts unless a PR explicitly changes them:
+
+- Wiii must never show raw internal tool JSON as the final answer.
+- Markdown tables, lists, links, and citations must render as readable blocks.
+- Mutating LMS actions must stay behind preview and approval.
+- Source references must remain visible when an answer uses uploaded documents.
+- Pointy should act only when the user enables or invokes that mode.
+- Voice mode must clearly show whether it is listening, speaking, or idle.
+- Visual artifacts must be framed without clipping important controls or text.
+- Vietnamese UI copy should be natural and accented unless the surrounding
+  surface is intentionally English.
+
+## Where To Start
+
+Common frontend entry points:
+
+- Chat shell: `src/EmbedApp.tsx`
+- Chat input: `src/components/chat/ChatInput.tsx`
+- SSE stream hook: `src/hooks/useSSEStream.ts`
+- Markdown rendering: `src/components/common/MarkdownRenderer.tsx`
+- Markdown styles: `src/styles/markdown.css`
+- Preview panel: `src/components/layout/PreviewPanel.tsx`
+- Source helpers: `src/lib/source-references.ts`
+- Host bridge: `src/lib/embed-bridge.ts`
+- Context bridge: `src/lib/context-bridge.ts`
+- Pointy host: `src/pointy-host/**`
+- Visual artifacts: `src/components/chat/VisualArtifactCard.tsx`,
+  `src/components/chat/VisualBlock.tsx`,
+  `src/components/common/InlineVisualFrame.tsx`
+
+## Verification
+
+Use focused checks before broad suites:
+
+```powershell
+cd wiii-desktop
+npx vitest run src/__tests__/tool-execution-strip.test.tsx src/__tests__/interleaved-block-sequence.test.tsx
+npx vitest run src/__tests__/preview-panel-ui.test.tsx src/__tests__/context-bridge.test.ts
+npx tsc --noEmit
+```
+
+For embed-visible changes, run or document a browser/Playwright check. For
+visual runtime changes, capture screenshot evidence when practical.
+
+## Editing Guidance
+
+- Keep renderer fixes in renderer or repair helpers, not inside random chat
+  components.
+- Keep host bridge contracts typed in `src/lib/**` before wiring UI behavior.
+- Avoid adding hidden global state for chat lifecycle.
+- Prefer explicit UI states over inferred string checks.
+- Do not commit `dist`, `dist-embed`, coverage, screenshots from temporary runs,
+  local logs, or secrets.
+- Do not combine UI polish, voice runtime, and LMS mutation behavior in one PR.


### PR DESCRIPTION
## Summary

Refs #397.

This PR cleans up the repository state after the large local full-surface WIP by documenting the recovery path and adding a small large-codebase harness layer for future Wiii work.

Changes:
- preserve the local WIP recovery record, including the named stash hash to recover focused slices
- add a concise Wiii codebase map under `docs/architecture/`
- add an agentic codebase harness runbook for scoped exploration, WIP recovery, PR slicing, and deterministic checks
- add approved backend and desktop path-specific `AGENTS.md` guidance
- update docs indexes and `.gitignore` to allow only those two approved nested `AGENTS.md` files
- address CodeRabbit review by normalizing repo-root-relative paths, replacing positional stash refs, moving dated audit out of primary entry points, and removing machine-local absolute paths from recovery docs

## Scope

In scope:
- docs and repo harness configuration only
- no runtime behavior changes
- no deployment changes

Out of scope:
- applying the preserved WIP
- cleaning stale local branches
- deploying Wiii
- changing backend or frontend runtime behavior

## Verification

Ran locally after the review fixes:

```powershell
git diff --check origin/main...HEAD
```

Result: passed.

Secret diff scan for provider key patterns:

```powershell
sk_car_, sk_live_, sk_test_, OPENAI_API_KEY=, ANTHROPIC_API_KEY=, NVIDIA_API_KEY=, GOOGLE_API_KEY=, ELEVENLABS_API_KEY=, CARTESIA_API_KEY=
```

Result: no matches in `origin/main...HEAD`.

## Risk

Low. This is documentation and `.gitignore` exception work only. The `.gitignore` change allows exactly two approved nested `AGENTS.md` files and keeps other nested agent configs ignored.

## Rollback

Revert this PR to remove the docs and restore the previous nested `AGENTS.md` ignore behavior.

## Notes

The large WIP was preserved locally as:

```text
0f88ba8632984b450c7157817756245ccc766ebb On codex/full-surface-test-2026-05-13: wiii-full-surface-wip-before-repo-cleanup-2026-05-19
```

Future runtime fixes should recover only the needed files from that stash hash or re-resolve the stash by message into focused branches.