### PR TITLE
fix: route raw provider tool-call JSON

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -26,6 +26,10 @@ from app.engine.multi_agent.direct_search_synthesis_fallback import (
     build_search_template_fallback,
 )
 from app.engine.multi_agent.state import AgentState
+from app.engine.multi_agent.tool_call_text_parser import (
+    extract_raw_tool_calls_from_text,
+    tool_names_from_tools,
+)
 from app.engine.multi_agent.visual_events import (
     _collect_active_visual_session_ids,
     _emit_visual_commit_events,
@@ -2819,6 +2823,33 @@ def _build_assistant_message(
     return Message(role="assistant", content=content)
 
 
+def _build_assistant_tool_call_message(
+    tool_calls: list[dict[str, Any]],
+    *,
+    native_tool_messages: bool,
+) -> Any:
+    if native_tool_messages:
+        from app.engine.native_chat_runtime import make_assistant_message
+
+        return make_assistant_message("", tool_calls=tool_calls)
+
+    from app.engine.messages import Message, ToolCall
+
+    return Message(
+        role="assistant",
+        content="",
+        tool_calls=[
+            ToolCall(
+                id=str(call.get("id") or f"raw_tool_call_{index}"),
+                name=str(call.get("name") or ""),
+                arguments=dict(call.get("args") or call.get("arguments") or {}),
+            )
+            for index, call in enumerate(tool_calls)
+            if str(call.get("name") or "").strip()
+        ],
+    )
+
+
 def _force_skills_for_turn(state: AgentState | None) -> set[str]:
     if not isinstance(state, dict):
         return set()
@@ -3553,6 +3584,22 @@ async def execute_direct_tool_rounds_impl(
         )
 
     tool_calls = getattr(llm_response, "tool_calls", [])
+    if tools and not tool_calls:
+        raw_tool_calls = extract_raw_tool_calls_from_text(
+            getattr(llm_response, "content", ""),
+            allowed_tool_names=tool_names_from_tools(tools) or None,
+        )
+        if raw_tool_calls:
+            logger.warning(
+                "[DIRECT] Converted raw JSON assistant content into %d structured tool call(s): %s",
+                len(raw_tool_calls),
+                [call.get("name") for call in raw_tool_calls],
+            )
+            llm_response = _build_assistant_tool_call_message(
+                raw_tool_calls,
+                native_tool_messages=native_tool_messages,
+            )
+            tool_calls = getattr(llm_response, "tool_calls", raw_tool_calls)
     logger.warning(
         "[DIRECT] LLM response: tool_calls=%d, content_len=%d",
         len(tool_calls) if tool_calls else 0,

--- a/maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py
@@ -26,6 +26,10 @@ from app.engine.native_chat_runtime import (
     normalize_tool_choice,
     openai_response_to_assistant_message,
 )
+from app.engine.multi_agent.tool_call_text_parser import (
+    extract_raw_tool_calls_from_text,
+    tool_names_from_tools,
+)
 from app.engine.reasoning import sanitize_visible_reasoning_text
 
 logger = logging.getLogger(__name__)
@@ -416,6 +420,7 @@ async def _stream_openai_compatible_answer_with_route_impl(
         request_kwargs["temperature"] = temperature
 
     bound_tools = list(getattr(route.llm, "_wiii_bound_tools", []) or [])
+    allowed_raw_tool_names = tool_names_from_tools(bound_tools)
     if bound_tools:
         request_kwargs["tools"] = bound_tools
     tool_choice = normalize_tool_choice(getattr(route.llm, "_wiii_tool_choice", None))
@@ -435,6 +440,8 @@ async def _stream_openai_compatible_answer_with_route_impl(
     google_tag_state = {"inside_thinking": False, "pending": ""}
     reasoning_started = False
     tool_call_chunks: dict[int, dict[str, str]] = {}
+    raw_tool_answer_candidate: bool | None = None
+    raw_tool_answer_chunks: list[str] = []
 
     # Phase 34 (#207): boundary-aware token batching. When the
     # ``enable_stream_smoother`` flag is on, we route every answer_delta
@@ -467,6 +474,35 @@ async def _stream_openai_compatible_answer_with_route_impl(
                 "node": node,
             })
         thinking_closed = True
+
+    async def _emit_visible_answer_delta(answer_text: str) -> None:
+        nonlocal emitted_answer, thinking_closed
+        if not answer_text:
+            return
+        if not thinking_closed:
+            if thinking_stop_signal is not None:
+                thinking_stop_signal.set()
+            if reasoning_started:
+                await push_event({
+                    "type": "thinking_end",
+                    "content": "",
+                    "node": node,
+                })
+            thinking_closed = True
+        if answer_smoother is not None:
+            for flushed in answer_smoother.feed(answer_text):
+                await push_event({
+                    "type": "answer_delta",
+                    "content": flushed,
+                    "node": node,
+                })
+        else:
+            await push_event({
+                "type": "answer_delta",
+                "content": answer_text,
+                "node": node,
+            })
+        emitted_answer += answer_text
 
     try:
         stream = await client.chat.completions.create(**request_kwargs)
@@ -527,35 +563,45 @@ async def _stream_openai_compatible_answer_with_route_impl(
                     })
                 if not answer_delta:
                     continue
-                if not thinking_closed:
-                    if thinking_stop_signal is not None:
-                        thinking_stop_signal.set()
-                    if reasoning_started:
-                        await push_event({
-                            "type": "thinking_end",
-                            "content": "",
-                            "node": node,
-                        })
-                    thinking_closed = True
+                if raw_tool_answer_candidate is not False:
+                    probe_text = "".join(raw_tool_answer_chunks) + answer_delta
+                    stripped_probe = probe_text.lstrip()
+                    if raw_tool_answer_candidate is None:
+                        if not stripped_probe:
+                            raw_tool_answer_chunks.append(answer_delta)
+                            continue
+                        raw_tool_answer_candidate = stripped_probe[0] in "{["
+                    if raw_tool_answer_candidate:
+                        raw_tool_answer_chunks.append(answer_delta)
+                        continue
+                    if raw_tool_answer_chunks:
+                        answer_delta = "".join(raw_tool_answer_chunks) + answer_delta
+                        raw_tool_answer_chunks.clear()
                 # Phase 34: route through StreamSmoother when enabled.
                 # Smoother yields 0+ flushed strings per chunk based on
                 # punctuation / length / time-watchdog boundaries, so
                 # the UI sees even-cadence repaints instead of provider-
                 # burst flicker. When disabled, single direct emit.
-                if answer_smoother is not None:
-                    for flushed in answer_smoother.feed(answer_delta):
-                        await push_event({
-                            "type": "answer_delta",
-                            "content": flushed,
-                            "node": node,
-                        })
-                else:
-                    await push_event({
-                        "type": "answer_delta",
-                        "content": answer_delta,
-                        "node": node,
-                    })
-                emitted_answer += answer_delta
+                await _emit_visible_answer_delta(answer_delta)
+        if raw_tool_answer_chunks:
+            raw_tool_text = "".join(raw_tool_answer_chunks)
+            raw_tool_calls = extract_raw_tool_calls_from_text(
+                raw_tool_text,
+                allowed_tool_names=allowed_raw_tool_names or None,
+            )
+            if raw_tool_calls:
+                from app.engine.llm_model_health import record_model_success
+
+                record_model_success(provider_name, model_name)
+                await _close_thinking_for_non_answer()
+                logger.info(
+                    "[%s] Converted raw JSON assistant text into %d structured tool call(s)",
+                    node.upper(),
+                    len(raw_tool_calls),
+                )
+                return make_assistant_message("", tool_calls=raw_tool_calls), False
+            await _emit_visible_answer_delta(raw_tool_text)
+            raw_tool_answer_chunks.clear()
         tool_calls = _finalize_tool_call_chunks(tool_call_chunks)
         if tool_calls:
             from app.engine.llm_model_health import record_model_success

--- a/maritime-ai-service/app/engine/multi_agent/tool_call_text_parser.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_call_text_parser.py
@@ -1,0 +1,139 @@
+"""Parse provider-emitted raw tool-call JSON safely.
+
+Some OpenAI-compatible models occasionally return a function-call object as
+plain assistant text instead of the structured ``tool_calls`` channel. This
+module only accepts a complete JSON object/array whose tool name is present in
+the bound tool inventory, so normal prose or JSON examples remain visible.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+
+_FENCED_JSON_RE = re.compile(
+    r"^\s*```(?:json)?\s*(.*?)\s*```\s*$",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def tool_names_from_tools(tools: list[Any] | tuple[Any, ...] | set[Any] | None) -> set[str]:
+    """Return tool names from LangChain-like tools or OpenAI function schemas."""
+    names: set[str] = set()
+    for tool in tools or []:
+        candidate = ""
+        if isinstance(tool, dict):
+            function = tool.get("function") if isinstance(tool.get("function"), dict) else {}
+            candidate = str(
+                function.get("name")
+                or tool.get("name")
+                or tool.get("tool_name")
+                or ""
+            ).strip()
+        else:
+            candidate = str(
+                getattr(tool, "name", "")
+                or getattr(tool, "__name__", "")
+                or ""
+            ).strip()
+        if candidate:
+            names.add(candidate)
+    return names
+
+
+def _strip_json_fence(value: str) -> str:
+    text = str(value or "").strip()
+    match = _FENCED_JSON_RE.match(text)
+    return match.group(1).strip() if match else text
+
+
+def _loads_json_object(value: str) -> Any | None:
+    text = _strip_json_fence(value)
+    if not text or text[0] not in "{[":
+        return None
+    try:
+        return json.loads(text)
+    except Exception:
+        return None
+
+
+def _coerce_arguments(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        args = dict(value)
+    elif isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            parsed = {}
+        args = dict(parsed) if isinstance(parsed, dict) else {}
+    else:
+        args = {}
+    if "query" not in args and "q" in args:
+        args["query"] = args.get("q")
+    return args
+
+
+def _candidate_tool_call_objects(payload: Any) -> list[Any]:
+    if isinstance(payload, list):
+        return payload
+    if not isinstance(payload, dict):
+        return []
+    if isinstance(payload.get("tool_calls"), list):
+        return list(payload.get("tool_calls") or [])
+    return [payload]
+
+
+def _normalize_raw_tool_call(
+    candidate: Any,
+    *,
+    allowed_tool_names: set[str] | None,
+    index: int,
+) -> dict[str, Any] | None:
+    if not isinstance(candidate, dict):
+        return None
+    function = candidate.get("function") if isinstance(candidate.get("function"), dict) else {}
+    name = str(
+        candidate.get("name")
+        or candidate.get("tool")
+        or candidate.get("tool_name")
+        or function.get("name")
+        or ""
+    ).strip()
+    if not name:
+        return None
+    if allowed_tool_names is not None and name not in allowed_tool_names:
+        return None
+    args = _coerce_arguments(
+        candidate.get("arguments")
+        if "arguments" in candidate
+        else candidate.get("args")
+        if "args" in candidate
+        else function.get("arguments")
+    )
+    call_id = str(candidate.get("id") or f"raw_tool_call_{index}").strip()
+    return {"id": call_id, "name": name, "args": args}
+
+
+def extract_raw_tool_calls_from_text(
+    value: Any,
+    *,
+    allowed_tool_names: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Extract structured tool calls from an assistant response that is only JSON."""
+    if not isinstance(value, str):
+        return []
+    payload = _loads_json_object(value)
+    if payload is None:
+        return []
+    calls: list[dict[str, Any]] = []
+    for index, candidate in enumerate(_candidate_tool_call_objects(payload)):
+        normalized = _normalize_raw_tool_call(
+            candidate,
+            allowed_tool_names=allowed_tool_names,
+            index=index,
+        )
+        if normalized:
+            calls.append(normalized)
+    return calls

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -243,6 +243,95 @@ async def test_execute_direct_tool_rounds_does_not_emit_authored_public_thinking
 
 
 @pytest.mark.asyncio
+async def test_execute_direct_tool_rounds_converts_raw_json_tool_call_text():
+    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+        execute_direct_tool_rounds_impl,
+    )
+
+    class FakeKnowledgeTool:
+        name = "tool_knowledge_search"
+
+        async def ainvoke(self, args):
+            return f"Nguon nhap mon hang hai cho {args['query']}"
+
+    events = []
+
+    async def push_event(event):
+        events.append(event)
+
+    async def fake_stream_direct_answer_with_fallback(*_args, **_kwargs):
+        return (
+            SimpleNamespace(
+                content=json.dumps(
+                    {
+                        "name": "tool_knowledge_search",
+                        "arguments": {
+                            "query": "gioi thieu nganh hang hai cho nguoi moi bat dau",
+                        },
+                    },
+                    ensure_ascii=False,
+                ),
+                tool_calls=[],
+            ),
+            True,
+        )
+
+    async def fake_ainvoke_with_fallback(_llm, _messages, **_kwargs):
+        return SimpleNamespace(
+            content=(
+                "Được chứ. Nếu mới bắt đầu học Hàng hải, mình sẽ đi từ bức tranh lớn: "
+                "tàu, cảng, an toàn, luật biển và nghiệp vụ vận hành."
+            ),
+            tool_calls=[],
+        )
+
+    async def fake_stream_direct_wait_heartbeats(*args, **kwargs):
+        stop_signal = kwargs.get("stop_signal")
+        if stop_signal is not None:
+            await stop_signal.wait()
+            return
+        await asyncio.Future()
+
+    async def push_status_only_progress(*args, **kwargs):
+        return None
+
+    with patch(
+        "app.engine.multi_agent.graph._ainvoke_with_fallback",
+        new=fake_ainvoke_with_fallback,
+    ), patch(
+        "app.engine.multi_agent.graph._stream_direct_answer_with_fallback",
+        new=fake_stream_direct_answer_with_fallback,
+    ), patch(
+        "app.engine.multi_agent.graph._stream_direct_wait_heartbeats",
+        new=fake_stream_direct_wait_heartbeats,
+    ):
+        llm_response, _messages, tool_call_events = await execute_direct_tool_rounds_impl(
+            llm_with_tools=object(),
+            llm_auto=object(),
+            messages=[],
+            tools=[FakeKnowledgeTool()],
+            push_event=push_event,
+            query="Mình đang muốn học về lĩnh vực Hàng Hải các bạn có thể giúp mình được không",
+            state={},
+            ainvoke_with_fallback=fake_ainvoke_with_fallback,
+            stream_direct_answer_with_fallback=fake_stream_direct_answer_with_fallback,
+            stream_direct_wait_heartbeats=fake_stream_direct_wait_heartbeats,
+            push_status_only_progress=push_status_only_progress,
+        )
+
+    assert "tool_knowledge_search" not in llm_response.content
+    assert "mới bắt đầu học Hàng hải" in llm_response.content
+    assert [event["type"] for event in tool_call_events] == ["call", "result"]
+    assert tool_call_events[0]["name"] == "tool_knowledge_search"
+    assert tool_call_events[0]["args"]["query"] == "gioi thieu nganh hang hai cho nguoi moi bat dau"
+    assert any(event["type"] == "tool_call" for event in events)
+    assert not any(
+        event["type"] == "answer_delta" and "tool_knowledge_search" in str(event.get("content", ""))
+        for event in events
+    )
+
+
+@pytest.mark.asyncio
 async def test_forced_web_search_runs_tool_without_planner_or_synthesis_llm():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (
         execute_direct_tool_rounds_impl,

--- a/maritime-ai-service/tests/unit/test_openai_stream_runtime.py
+++ b/maritime-ai-service/tests/unit/test_openai_stream_runtime.py
@@ -260,6 +260,89 @@ async def test_native_direct_stream_returns_tool_call_chunks_with_bound_tools():
 
 
 @pytest.mark.asyncio
+async def test_native_direct_stream_buffers_raw_json_tool_call_text():
+    events = []
+
+    async def _push_event(event):
+        events.append(event)
+
+    class _FakeStream:
+        def __aiter__(self):
+            async def _gen():
+                yield SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            delta=SimpleNamespace(
+                                content='{"name":"tool_knowledge_search",',
+                            )
+                        )
+                    ]
+                )
+                yield SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            delta=SimpleNamespace(
+                                content='"arguments":{"query":"gioi thieu hang hai"}}',
+                            )
+                        )
+                    ]
+                )
+
+            return _gen()
+
+    class _FakeChatCompletions:
+        async def create(self, **_kwargs):
+            return _FakeStream()
+
+    class _FakeChat:
+        completions = _FakeChatCompletions()
+
+    class _FakeClient:
+        chat = _FakeChat()
+
+    route = SimpleNamespace(
+        provider="nvidia",
+        llm=SimpleNamespace(
+            _wiii_tier_key="light",
+            _wiii_model_name="qwen/qwen3-next-80b-a3b-thinking",
+            _wiii_bound_tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "tool_knowledge_search",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        ),
+    )
+
+    response, streamed = await _stream_openai_compatible_answer_with_route_impl(
+        route,
+        messages=[{"role": "user", "content": "Hoc hang hai duoc khong?"}],
+        push_event=_push_event,
+        node="direct",
+        thinking_stop_signal=None,
+        supports_native_answer_streaming=lambda provider: provider == "nvidia",
+        create_openai_compatible_stream_client=lambda _provider: _FakeClient(),
+        resolve_openai_stream_model_name=lambda *_args: "qwen/qwen3-next-80b-a3b-thinking",
+        langchain_message_to_openai_payload=lambda message: message,
+        extract_openai_delta_text=lambda delta: ("", str(getattr(delta, "content", "") or "")),
+    )
+
+    assert streamed is False
+    assert response.content == ""
+    assert response.tool_calls == [
+        {
+            "id": "raw_tool_call_0",
+            "name": "tool_knowledge_search",
+            "args": {"query": "gioi thieu hang hai"},
+        }
+    ]
+    assert events == []
+
+
+@pytest.mark.asyncio
 async def test_native_direct_stream_timeout_marks_model_degraded():
     from app.engine.llm_model_health import is_model_degraded, reset_model_health_state
 


