### PR TITLE
refactor(runtime): quarantine legacy subagent graph shims

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -1,0 +1,72 @@
+# Wiii Runtime Cleanup Audit 2026-05-19
+
+Status: Active
+
+Owner: Project leadership
+
+Issue: #411
+
+## Purpose
+
+This audit records the cleanup boundary for the May 2026 runtime hygiene pass.
+It is intentionally practical: remove or quarantine confusing legacy surfaces
+without broad deletes, secret exposure, or unreviewed product behavior changes.
+
+## Cleaned In This Pass
+
+- Product-search, RAG, and tutor helper logic now lives under
+  `subagents/*/runtime.py`.
+- `subagents/*/graph.py` is reduced to a compatibility shim that preserves old
+  imports and explicit `build_*_subgraph()` deprecation failures.
+- Code Studio scaffold primitive and legacy-kind mapping moved into
+  `code_studio_scaffold_contract.py`, so routing and tests can depend on a
+  small typed contract instead of importing the full HTML renderer.
+
+## Preserved Intentionally
+
+- `graph.py` shim files remain because existing tests and possible external
+  imports still rely on those module paths. They are no longer the home of
+  active runtime logic.
+- Code Studio deterministic scaffold remains because it is a failure-mode UX
+  guard when LLM visual tool planning stalls. The cleanup separates contract
+  from renderer; it does not claim the renderer is the final visual system.
+- DeepSeek provider catalog entries remain as explicit legacy/failover/test
+  coverage. Qwen remains the NVIDIA default.
+- Auth, role, token, and memory compatibility paths were not mechanically
+  removed because they are high-risk tenant and identity surfaces.
+
+## Not Repository Trash
+
+The development worktree `E:\Sach\Sua\AI_v1` still has untracked LinkedIn/MCP
+work and `.mcp.json` changes. Those are user/WIP files, not cleanup targets.
+
+The product worktree may contain ignored local build/test outputs such as
+`.venv`, `.pytest_cache`, `.ruff_cache`, `__pycache__`, `wiii_service.egg-info`,
+desktop `node_modules`, `dist-pointy`, or Tauri `target`. These should be
+deleted only with explicit target paths and never together with `.env*`,
+backups, data PDFs, or local skill folders.
+
+## Remaining Debt
+
+- `direct_node_runtime.py` and `direct_tool_rounds_runtime.py` remain large.
+  The long-term cleanup direction is lifecycle, tool-loop, tool-dispatch, and
+  response-finalization modules with contract tests around SSE V3 parity.
+- `code_studio_template_scaffold.py` is still a large deterministic fallback.
+  The next durable step is a renderer registry plus scaffold-quality gates
+  that reject generic templates for simulation requests.
+- Some tests still import compatibility `graph.py` modules. Move tests toward
+  `runtime.py` imports when the external import window can close.
+
+## Verification Notes
+
+Targeted commands used during this pass:
+
+```powershell
+cd maritime-ai-service
+uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_code_studio_template_scaffold.py -q --tb=short
+uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_subagent_phase3.py tests/unit/test_subagent_search.py tests/unit/test_sprint202_curated_cards.py -q --tb=short
+```
+
+The first command passed with 52 tests. The second command passed with 140
+tests after adding the required `pytest-asyncio` test plugin to the temporary
+uv environment.

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_contract.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_contract.py
@@ -1,0 +1,66 @@
+"""Typed contract for deterministic Code Studio scaffold fallbacks.
+
+The scaffold renderer may stay large while Wiii evolves, but primitive names
+and legacy kind mapping are public compatibility surface. Keeping them here
+prevents renderer internals from becoming the source of truth for routing,
+metrics, and tests.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+ScaffoldPrimitive = Literal[
+    "particle_field",
+    "oscillation",
+    "timeline",
+    "function_plot",
+    "scene",
+    "data_band",
+]
+
+LegacyScaffoldKind = Literal[
+    "literary",
+    "physics",
+    "math",
+    "history",
+    "celestial",
+    "default",
+]
+
+PRIMITIVE_PARTICLE_FIELD: ScaffoldPrimitive = "particle_field"
+PRIMITIVE_OSCILLATION: ScaffoldPrimitive = "oscillation"
+PRIMITIVE_TIMELINE: ScaffoldPrimitive = "timeline"
+PRIMITIVE_FUNCTION_PLOT: ScaffoldPrimitive = "function_plot"
+PRIMITIVE_SCENE: ScaffoldPrimitive = "scene"
+PRIMITIVE_DATA_BAND: ScaffoldPrimitive = "data_band"
+
+LEGACY_KIND_TO_PRIMITIVE: dict[LegacyScaffoldKind, ScaffoldPrimitive] = {
+    "literary": PRIMITIVE_SCENE,
+    "physics": PRIMITIVE_OSCILLATION,
+    "math": PRIMITIVE_FUNCTION_PLOT,
+    "history": PRIMITIVE_TIMELINE,
+    "celestial": PRIMITIVE_PARTICLE_FIELD,
+    "default": PRIMITIVE_DATA_BAND,
+}
+
+PRIMITIVE_TO_LEGACY_KIND: dict[ScaffoldPrimitive, LegacyScaffoldKind] = {
+    PRIMITIVE_SCENE: "literary",
+    PRIMITIVE_OSCILLATION: "physics",
+    PRIMITIVE_FUNCTION_PLOT: "math",
+    PRIMITIVE_TIMELINE: "history",
+    PRIMITIVE_PARTICLE_FIELD: "celestial",
+    PRIMITIVE_DATA_BAND: "default",
+}
+
+
+def primitive_for_legacy_kind(kind: str | None) -> ScaffoldPrimitive | None:
+    """Return the primitive forced by a legacy kind override, if valid."""
+    if not kind:
+        return None
+    return LEGACY_KIND_TO_PRIMITIVE.get(kind)  # type: ignore[arg-type]
+
+
+def legacy_kind_for_primitive(primitive: str | None) -> LegacyScaffoldKind:
+    """Return the compatibility kind for a primitive name."""
+    return PRIMITIVE_TO_LEGACY_KIND.get(primitive, "default")  # type: ignore[arg-type]

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_template_scaffold.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_template_scaffold.py
@@ -101,37 +101,24 @@ import html
 import json
 import unicodedata
 
+from app.engine.multi_agent.code_studio_scaffold_contract import (
+    PRIMITIVE_DATA_BAND,
+    PRIMITIVE_FUNCTION_PLOT,
+    PRIMITIVE_OSCILLATION,
+    PRIMITIVE_PARTICLE_FIELD,
+    PRIMITIVE_SCENE,
+    PRIMITIVE_TIMELINE,
+    legacy_kind_for_primitive,
+    primitive_for_legacy_kind,
+)
 
 # ============================================================================
-# Primitive identifiers + legacy kind mapping
+# Primitive identifiers + legacy kind mapping contract
 # ============================================================================
 
-PRIMITIVE_PARTICLE_FIELD = "particle_field"
-PRIMITIVE_OSCILLATION = "oscillation"
-PRIMITIVE_TIMELINE = "timeline"
-PRIMITIVE_FUNCTION_PLOT = "function_plot"
-PRIMITIVE_SCENE = "scene"
-PRIMITIVE_DATA_BAND = "data_band"
-
-# Legacy kind → primitive default (used by ``detect_scaffold_kind`` callers
-# and by the public ``kind`` override in ``build_code_studio_scaffold``).
-_LEGACY_KIND_TO_PRIMITIVE = {
-    "literary": PRIMITIVE_SCENE,
-    "physics": PRIMITIVE_OSCILLATION,
-    "math": PRIMITIVE_FUNCTION_PLOT,
-    "history": PRIMITIVE_TIMELINE,
-    "celestial": PRIMITIVE_PARTICLE_FIELD,
-    "default": PRIMITIVE_DATA_BAND,
-}
-
-_PRIMITIVE_TO_LEGACY_KIND = {
-    PRIMITIVE_SCENE: "literary",
-    PRIMITIVE_OSCILLATION: "physics",
-    PRIMITIVE_FUNCTION_PLOT: "math",
-    PRIMITIVE_TIMELINE: "history",
-    PRIMITIVE_PARTICLE_FIELD: "celestial",
-    PRIMITIVE_DATA_BAND: "default",
-}
+# Primitive and legacy-kind names live in ``code_studio_scaffold_contract``.
+# This renderer imports them so public routing/metrics code can depend on the
+# contract without importing the full HTML scaffold module.
 
 # ============================================================================
 # Palette library (CSS variable-aware, host theme-overridable)
@@ -692,7 +679,7 @@ def _short_title(query: str, max_len: int = 60) -> str:
 
 def _legacy_kind_for(spec: dict) -> str:
     primitive = spec.get("primitive", PRIMITIVE_DATA_BAND)
-    return _PRIMITIVE_TO_LEGACY_KIND.get(primitive, "default")
+    return legacy_kind_for_primitive(primitive)
 
 
 def _aria_label(spec: dict, title: str) -> str:
@@ -1800,7 +1787,7 @@ def build_code_studio_scaffold(query: str, *, kind: str | None = None) -> str:
     """
     spec = extract_scaffold_spec(query)
     if kind:
