### PR TITLE
fix(runtime): default NVIDIA models to Qwen

### DIFF
--- a/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
+++ b/docs/operations/WIII_PRODUCT_RELEASE_RUNBOOK.md
@@ -35,7 +35,7 @@ On 2026-05-10, production was verified on `wiii-production` in project
 
 - `https://wiii.holilihu.online/api/v1/health/llm-models` was reachable
 - the active model pool contained primary `qwen/qwen3-next-80b-a3b-instruct`
-  and advanced fallback `deepseek-ai/deepseek-v4-pro`
+  and advanced fallback `qwen/qwen3-next-80b-a3b-thinking`
 - model-level health may temporarily mark the advanced model degraded after a
   timeout; routing should keep normal chat on the healthy primary model
 - `ENABLE_MAGIC_LINK_AUTH=true` was enabled after Resend API validation and
@@ -87,10 +87,10 @@ Production `.env.production` is secret-bearing and must stay on the VM. For the 
 LLM_PROVIDER=nvidia
 NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
 NVIDIA_MODEL=qwen/qwen3-next-80b-a3b-instruct
-NVIDIA_MODEL_ADVANCED=deepseek-ai/deepseek-v4-pro
+NVIDIA_MODEL_ADVANCED=qwen/qwen3-next-80b-a3b-thinking
 ENABLE_LLM_MODEL_HEALTH_PROBES=true
 LLM_MODEL_HEALTH_PROBE_TIMEOUT_SECONDS=45
-AGENT_PROVIDER_CONFIGS={"code_studio_agent":{"tier":"deep","provider":"nvidia","model":"deepseek-ai/deepseek-v4-pro"}}
+AGENT_PROVIDER_CONFIGS={"code_studio_agent":{"tier":"deep","provider":"nvidia","model":"qwen/qwen3-next-80b-a3b-thinking"}}
 
 # Required while production embeddings use models/gemini-embedding-001.
 # Use only the minimum Gemini/API permissions needed for embeddings, track its

--- a/maritime-ai-service/.env.example
+++ b/maritime-ai-service/.env.example
@@ -83,11 +83,11 @@ LLM_FAILOVER_CHAIN=["openrouter","ollama","google"]
 
 # NVIDIA NIM (Issue #110) — OpenAI-compatible endpoint with free tier
 # Get an NGC API key at https://build.nvidia.com/explore/discover
-# Default models: meta/llama-3.1-70b-instruct (light/moderate), 405B (deep)
+# Default models: Qwen instruct (light/moderate), Qwen thinking (deep)
 # NVIDIA_API_KEY=nvapi-...
 # NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
-# NVIDIA_MODEL=meta/llama-3.1-70b-instruct
-# NVIDIA_MODEL_ADVANCED=meta/llama-3.1-405b-instruct
+# NVIDIA_MODEL=qwen/qwen3-next-80b-a3b-instruct
+# NVIDIA_MODEL_ADVANCED=qwen/qwen3-next-80b-a3b-thinking
 # NVIDIA_VISION_MODEL=meta/llama-3.2-11b-vision-instruct
 
 # Google Gemini

--- a/maritime-ai-service/app/engine/model_catalog.py
+++ b/maritime-ai-service/app/engine/model_catalog.py
@@ -81,15 +81,18 @@ ZHIPU_DEFAULT_BASE_URL = "https://open.bigmodel.cn/api/paas/v4"
 # NVIDIA NIM — OpenAI-compatible endpoint (Issue #110)
 # Free tier available with NGC API key from build.nvidia.com.
 NVIDIA_DEFAULT_BASE_URL = "https://integrate.api.nvidia.com/v1"
-NVIDIA_DEFAULT_MODEL = "deepseek-ai/deepseek-v4-flash"
-NVIDIA_DEFAULT_MODEL_ADVANCED = "deepseek-ai/deepseek-v4-pro"
+NVIDIA_QWEN_INSTRUCT_MODEL = "qwen/qwen3-next-80b-a3b-instruct"
+NVIDIA_QWEN_THINKING_MODEL = "qwen/qwen3-next-80b-a3b-thinking"
+NVIDIA_DEEPSEEK_FLASH_MODEL = "deepseek-ai/deepseek-v4-flash"
+NVIDIA_DEEPSEEK_PRO_MODEL = "deepseek-ai/deepseek-v4-pro"
+NVIDIA_DEFAULT_MODEL = NVIDIA_QWEN_INSTRUCT_MODEL
+NVIDIA_DEFAULT_MODEL_ADVANCED = NVIDIA_QWEN_THINKING_MODEL
 NVIDIA_DEFAULT_VISION_MODEL = "meta/llama-3.2-11b-vision-instruct"
 # Phase 32a (#207): Qwen3 thinking model emits ``reasoning_content`` deltas
 # that Wiii's existing thinking-stream extractor already understands.