### PR DESCRIPTION
## Summary

Refs #399.

This PR fixes the case where an OpenAI-compatible provider returns a tool-call object as plain assistant text, causing Wiii to render JSON such as `{"name":"tool_knowledge_search",...}` in chat instead of executing the tool.

Changes:
- add a small parser for complete raw tool-call JSON, gated by the bound/available tool inventory
- buffer native streaming answer text when the first visible token looks like JSON, then promote it to structured `tool_calls` before emitting `answer_delta`
- promote direct-response raw JSON content into the existing tool loop before early streamed-answer return
- add focused regression tests for native stream and direct tool-round behavior

## Scope

In scope:
- backend runtime only
- provider stream finalization
- direct tool-loop parity
- focused tests

Out of scope:
- frontend renderer changes
- provider routing redesign
- LMS host action changes
- deploy changes

## Verification

Ran locally:

```powershell
cd maritime-ai-service
python -m pytest tests/unit/test_openai_stream_runtime.py tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short
# 64 passed

python -m ruff check app/engine/multi_agent/tool_call_text_parser.py app/engine/multi_agent/openai_stream_runtime.py app/engine/multi_agent/direct_tool_rounds_runtime.py tests/unit/test_openai_stream_runtime.py tests/unit/test_direct_tool_rounds_runtime.py
# All checks passed

cd ..
git diff --check origin/main...HEAD
# passed
```

Secret diff scan for provider key patterns returned no matches.

## Risk

Medium-low. This touches provider stream finalization and direct tool routing, but only for complete JSON objects/arrays matching known tool names. Normal prose and unknown JSON remain visible.

## Rollback

Revert this PR to remove the parser and runtime guards. Wiii will return to the previous behavior of streaming provider text directly.