-        forced_primitive = _LEGACY_KIND_TO_PRIMITIVE.get(kind)
+        forced_primitive = primitive_for_legacy_kind(kind)
         if forced_primitive:
             spec = {**spec, "primitive": forced_primitive}
     primitive = spec.get("primitive", PRIMITIVE_DATA_BAND)
@@ -1812,7 +1799,7 @@ def build_scaffold_visible_caption(query: str, *, kind: str | None = None) -> st
     """Short Vietnamese caption shown above the canvas in the chat thread."""
     spec = extract_scaffold_spec(query)
     if kind:
-        forced_primitive = _LEGACY_KIND_TO_PRIMITIVE.get(kind)
+        forced_primitive = primitive_for_legacy_kind(kind)
         if forced_primitive:
             spec["primitive"] = forced_primitive
     primitive = spec.get("primitive", PRIMITIVE_DATA_BAND)

--- a/maritime-ai-service/app/engine/multi_agent/subagents/rag/__init__.py
+++ b/maritime-ai-service/app/engine/multi_agent/subagents/rag/__init__.py
@@ -1,6 +1,9 @@
-"""RAG subgraph — retriever → grader → generator → corrector pipeline."""
+"""RAG native helpers.
+
+LangGraph builders were removed; use ``runtime`` helpers for WiiiRunner-native
+execution.
+"""
 
 from app.engine.multi_agent.subagents.rag.state import RAGSubgraphState
-# build_rag_subgraph removed (De-LangGraphing Phase 3) — pipeline runs via WiiiRunner
 
 __all__ = ["RAGSubgraphState"]

--- a/maritime-ai-service/app/engine/multi_agent/subagents/rag/graph.py
+++ b/maritime-ai-service/app/engine/multi_agent/subagents/rag/graph.py
@@ -1,175 +1,36 @@
-"""DEPRECATED: RAG subgraph builder — Corrective RAG pipeline as subgraph.
+"""Compatibility shim for the removed LangGraph RAG subgraph.
 
