### PR TITLE
refactor(runtime): centralize document preview contract

### DIFF
--- a/docs/WIII_TECHNICAL_SIMPLIFICATION_ROADMAP.md
+++ b/docs/WIII_TECHNICAL_SIMPLIFICATION_ROADMAP.md
@@ -218,6 +218,11 @@ Expected result:
 ## Immediate Execution Slice
 
 The first executed slices of this roadmap are feature-tier classification and the Core-to-Living post-response contract.
+Issue #407 adds the next Core/Host cleanup slice by moving uploaded-document
+preview/course intent, attachment parsing, and LMS host-action tool selection
+into `maritime-ai-service/app/engine/multi_agent/document_preview_contract.py`.
+The direct node and tool-round runtimes keep compatibility aliases, but no
+longer own separate copies of that contract.
 
 They are intentionally modest.
 The point is to establish durable simplification mechanisms, not to do a risky refactor in one move.

--- a/docs/architecture/WIII_CODEBASE_MAP.md
+++ b/docs/architecture/WIII_CODEBASE_MAP.md
@@ -65,6 +65,7 @@ The normal chat turn should be read in this order:
 | Tool registry | `maritime-ai-service/app/engine/tools/registry.py` and `maritime-ai-service/app/engine/multi_agent/tool_collection.py` |
 | LMS host actions | `maritime-ai-service/app/engine/context/action_tools.py`, `maritime-ai-service/app/engine/tools/lms_tools.py` |
 | Document context | `maritime-ai-service/app/api/v1/document_context.py`, document runtime helpers |
+| Uploaded-document preview/course contract | `maritime-ai-service/app/engine/multi_agent/document_preview_contract.py` |
 | Config | `maritime-ai-service/app/core/config/_settings*.py` |
 | Voice | `maritime-ai-service/app/api/v1/voice.py` |
 

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -12,6 +12,17 @@ from typing import Any
 from app.core.config import settings
 from app.core.exceptions import ProviderUnavailableError
 from app.engine.llm_failover_runtime import classify_failover_reason_impl