-# Switch ``NVIDIA_MODEL_ADVANCED`` to this id when you want a visible
-# reasoning block in the UI (the streaming pipeline picks it up
-# automatically via ``_extract_openai_delta_text_impl``).
-NVIDIA_THINKING_MODEL = "qwen/qwen3-next-80b-a3b-thinking"
+# The default NVIDIA profile stays on Qwen for both normal and deep turns so
+# Wiii does not silently fall back to DeepSeek when env overrides are absent.
+NVIDIA_THINKING_MODEL = NVIDIA_QWEN_THINKING_MODEL
 
 GOOGLE_CHAT_MODELS: dict[str, ChatModelMetadata] = {
     GOOGLE_DEFAULT_MODEL: ChatModelMetadata(
@@ -434,7 +437,7 @@ NVIDIA_CHAT_MODELS: dict[str, ChatModelMetadata] = {
     NVIDIA_DEFAULT_MODEL: ChatModelMetadata(
         provider="nvidia",
         model_name=NVIDIA_DEFAULT_MODEL,
-        display_name="DeepSeek V4 Flash (NVIDIA NIM)",
+        display_name="Qwen3 Next 80B Instruct (NVIDIA NIM)",
         status="current",
         supports_streaming=True,
         supports_structured_output=False,
@@ -443,21 +446,26 @@ NVIDIA_CHAT_MODELS: dict[str, ChatModelMetadata] = {
     NVIDIA_DEFAULT_MODEL_ADVANCED: ChatModelMetadata(
         provider="nvidia",
         model_name=NVIDIA_DEFAULT_MODEL_ADVANCED,
-        display_name="DeepSeek V4 Pro (NVIDIA NIM)",
+        display_name="Qwen3 80B Thinking (NVIDIA NIM)",
         status="current",
         supports_streaming=True,
         supports_structured_output=False,
         capability_source="static",
     ),
-    # Phase 32a (#207): Reasoning-capable model. Emits ``reasoning_content``
-    # deltas that surface as ``thinking_*`` SSE events in the UI. Slower
-    # per-turn (model thinks then answers) but gives the user the
-    # transparency that Claude / o3 / DeepSeek-R1 deliver natively.
-    NVIDIA_THINKING_MODEL: ChatModelMetadata(
+    NVIDIA_DEEPSEEK_FLASH_MODEL: ChatModelMetadata(
         provider="nvidia",
-        model_name=NVIDIA_THINKING_MODEL,
-        display_name="Qwen3 80B Thinking (NVIDIA NIM)",
-        status="current",
+        model_name=NVIDIA_DEEPSEEK_FLASH_MODEL,
+        display_name="DeepSeek V4 Flash (NVIDIA NIM)",
+        status="legacy",
+        supports_streaming=True,
+        supports_structured_output=False,
+        capability_source="static",
+    ),
+    NVIDIA_DEEPSEEK_PRO_MODEL: ChatModelMetadata(
+        provider="nvidia",
+        model_name=NVIDIA_DEEPSEEK_PRO_MODEL,
+        display_name="DeepSeek V4 Pro (NVIDIA NIM)",
+        status="legacy",
         supports_streaming=True,
         supports_structured_output=False,
         capability_source="static",

--- a/maritime-ai-service/tests/unit/test_model_catalog.py
+++ b/maritime-ai-service/tests/unit/test_model_catalog.py
@@ -2,10 +2,13 @@ from app.engine.model_catalog import (
     DEFAULT_EMBEDDING_MODEL,
     EMBEDDING_BENCHMARK_CANDIDATE,
     GOOGLE_DEFAULT_MODEL,
+    NVIDIA_DEFAULT_MODEL,
+    NVIDIA_DEFAULT_MODEL_ADVANCED,
     get_chat_model_metadata,
     get_current_google_chat_models,
     get_embedding_dimensions,
     get_embedding_model_metadata,
+    get_provider_chat_model_metadata,
     is_legacy_google_model,
 )
 from app.engine.model_catalog_runtime_support import hash_secret, sanitize_exception_for_log
@@ -17,6 +20,23 @@ def test_google_default_model_is_current():
     assert metadata is not None
     assert metadata.model_name == GOOGLE_DEFAULT_MODEL
     assert metadata.status == "current"
+
+
+def test_nvidia_defaults_are_qwen_models():
+    default_metadata = get_provider_chat_model_metadata("nvidia", NVIDIA_DEFAULT_MODEL)
+    advanced_metadata = get_provider_chat_model_metadata(
+        "nvidia",
+        NVIDIA_DEFAULT_MODEL_ADVANCED,
+    )
+
+    assert NVIDIA_DEFAULT_MODEL == "qwen/qwen3-next-80b-a3b-instruct"
+    assert NVIDIA_DEFAULT_MODEL_ADVANCED == "qwen/qwen3-next-80b-a3b-thinking"
+    assert default_metadata is not None
+    assert default_metadata.status == "current"
+    assert "Qwen" in default_metadata.display_name
+    assert advanced_metadata is not None
+    assert advanced_metadata.status == "current"
+    assert "Qwen" in advanced_metadata.display_name
 
 
 def test_legacy_google_model_is_marked_legacy():

--- a/maritime-ai-service/tests/unit/test_native_chat_runtime.py
+++ b/maritime-ai-service/tests/unit/test_native_chat_runtime.py
@@ -206,6 +206,8 @@ def test_make_assistant_message_preserves_langchain_like_surface_without_langcha
 
 
 def test_agent_config_can_resolve_native_nvidia_handle(monkeypatch):
+    from app.core.config import settings
+    from app.engine.openai_compatible_credentials import resolve_nvidia_model
     from app.engine.multi_agent.agent_config import AgentConfigRegistry, AgentNodeConfig
 
     def _fake_runtime(cls, node_id, *, provider_override=None):
@@ -231,12 +233,12 @@ def test_agent_config_can_resolve_native_nvidia_handle(monkeypatch):
     assert handle is not None
     assert handle._wiii_native_route is True
     assert handle._wiii_provider_name == "nvidia"
-    assert handle._wiii_model_name == "deepseek-ai/deepseek-v4-flash"
+    assert handle._wiii_model_name == resolve_nvidia_model(settings)
     assert handle._wiii_tier_key == "light"
     assert handle.temperature == 0.25
 
 
-def test_agent_config_native_nvidia_handle_skips_degraded_flash(monkeypatch):
+def test_agent_config_native_nvidia_handle_skips_degraded_primary(monkeypatch):
     from app.engine.llm_model_health import record_model_failure, reset_model_health_state
     from app.core.config import settings
     from app.engine.openai_compatible_credentials import (

--- a/maritime-ai-service/tests/unit/test_nvidia_provider.py
+++ b/maritime-ai-service/tests/unit/test_nvidia_provider.py
@@ -39,15 +39,15 @@ class TestNvidiaRegistry:
 # ---------------------------------------------------------------------------
 
 class TestNvidiaResolvers:
-    def test_default_models_are_current_deepseek_v4_targets(self):
+    def test_default_models_are_current_qwen_targets(self):
         from app.engine.model_catalog import (
             NVIDIA_DEFAULT_MODEL,
             NVIDIA_DEFAULT_MODEL_ADVANCED,
             get_all_static_chat_models,
         )
 
-        assert NVIDIA_DEFAULT_MODEL == "deepseek-ai/deepseek-v4-flash"
-        assert NVIDIA_DEFAULT_MODEL_ADVANCED == "deepseek-ai/deepseek-v4-pro"
+        assert NVIDIA_DEFAULT_MODEL == "qwen/qwen3-next-80b-a3b-instruct"
+        assert NVIDIA_DEFAULT_MODEL_ADVANCED == "qwen/qwen3-next-80b-a3b-thinking"
         assert NVIDIA_DEFAULT_MODEL in get_all_static_chat_models()["nvidia"]
         assert NVIDIA_DEFAULT_MODEL_ADVANCED in get_all_static_chat_models()["nvidia"]
 


### PR DESCRIPTION
Closes #409.

## Summary
- Change backend NVIDIA primary/default model from DeepSeek Flash to qwen/qwen3-next-80b-a3b-instruct.
- Change backend NVIDIA advanced default to qwen/qwen3-next-80b-a3b-thinking and keep DeepSeek NIM models as legacy catalog entries for explicit env overrides.
- Update release runbook and .env.example so product rebuild docs no longer reintroduce DeepSeek defaults.
- Add a model catalog invariant test that locks NVIDIA defaults to Qwen.

## Verification
- cd maritime-ai-service && .\\.venv\\Scripts\\python.exe -m pytest tests/unit/test_model_catalog.py tests/unit/test_model_catalog_service.py tests/unit/test_document_context_api.py tests/unit/test_llm_model_health_probe_service.py tests/unit/test_llm_model_health_endpoint.py -q --tb=short -> 56 passed
- cd maritime-ai-service && .\\.venv\\Scripts\\python.exe -m pytest tests/unit/test_llm_failover.py tests/unit/test_llm_runtime_audit_service.py tests/unit/test_admin_llm_runtime.py tests/unit/test_openai_stream_runtime.py -q --tb=short -> 67 passed
- cd maritime-ai-service && .\\.venv\\Scripts\\python.exe -m ruff check app/engine/model_catalog.py tests/unit/test_model_catalog.py --select=E9,F63,F7 -> passed
- git diff --check -> passed

## Risk / rollback
Provider-routing risk. No migration or persistent data changes. Rollback is reverting this PR, or temporarily setting NVIDIA_MODEL / NVIDIA_MODEL_ADVANCED explicitly in the environment while investigating.