-LangGraph removed (De-LangGraphing Phase 3).
-The node functions (retrieve_node, grade_node, correct_node, generate_node)
-are preserved as they may be reused by a future pipeline implementation.
-
-Original flow:
-    START → retrieve → grade → should_correct?
-                                  ├─ yes → correct → retrieve (loop)
-                                  └─ no  → generate → END
+Use ``app.engine.multi_agent.subagents.rag.runtime`` for native helpers.
+This module preserves older imports and the explicit deprecated builder
+failure expected by compatibility tests.
 """
 
 from __future__ import annotations
 
-import logging
-from typing import Any, Dict, Literal
-
-# LangGraph imports removed
-# from langgraph.graph import END, START, StateGraph
-
-from app.engine.multi_agent.subagents.rag.state import RAGSubgraphState
-
-logger = logging.getLogger(__name__)
-
-
-async def retrieve_node(state: Dict[str, Any]) -> dict:
-    """Hybrid search: dense (pgvector) + sparse (tsvector) + RRF reranking.
-
-    Delegates to existing HybridSearchService for consistency.
-    """
-    query = state.get("query", "")
-    domain_id = state.get("domain_id", "maritime")
-    org_id = state.get("organization_id")
-    correction_round = state.get("correction_round", 0)
-
-    docs = []
-    scores = []
-
-    try:
-        from app.services.hybrid_search_service import get_hybrid_search_service
-
-        search_svc = get_hybrid_search_service()
-        results = await search_svc.search(
-            query=query,
-            domain_id=domain_id,
-            top_k=10,
-            organization_id=org_id,
-        )
-        for r in results:
-            docs.append({
-                "content": r.get("content", ""),
-                "metadata": r.get("metadata", {}),
-                "score": r.get("score", 0.0),
-            })
-            scores.append(r.get("score", 0.0))
-    except Exception as exc:
-        logger.warning("[RAG_SUBGRAPH] Retrieval failed (round %d): %s", correction_round, exc)
-
-    return {
-        "retrieval_docs": docs,
-        "retrieval_scores": scores,
-        "correction_round": correction_round,
-    }
-
-
-async def grade_node(state: Dict[str, Any]) -> dict:
-    """Grade retrieved documents for relevance.
-
-    Uses tiered grading: pre-filter → MiniJudge → Full LLM (early exit).
-    """
-    docs = state.get("retrieval_docs", [])
-    query = state.get("query", "")
-
-    if not docs:
-        return {"retrieval_confidence": 0.0, "grading_results": []}
-
-    # Confidence from retrieval scores — 0-1 scale
-    # (matches quality_skip_threshold=0.85 comparison in graph.py)
-    scores = state.get("retrieval_scores", [])
-    avg_score = sum(scores) / len(scores) if scores else 0.0
-    confidence = min(avg_score, 1.0)
-
-    grading_results = [
-        {"doc_index": i, "relevant": score > 0.3, "score": score}
-        for i, score in enumerate(scores)
-    ]
-
-    return {
-        "retrieval_confidence": confidence,
-        "grading_results": grading_results,
-    }
-
-
-def should_correct(state: Dict[str, Any]) -> Literal["generate", "correct"]:
-    """Decide whether to self-correct or proceed to generation."""
-    confidence = state.get("retrieval_confidence", 0.0)
-    correction_round = state.get("correction_round", 0)
-    max_rounds = state.get("max_correction_rounds", 3)
-
-    if confidence >= 0.85 or correction_round >= max_rounds:
-        return "generate"
-    return "correct"
-
-
-async def correct_node(state: Dict[str, Any]) -> dict:
-    """Reformulate query for better retrieval."""
-    return {
-        "correction_round": state.get("correction_round", 0) + 1,
-    }
-
-
-async def generate_node(state: Dict[str, Any]) -> dict:
-    """Generate final response from retrieved documents.
-
-    Sprint 165: When no docs found, uses LLM general knowledge (like corrective_rag._generate_fallback)
-    instead of returning a hardcoded error message.
-    """
-    docs = state.get("retrieval_docs", [])
-    query = state.get("query", "")
-    confidence = state.get("retrieval_confidence", 0.0)
-
-    if not docs:
-        # Sprint 165: LLM fallback — use general knowledge instead of hardcoded error
-        response = await _generate_fallback_response(query, state)
-        confidence = 0.55  # Capped confidence for fallback (0-1 scale)
-    else:
-        # Build context from relevant docs
-        context_parts = [d.get("content", "")[:500] for d in docs[:5]]
-        response = f"Dựa trên {len(docs)} tài liệu tìm được:\n" + "\n".join(context_parts[:3])
-
-    sources = [
-        {"content": d.get("content", "")[:200], "metadata": d.get("metadata", {})}
-        for d in docs[:5]
-    ]
-
-    return {
-        "final_response": response,
-        "agent_outputs": {"rag": response},
-        "current_agent": "rag_agent",
-        "sources": sources,
-        "crag_confidence": confidence,
-    }
-
-
-async def _generate_fallback_response(query: str, state: Dict[str, Any]) -> str:
-    """Generate LLM response when KB has 0 documents.
-
-    Reuses CorrectiveRAG._generate_fallback() logic for consistency.
-    Falls back to static message if LLM is unavailable.
-    """
-    try:
-        from app.engine.agentic_rag.corrective_rag import get_corrective_rag
-
-        crag = get_corrective_rag()
-        context = state.get("context") or {}
-        context.setdefault("domain_name", state.get("domain_id", ""))
-        response = await crag._generate_fallback(query, context)
-        if response:
-            return response
-    except Exception as exc:
-        logger.warning("[RAG_SUBGRAPH] LLM fallback failed: %s", exc)
-
-    return "Xin lỗi, mình chưa tìm thấy tài liệu liên quan nha~ (˶˃ ᵕ ˂˶)"
+from app.engine.multi_agent.subagents.rag.runtime import (
+    RAGSubgraphState,
+    correct_node,
+    generate_node,
+    grade_node,
+    retrieve_node,
+    should_correct,
+)
 
 
 def build_rag_subgraph():
-    """DEPRECATED — LangGraph removed (De-LangGraphing Phase 3).
-
-    Node functions (retrieve_node, grade_node, etc.) are still available
-    for direct async calls. Use WiiiRunner for orchestration.
-    """
+    """Deprecated LangGraph builder kept only for import compatibility."""
     raise RuntimeError(
         "build_rag_subgraph() is deprecated (De-LangGraphing Phase 3). "
-        "Use node functions directly or via WiiiRunner."
+        "Use app.engine.multi_agent.subagents.rag.runtime helpers directly."
     )
+
+
+__all__ = [
+    "RAGSubgraphState",
+    "build_rag_subgraph",
+    "correct_node",
+    "generate_node",
+    "grade_node",
+    "retrieve_node",
+    "should_correct",
+]

--- a/maritime-ai-service/app/engine/multi_agent/subagents/rag/runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/subagents/rag/runtime.py
@@ -1,0 +1,162 @@
+"""Native RAG runtime helpers.
+
+LangGraph is no longer part of Wiii's runtime. This module owns the remaining
+plain-Python retrieval, grading, correction, and generation helpers that can be
+called directly by WiiiRunner or tests.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Literal
+
+from app.engine.multi_agent.subagents.rag.state import RAGSubgraphState
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "RAGSubgraphState",
+    "correct_node",
+    "generate_node",
+    "grade_node",
+    "retrieve_node",
+    "should_correct",
+]
+
+
+async def retrieve_node(state: Dict[str, Any]) -> dict:
+    """Hybrid search: dense (pgvector) + sparse (tsvector) + RRF reranking.
+
+    Delegates to existing HybridSearchService for consistency.
+    """
+    query = state.get("query", "")
+    domain_id = state.get("domain_id", "maritime")
+    org_id = state.get("organization_id")
+    correction_round = state.get("correction_round", 0)
+
+    docs = []
+    scores = []
+
+    try:
+        from app.services.hybrid_search_service import get_hybrid_search_service
+
+        search_svc = get_hybrid_search_service()
+        results = await search_svc.search(
+            query=query,
+            domain_id=domain_id,
+            top_k=10,
+            organization_id=org_id,
+        )
+        for r in results:
+            docs.append({
+                "content": r.get("content", ""),
+                "metadata": r.get("metadata", {}),
+                "score": r.get("score", 0.0),
+            })
+            scores.append(r.get("score", 0.0))
+    except Exception as exc:
+        logger.warning("[RAG_SUBGRAPH] Retrieval failed (round %d): %s", correction_round, exc)
+
+    return {
+        "retrieval_docs": docs,
+        "retrieval_scores": scores,
+        "correction_round": correction_round,
+    }
+
+
+async def grade_node(state: Dict[str, Any]) -> dict:
+    """Grade retrieved documents for relevance.
+
+    Uses tiered grading: pre-filter → MiniJudge → Full LLM (early exit).
+    """
+    docs = state.get("retrieval_docs", [])
+    if not docs:
+        return {"retrieval_confidence": 0.0, "grading_results": []}
+
+    # Confidence from retrieval scores — 0-1 scale
+    # (matches quality_skip_threshold=0.85 comparison in graph.py)
+    scores = state.get("retrieval_scores", [])
+    avg_score = sum(scores) / len(scores) if scores else 0.0
+    confidence = min(avg_score, 1.0)
+
+    grading_results = [
+        {"doc_index": i, "relevant": score > 0.3, "score": score}
+        for i, score in enumerate(scores)
+    ]
+
+    return {
+        "retrieval_confidence": confidence,
+        "grading_results": grading_results,
+    }
+
+
+def should_correct(state: Dict[str, Any]) -> Literal["generate", "correct"]:
+    """Decide whether to self-correct or proceed to generation."""
+    confidence = state.get("retrieval_confidence", 0.0)
+    correction_round = state.get("correction_round", 0)
+    max_rounds = state.get("max_correction_rounds", 3)
+
+    if confidence >= 0.85 or correction_round >= max_rounds:
+        return "generate"
+    return "correct"
+
+
+async def correct_node(state: Dict[str, Any]) -> dict:
+    """Reformulate query for better retrieval."""
+    return {
+        "correction_round": state.get("correction_round", 0) + 1,
+    }
+
+
+async def generate_node(state: Dict[str, Any]) -> dict:
+    """Generate final response from retrieved documents.
+
+    Sprint 165: When no docs found, uses LLM general knowledge (like corrective_rag._generate_fallback)
+    instead of returning a hardcoded error message.
+    """
+    docs = state.get("retrieval_docs", [])
+    query = state.get("query", "")
+    confidence = state.get("retrieval_confidence", 0.0)
+
+    if not docs:
+        # Sprint 165: LLM fallback — use general knowledge instead of hardcoded error
+        response = await _generate_fallback_response(query, state)
+        confidence = 0.55  # Capped confidence for fallback (0-1 scale)
+    else:
+        # Build context from relevant docs
+        context_parts = [d.get("content", "")[:500] for d in docs[:5]]
+        response = f"Dựa trên {len(docs)} tài liệu tìm được:\n" + "\n".join(context_parts[:3])
+
+    sources = [
+        {"content": d.get("content", "")[:200], "metadata": d.get("metadata", {})}
+        for d in docs[:5]
+    ]
+
+    return {
+        "final_response": response,
+        "agent_outputs": {"rag": response},
+        "current_agent": "rag_agent",
+        "sources": sources,
+        "crag_confidence": confidence,
+    }
+
+
+async def _generate_fallback_response(query: str, state: Dict[str, Any]) -> str:
+    """Generate LLM response when KB has 0 documents.
+
+    Reuses CorrectiveRAG._generate_fallback() logic for consistency.
+    Falls back to static message if LLM is unavailable.
+    """
+    try:
+        from app.engine.agentic_rag.corrective_rag import get_corrective_rag
+
+        crag = get_corrective_rag()
+        context = state.get("context") or {}
+        context.setdefault("domain_name", state.get("domain_id", ""))
+        response = await crag._generate_fallback(query, context)
+        if response:
+            return response
+    except Exception as exc:
+        logger.warning("[RAG_SUBGRAPH] LLM fallback failed: %s", exc)
+
+    return "Xin lỗi, mình chưa tìm thấy tài liệu liên quan nha~ (˶˃ ᵕ ˂˶)"