+from app.engine.multi_agent.document_preview_contract import (
+    DOC_COURSE_HOST_ACTION_TOOL as _DOC_COURSE_HOST_ACTION_TOOL,
+    DOC_PREVIEW_HOST_ACTION_TOOL as _DOC_PREVIEW_HOST_ACTION_TOOL,
+    as_plain_mapping as _as_plain_direct_mapping,
+    document_preview_forced_tool_choice as _document_preview_forced_tool_choice,
+    extract_document_preview_capabilities as _extract_document_preview_capabilities,
+    has_document_preview_host_action_tool as _has_document_preview_host_action_tool,
+    has_uploaded_document_context as _has_uploaded_document_context,
+    looks_uploaded_document_course_request as _looks_uploaded_document_course_request,
+    uploaded_document_attachments_from_context as _uploaded_document_attachments,
+)
 from app.engine.multi_agent.direct_intent import (
     _looks_emotional_support_turn,
     _normalize_for_intent,
@@ -62,140 +73,6 @@ from app.engine.multi_agent.supervisor_runtime_support import (
 )
 
 logger = logging.getLogger(__name__)
-
-_DOC_PREVIEW_HOST_ACTION_TOOL = "host_action__authoring__preview_lesson_patch"
-_DOC_COURSE_HOST_ACTION_TOOL = "host_action__authoring__generate_course_from_document"
-
-
-def _has_document_preview_host_action_tool(tools: list[Any]) -> bool:
-    return any(
-        str(getattr(tool, "name", "") or getattr(tool, "__name__", "")).strip().lower()
-        in {_DOC_PREVIEW_HOST_ACTION_TOOL, _DOC_COURSE_HOST_ACTION_TOOL}
-        for tool in tools
-    )
-
-
-def _looks_uploaded_document_course_request(query: str) -> bool:
-    folded = _fold_direct_text(query)
-    if any(
-        marker in folded
-        for marker in (
-            "preview_lesson_patch",
-            "lesson patch",
-            "bai hoc hien tai",
-            "cap nhat bai hoc",
-        )
-    ):
-        return False
-    return any(
-        marker in folded
-        for marker in (
-            "generate_course_from_document",
-            "course architect",
-            "course outline",
-            "course syllabus",
-            "curriculum",
-            "full course",
-            "lap bai giang",
-            "soan bai giang",
-            "soan giao an",
-            "tao bai giang",
-            "tao giao an",
-            "tao hoc lieu",
-            "toan bo khoa",
-            "cay khoa",
-            "chia khoa",
-            "chia thanh bai",
-            "chia thanh chuong",
-            "chuong trinh dao tao",
-            "de cuong khoa",
-            "de cuong mon",
-            "giao trinh",
-            "ke hoach giang day",
-            "khoa dao tao",
-            "khoa day du",
-            "khoa hoan chinh",
-            "learning path",
-            "lo trinh hoc",
-            "lo trinh khoa",
-            "nhieu bai hoc",
-            "nhieu chuong",
-            "phan chia bai hoc",
-            "syllabus",
-            "tao khoa hoc",
-            "thiet ke bai giang",
-            "thiet ke khoa hoc",
-            "xay dung bai giang",
-            "cau truc khoa hoc",
-            "chuong/bai",
-            "chuong bai",
-            "module",
-            "outline",
-        )
-    )
-
-
-def _document_preview_forced_tool_choice(query: str, tools: list[Any]) -> str:
-    preferred = (
-        _DOC_COURSE_HOST_ACTION_TOOL
-        if _looks_uploaded_document_course_request(query)
-        else _DOC_PREVIEW_HOST_ACTION_TOOL
-    )
-    tool_names = {
-        str(getattr(tool, "name", "") or getattr(tool, "__name__", "")).strip().lower()
-        for tool in tools
-    }
-    if preferred in tool_names:
-        return preferred
-    if _DOC_PREVIEW_HOST_ACTION_TOOL in tool_names:
-        return _DOC_PREVIEW_HOST_ACTION_TOOL
-    return _DOC_COURSE_HOST_ACTION_TOOL
-
-
-def _as_plain_direct_mapping(value: Any) -> dict[str, Any]:
-    if isinstance(value, dict):
-        return value
-    if hasattr(value, "model_dump"):
-        try:
-            dumped = value.model_dump(exclude_none=True)
-            return dumped if isinstance(dumped, dict) else {}
-        except Exception:
-            return {}
-    if hasattr(value, "dict"):
-        try:
-            dumped = value.dict(exclude_none=True)
-            return dumped if isinstance(dumped, dict) else {}
-        except Exception:
-            return {}
-    return {}
-
-
-def _extract_document_preview_capabilities(
-    state: dict[str, Any],
-    ctx: dict[str, Any],
-) -> list[dict[str, Any]]:
-    """Recover the preview capability from raw runtime state if collection misses it."""
-
-    state_context = state.get("context") if isinstance(state.get("context"), dict) else {}
-    raw_sources = [
-        state.get("host_capabilities"),
-        ctx.get("host_capabilities"),
-        state_context.get("host_capabilities") if isinstance(state_context, dict) else None,
-    ]
-    preview_capabilities: list[dict[str, Any]] = []
-    for raw_caps in raw_sources:
-        caps = _as_plain_direct_mapping(raw_caps)
-        raw_tools = caps.get("tools")
-        if not isinstance(raw_tools, list):
-            continue
-        for raw_tool in raw_tools:
-            tool_def = _as_plain_direct_mapping(raw_tool)
-            if str(tool_def.get("name") or "").strip().lower() in {
-                "authoring.preview_lesson_patch",
-                "authoring.generate_course_from_document",
-            }:
-                preview_capabilities.append(tool_def)
-    return preview_capabilities
 
 
 def _direct_role_candidates(state: dict[str, Any], ctx: dict[str, Any]) -> list[str]:
@@ -1148,37 +1025,6 @@ def _image_payload_attr(image: Any, key: str, default: Any = None) -> Any:
     if isinstance(image, dict):
         return image.get(key, default)
     return getattr(image, key, default)
-
-
-def _has_uploaded_document_context(ctx: dict[str, Any]) -> bool:
-    ctx = _as_plain_direct_mapping(ctx)
-    document_context = _as_plain_direct_mapping(ctx.get("document_context"))
-    if not isinstance(document_context, dict):
-        return False
-    attachments = document_context.get("attachments")
-    if not isinstance(attachments, list):
-        return False
-    for item in attachments:
-        attachment = _as_plain_direct_mapping(item)
-        if attachment and str(attachment.get("markdown") or "").strip():
-            return True
-    return False
-
-
-def _uploaded_document_attachments(ctx: dict[str, Any]) -> list[dict[str, Any]]:
-    ctx = _as_plain_direct_mapping(ctx)
-    document_context = _as_plain_direct_mapping(ctx.get("document_context"))
-    if not isinstance(document_context, dict):
-        return []
-    attachments = document_context.get("attachments")
-    if not isinstance(attachments, list):
-        return []
-    parsed: list[dict[str, Any]] = []
-    for item in attachments:
-        attachment = _as_plain_direct_mapping(item)
-        if attachment and str(attachment.get("markdown") or "").strip():
-            parsed.append(attachment)
-    return parsed
 
 
 def _first_markdown_line(markdown: str, label: str) -> str:

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -10,6 +10,14 @@ import unicodedata
 from typing import Any, Optional
 
 from app.core.config import settings
+from app.engine.multi_agent.document_preview_contract import (
+    DOC_COURSE_HOST_ACTION_TOOL as _DOC_COURSE_HOST_ACTION_TOOL,
+    DOC_PREVIEW_HOST_ACTION_TOOL as _DOC_PREVIEW_HOST_ACTION_TOOL,
+    find_document_host_action_tool,
+    looks_uploaded_document_course_request as _looks_uploaded_doc_course_request,
+    normalize_document_contract_text as _normalize_doc_preview_text,
+    uploaded_document_attachments_from_state as _uploaded_document_attachments_from_state,
+)
 from app.engine.multi_agent.direct_opening_runtime import (
     finalize_direct_opening_phase_impl,
     start_direct_opening_phase_impl,
@@ -51,8 +59,6 @@ _FORCED_WEB_SEARCH_TOOL_NAMES = (
     "web_search",
 )
 _RICH_SEARCH_RESULT_CHAR_FLOOR = 1200
-_DOC_PREVIEW_HOST_ACTION_TOOL = "host_action__authoring__preview_lesson_patch"
-_DOC_COURSE_HOST_ACTION_TOOL = "host_action__authoring__generate_course_from_document"
 _DOC_PREVIEW_LOW_VALUE_LABELS = {
     "buoc",
     "checkpoint",
@@ -68,12 +74,6 @@ _DOC_PREVIEW_LOW_VALUE_LABELS = {
     "thao tac",
     "vai tro",
 }
-
-
-def _normalize_doc_preview_text(value: Any) -> str:
-    text = str(value or "").replace("\\_", "_")
-    normalized = unicodedata.normalize("NFKD", text)
-    return "".join(ch for ch in normalized if not unicodedata.combining(ch)).lower()
 
 
 def _is_doc_preview_scaffold_line(value: str) -> bool:
@@ -114,97 +114,19 @@ def _is_doc_preview_low_value_line(value: str) -> bool:
     return bool(re.match(r"^\d+(?:\.\d+)*[.)]\s+\S+", line))
 
 
-def _uploaded_document_attachments_from_state(state: AgentState | None) -> list[dict[str, Any]]:
-    if not isinstance(state, dict):
-        return []
-    ctx = state.get("context")
-    if not isinstance(ctx, dict):
-        return []
-    document_context = ctx.get("document_context")
-    if not isinstance(document_context, dict):
-        return []
-    attachments = document_context.get("attachments")
-    if not isinstance(attachments, list):
-        return []
-    return [
-        item
-        for item in attachments
-        if isinstance(item, dict) and str(item.get("markdown") or "").strip()
-    ]
-
-
 def _find_doc_preview_host_action_tool(tools: list[Any]) -> Any | None:
-    for tool in tools or []:
-        if _tool_name(tool).lower() == _DOC_PREVIEW_HOST_ACTION_TOOL:
-            return tool
-    return None
+    return find_document_host_action_tool(
+        tools,
+        _DOC_PREVIEW_HOST_ACTION_TOOL,
+        tool_name_resolver=_tool_name,
+    )
 
 
 def _find_doc_course_host_action_tool(tools: list[Any]) -> Any | None:
-    for tool in tools or []:
-        if _tool_name(tool).lower() == _DOC_COURSE_HOST_ACTION_TOOL:
-            return tool
-    return None
-
-
-def _looks_uploaded_doc_course_request(query: str) -> bool:
-    normalized = _normalize_doc_preview_text(query)
-    if any(
-        marker in normalized
-        for marker in (
-            "preview_lesson_patch",
-            "lesson patch",
-            "bai hoc hien tai",
-            "cap nhat bai hoc",
-        )
-    ):
-        return False
-    return any(
-        marker in normalized
-        for marker in (
-            "generate_course_from_document",
-            "course architect",
-            "course plan",
-            "course outline",
-            "course syllabus",
-            "curriculum",
-            "full course",
-            "lap bai giang",
-            "soan bai giang",
-            "soan giao an",
-            "tao bai giang",
-            "tao giao an",
-            "tao hoc lieu",
-            "toan bo khoa",
-            "cay khoa",
-            "chia khoa",
-            "chia thanh bai",
-            "chia thanh chuong",
-            "chuong trinh dao tao",
-            "de cuong khoa",
-            "de cuong mon",
-            "giao trinh",
-            "ke hoach giang day",
-            "khoa dao tao",
-            "khoa day du",
-            "khoa hoan chinh",
-            "learning path",
-            "lo trinh hoc",
-            "lo trinh khoa",
-            "nhieu bai hoc",
-            "nhieu chuong",
-            "phan chia bai hoc",
-            "syllabus",
-            "tao khoa hoc",
-            "thiet ke bai giang",
-            "thiet ke khoa hoc",
-            "xay dung bai giang",
-            "cau truc khoa hoc",
-            "chuong/bai",
-            "chuong bai",
-            "module",
-            "outline",
-        )
+    return find_document_host_action_tool(
+        tools,
+        _DOC_COURSE_HOST_ACTION_TOOL,
+        tool_name_resolver=_tool_name,
     )
 
 

--- a/maritime-ai-service/app/engine/multi_agent/document_preview_contract.py
+++ b/maritime-ai-service/app/engine/multi_agent/document_preview_contract.py
@@ -1,0 +1,212 @@
+"""Shared uploaded-document preview/course contract for direct runtimes."""
+
+from __future__ import annotations
+
+import unicodedata
+from collections.abc import Callable
+from typing import Any
+
+DOC_PREVIEW_HOST_ACTION_TOOL = "host_action__authoring__preview_lesson_patch"
+DOC_COURSE_HOST_ACTION_TOOL = "host_action__authoring__generate_course_from_document"
+
+DOCUMENT_PREVIEW_CAPABILITY_NAMES = {
+    "authoring.preview_lesson_patch",
+    "authoring.generate_course_from_document",
+}
+
+_COURSE_REQUEST_BLOCKERS = (
+    "preview_lesson_patch",
+    "lesson patch",
+    "bai hoc hien tai",
+    "cap nhat bai hoc",
+)
+
+_COURSE_REQUEST_MARKERS = (
+    "generate_course_from_document",
+    "course architect",
+    "course plan",
+    "course outline",
+    "course syllabus",
+    "curriculum",
+    "full course",
+    "lap bai giang",
+    "soan bai giang",
+    "soan giao an",
+    "tao bai giang",
+    "tao giao an",
+    "tao hoc lieu",
+    "toan bo khoa",
+    "cay khoa",
+    "chia khoa",
+    "chia thanh bai",
+    "chia thanh chuong",
+    "chuong trinh dao tao",
+    "de cuong khoa",
+    "de cuong mon",
+    "giao trinh",
+    "ke hoach giang day",
+    "khoa dao tao",
+    "khoa day du",
+    "khoa hoan chinh",
+    "learning path",
+    "lo trinh hoc",
+    "lo trinh khoa",
+    "nhieu bai hoc",
+    "nhieu chuong",
+    "phan chia bai hoc",
+    "syllabus",
+    "tao khoa hoc",
+    "thiet ke bai giang",
+    "thiet ke khoa hoc",
+    "xay dung bai giang",
+    "cau truc khoa hoc",
+    "chuong/bai",
+    "chuong bai",
+    "module",
+    "outline",
+)
+
+
+def normalize_document_contract_text(value: Any) -> str:
+    text = str(value or "").replace("\\_", "_")
+    normalized = unicodedata.normalize("NFKD", text)
+    return "".join(ch for ch in normalized if not unicodedata.combining(ch)).lower()
+
+
+def as_plain_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if hasattr(value, "model_dump"):
+        try:
+            dumped = value.model_dump(exclude_none=True)
+            return dumped if isinstance(dumped, dict) else {}
+        except Exception:
+            return {}
+    if hasattr(value, "dict"):
+        try:
+            dumped = value.dict(exclude_none=True)
+            return dumped if isinstance(dumped, dict) else {}
+        except Exception:
+            return {}
+    return {}
+
+
+def uploaded_document_attachments_from_context(ctx: dict[str, Any]) -> list[dict[str, Any]]:
+    ctx = as_plain_mapping(ctx)
+    document_context = as_plain_mapping(ctx.get("document_context"))
+    attachments = document_context.get("attachments")
+    if not isinstance(attachments, list):
+        return []
+
+    parsed: list[dict[str, Any]] = []
+    for item in attachments:
+        attachment = as_plain_mapping(item)
+        if attachment and str(attachment.get("markdown") or "").strip():
+            parsed.append(attachment)
+    return parsed
+
+
+def has_uploaded_document_context(ctx: dict[str, Any]) -> bool:
+    return bool(uploaded_document_attachments_from_context(ctx))
+
+
+def uploaded_document_attachments_from_state(state: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(state, dict):
+        return []
+    ctx = state.get("context")
+    if not isinstance(ctx, dict):
+        return []
+    return uploaded_document_attachments_from_context(ctx)
+
+
+def looks_uploaded_document_course_request(query: str) -> bool:
+    normalized = normalize_document_contract_text(query)
+    if any(marker in normalized for marker in _COURSE_REQUEST_BLOCKERS):
+        return False
+    return any(marker in normalized for marker in _COURSE_REQUEST_MARKERS)
+
+
+def _runtime_tool_name(
+    tool: Any,
+    *,
+    tool_name_resolver: Callable[[Any], str] | None = None,
+) -> str:
+    if tool_name_resolver is not None:
+        try:
+            return str(tool_name_resolver(tool) or "").strip().lower()
+        except Exception:
+            return ""
+    return str(getattr(tool, "name", "") or getattr(tool, "__name__", "")).strip().lower()
+
+
+def find_document_host_action_tool(
+    tools: list[Any],
+    desired_tool_name: str,
+    *,
+    tool_name_resolver: Callable[[Any], str] | None = None,
+) -> Any | None:
+    desired = str(desired_tool_name or "").strip().lower()
+    for tool in tools or []:
+        if _runtime_tool_name(tool, tool_name_resolver=tool_name_resolver) == desired:
+            return tool
+    return None
+
+
+def has_document_preview_host_action_tool(
+    tools: list[Any],
+    *,
+    tool_name_resolver: Callable[[Any], str] | None = None,
+) -> bool:
+    return any(
+        _runtime_tool_name(tool, tool_name_resolver=tool_name_resolver)
+        in {DOC_PREVIEW_HOST_ACTION_TOOL, DOC_COURSE_HOST_ACTION_TOOL}
+        for tool in tools or []
+    )
+
+
+def document_preview_forced_tool_choice(
+    query: str,
+    tools: list[Any],
+    *,
+    tool_name_resolver: Callable[[Any], str] | None = None,
+) -> str:
+    preferred = (
+        DOC_COURSE_HOST_ACTION_TOOL
+        if looks_uploaded_document_course_request(query)
+        else DOC_PREVIEW_HOST_ACTION_TOOL
+    )
+    tool_names = {
+        _runtime_tool_name(tool, tool_name_resolver=tool_name_resolver)
+        for tool in tools or []
+    }
+    if preferred in tool_names:
+        return preferred
+    if DOC_PREVIEW_HOST_ACTION_TOOL in tool_names:
+        return DOC_PREVIEW_HOST_ACTION_TOOL
+    return DOC_COURSE_HOST_ACTION_TOOL
+
+
+def extract_document_preview_capabilities(
+    state: dict[str, Any],
+    ctx: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Recover LMS preview capability definitions from raw runtime state."""
+
+    state_context = state.get("context") if isinstance(state.get("context"), dict) else {}
+    raw_sources = [
+        state.get("host_capabilities"),
+        ctx.get("host_capabilities"),
+        state_context.get("host_capabilities") if isinstance(state_context, dict) else None,
+    ]
+    preview_capabilities: list[dict[str, Any]] = []
+    for raw_caps in raw_sources:
+        caps = as_plain_mapping(raw_caps)
+        raw_tools = caps.get("tools")
+        if not isinstance(raw_tools, list):
+            continue
+        for raw_tool in raw_tools:
+            tool_def = as_plain_mapping(raw_tool)
+            name = str(tool_def.get("name") or "").strip().lower()
+            if name in DOCUMENT_PREVIEW_CAPABILITY_NAMES:
+                preview_capabilities.append(tool_def)
+    return preview_capabilities

--- a/maritime-ai-service/app/engine/multi_agent/document_preview_contract.py
+++ b/maritime-ai-service/app/engine/multi_agent/document_preview_contract.py
@@ -69,6 +69,7 @@ _COURSE_REQUEST_MARKERS = (
 
 def normalize_document_contract_text(value: Any) -> str:
     text = str(value or "").replace("\\_", "_")
+    text = text.replace("đ", "d").replace("Đ", "D")
     normalized = unicodedata.normalize("NFKD", text)
     return "".join(ch for ch in normalized if not unicodedata.combining(ch)).lower()
 

--- a/maritime-ai-service/tests/unit/test_document_preview_contract.py
+++ b/maritime-ai-service/tests/unit/test_document_preview_contract.py
@@ -38,6 +38,8 @@ def test_uploaded_document_attachment_contract_accepts_mapping_like_values():
 
 def test_uploaded_document_course_intent_is_shared_by_preview_and_tool_rounds():
     assert looks_uploaded_document_course_request("tao bai giang di")
+    assert looks_uploaded_document_course_request("lap de cuong khoa hoc tu tai lieu")
+    assert looks_uploaded_document_course_request("lập đề cương khóa học từ tài liệu")
     assert looks_uploaded_document_course_request("turn this document into a course plan")
     assert not looks_uploaded_document_course_request("cap nhat bai hoc hien tai")
 

--- a/maritime-ai-service/tests/unit/test_document_preview_contract.py
+++ b/maritime-ai-service/tests/unit/test_document_preview_contract.py
@@ -1,0 +1,83 @@
+from types import SimpleNamespace
+
+from app.engine.multi_agent.document_preview_contract import (
+    DOC_COURSE_HOST_ACTION_TOOL,
+    DOC_PREVIEW_HOST_ACTION_TOOL,
+    document_preview_forced_tool_choice,
+    extract_document_preview_capabilities,
+    has_document_preview_host_action_tool,
+    has_uploaded_document_context,
+    looks_uploaded_document_course_request,
+    uploaded_document_attachments_from_context,
+    uploaded_document_attachments_from_state,
+)
+
+
+class Dumpable:
+    def __init__(self, value):
+        self.value = value
+
+    def model_dump(self, exclude_none=True):
+        return self.value
+
+
+def test_uploaded_document_attachment_contract_accepts_mapping_like_values():
+    attachment = Dumpable(
+        {
+            "file_name": "lesson.docx",
+            "title": "Lesson",
+            "markdown": "# Lesson\n\nSource-backed content.",
+        }
+    )
+    ctx = {"document_context": {"attachments": [attachment, {"markdown": "   "}]}}
+
+    assert has_uploaded_document_context(ctx)
+    assert uploaded_document_attachments_from_context(ctx) == [attachment.value]
+    assert uploaded_document_attachments_from_state({"context": ctx}) == [attachment.value]
+
+
+def test_uploaded_document_course_intent_is_shared_by_preview_and_tool_rounds():
+    assert looks_uploaded_document_course_request("tao bai giang di")
+    assert looks_uploaded_document_course_request("turn this document into a course plan")
+    assert not looks_uploaded_document_course_request("cap nhat bai hoc hien tai")
+
+
+def test_document_preview_forced_tool_choice_prefers_course_when_available():
+    tools = [
+        SimpleNamespace(name=DOC_PREVIEW_HOST_ACTION_TOOL),
+        SimpleNamespace(name=DOC_COURSE_HOST_ACTION_TOOL),
+    ]
+
+    assert has_document_preview_host_action_tool(tools)
+    assert (
+        document_preview_forced_tool_choice("tao bai giang di", tools)
+        == DOC_COURSE_HOST_ACTION_TOOL
+    )
+    assert (
+        document_preview_forced_tool_choice("cap nhat bai hoc hien tai", tools)
+        == DOC_PREVIEW_HOST_ACTION_TOOL
+    )
+
+
+def test_extract_document_preview_capabilities_from_state_and_context():
+    state = {
+        "context": {
+            "host_capabilities": {
+                "tools": [
+                    {"name": "authoring.generate_course_from_document", "source": "state"}
+                ]
+            }
+        }
+    }
+    ctx = {
+        "host_capabilities": {
+            "tools": [{"name": "authoring.preview_lesson_patch", "source": "ctx"}]
+        }
+    }
+
+    names = [item["name"] for item in extract_document_preview_capabilities(state, ctx)]
+
+    assert names == [
+        "authoring.preview_lesson_patch",
+        "authoring.generate_course_from_document",
+    ]


### PR DESCRIPTION
Closes #407.

## Summary
- Extract uploaded-document preview/course intent, attachment parsing, host-action tool lookup, forced tool choice, and capability recovery into `document_preview_contract.py`.
- Wire `direct_node_runtime.py` and `direct_tool_rounds_runtime.py` through the shared contract while preserving their existing compatibility helper names.
- Add focused contract tests and update architecture/roadmap docs so the new boundary is discoverable.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_document_preview_contract.py tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_document_context_api.py tests/unit/test_direct_node_provider_errors.py -q --tb=short` -> 110 passed
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m ruff check app/engine/multi_agent/document_preview_contract.py app/engine/multi_agent/direct_tool_rounds_runtime.py app/engine/multi_agent/direct_node_runtime.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed, with existing CRLF warning for touched roadmap doc

## Risk / rollback
Medium runtime-routing risk because this touches LMS uploaded-document preview/course host-action selection. No migration or persistent data changes. Rollback is reverting this PR; existing runtime compatibility helper names remain in place for callers/tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated technical roadmap and codebase map to reflect code organization improvements.

* **Refactor**
  * Consolidated duplicate document preview and course-handling logic into a centralized shared module, reducing code duplication and improving maintainability across runtime components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->