--- a/maritime-ai-service/app/engine/multi_agent/subagents/registry.py
+++ b/maritime-ai-service/app/engine/multi_agent/subagents/registry.py
@@ -18,7 +18,7 @@ class SubagentRegistry:
         registry = SubagentRegistry.get_instance()
         registry.register(
             "deep_search",
-            builder=build_search_subgraph,
+            builder=run_product_search,
             config=SubagentConfig(name="deep_search", timeout_seconds=90),
             description="Parallel product search across platforms",
         )

--- a/maritime-ai-service/app/engine/multi_agent/subagents/search/__init__.py
+++ b/maritime-ai-service/app/engine/multi_agent/subagents/search/__init__.py
@@ -1,10 +1,13 @@
-"""Product search subgraph — parallel platform search via Send() map-reduce."""
+"""Product-search native helpers.
+
+LangGraph builders were removed; use ``runtime`` and ``workers`` helpers for
+WiiiRunner-native execution.
+"""
 
 from app.engine.multi_agent.subagents.search.state import (
     PlatformWorkerState,
     SearchSubgraphState,
 )
-# build_search_subgraph removed (De-LangGraphing Phase 3) — pipeline runs via WiiiRunner
 
 __all__ = [
     "PlatformWorkerState",

--- a/maritime-ai-service/app/engine/multi_agent/subagents/search/graph.py
+++ b/maritime-ai-service/app/engine/multi_agent/subagents/search/graph.py
@@ -1,78 +1,38 @@
-"""DEPRECATED: Product search subgraph builder — LangGraph Send() map-reduce.
+"""Compatibility shim for the removed LangGraph product-search subgraph.
 
-LangGraph removed (De-LangGraphing Phase 3).
-The worker functions (plan_search, platform_worker, aggregate_results, etc.)
-are preserved in workers.py for reuse.
-
-Original flow:
-    START → plan_search → [platform_worker × N] (parallel) → aggregate_results → curate_products → synthesize_response → END
+Use ``app.engine.multi_agent.subagents.search.runtime`` for native helpers.
+This module only preserves older imports and the explicit deprecated builder
+failure expected by compatibility tests.
 """
 
 from __future__ import annotations
 
-import logging
-from typing import Any, Dict, List
-
-# LangGraph imports removed
-# from langgraph.graph import END, START, StateGraph
-# from langgraph.types import Send
-
-from app.engine.multi_agent.subagents.search.state import SearchSubgraphState
-from app.engine.multi_agent.subagents.search.workers import (
+from app.engine.multi_agent.subagents.search.runtime import (
+    SearchSubgraphState,
     aggregate_results,
     curate_products,
     plan_search,
     platform_worker,
+    route_to_platforms,
     synthesize_response,
 )
 
-logger = logging.getLogger(__name__)
-
-
-def route_to_platforms(state: Dict[str, Any]) -> List[dict]:
-    """Fan-out: create parallel task dicts for each platform.
-
-    DEPRECATED: No longer returns Send() objects. Returns plain dicts
-    for use with asyncio.gather() instead.
-    """
-    platforms = state.get("platforms_to_search", [])
-    query = state.get("query", "")
-    org_id = state.get("organization_id")
-    bus_id = state.get("_event_bus_id")
-
-    tasks = [
-        {
-            "query": query,
-            "platform_id": pid,
-            "max_results": 20,
-            "page": 1,
-            "organization_id": org_id,
-            "_event_bus_id": bus_id,
-        }
-        for pid in platforms
-    ]
-
-    if not tasks:
-        tasks.append({
-            "query": query,
-            "platform_id": "google_shopping",
-            "max_results": 20,
-            "page": 1,
-            "organization_id": org_id,
-            "_event_bus_id": bus_id,
-        })
-
-    logger.info("[SEARCH_SUBGRAPH] Fan-out: %d parallel platform workers", len(tasks))
-    return tasks
-
 
 def build_search_subgraph():
-    """DEPRECATED — LangGraph removed (De-LangGraphing Phase 3).
-
-    Worker functions are still available in workers.py for direct async calls.
-    Use asyncio.gather() for parallel execution instead of LangGraph Send().
-    """
+    """Deprecated LangGraph builder kept only for import compatibility."""
     raise RuntimeError(
         "build_search_subgraph() is deprecated (De-LangGraphing Phase 3). "
-        "Use worker functions directly with asyncio.gather()."
+        "Use app.engine.multi_agent.subagents.search.runtime helpers directly."
     )
+
+
+__all__ = [
+    "SearchSubgraphState",
+    "aggregate_results",
+    "build_search_subgraph",
+    "curate_products",
+    "plan_search",
+    "platform_worker",
+    "route_to_platforms",
+    "synthesize_response",
+]

--- a/maritime-ai-service/app/engine/multi_agent/subagents/search/runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/subagents/search/runtime.py
@@ -1,0 +1,72 @@
+"""Native product-search runtime helpers.
+
+LangGraph is no longer part of Wiii's runtime. This module owns the remaining
+plain-Python helpers used by WiiiRunner and tests: platform fan-out plus the
+worker functions imported from ``workers.py``.
+
+Compatibility imports from ``subagents.search.graph`` are kept in a small shim
+so old tests/extensions fail predictably without making this file look like a
+live graph runtime.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+from app.engine.multi_agent.subagents.search.state import SearchSubgraphState
+from app.engine.multi_agent.subagents.search.workers import (
+    aggregate_results,
+    curate_products,
+    plan_search,
+    platform_worker,
+    synthesize_response,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "SearchSubgraphState",
+    "aggregate_results",
+    "curate_products",
+    "plan_search",
+    "platform_worker",
+    "route_to_platforms",
+    "synthesize_response",
+]
+
+
+def route_to_platforms(state: Dict[str, Any]) -> List[dict]:
+    """Fan-out: create parallel task dicts for each platform.
+
+    Returns plain task dicts for use with WiiiRunner/``asyncio.gather``.
+    """
+    platforms = state.get("platforms_to_search", [])
+    query = state.get("query", "")
+    org_id = state.get("organization_id")
+    bus_id = state.get("_event_bus_id")
+
+    tasks = [
+        {
+            "query": query,
+            "platform_id": pid,
+            "max_results": 20,
+            "page": 1,
+            "organization_id": org_id,
+            "_event_bus_id": bus_id,
+        }
+        for pid in platforms
+    ]
+
+    if not tasks:
+        tasks.append({
+            "query": query,
+            "platform_id": "google_shopping",
+            "max_results": 20,
+            "page": 1,
+            "organization_id": org_id,
+            "_event_bus_id": bus_id,
+        })
+
+    logger.info("[SEARCH_SUBGRAPH] Fan-out: %d parallel platform workers", len(tasks))
+    return tasks

--- a/maritime-ai-service/app/engine/multi_agent/subagents/tutor/__init__.py
+++ b/maritime-ai-service/app/engine/multi_agent/subagents/tutor/__init__.py
@@ -1,6 +1,9 @@
-"""Tutor subgraph — analysis → generation → refinement pipeline."""
+"""Tutor native helpers.
+
+LangGraph builders were removed; use ``runtime`` helpers for WiiiRunner-native
+execution.
+"""
 
 from app.engine.multi_agent.subagents.tutor.state import TutorSubgraphState
-# build_tutor_subgraph removed (De-LangGraphing Phase 3) — pipeline runs via WiiiRunner
 
 __all__ = ["TutorSubgraphState"]

--- a/maritime-ai-service/app/engine/multi_agent/subagents/tutor/graph.py
+++ b/maritime-ai-service/app/engine/multi_agent/subagents/tutor/graph.py
@@ -1,107 +1,36 @@
-"""DEPRECATED: Tutor subgraph builder — three-phase teaching pipeline.
+"""Compatibility shim for the removed LangGraph tutor subgraph.
 
-LangGraph removed (De-LangGraphing Phase 3).
-The node functions (analyze_node, generate_node, refine_node, output_node)
-are preserved as they may be reused by a future pipeline implementation.
-
-Original flow:
-    START → analyze → generate → refine → END
+Use ``app.engine.multi_agent.subagents.tutor.runtime`` for native helpers.
+This module preserves older imports and the explicit deprecated builder
+failure expected by compatibility tests.
 """
 
 from __future__ import annotations
 
-import logging
-from typing import Any, Dict, Literal
-
-# LangGraph imports removed
-# from langgraph.graph import END, START, StateGraph
-
-from app.engine.multi_agent.subagents.tutor.state import TutorSubgraphState
-
-logger = logging.getLogger(__name__)
-
-
-async def analyze_node(state: Dict[str, Any]) -> dict:
-    """Phase 1: Understand question, identify concepts, assess learner level."""
-    query = state.get("query", "")
-    context = state.get("context", {})
-
-    # Determine pedagogical approach
-    query_lower = query.lower()
-    if any(kw in query_lower for kw in ["giải thích", "explain", "là gì", "what is"]):
-        approach = "explain"
-    elif any(kw in query_lower for kw in ["tại sao", "why", "vì sao"]):
-        approach = "socratic"
-    else:
-        approach = "example"
-
-    # Learner level from context
-    level = context.get("learner_level", "intermediate")
-
-    return {
-        "phase": "analysis",
-        "pedagogical_approach": approach,
-        "learner_level": level,
-        "concepts_identified": [],
-    }
-
-
-async def generate_node(state: Dict[str, Any]) -> dict:
-    """Phase 2: Synthesize explanation using knowledge + tools if needed."""
-    query = state.get("query", "")
-    approach = state.get("pedagogical_approach", "explain")
-
-    # Delegate to existing tutor agent for actual LLM generation
-    response = f"[Tutor subgraph] Giải thích ({approach}): {query[:100]}"
-
-    return {
-        "phase": "generation",
-        "explanation_draft": response,
-    }
-
-
-def should_refine(state: Dict[str, Any]) -> Literal["refine", "output"]:
-    """Simple queries skip refinement."""
-    query = state.get("query", "")
-    if len(query) < 50:
-        return "output"
-    return "refine"
-
-
-async def refine_node(state: Dict[str, Any]) -> dict:
-    """Phase 3: Adapt to learner level, add examples, check understanding."""
-    draft = state.get("explanation_draft", "")
-    level = state.get("learner_level", "intermediate")
-
-    refined = draft  # In full impl, LLM refines based on learner level
-
-    return {
-        "phase": "refinement",
-        "final_response": refined,
-        "agent_outputs": {"tutor": refined},
-        "current_agent": "tutor_agent",
-    }
-
-
-async def output_node(state: Dict[str, Any]) -> dict:
-    """Direct output without refinement (for simple queries)."""
-    draft = state.get("explanation_draft", "")
-
-    return {
-        "phase": "output",
-        "final_response": draft,
-        "agent_outputs": {"tutor": draft},
-        "current_agent": "tutor_agent",
-    }
+from app.engine.multi_agent.subagents.tutor.runtime import (
+    TutorSubgraphState,
+    analyze_node,
+    generate_node,
+    output_node,
+    refine_node,
+    should_refine,
+)
 
 
 def build_tutor_subgraph():
-    """DEPRECATED — LangGraph removed (De-LangGraphing Phase 3).
-
-    Node functions (analyze_node, generate_node, etc.) are still available
-    for direct async calls. Use WiiiRunner for orchestration.
-    """
+    """Deprecated LangGraph builder kept only for import compatibility."""
     raise RuntimeError(
         "build_tutor_subgraph() is deprecated (De-LangGraphing Phase 3). "
-        "Use node functions directly or via WiiiRunner."
+        "Use app.engine.multi_agent.subagents.tutor.runtime helpers directly."
     )
+
+
+__all__ = [
+    "TutorSubgraphState",
+    "analyze_node",
+    "build_tutor_subgraph",
+    "generate_node",
+    "output_node",
+    "refine_node",
+    "should_refine",
+]

--- a/maritime-ai-service/app/engine/multi_agent/subagents/tutor/runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/subagents/tutor/runtime.py
@@ -1,0 +1,97 @@
+"""Native tutor runtime helpers.
+
+LangGraph is no longer part of Wiii's runtime. This module owns the remaining
+plain-Python analysis, generation, refinement, and output helpers that can be
+called directly by WiiiRunner or tests.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Literal
+
+from app.engine.multi_agent.subagents.tutor.state import TutorSubgraphState
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "TutorSubgraphState",
+    "analyze_node",
+    "generate_node",
+    "output_node",
+    "refine_node",
+    "should_refine",
+]
+
+
+async def analyze_node(state: Dict[str, Any]) -> dict:
+    """Phase 1: Understand question, identify concepts, assess learner level."""
+    query = state.get("query", "")
+    context = state.get("context", {})
+
+    # Determine pedagogical approach
+    query_lower = query.lower()
+    if any(kw in query_lower for kw in ["giải thích", "explain", "là gì", "what is"]):
+        approach = "explain"
+    elif any(kw in query_lower for kw in ["tại sao", "why", "vì sao"]):
+        approach = "socratic"
+    else:
+        approach = "example"
+
+    # Learner level from context
+    level = context.get("learner_level", "intermediate")
+
+    return {
+        "phase": "analysis",
+        "pedagogical_approach": approach,
+        "learner_level": level,
+        "concepts_identified": [],
+    }
+
+
+async def generate_node(state: Dict[str, Any]) -> dict:
+    """Phase 2: Synthesize explanation using knowledge + tools if needed."""
+    query = state.get("query", "")
+    approach = state.get("pedagogical_approach", "explain")
+
+    # Delegate to existing tutor agent for actual LLM generation
+    response = f"[Tutor subgraph] Giải thích ({approach}): {query[:100]}"
+
+    return {
+        "phase": "generation",
+        "explanation_draft": response,
+    }
+
+
+def should_refine(state: Dict[str, Any]) -> Literal["refine", "output"]:
+    """Simple queries skip refinement."""
+    query = state.get("query", "")
+    if len(query) < 50:
+        return "output"
+    return "refine"
+
+
+async def refine_node(state: Dict[str, Any]) -> dict:
+    """Phase 3: Adapt to learner level, add examples, check understanding."""
+    draft = state.get("explanation_draft", "")
+
+    refined = draft  # In full impl, LLM refines based on learner level
+
+    return {
+        "phase": "refinement",
+        "final_response": refined,
+        "agent_outputs": {"tutor": refined},
+        "current_agent": "tutor_agent",
+    }
+
+
+async def output_node(state: Dict[str, Any]) -> dict:
+    """Direct output without refinement (for simple queries)."""
+    draft = state.get("explanation_draft", "")
+
+    return {
+        "phase": "output",
+        "final_response": draft,
+        "agent_outputs": {"tutor": draft},
+        "current_agent": "tutor_agent",
+    }

--- a/maritime-ai-service/tests/unit/test_code_studio_template_scaffold.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_template_scaffold.py
@@ -17,6 +17,16 @@ from __future__ import annotations
 
 import pytest
 
+from app.engine.multi_agent.code_studio_scaffold_contract import (
+    PRIMITIVE_DATA_BAND,
+    PRIMITIVE_FUNCTION_PLOT,
+    PRIMITIVE_OSCILLATION,
+    PRIMITIVE_PARTICLE_FIELD,
+    PRIMITIVE_SCENE,
+    PRIMITIVE_TIMELINE,
+    legacy_kind_for_primitive,
+    primitive_for_legacy_kind,
+)
 from app.engine.multi_agent.code_studio_template_scaffold import (
     build_code_studio_scaffold,
     build_scaffold_visible_caption,
@@ -27,6 +37,19 @@ from app.engine.multi_agent.code_studio_template_scaffold import (
 # ---------------------------------------------------------------------------
 # detect_scaffold_kind — mapping queries to the right scaffold family
 # ---------------------------------------------------------------------------
+
+
+def test_scaffold_contract_maps_legacy_kinds_without_renderer_imports() -> None:
+    """Routing code can depend on the typed scaffold contract directly."""
+    assert primitive_for_legacy_kind("literary") == PRIMITIVE_SCENE
+    assert primitive_for_legacy_kind("physics") == PRIMITIVE_OSCILLATION
+    assert primitive_for_legacy_kind("math") == PRIMITIVE_FUNCTION_PLOT
+    assert primitive_for_legacy_kind("history") == PRIMITIVE_TIMELINE
+    assert primitive_for_legacy_kind("celestial") == PRIMITIVE_PARTICLE_FIELD
+    assert primitive_for_legacy_kind("default") == PRIMITIVE_DATA_BAND
+    assert primitive_for_legacy_kind("unknown") is None
+    assert legacy_kind_for_primitive(PRIMITIVE_SCENE) == "literary"
+    assert legacy_kind_for_primitive("unknown") == "default"
 
 
 @pytest.mark.parametrize(

--- a/maritime-ai-service/tests/unit/test_phase4_aggregator.py
+++ b/maritime-ai-service/tests/unit/test_phase4_aggregator.py
@@ -1052,7 +1052,7 @@ class TestRAGSubgraphFallback:
     @pytest.mark.asyncio
     async def test_rag_subgraph_fallback_empty_kb(self):
         """When no docs found, generate_node calls LLM fallback instead of hardcoded error."""
-        from app.engine.multi_agent.subagents.rag.graph import generate_node
+        from app.engine.multi_agent.subagents.rag.runtime import generate_node
 
         state = {
             "retrieval_docs": [],
@@ -1079,7 +1079,7 @@ class TestRAGSubgraphFallback:
     @pytest.mark.asyncio
     async def test_rag_subgraph_fallback_confidence_scale(self):
         """Fallback response gets capped confidence on 0-1 scale."""
-        from app.engine.multi_agent.subagents.rag.graph import generate_node
+        from app.engine.multi_agent.subagents.rag.runtime import generate_node
 
         state = {
             "retrieval_docs": [],
@@ -1104,7 +1104,7 @@ class TestRAGSubgraphFallback:
     @pytest.mark.asyncio
     async def test_rag_subgraph_fallback_failure_returns_static(self):
         """When LLM fallback fails, returns static error message."""
-        from app.engine.multi_agent.subagents.rag.graph import generate_node
+        from app.engine.multi_agent.subagents.rag.runtime import generate_node
 
         state = {
             "retrieval_docs": [],
@@ -1204,7 +1204,7 @@ class TestAggregatorEmptyKBFallback:
     @pytest.mark.asyncio
     async def test_confidence_scale_consistency(self):
         """Confidence values throughout pipeline stay on 0-1 scale."""
-        from app.engine.multi_agent.subagents.rag.graph import grade_node
+        from app.engine.multi_agent.subagents.rag.runtime import grade_node
 
         # Simulating retrieval scores (already 0-1 from search service)
         state = {

--- a/maritime-ai-service/tests/unit/test_subagent_phase3.py
+++ b/maritime-ai-service/tests/unit/test_subagent_phase3.py
@@ -267,7 +267,7 @@ class TestRAGNodes:
 
     @pytest.mark.asyncio
     async def test_retrieve_returns_docs(self):
-        from app.engine.multi_agent.subagents.rag.graph import retrieve_node
+        from app.engine.multi_agent.subagents.rag.runtime import retrieve_node
 
         mock_search = AsyncMock()
         mock_search.search.return_value = [
@@ -286,7 +286,7 @@ class TestRAGNodes:
 
     @pytest.mark.asyncio
     async def test_retrieve_handles_failure(self):
-        from app.engine.multi_agent.subagents.rag.graph import retrieve_node
+        from app.engine.multi_agent.subagents.rag.runtime import retrieve_node
 
         with patch(
             "app.services.hybrid_search_service.get_hybrid_search_service",
@@ -298,7 +298,7 @@ class TestRAGNodes:
 
     @pytest.mark.asyncio
     async def test_grade_calculates_confidence(self):
-        from app.engine.multi_agent.subagents.rag.graph import grade_node
+        from app.engine.multi_agent.subagents.rag.runtime import grade_node
 
         result = await grade_node({
             "retrieval_docs": [{"content": "A"}, {"content": "B"}],
@@ -311,7 +311,7 @@ class TestRAGNodes:
 
     @pytest.mark.asyncio
     async def test_grade_empty_docs(self):
-        from app.engine.multi_agent.subagents.rag.graph import grade_node
+        from app.engine.multi_agent.subagents.rag.runtime import grade_node
 
         result = await grade_node({
             "retrieval_docs": [],
@@ -322,17 +322,17 @@ class TestRAGNodes:
         assert result["retrieval_confidence"] == 0.0
 
     def test_should_correct_high_confidence(self):
-        from app.engine.multi_agent.subagents.rag.graph import should_correct
+        from app.engine.multi_agent.subagents.rag.runtime import should_correct
 
         assert should_correct({"retrieval_confidence": 0.9, "correction_round": 0}) == "generate"
 
     def test_should_correct_low_confidence(self):
-        from app.engine.multi_agent.subagents.rag.graph import should_correct
+        from app.engine.multi_agent.subagents.rag.runtime import should_correct
 
         assert should_correct({"retrieval_confidence": 0.3, "correction_round": 0}) == "correct"
 
     def test_should_correct_max_rounds(self):
-        from app.engine.multi_agent.subagents.rag.graph import should_correct
+        from app.engine.multi_agent.subagents.rag.runtime import should_correct
 
         assert should_correct({
             "retrieval_confidence": 0.3,
@@ -342,14 +342,14 @@ class TestRAGNodes:
 
     @pytest.mark.asyncio
     async def test_correct_increments_round(self):
-        from app.engine.multi_agent.subagents.rag.graph import correct_node
+        from app.engine.multi_agent.subagents.rag.runtime import correct_node
 
         result = await correct_node({"correction_round": 1})
         assert result["correction_round"] == 2
 
     @pytest.mark.asyncio
     async def test_generate_with_docs(self):
-        from app.engine.multi_agent.subagents.rag.graph import generate_node
+        from app.engine.multi_agent.subagents.rag.runtime import generate_node
 
         result = await generate_node({
             "retrieval_docs": [{"content": "Important fact"}],
@@ -364,7 +364,7 @@ class TestRAGNodes:
     @pytest.mark.asyncio
     async def test_generate_no_docs(self):
         """Sprint 165: Empty KB now uses LLM fallback instead of hardcoded error."""
-        from app.engine.multi_agent.subagents.rag.graph import generate_node
+        from app.engine.multi_agent.subagents.rag.runtime import generate_node
 
         result = await generate_node({
             "retrieval_docs": [],
@@ -419,28 +419,28 @@ class TestTutorNodes:
 
     @pytest.mark.asyncio
     async def test_analyze_explain_approach(self):
-        from app.engine.multi_agent.subagents.tutor.graph import analyze_node
+        from app.engine.multi_agent.subagents.tutor.runtime import analyze_node
 
         result = await analyze_node({"query": "Giải thích quy tắc COLREG", "context": {}})
         assert result["pedagogical_approach"] == "explain"
 
     @pytest.mark.asyncio
     async def test_analyze_socratic_approach(self):
-        from app.engine.multi_agent.subagents.tutor.graph import analyze_node
+        from app.engine.multi_agent.subagents.tutor.runtime import analyze_node
 
         result = await analyze_node({"query": "Tại sao tàu phải nhường?", "context": {}})
         assert result["pedagogical_approach"] == "socratic"
 
     @pytest.mark.asyncio
     async def test_analyze_example_approach(self):
-        from app.engine.multi_agent.subagents.tutor.graph import analyze_node
+        from app.engine.multi_agent.subagents.tutor.runtime import analyze_node
 
         result = await analyze_node({"query": "Cho ví dụ về SOLAS", "context": {}})
         assert result["pedagogical_approach"] == "example"
 
     @pytest.mark.asyncio
     async def test_generate_produces_draft(self):
-        from app.engine.multi_agent.subagents.tutor.graph import generate_node
+        from app.engine.multi_agent.subagents.tutor.runtime import generate_node
 
         result = await generate_node({
             "query": "Test query",
@@ -450,19 +450,19 @@ class TestTutorNodes:
         assert result["phase"] == "generation"
 
     def test_should_refine_short_query(self):
-        from app.engine.multi_agent.subagents.tutor.graph import should_refine
+        from app.engine.multi_agent.subagents.tutor.runtime import should_refine
 
         assert should_refine({"query": "COLREG là gì?"}) == "output"
 
     def test_should_refine_long_query(self):
-        from app.engine.multi_agent.subagents.tutor.graph import should_refine
+        from app.engine.multi_agent.subagents.tutor.runtime import should_refine
 
         long_query = "Giải thích chi tiết về quy tắc tránh va trên biển theo COLREG 72 trong trường hợp hai tàu đi ngược chiều nhau"
         assert should_refine({"query": long_query}) == "refine"
 
     @pytest.mark.asyncio
     async def test_refine_sets_output(self):
-        from app.engine.multi_agent.subagents.tutor.graph import refine_node
+        from app.engine.multi_agent.subagents.tutor.runtime import refine_node
 
         result = await refine_node({
             "explanation_draft": "Draft text",
@@ -473,7 +473,7 @@ class TestTutorNodes:
 
     @pytest.mark.asyncio
     async def test_output_node(self):
-        from app.engine.multi_agent.subagents.tutor.graph import output_node
+        from app.engine.multi_agent.subagents.tutor.runtime import output_node
 
         result = await output_node({"explanation_draft": "Quick answer"})
         assert result["final_response"] == "Quick answer"

--- a/maritime-ai-service/tests/unit/test_subagent_search.py
+++ b/maritime-ai-service/tests/unit/test_subagent_search.py
@@ -681,7 +681,7 @@ class TestRouteToPlatforms:
     """route_to_platforms dict creation tests (updated for De-LangGraphing Phase 3)."""
 
     def test_creates_task_per_platform(self):
-        from app.engine.multi_agent.subagents.search.graph import route_to_platforms
+        from app.engine.multi_agent.subagents.search.runtime import route_to_platforms
 
         tasks = route_to_platforms({
             "platforms_to_search": ["shopee", "lazada", "google_shopping"],
@@ -692,7 +692,7 @@ class TestRouteToPlatforms:
         assert all(isinstance(t, dict) for t in tasks)
 
     def test_tasks_contain_correct_platform_ids(self):
-        from app.engine.multi_agent.subagents.search.graph import route_to_platforms
+        from app.engine.multi_agent.subagents.search.runtime import route_to_platforms
 
         tasks = route_to_platforms({
             "platforms_to_search": ["shopee", "lazada"],
@@ -704,7 +704,7 @@ class TestRouteToPlatforms:
         assert "lazada" in platform_ids
 
     def test_empty_platforms_fallback(self):
-        from app.engine.multi_agent.subagents.search.graph import route_to_platforms
+        from app.engine.multi_agent.subagents.search.runtime import route_to_platforms
 
         tasks = route_to_platforms({
             "platforms_to_search": [],
@@ -715,7 +715,7 @@ class TestRouteToPlatforms:
         assert tasks[0]["platform_id"] == "google_shopping"
 
     def test_org_id_propagated(self):
-        from app.engine.multi_agent.subagents.search.graph import route_to_platforms
+        from app.engine.multi_agent.subagents.search.runtime import route_to_platforms
 
         tasks = route_to_platforms({
             "platforms_to_search": ["shopee"],
@@ -726,7 +726,7 @@ class TestRouteToPlatforms:
         assert tasks[0]["organization_id"] == "org_abc"
 
     def test_bus_id_propagated(self):
-        from app.engine.multi_agent.subagents.search.graph import route_to_platforms
+        from app.engine.multi_agent.subagents.search.runtime import route_to_platforms
 
         tasks = route_to_platforms({
             "platforms_to_search": ["shopee"],
@@ -737,7 +737,7 @@ class TestRouteToPlatforms:
         assert tasks[0]["_event_bus_id"] == "bus_xyz"
 
     def test_default_max_results_and_page(self):
-        from app.engine.multi_agent.subagents.search.graph import route_to_platforms
+        from app.engine.multi_agent.subagents.search.runtime import route_to_platforms
 
         tasks = route_to_platforms({
             "platforms_to_search": ["shopee"],
@@ -968,7 +968,7 @@ class TestOrganizationPropagation:
     """Organization ID flows through the subgraph."""
 
     def test_send_carries_org_id(self):
-        from app.engine.multi_agent.subagents.search.graph import route_to_platforms
+        from app.engine.multi_agent.subagents.search.runtime import route_to_platforms
 
         tasks = route_to_platforms({
             "platforms_to_search": ["shopee", "lazada"],
@@ -980,7 +980,7 @@ class TestOrganizationPropagation:
             assert task["organization_id"] == "org_maritime_uni"
 
     def test_send_carries_none_org_id(self):
-        from app.engine.multi_agent.subagents.search.graph import route_to_platforms
+        from app.engine.multi_agent.subagents.search.runtime import route_to_platforms
 
         tasks = route_to_platforms({
             "platforms_to_search": ["shopee"],


### PR DESCRIPTION
## Summary
- Moves active search/RAG/tutor helper logic out of legacy `subagents/*/graph.py` modules into native `runtime.py` modules.
- Leaves `graph.py` as compatibility shims with explicit deprecated `build_*_subgraph()` failures.
- Extracts Code Studio scaffold primitive and legacy-kind mapping into a typed contract module.
- Updates tests to import active helpers from `runtime.py` and adds a cleanup audit doc for the remaining debt boundary.

Closes #411.

## In scope
- Backend runtime cleanup for subagent helper modules.
- Code Studio scaffold contract extraction.
- Targeted tests/docs for the cleanup boundary.

## Out of scope
- No LMS mutation behavior change.
- No provider default change.
- No frontend UI redesign.
- No broad deletion of `.env`, backups, data PDFs, dependency folders, or user WIP.

## Verification
```powershell
cd maritime-ai-service
uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_code_studio_template_scaffold.py tests/unit/test_subagent_phase3.py tests/unit/test_subagent_search.py tests/unit/test_sprint202_curated_cards.py -q --tb=short
# 192 passed

uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short
# 56 passed

uv run --with ruff ruff check app/engine/multi_agent/code_studio_scaffold_contract.py app/engine/multi_agent/code_studio_template_scaffold.py app/engine/multi_agent/subagents/rag app/engine/multi_agent/subagents/search app/engine/multi_agent/subagents/tutor
# All checks passed

uv run --with ruff ruff check app/ --select=E9,F63,F7
# All checks passed

git diff --check
# passed
```

## Risk
Runtime/tool routing is a high-risk surface, but this PR is intended to be behavior-preserving. Compatibility imports remain in `graph.py`, and existing deprecation tests still assert `build_*_subgraph()` fails clearly.

## Rollback
Revert this PR. That restores active helper logic inside `graph.py` and restores Code Studio scaffold constants inside the renderer module.

## Reviewer focus
- Confirm no active runtime path still depends on LangGraph builders.
- Confirm compatibility shims preserve older imports without hiding active logic in `graph.py`.
- Confirm Code Studio contract extraction does not change scaffold output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal execution architecture for multi-agent subagents (RAG, Search, Tutor) by consolidating runtime helpers and removing legacy LangGraph builders.
  * Established Code Studio scaffold contract mappings for deterministic fallback behavior.
  * Updated test imports to align with new implementation structure.

* **Documentation**
  * Updated module documentation to reflect migration to native runtime helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->