### PR TITLE
refactor(runtime): extract direct policy contracts

### DIFF
--- a/docs/architecture/WIII_CODEBASE_MAP.md
+++ b/docs/architecture/WIII_CODEBASE_MAP.md
@@ -59,7 +59,7 @@ The normal chat turn should be read in this order:
 |---|---|
 | Sync chat behavior | `maritime-ai-service/app/api/v1/chat.py`, then `maritime-ai-service/app/services/chat_orchestrator.py` |
 | Streaming behavior | `maritime-ai-service/app/api/v1/chat_stream.py`, then `maritime-ai-service/app/services/chat_stream_coordinator.py` |
-| Direct tool loop | `maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py` |
+| Direct tool loop | `maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py`; Pointy policy lives in `direct_pointy_runtime.py`; explicit web-search policy lives in `direct_web_search_policy.py`; current-session memory fast paths live in `direct_session_memory_runtime.py` |
 | Native stream/provider quirks | `maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py` |
 | Routing and supervisor behavior | `maritime-ai-service/app/engine/multi_agent/supervisor*.py` |
 | Tool registry | `maritime-ai-service/app/engine/tools/registry.py` and `maritime-ai-service/app/engine/multi_agent/tool_collection.py` |
@@ -82,7 +82,7 @@ The normal chat turn should be read in this order:
 | Host bridge | `wiii-desktop/src/lib/embed-bridge.ts`, `wiii-desktop/src/lib/context-bridge.ts` |
 | Pointy | `wiii-desktop/src/pointy-host/**` and `wiii-desktop/src/components/chat/PointyModeToggle.tsx` |
 | Voice | `wiii-desktop/src/api/voice.ts`, voice mode/toggle components |
-| Visual artifacts | `wiii-desktop/src/components/chat/VisualArtifactCard.tsx`, `wiii-desktop/src/components/common/InlineVisualFrame.tsx` |
+| Visual artifacts | `wiii-desktop/src/components/chat/VisualArtifactCard.tsx`, `wiii-desktop/src/components/common/InlineVisualFrame.tsx`; deterministic Code Studio fallback contracts live in backend `code_studio_scaffold_*` modules |
 
 ## Canonical Contracts
 

--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,6 +6,8 @@ Owner: Project leadership
 
 Issue: #411
 
+Follow-up issue: #413
+
 ## Purpose
 
 This audit records the cleanup boundary for the May 2026 runtime hygiene pass.
@@ -21,6 +23,16 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
 - Code Studio scaffold primitive and legacy-kind mapping moved into
   `code_studio_scaffold_contract.py`, so routing and tests can depend on a
   small typed contract instead of importing the full HTML renderer.
+- Follow-up #413 moved direct Pointy selector/inventory policy into
+  `direct_pointy_runtime.py`.
+- Follow-up #413 moved explicit web-search forcing and fallback-selection
+  policy into `direct_web_search_policy.py`.
+- Follow-up #413 moved current-session memory fast-path parsing/recall into
+  `direct_session_memory_runtime.py` and shared direct text folding into
+  `direct_text_utils.py`.
+- Follow-up #413 moved Code Studio scaffold renderer dispatch into
+  `code_studio_scaffold_registry.py` and visible Vietnamese fallback copy into
+  `code_studio_scaffold_captions.py`.
 
 ## Preserved Intentionally
 
@@ -48,12 +60,16 @@ backups, data PDFs, or local skill folders.
 
 ## Remaining Debt
 
-- `direct_node_runtime.py` and `direct_tool_rounds_runtime.py` remain large.
-  The long-term cleanup direction is lifecycle, tool-loop, tool-dispatch, and
-  response-finalization modules with contract tests around SSE V3 parity.
-- `code_studio_template_scaffold.py` is still a large deterministic fallback.
-  The next durable step is a renderer registry plus scaffold-quality gates
-  that reject generic templates for simulation requests.
+- `direct_node_runtime.py` remains large, but session-memory parsing/recall
+  has moved out. The long-term cleanup direction is lifecycle,
+  response-finalization, and SSE V3 parity modules with narrow contract tests.
+- `direct_tool_rounds_runtime.py` remains large, but Pointy and explicit
+  web-search policy have moved out. The next durable step is separating
+  tool-dispatch execution from deterministic host-action shortcuts.
+- `code_studio_template_scaffold.py` is still a large deterministic fallback,
+  but contract, renderer dispatch, and caption copy are no longer embedded in
+  the renderer body. The next durable step is scaffold-quality gates that
+  reject generic templates for simulation requests.
 - Some tests still import compatibility `graph.py` modules. Move tests toward
   `runtime.py` imports when the external import window can close.
 
@@ -65,8 +81,12 @@ Targeted commands used during this pass:
 cd maritime-ai-service
 uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_code_studio_template_scaffold.py -q --tb=short
 uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_subagent_phase3.py tests/unit/test_subagent_search.py tests/unit/test_sprint202_curated_cards.py -q --tb=short
+uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short
+uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_conservative_evolution.py tests/unit/test_direct_node_provider_errors.py -q --tb=short
 ```
 
 The first command passed with 52 tests. The second command passed with 140
 tests after adding the required `pytest-asyncio` test plugin to the temporary
-uv environment.
+uv environment. In follow-up #413, the Code Studio scaffold command passed
+with 54 tests, the direct tool-round command passed with 56 tests, and the
+combined direct-runtime regression set passed with 205 tests.

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_captions.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_captions.py
@@ -1,0 +1,52 @@
+"""Vietnamese captions for Code Studio scaffold fallback previews."""
+
+from __future__ import annotations
+
+from app.engine.multi_agent.code_studio_scaffold_contract import (
+    PRIMITIVE_DATA_BAND,
+    PRIMITIVE_FUNCTION_PLOT,
+    PRIMITIVE_OSCILLATION,
+    PRIMITIVE_PARTICLE_FIELD,
+    PRIMITIVE_SCENE,
+    PRIMITIVE_TIMELINE,
+)
+
+
+_CAPTIONS_BY_PRIMITIVE = {
+    PRIMITIVE_PARTICLE_FIELD: (
+        "Mình đã dựng khung hạt tương tác. Kéo thanh trượt để thay đổi "
+        "mật độ. Cho mình biết bạn muốn thêm hiệu ứng hoặc khung cảnh gì "
+        "để mở rộng nhé."
+    ),
+    PRIMITIVE_OSCILLATION: (
+        "Mình đã dựng khung mô phỏng dao động đầu tiên. Cho mình biết "
+        "tham số như chiều dài, ma sát, trọng trường hoặc hiện tượng cụ "
+        "thể để thay phần lõi bằng vật lý chính xác."
+    ),
+    PRIMITIVE_FUNCTION_PLOT: (
+        "Mình đã mở canvas với khung lưới toạ độ. Cho mình biết hàm số "
+        "hoặc phạm vi trục để vẽ đúng đồ thị bạn cần."
+    ),
+    PRIMITIVE_TIMELINE: (
+        "Mình đã dựng khung dòng thời gian. Cho mình biết bạn quan tâm "
+        "tới mặt trận, nhân vật hoặc chiến dịch nào để mở rộng cảnh."
+    ),
+    PRIMITIVE_SCENE: (
+        "Mình đã mở canvas và dựng khung scene đầu tiên. Hãy mô tả thêm "
+        "về tâm trạng, bối cảnh hoặc đoạn thơ trích dẫn để mình mở rộng "
+        "cảnh đúng hướng nhé."
+    ),
+    PRIMITIVE_DATA_BAND: (
+        "Mình đã mở canvas và dựng khung tạm để bạn không phải chờ. "
+        "Hãy mô tả cụ thể hơn về nội dung bạn muốn dựng, Wiii sẽ mở rộng "
+        "đúng hướng."
+    ),
+}
+
+
+def caption_for_scaffold_primitive(primitive: str | None) -> str:
+    """Return a Vietnamese caption for the selected scaffold primitive."""
+    return _CAPTIONS_BY_PRIMITIVE.get(
+        primitive,
+        _CAPTIONS_BY_PRIMITIVE[PRIMITIVE_DATA_BAND],
+    )

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_registry.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_registry.py
@@ -1,0 +1,30 @@
+"""Renderer registry for deterministic Code Studio scaffold fallbacks."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from app.engine.multi_agent.code_studio_scaffold_contract import PRIMITIVE_DATA_BAND
+
+
+ScaffoldRenderer = Callable[[dict[str, Any]], str]
+
+
+@dataclass(frozen=True)
+class ScaffoldRendererRegistry:
+    """Map scaffold primitives to renderer functions with one audited fallback."""
+
+    renderers: Mapping[str, ScaffoldRenderer]
+    fallback_renderer: ScaffoldRenderer
+    fallback_primitive: str = PRIMITIVE_DATA_BAND
+
+    def renderer_for(self, primitive: str | None) -> ScaffoldRenderer:
+        if primitive and primitive in self.renderers:
+            return self.renderers[primitive]
+        return self.fallback_renderer
+
+    def render(self, spec: dict[str, Any]) -> str:
+        primitive = str(spec.get("primitive") or self.fallback_primitive)
+        return self.renderer_for(primitive)(spec)

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_template_scaffold.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_template_scaffold.py
@@ -111,6 +111,12 @@ from app.engine.multi_agent.code_studio_scaffold_contract import (
     legacy_kind_for_primitive,
     primitive_for_legacy_kind,
 )
+from app.engine.multi_agent.code_studio_scaffold_captions import (
+    caption_for_scaffold_primitive,
+)
+from app.engine.multi_agent.code_studio_scaffold_registry import (
+    ScaffoldRendererRegistry,
+)
 
 # ============================================================================
 # Primitive identifiers + legacy kind mapping contract
@@ -1766,6 +1772,11 @@ _PRIMITIVE_RENDERERS = {
     PRIMITIVE_DATA_BAND: _render_data_band,
 }
 
+_RENDERER_REGISTRY = ScaffoldRendererRegistry(
+    renderers=_PRIMITIVE_RENDERERS,
+    fallback_renderer=_render_data_band,
+)
+
 
 def build_code_studio_scaffold(query: str, *, kind: str | None = None) -> str:
     """Return Canvas-first HTML scaffold satisfying tool_create_visual_code.
@@ -1790,9 +1801,7 @@ def build_code_studio_scaffold(query: str, *, kind: str | None = None) -> str:
         forced_primitive = primitive_for_legacy_kind(kind)
         if forced_primitive:
             spec = {**spec, "primitive": forced_primitive}
-    primitive = spec.get("primitive", PRIMITIVE_DATA_BAND)
-    renderer = _PRIMITIVE_RENDERERS.get(primitive, _render_data_band)
-    return renderer(spec)
+    return _RENDERER_REGISTRY.render(spec)
 
 
 def build_scaffold_visible_caption(query: str, *, kind: str | None = None) -> str:
@@ -1803,34 +1812,4 @@ def build_scaffold_visible_caption(query: str, *, kind: str | None = None) -> st
         if forced_primitive:
             spec["primitive"] = forced_primitive
     primitive = spec.get("primitive", PRIMITIVE_DATA_BAND)
-    captions = {
-        PRIMITIVE_PARTICLE_FIELD: (
-            "Mình đã dựng khung hạt tương tác. Kéo thanh trượt để thay đổi "
-            "mật độ. Cho mình biết bạn muốn thêm hiệu ứng/khung cảnh gì để "
-            "mở rộng nhé."
-        ),
-        PRIMITIVE_OSCILLATION: (
-            "Mình đã dựng khung mô phỏng dao động đầu tiên. Cho mình biết "
-            "tham số (chiều dài, ma sát, trọng trường) hoặc hiện tượng cụ "
-            "thể để thay phần lõi bằng vật lý chính xác."
-        ),
-        PRIMITIVE_FUNCTION_PLOT: (
-            "Mình đã mở canvas với khung lưới toạ độ. Cho mình biết hàm số "
-            "hoặc phạm vi trục để vẽ đúng đồ thị bạn cần."
-        ),
-        PRIMITIVE_TIMELINE: (
-            "Mình đã dựng khung dòng thời gian. Cho mình biết bạn quan tâm "
-            "tới mặt trận/nhân vật/chiến dịch nào để mở rộng cảnh."
-        ),
-        PRIMITIVE_SCENE: (
-            "Mình đã mở canvas và dựng khung scene đầu tiên. Hãy mô tả thêm "
-            "về tâm trạng, bối cảnh, hoặc đoạn thơ trích dẫn để mình mở rộng "
-            "cảnh đúng hướng nhé."
-        ),
-        PRIMITIVE_DATA_BAND: (
-            "Mình đã mở canvas và dựng khung tạm để bạn không phải chờ. "
-            "Hãy mô tả cụ thể hơn về nội dung bạn muốn dựng — Wiii sẽ mở rộng "
-            "đúng hướng."
-        ),
-    }
-    return captions.get(primitive, captions[PRIMITIVE_DATA_BAND])
+    return caption_for_scaffold_primitive(primitive)

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -6,21 +6,18 @@ import asyncio
 import inspect
 import logging
 import re
-import unicodedata
 from typing import Any
 
 from app.core.config import settings
 from app.core.exceptions import ProviderUnavailableError
 from app.engine.llm_failover_runtime import classify_failover_reason_impl
 from app.engine.multi_agent.document_preview_contract import (
-    DOC_COURSE_HOST_ACTION_TOOL as _DOC_COURSE_HOST_ACTION_TOOL,
     DOC_PREVIEW_HOST_ACTION_TOOL as _DOC_PREVIEW_HOST_ACTION_TOOL,
     as_plain_mapping as _as_plain_direct_mapping,
     document_preview_forced_tool_choice as _document_preview_forced_tool_choice,
     extract_document_preview_capabilities as _extract_document_preview_capabilities,
     has_document_preview_host_action_tool as _has_document_preview_host_action_tool,
     has_uploaded_document_context as _has_uploaded_document_context,
-    looks_uploaded_document_course_request as _looks_uploaded_document_course_request,
     uploaded_document_attachments_from_context as _uploaded_document_attachments,
 )
 from app.engine.multi_agent.direct_intent import (
@@ -46,6 +43,14 @@ from app.engine.multi_agent.direct_search_synthesis_fallback import (
     build_search_template_fallback,
     looks_like_search_placeholder_answer,
 )
+from app.engine.multi_agent.direct_session_memory_runtime import (
+    _build_session_memory_write_answer,
+    _build_session_memory_write_thinking,
+    _extract_session_memory_items_from_text,
+    _extract_session_memory_recall_answer,
+    _with_requested_response_marker,
+)
+from app.engine.multi_agent.direct_text_utils import _fold_direct_text
 from app.engine.runtime.runtime_metrics import inc_counter
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.visual_events import _summarize_tool_result_for_stream
@@ -67,12 +72,15 @@ from app.engine.multi_agent.supervisor_runtime_support import (
     _looks_session_memory_ack_only_turn,
     _looks_session_memory_recall_turn,
     _looks_session_memory_write_turn,
-    _looks_memory_write_turn,
     _looks_wiii_capability_inventory_turn,
     _looks_wiii_pipeline_meta_turn,
 )
 
 logger = logging.getLogger(__name__)
+
+_DIRECT_SESSION_MEMORY_COMPAT_EXPORTS = (
+    _extract_session_memory_items_from_text,
+)
 
 
 def _direct_role_candidates(state: dict[str, Any], ctx: dict[str, Any]) -> list[str]:
@@ -277,12 +285,6 @@ _DIRECT_ANALYTICAL_THINKING_MODES = {
 }
 
 
-def _fold_direct_text(value: str) -> str:
-    normalized = unicodedata.normalize("NFKD", str(value or ""))
-    stripped = "".join(ch for ch in normalized if not unicodedata.combining(ch))
-    return " ".join(stripped.lower().replace("đ", "d").split())
-
-
 def _is_explicit_web_search_turn_for_direct(query: str, state: AgentState | None = None) -> bool:
     folded = _fold_direct_text(query)
     if "@web-search" in folded or "@web_search" in folded or "search the web" in folded:
@@ -351,353 +353,6 @@ def _extract_direct_reply_only_answer(query: str) -> str:
     if any(marker in candidate for marker in ("```", "<script", "</")):
         return ""
     return candidate
-
-
-def _message_content_from_any(value: Any) -> str:
-    if isinstance(value, dict):
-        content = value.get("content") or value.get("text") or value.get("message") or ""
-    else:
-        content = getattr(value, "content", "")
-    if isinstance(content, list):
-        parts: list[str] = []
-        for item in content:
-            if isinstance(item, dict):
-                parts.append(str(item.get("text") or item.get("content") or ""))
-            else:
-                parts.append(str(item or ""))
-        return "\n".join(part for part in parts if part.strip()).strip()
-    return str(content or "").strip()
-
-
-_SESSION_MEMORY_NOISE_RE = re.compile(
-    r"(?:mã|ma)\s+(?:kiểm\s+thử|kiem\s+thu|test)\s+[A-Za-z0-9_.:]*-[A-Za-z0-9_.:-]+.*$",
-    flags=re.IGNORECASE,
-)
-
-
-_SESSION_MEMORY_FIELD_MARKER_RE = re.compile(r"(\[[A-Z][A-Z0-9_.:-]{3,}\])")
-
-
-def _clean_session_memory_fragment(value: str) -> str:
-    cleaned = _SESSION_MEMORY_NOISE_RE.sub("", str(value or "")).strip()
-    cleaned = re.sub(r"^(?:[-*]\s*)+", "", cleaned).strip()
-    cleaned = re.split(
-        r"\b(?:Hỏi\s+lại\s+ngay|Hoi\s+lai\s+ngay|Hỏi\s+lại|Hoi\s+lai)\b",
-        cleaned,
-        maxsplit=1,
-        flags=re.IGNORECASE,
-    )[0].strip()
-    return cleaned.strip(" .ã€‚")
-
-
-def _extract_requested_response_marker(query: str) -> str:
-    """Preserve explicit field-test markers when the user asks for them."""
-    raw = str(query or "")
-    folded = _fold_direct_text(raw)
-    if not any(marker in folded for marker in ("bat dau bang", "begin with", "start with")):
-        return ""
-    match = _SESSION_MEMORY_FIELD_MARKER_RE.search(raw)
-    return match.group(1) if match else ""
-
-
-def _with_requested_response_marker(query: str, answer: str) -> str:
-    marker = _extract_requested_response_marker(query)
-    if not marker:
-        return answer
-    if answer.lstrip().startswith(marker):
-        return answer
-    if answer.lstrip().startswith("- "):
-        return f"{marker}\n{answer}"
-    return f"{marker} {answer}"
-
-
-def _extract_session_memory_items_from_text(text: str) -> list[str]:
-    raw = str(text or "").strip()
-    if not raw:
-        return []
-    folded = _fold_direct_text(raw)
-    if not _looks_memory_write_turn(folded):
-        return []
-
-    before_reply_directive = re.split(
-        r"\b(?:trả\s+lời|tra\s+loi|chỉ\s+xác\s+nhận|chi\s+xac\s+nhan|answer\s+only|reply\s+only|respond\s+only)\b",
-        raw,
-        maxsplit=1,
-        flags=re.IGNORECASE,
-    )[0].strip()
-    before_reply_directive = re.split(
-        r"\b(?:không\s+(?:sử\s+dụng|dùng)\s+(?:web|rag|pointy|tool|công\s+cụ)|khong\s+(?:su\s+dung|dung)\s+(?:web|rag|pointy|tool|cong\s+cu)|do\s+not\s+use\s+(?:web|rag|pointy|tools?)|without\s+(?:web|rag|pointy|tools?))\b",
-        before_reply_directive,
-        maxsplit=1,
-        flags=re.IGNORECASE,
-    )[0].strip()
-    marker_split = re.split(
-        r"\b(?:hãy\s+nhớ|hay\s+nho|ghi\s+nhớ|ghi\s+nho|nhớ\s+trong|nho\s+trong|nhớ\s+giúp(?:\s+mình)?|nho\s+giup(?:\s+minh)?|nhớ\s+rằng|nho\s+rang|remember\s+that|please\s+remember|keep\s+in\s+mind|lưu\s+lại|luu\s+lai)\b",
-        before_reply_directive,
-        maxsplit=1,
-        flags=re.IGNORECASE,
-    )
-    segment_source = marker_split[-1].strip(" :：") if len(marker_split) > 1 else before_reply_directive
-    segment = re.split(r"[:：]", segment_source)[-1].strip()
-    if not segment or segment == before_reply_directive:
-        return []
-
-    numbered_items = [
-        _clean_session_memory_fragment(match.group(1).strip(" .)]"))
-        for match in re.finditer(
-            r"(?:^|\s)[\(\[]?\d+[\)\].]\s*(.*?)(?=\s+[\(\[]?\d+[\)\].]\s*|$)",
-            segment,
-            flags=re.DOTALL,
-        )
-        if len(_clean_session_memory_fragment(match.group(1).strip(" .)]"))) >= 4
-    ]
-    if len(numbered_items) >= 2:
-        return numbered_items
-
-    pieces = re.split(r"\s*(?:,|;|\n+|\s+và\s+|\s+va\s+|\s+and\s+)\s*", segment)
-    items: list[str] = []
-    for piece in pieces:
-        item = re.sub(r"^(?:và|va|and)\s+", "", piece.strip(), flags=re.IGNORECASE)
-        item = item.strip(" .。")
-        item = _clean_session_memory_fragment(item)
-        if len(item) < 4:
-            continue
-        if re.search(r"\b(?:trả\s+lời|tra\s+loi|chỉ\s+xác\s+nhận|chi\s+xac\s+nhan|answer\s+only|reply\s+only)\b", item, re.IGNORECASE):
-            continue
-        items.append(item)
-    return _merge_session_priority_items(items)
-
-
-def _merge_session_priority_items(items: list[str]) -> list[str]:
-    """Keep labeled multi-part bundles as one recallable memory item."""
-    merged: list[str] = []
-    index = 0
-    while index < len(items):
-        item = items[index]
-        folded = _fold_direct_text(item)
-        is_anchor_fact = bool(re.search(r"\b[A-Z0-9_:-]*ANCHOR[A-Z0-9_:-]*\b", item))
-        if merged and not is_anchor_fact and "anchor" in _fold_direct_text(merged[-1]):
-            merged[-1] = f"{merged[-1]} va {item}"
-            index += 1
-            continue
-
-        is_labeled_bundle = "uu tien" in folded or "tieu chi" in folded
-        if not is_labeled_bundle:
-            merged.append(item)
-            index += 1
-            continue
-
-        priority_parts = [item]
-        index += 1
-        while index < len(items):
-            next_item = items[index]
-            next_folded = _fold_direct_text(next_item)
-            starts_new_labeled_fact = (
-                re.search(r"\b(?:ma|mau|color|code|token)\b", next_folded) is not None
-                or re.search(r"^(?:tieu chi|uu tien|priority|criterion)\b", next_folded) is not None
-                or " la " in f" {next_folded} "
-                or "=" in next_item
-            )
-            if starts_new_labeled_fact:
-                break
-            priority_parts.append(next_item)
-            index += 1
-        merged.append("; ".join(priority_parts))
-    return merged
-
-
-def _build_session_memory_write_answer(query: str) -> str:
-    """Acknowledge current-session memory without invoking durable memory."""
-    items = _extract_session_memory_items_from_text(query)
-    if not items:
-        return (
-            "Mình ghi nhớ điều này trong phiên hiện tại rồi. Nếu cậu hỏi lại trong đoạn chat này, "
-            "mình sẽ dựa vào đó thay vì đoán mò."
-        )
-    if len(items) == 1:
-        return (
-            f"Mình ghi nhớ trong phiên này rồi: **{items[0]}**. "
-            "Hỏi lại ngay trong đoạn chat này là mình nhắc được."
-        )
-    lines = "\n".join(f"- {item}" for item in items[:5])
-    return f"Mình ghi nhớ trong phiên này rồi:\n{lines}\n\nHỏi lại ngay trong đoạn chat này là mình nhắc được."
-
-
-def _build_session_memory_write_thinking(_query: str) -> str:
-    return (
-        "Mình hiểu đây là trí nhớ tạm trong phiên, không phải một fact dài hạn cần đẩy qua semantic memory. "
-        "Cách đúng là xác nhận cụ thể điều vừa giữ, trả lời nhanh, rồi để chính lịch sử hội thoại làm nguồn cho lượt nhắc lại kế tiếp."
-    )
-
-
-_SESSION_RECALL_STOPWORDS = {
-    "ban",
-    "bao",
-    "cau",
-    "cho",
-    "dung",
-    "gi",
-    "hoi",
-    "la",
-    "minh",
-    "nao",
-    "nho",
-    "noi",
-    "tra",
-    "loi",
-    "vua",
-}
-
-
-def _session_recall_tokens(value: str) -> set[str]:
-    return {
-        token
-        for token in re.findall(r"[a-z0-9]+", _fold_direct_text(value))
-        if token and token not in _SESSION_RECALL_STOPWORDS and len(token) > 1
-    }
-
-
-def _requested_session_memory_list_count(query: str) -> int | None:
-    folded = _fold_direct_text(query)
-    if not folded:
-        return None
-    list_noun = (
-        r"(?:uu\s+tien|tieu\s+chi|criteria|anchor|neo|moc(?:\s+neo)?|diem\s+neo|"
-        r"y|muc|gach|dau\s+dong|bullet)"
-    )
-    digit_match = re.search(rf"\b([2-9])\s+{list_noun}", folded)
-    if digit_match:
-        return int(digit_match.group(1))
-    if re.search(rf"\bba\s+{list_noun}", folded):
-        return 3
-    if re.search(rf"\bhai\s+{list_noun}", folded):
-        return 2
-    if (
-        "cac uu tien" in folded
-        or "nhung uu tien" in folded
-        or "cac tieu chi" in folded
-        or "cac anchor" in folded
-        or "nhung anchor" in folded
-        or "cac neo" in folded
-        or "nhung neo" in folded
-        or "cac moc" in folded
-    ):
-        return 99
-    return None
-
-
-def _format_session_memory_item_for_query(item: str, query: str) -> str:
-    folded_query = _fold_direct_text(query)
-    if any(marker in folded_query for marker in ("ma ", "ma kiem thu", "code", "token", "mau ", "color")):
-        match = re.search(r"\b(?:là|la|=)\s+(.+)$", item, flags=re.IGNORECASE)
-        if match:
-            value = match.group(1).strip(" .。")
-            value = _clean_session_memory_fragment(value).strip("\"'“”‘’")
-            if 1 <= len(value) <= 120:
-                return value
-    return _clean_session_memory_fragment(item)
-
-
-def _select_session_memory_items_for_query(items: list[str], query: str) -> list[str]:
-    if not items:
-        return []
-    requested_count = _requested_session_memory_list_count(query)
-    if requested_count is not None and requested_count >= 2:
-        return items[: min(requested_count, len(items))]
-
-    query_tokens = _session_recall_tokens(query)
-    if not query_tokens:
-        return items
-
-    scored: list[tuple[int, int, str]] = []
-    for index, item in enumerate(items):
-        item_tokens = _session_recall_tokens(item)
-        score = len(query_tokens & item_tokens)
-        if "ma" in query_tokens and "ma" in item_tokens:
-            score += 3
-        if "uu" in query_tokens and "tien" in query_tokens and {"uu", "tien"} <= item_tokens:
-            score += 3
-        scored.append((score, -index, item))
-
-    best_score = max(score for score, _index, _item in scored)
-    if best_score <= 0:
-        return items
-    return [item for score, _index, item in scored if score == best_score]
-
-
-def _query_requests_session_memory_test_impact(query: str) -> bool:
-    folded = _fold_direct_text(query)
-    return any(
-        marker in folded
-        for marker in (
-            "anh huong test",
-            "tac dong test",
-            "anh huong kiem thu",
-            "tac dong kiem thu",
-            "test wiii",
-            "kiem thu wiii",
-        )
-    )
-
-
-def _format_session_memory_item_with_test_impact(item: str) -> str:
-    cleaned = _clean_session_memory_fragment(item)
-    folded = _fold_direct_text(cleaned)
-    if "pointy" in folded and "dom" in folded:
-        impact = (
-            "Test Pointy phải quét DOM/inventory mới nhất trước khi highlight, "
-            "nếu selector lệch hoặc target bị stale thì fail ngay."
-        )
-    elif "voice" in folded:
-        impact = (
-            "Test voice phải opt-in, có nút bỏ qua/hủy rõ ràng, "
-            "và không tự ép người dùng nghe TTS khi họ chỉ muốn đọc."
-        )
-    elif "document" in folded or "video" in folded or "context" in folded:
-        impact = (
-            "Test upload phải trả lời từ context đã parse và nguồn đính kèm, "
-            "không được đoán khi thiếu vision/transcript hoặc khi parser chưa đủ dữ kiện."
-        )
-    else:
-        impact = (
-            "Test dùng anchor này như checkpoint hồi quy: Wiii phải nhắc đúng, "
-            "giữ đúng ngữ cảnh phiên và không tự bịa thêm thông tin."
-        )
-    return f"{cleaned} -> {impact}"
-
-
-def _extract_session_memory_recall_answer(state: AgentState, query: str) -> str:
-    folded_query = _fold_direct_text(query)
-    if not _looks_session_memory_recall_turn(folded_query):
-        return ""
-
-    messages = state.get("messages") if isinstance(state, dict) else None
-    if not isinstance(messages, list):
-        return ""
-
-    current_query_folded = _fold_direct_text(query)
-    for message in reversed(messages):
-        content = _message_content_from_any(message)
-        folded_content = _fold_direct_text(content)
-        if not content or folded_content == current_query_folded:
-            continue
-        if _looks_session_memory_recall_turn(folded_content):
-            continue
-        items = _extract_session_memory_items_from_text(content)
-        selected_items = _select_session_memory_items_for_query(items, query)
-        if len(selected_items) == 1:
-            return _format_session_memory_item_for_query(selected_items[0], query)
-        if len(selected_items) >= 2:
-            formatted_items = [
-                (
-                    _format_session_memory_item_with_test_impact(item)
-                    if _query_requests_session_memory_test_impact(query)
-                    else _clean_session_memory_fragment(item)
-                )
-                for item in selected_items[:5]
-            ]
-            return "\n".join(f"- {item}" for item in formatted_items if item)
-    return ""
 
 
 def _extract_pointy_fast_path_answer(state: AgentState) -> str:

--- a/maritime-ai-service/app/engine/multi_agent/direct_pointy_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_pointy_runtime.py
@@ -1,0 +1,210 @@
+"""Pointy selector and inventory policy for direct tool rounds.
+
+This module owns server-side selector validation and host inventory formatting
+so the direct tool-loop can depend on a small audited contract instead of
+carrying Pointy policy inline.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _validate_pointy_selector(selector: str, state: Any) -> str | None:
+    """Validate LLM-provided pointy selector vs available_targets.
+
+    Returns None khi selector OK, hoặc error message string khi hallucinated.
+    Error message được trả về như tool_result để LLM thấy + correct round
+    tiếp với exact id từ inventory.
+
+    v3.0 anti-hallucination defense (server-side). Compound CSS, aria-label
+    patterns, .class selectors đều bị reject vì:
+
+    1. Bypass Wiii's data-wiii-id stable handle priority (architectural)
+    2. Brittle vs UI refactors (Tailwind classes, BEM names change)
+    3. Silent fail mode trên frontend khi không match real DOM
+    """
+    if not selector:
+        return (
+            "ERROR: Empty selector. Required: exact `id` from "
+            "tool_pointy_inventory. Example: tool_pointy_show("
+            'selector="chat-send-button", caption="..."). Call '
+            "tool_pointy_inventory first if unsure."
+        )
+
+    # Exact Wiii ids include annotated handles (chat-send-button) and
+    # scanner-generated synthetic ids (auto:button:gui-tin-nhan).
+    import re
+    wiii_id_re = re.compile(
+        r"^(?:[a-zA-Z][a-zA-Z0-9_-]*|auto:[a-z0-9_-]+:[a-z0-9_-]+(?:-\d+)?)$"
+    )
+    is_wiii_id = bool(wiii_id_re.match(selector))
+
+    # Verbose [data-wiii-id="..."] form cũng OK (Wiii's documented selector form).
+    is_data_wiii_id_form = bool(
+        re.match(r'^\[data-wiii-id=("[\w-]+"|\'[\w-]+\'|[\w-]+)\]$', selector)
+    )
+
+    # v9.0 F18: read inventory from BOTH state forms (dict + attr).
+    # state can be plain dict (graph_stream_runtime) OR SimpleNamespace.
+    def _read_inventory_ids(s: Any) -> list[str]:
+        host = None
+        if isinstance(s, dict):
+            host = s.get("host_context") or (s.get("context") or {}).get("host_context")
+        else:
+            host = getattr(s, "host_context", None)
+        if not isinstance(host, dict):
+            return []
+        page = host.get("page") or {}
+        metadata = page.get("metadata") or {} if isinstance(page, dict) else {}
+        targets = metadata.get("available_targets") or []
+        if not isinstance(targets, list):
+            return []
+        return [str(t.get("id")) for t in targets if isinstance(t, dict) and t.get("id")]
+
+    inventory_ids = _read_inventory_ids(state)
+    if inventory_ids and selector in inventory_ids:
+        return None
+
+    # Bất kỳ form nào KHÔNG phải Wiii id và KHÔNG phải data-wiii-id form
+    # → likely hallucination (compound CSS, aria-label, .class, ...).
+    if not (is_wiii_id or is_data_wiii_id_form):
+        examples = ", ".join(f'"{i}"' for i in inventory_ids[:3]) if inventory_ids else '"chat-send-button"'
+        return (
+            f"ERROR: Selector {selector!r} is NOT a valid Wiii Pointy id.\n"
+            f"DO NOT generate CSS selectors, aria-label patterns, or .class selectors.\n"
+            f"REQUIRED: exact id from current inventory. Synthetic auto ids like "
+            f"`auto:button:gui-tin-nhan` are valid when they appear in inventory.\n"
+            f"Available ids on this page: {inventory_ids[:10]}\n"
+            f"Correct form: tool_pointy_show(selector={examples.split(',')[0] if examples else '...'}, caption=\"...\")"
+        )
+
+    # Wiii id form: verify exists trong available_targets if inventory available.
+    if is_wiii_id and inventory_ids:
+        available_list = sorted(set(inventory_ids))[:10]
+        return (
+            f"ERROR: id {selector!r} không có trong available_targets trên page hiện tại.\n"
+            f"Available ids: {available_list}\n"
+            f"Re-call tool_pointy_show với một id chính xác từ list trên, "
+            f"hoặc nói prose nếu element không tồn tại."
+        )
+
+    return None
+
+
+def _format_pointy_inventory(state: Any) -> str:
+    """Format pointable elements + cursor state cho LLM.
+
+    Reads ``state.host_context.page.metadata.available_targets`` (set
+    bởi frontend qua HostContextStore Sprint 222 mechanism) plus
+    ``state.host_context.page.metadata.cursor_state`` nếu có.
+
+    v3.0 (Battleship): inventory text là PRESCRIPTIVE — mỗi item include
+    inline directive ``→ call: tool_pointy_show(selector="<id>")`` để
+    LLM khó ignore và không hallucinate compound CSS selectors.
+    """
+    if state is None:
+        return "Pointy inventory unavailable (no chat state)."
+    host_context = getattr(state, "host_context", None) or {}
+    page = host_context.get("page", {}) if isinstance(host_context, dict) else {}
+    metadata = page.get("metadata", {}) if isinstance(page, dict) else {}
+    targets = metadata.get("available_targets") or []
+    cursor_state = metadata.get("cursor_state")
+
+    lines: list[str] = []
+    if not targets:
+        lines.append(
+            "No pointable elements published by the host. The frontend "
+            "may not have integrated PageScanner yet, or this turn ran "
+            "without host_context. Use prose to describe locations."
+        )
+    else:
+        visible = [t for t in targets if t.get("visible")]
+        offscreen = [t for t in targets if not t.get("visible")]
+        lines.append(
+            f"Pointable elements ({len(visible)} visible, "
+            f"{len(offscreen)} off-screen). USE EXACT id BELOW — DO NOT "
+            f"generate CSS / compound / aria-label selectors:"
+        )
+        display = visible if visible else targets
+        for t in display[:30]:
+            tid = t.get("id") or t.get("selector") or "?"
+            role = t.get("role", "other")
+            label = t.get("label") or ""
+            click_safe = " (click_safe)" if t.get("click_safe") else ""
+            label_part = f' "{label}"' if label else ""
+            offscreen_tag = " [offscreen]" if not t.get("visible") else ""
+            # v3.0: prescriptive directive — LLM khó ignore inline call hint.
+            lines.append(
+                f'- id="{tid}" ({role}){label_part}{click_safe}{offscreen_tag}\n'
+                f'  → call: tool_pointy_show(selector="{tid}", caption="...")'
+            )
+        if len(display) > 30:
+            lines.append(f"… {len(display) - 30} more elements omitted.")
+
+    if isinstance(cursor_state, dict):
+        pos = cursor_state.get("position") or {}
+        x = pos.get("x", "?")
+        y = pos.get("y", "?")
+        state_name = cursor_state.get("awarenessState", "?")
+        last = cursor_state.get("currentSelector")
+        last_part = f' last_target="{last}"' if last else ""
+        lines.append(
+            f"Wiii cursor: pos=({x}, {y}) state={state_name}{last_part}"
+        )
+
+    # User's real OS cursor (Wiii Pointy v2.5).
+    user_cursor = metadata.get("user_cursor_state")
+    if isinstance(user_cursor, dict):
+        upos = user_cursor.get("position")
+        if isinstance(upos, dict):
+            ux = upos.get("x", "?")
+            uy = upos.get("y", "?")
+            idle = user_cursor.get("idle_ms", 0)
+            hovered = user_cursor.get("hovered_id")
+            hovered_label = user_cursor.get("hovered_label")
+            clicked = user_cursor.get("recently_clicked", False)
+            parts = [f"User cursor: pos=({ux}, {uy}) idle={idle}ms"]
+            if hovered:
+                hover_part = f' hovering="{hovered}"'
+                if hovered_label:
+                    hover_part += f' (label="{hovered_label}")'
+                parts.append(hover_part)
+            if clicked:
+                parts.append("recently_clicked=true")
+            lines.append(" ".join(parts))
+        else:
+            lines.append("User cursor: not yet tracked.")
+
+    # User's attention/presence (Wiii Pointy v2.6 — tab visibility, blur, idle
+    # + v2.7 behavior counters: copy/paste/right-click + selected text).
+    attention = metadata.get("user_attention")
+    if isinstance(attention, dict):
+        status = attention.get("status", "?")
+        blurs = attention.get("blur_count", 0)
+        tab_switches = attention.get("tab_switch_count", 0)
+        away_ms = attention.get("total_away_ms", 0)
+        last_away = attention.get("last_away_duration_ms", 0)
+        parts = [f"User attention: status={status}"]
+        if blurs > 0 or tab_switches > 0:
+            parts.append(f"blurs={blurs} tab_switches={tab_switches}")
+        if away_ms > 0:
+            parts.append(f"total_away={away_ms // 1000}s")
+        if last_away > 0 and status == "active":
+            parts.append(f"just_returned (was away {last_away // 1000}s)")
+        # v2.7 behavior counters
+        copies = attention.get("copy_count", 0)
+        pastes = attention.get("paste_count", 0)
+        right_clicks = attention.get("context_menu_count", 0)
+        if copies or pastes or right_clicks:
+            parts.append(
+                f"behaviour: copies={copies} pastes={pastes} right_clicks={right_clicks}"
+            )
+        lines.append(" ".join(parts))
+        # Last selected text on its own line for readability.
+        selected = attention.get("last_selected_text")
+        if isinstance(selected, str) and selected.strip():
+            preview = selected[:60].replace("\n", " ")
+            lines.append(f'User selected text: "{preview}"')
+
+    return "\n".join(lines)

--- a/maritime-ai-service/app/engine/multi_agent/direct_session_memory_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_session_memory_runtime.py
@@ -1,0 +1,360 @@
+"""Current-session memory fast-path helpers for the direct node."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.engine.multi_agent.direct_text_utils import _fold_direct_text
+from app.engine.multi_agent.state import AgentState
+from app.engine.multi_agent.supervisor_runtime_support import (
+    _looks_memory_write_turn,
+    _looks_session_memory_recall_turn,
+)
+
+
+def _message_content_from_any(value: Any) -> str:
+    if isinstance(value, dict):
+        content = value.get("content") or value.get("text") or value.get("message") or ""
+    else:
+        content = getattr(value, "content", "")
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                parts.append(str(item.get("text") or item.get("content") or ""))
+            else:
+                parts.append(str(item or ""))
+        return "\n".join(part for part in parts if part.strip()).strip()
+    return str(content or "").strip()
+
+
+_SESSION_MEMORY_NOISE_RE = re.compile(
+    r"(?:mã|ma)\s+(?:kiểm\s+thử|kiem\s+thu|test)\s+[A-Za-z0-9_.:]*-[A-Za-z0-9_.:-]+.*$",
+    flags=re.IGNORECASE,
+)
+
+
+_SESSION_MEMORY_FIELD_MARKER_RE = re.compile(r"(\[[A-Z][A-Z0-9_.:-]{3,}\])")
+
+
+def _clean_session_memory_fragment(value: str) -> str:
+    cleaned = _SESSION_MEMORY_NOISE_RE.sub("", str(value or "")).strip()
+    cleaned = re.sub(r"^(?:[-*]\s*)+", "", cleaned).strip()
+    cleaned = re.split(
+        r"\b(?:Hỏi\s+lại\s+ngay|Hoi\s+lai\s+ngay|Hỏi\s+lại|Hoi\s+lai)\b",
+        cleaned,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0].strip()
+    return cleaned.strip(" .ã€‚")
+
+
+def _extract_requested_response_marker(query: str) -> str:
+    """Preserve explicit field-test markers when the user asks for them."""
+    raw = str(query or "")
+    folded = _fold_direct_text(raw)
+    if not any(marker in folded for marker in ("bat dau bang", "begin with", "start with")):
+        return ""
+    match = _SESSION_MEMORY_FIELD_MARKER_RE.search(raw)
+    return match.group(1) if match else ""
+
+
+def _with_requested_response_marker(query: str, answer: str) -> str:
+    marker = _extract_requested_response_marker(query)
+    if not marker:
+        return answer
+    if answer.lstrip().startswith(marker):
+        return answer
+    if answer.lstrip().startswith("- "):
+        return f"{marker}\n{answer}"
+    return f"{marker} {answer}"
+
+
+def _extract_session_memory_items_from_text(text: str) -> list[str]:
+    raw = str(text or "").strip()
+    if not raw:
+        return []
+    folded = _fold_direct_text(raw)
+    if not _looks_memory_write_turn(folded):
+        return []
+
+    before_reply_directive = re.split(
+        r"\b(?:trả\s+lời|tra\s+loi|chỉ\s+xác\s+nhận|chi\s+xac\s+nhan|answer\s+only|reply\s+only|respond\s+only)\b",
+        raw,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0].strip()
+    before_reply_directive = re.split(
+        r"\b(?:không\s+(?:sử\s+dụng|dùng)\s+(?:web|rag|pointy|tool|công\s+cụ)|khong\s+(?:su\s+dung|dung)\s+(?:web|rag|pointy|tool|cong\s+cu)|do\s+not\s+use\s+(?:web|rag|pointy|tools?)|without\s+(?:web|rag|pointy|tools?))\b",
+        before_reply_directive,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0].strip()
+    marker_split = re.split(
+        r"\b(?:hãy\s+nhớ|hay\s+nho|ghi\s+nhớ|ghi\s+nho|nhớ\s+trong|nho\s+trong|nhớ\s+giúp(?:\s+mình)?|nho\s+giup(?:\s+minh)?|nhớ\s+rằng|nho\s+rang|remember\s+that|please\s+remember|keep\s+in\s+mind|lưu\s+lại|luu\s+lai)\b",
+        before_reply_directive,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )
+    segment_source = marker_split[-1].strip(" :：") if len(marker_split) > 1 else before_reply_directive
+    segment = re.split(r"[:：]", segment_source)[-1].strip()
+    if not segment or segment == before_reply_directive:
+        return []
+
+    numbered_items = [
+        _clean_session_memory_fragment(match.group(1).strip(" .)]"))
+        for match in re.finditer(
+            r"(?:^|\s)[\(\[]?\d+[\)\].]\s*(.*?)(?=\s+[\(\[]?\d+[\)\].]\s*|$)",
+            segment,
+            flags=re.DOTALL,
+        )
+        if len(_clean_session_memory_fragment(match.group(1).strip(" .)]"))) >= 4
+    ]
+    if len(numbered_items) >= 2:
+        return numbered_items
+
+    pieces = re.split(r"\s*(?:,|;|\n+|\s+và\s+|\s+va\s+|\s+and\s+)\s*", segment)
+    items: list[str] = []
+    for piece in pieces:
+        item = re.sub(r"^(?:và|va|and)\s+", "", piece.strip(), flags=re.IGNORECASE)
+        item = item.strip(" .。")
+        item = _clean_session_memory_fragment(item)
+        if len(item) < 4:
+            continue
+        if re.search(r"\b(?:trả\s+lời|tra\s+loi|chỉ\s+xác\s+nhận|chi\s+xac\s+nhan|answer\s+only|reply\s+only)\b", item, re.IGNORECASE):
+            continue
+        items.append(item)
+    return _merge_session_priority_items(items)
+
+
+def _merge_session_priority_items(items: list[str]) -> list[str]:
+    """Keep labeled multi-part bundles as one recallable memory item."""
+    merged: list[str] = []
+    index = 0
+    while index < len(items):
+        item = items[index]
+        folded = _fold_direct_text(item)
+        is_anchor_fact = bool(re.search(r"\b[A-Z0-9_:-]*ANCHOR[A-Z0-9_:-]*\b", item))
+        if merged and not is_anchor_fact and "anchor" in _fold_direct_text(merged[-1]):
+            merged[-1] = f"{merged[-1]} va {item}"
+            index += 1
+            continue
+
+        is_labeled_bundle = "uu tien" in folded or "tieu chi" in folded
+        if not is_labeled_bundle:
+            merged.append(item)
+            index += 1
+            continue
+
+        priority_parts = [item]
+        index += 1
+        while index < len(items):
+            next_item = items[index]
+            next_folded = _fold_direct_text(next_item)
+            starts_new_labeled_fact = (
+                re.search(r"\b(?:ma|mau|color|code|token)\b", next_folded) is not None
+                or re.search(r"^(?:tieu chi|uu tien|priority|criterion)\b", next_folded) is not None
+                or " la " in f" {next_folded} "
+                or "=" in next_item
+            )
+            if starts_new_labeled_fact:
+                break
+            priority_parts.append(next_item)
+            index += 1
+        merged.append("; ".join(priority_parts))
+    return merged
+
+
+def _build_session_memory_write_answer(query: str) -> str:
+    """Acknowledge current-session memory without invoking durable memory."""
+    items = _extract_session_memory_items_from_text(query)
+    if not items:
+        return (
+            "Mình ghi nhớ điều này trong phiên hiện tại rồi. Nếu cậu hỏi lại trong đoạn chat này, "
+            "mình sẽ dựa vào đó thay vì đoán mò."
+        )
+    if len(items) == 1:
+        return (
+            f"Mình ghi nhớ trong phiên này rồi: **{items[0]}**. "
+            "Hỏi lại ngay trong đoạn chat này là mình nhắc được."
+        )
+    lines = "\n".join(f"- {item}" for item in items[:5])
+    return f"Mình ghi nhớ trong phiên này rồi:\n{lines}\n\nHỏi lại ngay trong đoạn chat này là mình nhắc được."
+
+
+def _build_session_memory_write_thinking(_query: str) -> str:
+    return (
+        "Mình hiểu đây là trí nhớ tạm trong phiên, không phải một fact dài hạn cần đẩy qua semantic memory. "
+        "Cách đúng là xác nhận cụ thể điều vừa giữ, trả lời nhanh, rồi để chính lịch sử hội thoại làm nguồn cho lượt nhắc lại kế tiếp."
+    )
+
+
+_SESSION_RECALL_STOPWORDS = {
+    "ban",
+    "bao",
+    "cau",
+    "cho",
+    "dung",
+    "gi",
+    "hoi",
+    "la",
+    "minh",
+    "nao",
+    "nho",
+    "noi",
+    "tra",
+    "loi",
+    "vua",
+}
+
+
+def _session_recall_tokens(value: str) -> set[str]:
+    return {
+        token
+        for token in re.findall(r"[a-z0-9]+", _fold_direct_text(value))
+        if token and token not in _SESSION_RECALL_STOPWORDS and len(token) > 1
+    }
+
+
+def _requested_session_memory_list_count(query: str) -> int | None:
+    folded = _fold_direct_text(query)
+    if not folded:
+        return None
+    list_noun = (
+        r"(?:uu\s+tien|tieu\s+chi|criteria|anchor|neo|moc(?:\s+neo)?|diem\s+neo|"
+        r"y|muc|gach|dau\s+dong|bullet)"
+    )
+    digit_match = re.search(rf"\b([2-9])\s+{list_noun}", folded)
+    if digit_match:
+        return int(digit_match.group(1))
+    if re.search(rf"\bba\s+{list_noun}", folded):
+        return 3
+    if re.search(rf"\bhai\s+{list_noun}", folded):
+        return 2
+    if (
+        "cac uu tien" in folded
+        or "nhung uu tien" in folded
+        or "cac tieu chi" in folded
+        or "cac anchor" in folded
+        or "nhung anchor" in folded
+        or "cac neo" in folded
+        or "nhung neo" in folded
+        or "cac moc" in folded
+    ):
+        return 99
+    return None
+
+
+def _format_session_memory_item_for_query(item: str, query: str) -> str:
+    folded_query = _fold_direct_text(query)
+    if any(marker in folded_query for marker in ("ma ", "ma kiem thu", "code", "token", "mau ", "color")):
+        match = re.search(r"\b(?:là|la|=)\s+(.+)$", item, flags=re.IGNORECASE)
+        if match:
+            value = match.group(1).strip(" .。")
+            value = _clean_session_memory_fragment(value).strip("\"'“”‘’")
+            if 1 <= len(value) <= 120:
+                return value
+    return _clean_session_memory_fragment(item)
+
+
+def _select_session_memory_items_for_query(items: list[str], query: str) -> list[str]:
+    if not items:
+        return []
+    requested_count = _requested_session_memory_list_count(query)
+    if requested_count is not None and requested_count >= 2:
+        return items[: min(requested_count, len(items))]
+
+    query_tokens = _session_recall_tokens(query)
+    if not query_tokens:
+        return items
+
+    scored: list[tuple[int, int, str]] = []
+    for index, item in enumerate(items):
+        item_tokens = _session_recall_tokens(item)
+        score = len(query_tokens & item_tokens)
+        if "ma" in query_tokens and "ma" in item_tokens:
+            score += 3
+        if "uu" in query_tokens and "tien" in query_tokens and {"uu", "tien"} <= item_tokens:
+            score += 3
+        scored.append((score, -index, item))
+
+    best_score = max(score for score, _index, _item in scored)
+    if best_score <= 0:
+        return items
+    return [item for score, _index, item in scored if score == best_score]
+
+
+def _query_requests_session_memory_test_impact(query: str) -> bool:
+    folded = _fold_direct_text(query)
+    return any(
+        marker in folded
+        for marker in (
+            "anh huong test",
+            "tac dong test",
+            "anh huong kiem thu",
+            "tac dong kiem thu",
+            "test wiii",
+            "kiem thu wiii",
+        )
+    )
+
+
+def _format_session_memory_item_with_test_impact(item: str) -> str:
+    cleaned = _clean_session_memory_fragment(item)
+    folded = _fold_direct_text(cleaned)
+    if "pointy" in folded and "dom" in folded:
+        impact = (
+            "Test Pointy phải quét DOM/inventory mới nhất trước khi highlight, "
+            "nếu selector lệch hoặc target bị stale thì fail ngay."
+        )
+    elif "voice" in folded:
+        impact = (
+            "Test voice phải opt-in, có nút bỏ qua/hủy rõ ràng, "
+            "và không tự ép người dùng nghe TTS khi họ chỉ muốn đọc."
+        )
+    elif "document" in folded or "video" in folded or "context" in folded:
+        impact = (
+            "Test upload phải trả lời từ context đã parse và nguồn đính kèm, "
+            "không được đoán khi thiếu vision/transcript hoặc khi parser chưa đủ dữ kiện."
+        )
+    else:
+        impact = (
+            "Test dùng anchor này như checkpoint hồi quy: Wiii phải nhắc đúng, "
+            "giữ đúng ngữ cảnh phiên và không tự bịa thêm thông tin."
+        )
+    return f"{cleaned} -> {impact}"
+
+
+def _extract_session_memory_recall_answer(state: AgentState, query: str) -> str:
+    folded_query = _fold_direct_text(query)
+    if not _looks_session_memory_recall_turn(folded_query):
+        return ""
+
+    messages = state.get("messages") if isinstance(state, dict) else None
+    if not isinstance(messages, list):
+        return ""
+
+    current_query_folded = _fold_direct_text(query)
+    for message in reversed(messages):
+        content = _message_content_from_any(message)
+        folded_content = _fold_direct_text(content)
+        if not content or folded_content == current_query_folded:
+            continue
+        if _looks_session_memory_recall_turn(folded_content):
+            continue
+        items = _extract_session_memory_items_from_text(content)
+        selected_items = _select_session_memory_items_for_query(items, query)
+        if len(selected_items) == 1:
+            return _format_session_memory_item_for_query(selected_items[0], query)
+        if len(selected_items) >= 2:
+            formatted_items = [
+                (
+                    _format_session_memory_item_with_test_impact(item)
+                    if _query_requests_session_memory_test_impact(query)
+                    else _clean_session_memory_fragment(item)
+                )
+                for item in selected_items[:5]
+            ]
+            return "\n".join(f"- {item}" for item in formatted_items if item)
+    return ""

--- a/maritime-ai-service/app/engine/multi_agent/direct_text_utils.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_text_utils.py
@@ -1,0 +1,11 @@
+"""Shared direct-runtime text normalization helpers."""
+
+from __future__ import annotations
+
+import unicodedata
+
+
+def _fold_direct_text(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", str(value or ""))
+    stripped = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    return " ".join(stripped.lower().replace("đ", "d").split())

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 import re
 import sys
-import unicodedata
 from typing import Any, Optional
 
 from app.core.config import settings
@@ -33,10 +32,24 @@ from app.engine.multi_agent.direct_reasoning import (
 from app.engine.multi_agent.direct_search_synthesis_fallback import (
     build_search_template_fallback,
 )
+from app.engine.multi_agent.direct_pointy_runtime import (
+    _format_pointy_inventory,
+    _validate_pointy_selector,
+)
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.tool_call_text_parser import (
     extract_raw_tool_calls_from_text,
     tool_names_from_tools,
+)
+from app.engine.multi_agent.direct_web_search_policy import (
+    FORCED_WEB_SEARCH_TOOL_NAMES as _FORCED_WEB_SEARCH_TOOL_NAMES,
+    _clean_forced_web_search_query,
+    _force_skills_for_turn,
+    _has_search_tool_result,
+    _is_search_tool_name,
+    _prefer_official_query_for_known_docs,
+    _should_return_search_template_after_tool_round,
+    _should_use_search_template_for_empty_response,
 )
 from app.engine.multi_agent.visual_events import (
     _collect_active_visual_session_ids,
@@ -54,11 +67,6 @@ from app.engine.reasoning import record_thinking_snapshot
 
 logger = logging.getLogger(__name__)
 
-_FORCED_WEB_SEARCH_TOOL_NAMES = (
-    "tool_web_search",
-    "web_search",
-)
-_RICH_SEARCH_RESULT_CHAR_FLOOR = 1200
 _DOC_PREVIEW_LOW_VALUE_LABELS = {
     "buoc",
     "checkpoint",
@@ -2514,206 +2522,6 @@ def _build_tool_result_message(
     return Message(role="tool", content=content, tool_call_id=tool_call_id)
 
 
-def _validate_pointy_selector(selector: str, state: Any) -> str | None:
-    """Validate LLM-provided pointy selector vs available_targets.
-
-    Returns None khi selector OK, hoặc error message string khi hallucinated.
-    Error message được trả về như tool_result để LLM thấy + correct round
-    tiếp với exact id từ inventory.
-
-    v3.0 anti-hallucination defense (server-side). Compound CSS, aria-label
-    patterns, .class selectors đều bị reject vì:
-
-    1. Bypass Wiii's data-wiii-id stable handle priority (architectural)
-    2. Brittle vs UI refactors (Tailwind classes, BEM names change)
-    3. Silent fail mode trên frontend khi không match real DOM
-    """
-    if not selector:
-        return (
-            "ERROR: Empty selector. Required: exact `id` from "
-            "tool_pointy_inventory. Example: tool_pointy_show("
-            'selector="chat-send-button", caption="..."). Call '
-            "tool_pointy_inventory first if unsure."
-        )
-
-    # Exact Wiii ids include annotated handles (chat-send-button) and
-    # scanner-generated synthetic ids (auto:button:gui-tin-nhan).
-    import re
-    wiii_id_re = re.compile(
-        r"^(?:[a-zA-Z][a-zA-Z0-9_-]*|auto:[a-z0-9_-]+:[a-z0-9_-]+(?:-\d+)?)$"
-    )
-    is_wiii_id = bool(wiii_id_re.match(selector))
-
-    # Verbose [data-wiii-id="..."] form cũng OK (Wiii's documented selector form).
-    is_data_wiii_id_form = bool(
-        re.match(r'^\[data-wiii-id=("[\w-]+"|\'[\w-]+\'|[\w-]+)\]$', selector)
-    )
-
-    # v9.0 F18: read inventory from BOTH state forms (dict + attr).
-    # state can be plain dict (graph_stream_runtime) OR SimpleNamespace.
-    def _read_inventory_ids(s: Any) -> list[str]:
-        host = None
-        if isinstance(s, dict):
-            host = s.get("host_context") or (s.get("context") or {}).get("host_context")
-        else:
-            host = getattr(s, "host_context", None)
-        if not isinstance(host, dict):
-            return []
-        page = host.get("page") or {}
-        metadata = page.get("metadata") or {} if isinstance(page, dict) else {}
-        targets = metadata.get("available_targets") or []
-        if not isinstance(targets, list):
-            return []
-        return [str(t.get("id")) for t in targets if isinstance(t, dict) and t.get("id")]
-
-    inventory_ids = _read_inventory_ids(state)
-    if inventory_ids and selector in inventory_ids:
-        return None
-
-    # Bất kỳ form nào KHÔNG phải Wiii id và KHÔNG phải data-wiii-id form
-    # → likely hallucination (compound CSS, aria-label, .class, ...).
-    if not (is_wiii_id or is_data_wiii_id_form):
-        examples = ", ".join(f'"{i}"' for i in inventory_ids[:3]) if inventory_ids else '"chat-send-button"'
-        return (
-            f"ERROR: Selector {selector!r} is NOT a valid Wiii Pointy id.\n"
-            f"DO NOT generate CSS selectors, aria-label patterns, or .class selectors.\n"
-            f"REQUIRED: exact id from current inventory. Synthetic auto ids like "
-            f"`auto:button:gui-tin-nhan` are valid when they appear in inventory.\n"
-            f"Available ids on this page: {inventory_ids[:10]}\n"
-            f"Correct form: tool_pointy_show(selector={examples.split(',')[0] if examples else '...'}, caption=\"...\")"
-        )
-
-    # Wiii id form: verify exists trong available_targets if inventory available.
-    if is_wiii_id and inventory_ids:
-        available_list = sorted(set(inventory_ids))[:10]
-        return (
-            f"ERROR: id {selector!r} không có trong available_targets trên page hiện tại.\n"
-            f"Available ids: {available_list}\n"
-            f"Re-call tool_pointy_show với một id chính xác từ list trên, "
-            f"hoặc nói prose nếu element không tồn tại."
-        )
-
-    return None
-
-
-def _format_pointy_inventory(state: Any) -> str:
-    """Format pointable elements + cursor state cho LLM.
-
-    Reads ``state.host_context.page.metadata.available_targets`` (set
-    bởi frontend qua HostContextStore Sprint 222 mechanism) plus
-    ``state.host_context.page.metadata.cursor_state`` nếu có.
-
-    v3.0 (Battleship): inventory text là PRESCRIPTIVE — mỗi item include
-    inline directive ``→ call: tool_pointy_show(selector="<id>")`` để
-    LLM khó ignore và không hallucinate compound CSS selectors.
-    """
-    if state is None:
-        return "Pointy inventory unavailable (no chat state)."
-    host_context = getattr(state, "host_context", None) or {}
-    page = host_context.get("page", {}) if isinstance(host_context, dict) else {}
-    metadata = page.get("metadata", {}) if isinstance(page, dict) else {}
-    targets = metadata.get("available_targets") or []
-    cursor_state = metadata.get("cursor_state")
-
-    lines: list[str] = []
-    if not targets:
-        lines.append(
-            "No pointable elements published by the host. The frontend "
-            "may not have integrated PageScanner yet, or this turn ran "
-            "without host_context. Use prose to describe locations."
-        )
-    else:
-        visible = [t for t in targets if t.get("visible")]
-        offscreen = [t for t in targets if not t.get("visible")]
-        lines.append(
-            f"Pointable elements ({len(visible)} visible, "
-            f"{len(offscreen)} off-screen). USE EXACT id BELOW — DO NOT "
-            f"generate CSS / compound / aria-label selectors:"
-        )
-        display = visible if visible else targets
-        for t in display[:30]:
-            tid = t.get("id") or t.get("selector") or "?"
-            role = t.get("role", "other")
-            label = t.get("label") or ""
-            click_safe = " (click_safe)" if t.get("click_safe") else ""
-            label_part = f' "{label}"' if label else ""
-            offscreen_tag = " [offscreen]" if not t.get("visible") else ""
-            # v3.0: prescriptive directive — LLM khó ignore inline call hint.
-            lines.append(
-                f'- id="{tid}" ({role}){label_part}{click_safe}{offscreen_tag}\n'
-                f'  → call: tool_pointy_show(selector="{tid}", caption="...")'
-            )
-        if len(display) > 30:
-            lines.append(f"… {len(display) - 30} more elements omitted.")
-
-    if isinstance(cursor_state, dict):
-        pos = cursor_state.get("position") or {}
-        x = pos.get("x", "?")
-        y = pos.get("y", "?")
-        state_name = cursor_state.get("awarenessState", "?")
-        last = cursor_state.get("currentSelector")
-        last_part = f' last_target="{last}"' if last else ""
-        lines.append(
-            f"Wiii cursor: pos=({x}, {y}) state={state_name}{last_part}"
-        )
-
-    # User's real OS cursor (Wiii Pointy v2.5).
-    user_cursor = metadata.get("user_cursor_state")
-    if isinstance(user_cursor, dict):
-        upos = user_cursor.get("position")
-        if isinstance(upos, dict):
-            ux = upos.get("x", "?")
-            uy = upos.get("y", "?")
-            idle = user_cursor.get("idle_ms", 0)
-            hovered = user_cursor.get("hovered_id")
-            hovered_label = user_cursor.get("hovered_label")
-            clicked = user_cursor.get("recently_clicked", False)
-            parts = [f"User cursor: pos=({ux}, {uy}) idle={idle}ms"]
-            if hovered:
-                hover_part = f' hovering="{hovered}"'
-                if hovered_label:
-                    hover_part += f' (label="{hovered_label}")'
-                parts.append(hover_part)
-            if clicked:
-                parts.append("recently_clicked=true")
-            lines.append(" ".join(parts))
-        else:
-            lines.append("User cursor: not yet tracked.")
-
-    # User's attention/presence (Wiii Pointy v2.6 — tab visibility, blur, idle
-    # + v2.7 behavior counters: copy/paste/right-click + selected text).
-    attention = metadata.get("user_attention")
-    if isinstance(attention, dict):
-        status = attention.get("status", "?")
-        blurs = attention.get("blur_count", 0)
-        tab_switches = attention.get("tab_switch_count", 0)
-        away_ms = attention.get("total_away_ms", 0)
-        last_away = attention.get("last_away_duration_ms", 0)
-        parts = [f"User attention: status={status}"]
-        if blurs > 0 or tab_switches > 0:
-            parts.append(f"blurs={blurs} tab_switches={tab_switches}")
-        if away_ms > 0:
-            parts.append(f"total_away={away_ms // 1000}s")
-        if last_away > 0 and status == "active":
-            parts.append(f"just_returned (was away {last_away // 1000}s)")
-        # v2.7 behavior counters
-        copies = attention.get("copy_count", 0)
-        pastes = attention.get("paste_count", 0)
-        right_clicks = attention.get("context_menu_count", 0)
-        if copies or pastes or right_clicks:
-            parts.append(
-                f"behaviour: copies={copies} pastes={pastes} right_clicks={right_clicks}"
-            )
-        lines.append(" ".join(parts))
-        # Last selected text on its own line for readability.
-        selected = attention.get("last_selected_text")
-        if isinstance(selected, str) and selected.strip():
-            preview = selected[:60].replace("\n", " ")
-            lines.append(f'User selected text: "{preview}"')
-
-    return "\n".join(lines)
-
-
 def _build_user_instruction_message(
     content: str,
     *,
@@ -2770,157 +2578,6 @@ def _build_assistant_tool_call_message(
             if str(call.get("name") or "").strip()
         ],
     )
-
-
-def _force_skills_for_turn(state: AgentState | None) -> set[str]:
-    if not isinstance(state, dict):
-        return set()
-    force_skills = state.get("force_skills")
-    if not force_skills:
-        ctx = state.get("context")
-        if isinstance(ctx, dict):
-            force_skills = ctx.get("force_skills")
-    if isinstance(force_skills, (list, tuple, set)):
-        return {str(skill).strip().lower() for skill in force_skills if skill}
-    return set()
-
-
-def _has_search_tool_result(tool_call_events: list[dict]) -> bool:
-    search_tool_names = {
-        "tool_web_search",
-        "web_search",
-        "tool_search_news",
-        "search_news",
-        "tool_search_legal",
-        "search_legal",
-        "tool_search_maritime",
-        "search_maritime",
-    }
-    return any(
-        event.get("type") == "result"
-        and str(event.get("name") or "").strip().lower() in search_tool_names
-        and str(event.get("result") or "").strip()
-        for event in tool_call_events or []
-    )
-
-
-def _has_fetch_tool_result(tool_call_events: list[dict]) -> bool:
-    return any(
-        event.get("type") == "result"
-        and str(event.get("name") or "").strip().lower() in {"tool_fetch_url", "fetch_url"}
-        and str(event.get("result") or "").strip()
-        for event in tool_call_events or []
-    )
-
-
-def _fold_tool_round_text(value: str) -> str:
-    normalized = unicodedata.normalize("NFKD", str(value or ""))
-    stripped = "".join(ch for ch in normalized if not unicodedata.combining(ch))
-    return " ".join(stripped.lower().replace("đ", "d").split())
-
-
-def _looks_explicit_web_search_query(query: str) -> bool:
-    folded = _fold_tool_round_text(query)
-    if not folded:
-        return False
-    if "@web-search" in folded or "@web_search" in folded:
-        return True
-    if "web" in folded and any(marker in folded for marker in ("tim", "search", "tra cuu")):
-        return True
-    return any(
-        marker in folded
-        for marker in (
-            "tim tren mang",
-            "tim kiem tren mang",
-            "search the web",
-            "look up online",
-        )
-    )
-
-
-def _is_search_tool_name(name: str) -> bool:
-    return str(name or "").strip().lower() in {
-        "tool_web_search",
-        "web_search",
-        "tool_search_news",
-        "search_news",
-        "tool_search_legal",
-        "search_legal",
-        "tool_search_maritime",
-        "search_maritime",
-    }
-
-
-def _prefer_official_query_for_known_docs(args: Any, user_query: str) -> dict:
-    normalized_args = dict(args or {}) if isinstance(args, dict) else {}
-    current_query = str(normalized_args.get("query") or normalized_args.get("q") or "")
-    folded = _fold_tool_round_text(f"{user_query} {current_query}")
-    if "openai" in folded and "responses api" in folded:
-        normalized_args["query"] = (
-            "OpenAI API Reference Responses POST /v1/responses platform.openai.com"
-        )
-    return normalized_args
-
-
-def _should_return_search_template_after_tool_round(
-    *,
-    query: str,
-    state: AgentState | None,
-    tool_call_events: list[dict],
-    tool_round: int,
-) -> bool:
-    if not _has_search_tool_result(tool_call_events):
-        return False
-    routing_meta = state.get("routing_metadata") if isinstance(state, dict) else {}
-    routing_intent = str((routing_meta or {}).get("intent") or "").strip().lower()
-    explicit_web = routing_intent == "web_search" or _looks_explicit_web_search_query(query)
-    if not explicit_web:
-        return False
-    search_result_chars = sum(
-        len(str(event.get("result") or ""))
-        for event in tool_call_events or []
-        if event.get("type") == "result" and _is_search_tool_name(str(event.get("name") or ""))
-    )
-    return (
-        _has_fetch_tool_result(tool_call_events)
-        or tool_round >= 1
-        or search_result_chars >= _RICH_SEARCH_RESULT_CHAR_FLOOR
-    )
-
-
-def _is_explicit_web_search_turn(query: str, state: AgentState | None) -> bool:
-    routing_meta = state.get("routing_metadata") if isinstance(state, dict) else {}
-    routing_intent = str((routing_meta or {}).get("intent") or "").strip().lower()
-    return (
-        "web-search" in _force_skills_for_turn(state)
-        or routing_intent == "web_search"
-        or _looks_explicit_web_search_query(query)
-    )
-
-
-def _should_use_search_template_for_empty_response(
-    *,
-    query: str,
-    state: AgentState | None,
-    tool_call_events: list[dict],
-) -> bool:
-    return (
-        _is_explicit_web_search_turn(query, state)
-        and _has_search_tool_result(tool_call_events)
-    )
-
-
-def _clean_forced_web_search_query(query: str) -> str:
-    """Convert an explicit @web-search turn into a clean tool query."""
-    text = str(query or "").strip()
-    text = re.sub(r"(?i)@web-search\b", "", text).strip()
-    text = re.split(
-        r"(?i)\b(?:trả\s+lời|tra\s+loi|answer|respond|reply)\b",
-        text,
-        maxsplit=1,
-    )[0].strip()
-    text = text.strip(" .:-–—")
-    return text or str(query or "").strip()
 
 
 async def execute_direct_tool_rounds_impl(

--- a/maritime-ai-service/app/engine/multi_agent/direct_web_search_policy.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_web_search_policy.py
@@ -1,0 +1,172 @@
+"""Explicit web-search policy for direct tool rounds.
+
+The direct runtime uses these helpers to decide when web-search results are
+rich enough to synthesize from tool evidence, when to force source-backed
+templates, and how to clean explicit @web-search user turns.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Any
+
+from app.engine.multi_agent.state import AgentState
+
+
+FORCED_WEB_SEARCH_TOOL_NAMES = (
+    "tool_web_search",
+    "web_search",
+)
+_RICH_SEARCH_RESULT_CHAR_FLOOR = 1200
+
+
+def _force_skills_for_turn(state: AgentState | None) -> set[str]:
+    if not isinstance(state, dict):
+        return set()
+    force_skills = state.get("force_skills")
+    if not force_skills:
+        ctx = state.get("context")
+        if isinstance(ctx, dict):
+            force_skills = ctx.get("force_skills")
+    if isinstance(force_skills, (list, tuple, set)):
+        return {str(skill).strip().lower() for skill in force_skills if skill}
+    return set()
+
+
+def _has_search_tool_result(tool_call_events: list[dict]) -> bool:
+    search_tool_names = {
+        "tool_web_search",
+        "web_search",
+        "tool_search_news",
+        "search_news",
+        "tool_search_legal",
+        "search_legal",
+        "tool_search_maritime",
+        "search_maritime",
+    }
+    return any(
+        event.get("type") == "result"
+        and str(event.get("name") or "").strip().lower() in search_tool_names
+        and str(event.get("result") or "").strip()
+        for event in tool_call_events or []
+    )
+
+
+def _has_fetch_tool_result(tool_call_events: list[dict]) -> bool:
+    return any(
+        event.get("type") == "result"
+        and str(event.get("name") or "").strip().lower() in {"tool_fetch_url", "fetch_url"}
+        and str(event.get("result") or "").strip()
+        for event in tool_call_events or []
+    )
+
+
+def _fold_tool_round_text(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", str(value or ""))
+    stripped = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    return " ".join(stripped.lower().replace("đ", "d").split())
+
+
+def _looks_explicit_web_search_query(query: str) -> bool:
+    folded = _fold_tool_round_text(query)
+    if not folded:
+        return False
+    if "@web-search" in folded or "@web_search" in folded:
+        return True
+    if "web" in folded and any(marker in folded for marker in ("tim", "search", "tra cuu")):
+        return True
+    return any(
+        marker in folded
+        for marker in (
+            "tim tren mang",
+            "tim kiem tren mang",
+            "search the web",
+            "look up online",
+        )
+    )
+
+
+def _is_search_tool_name(name: str) -> bool:
+    return str(name or "").strip().lower() in {
+        "tool_web_search",
+        "web_search",
+        "tool_search_news",
+        "search_news",
+        "tool_search_legal",
+        "search_legal",
+        "tool_search_maritime",
+        "search_maritime",
+    }
+
+
+def _prefer_official_query_for_known_docs(args: Any, user_query: str) -> dict:
+    normalized_args = dict(args or {}) if isinstance(args, dict) else {}
+    current_query = str(normalized_args.get("query") or normalized_args.get("q") or "")
+    folded = _fold_tool_round_text(f"{user_query} {current_query}")
+    if "openai" in folded and "responses api" in folded:
+        normalized_args["query"] = (
+            "OpenAI API Reference Responses POST /v1/responses platform.openai.com"
+        )
+    return normalized_args
+
+
+def _should_return_search_template_after_tool_round(
+    *,
+    query: str,
+    state: AgentState | None,
+    tool_call_events: list[dict],
+    tool_round: int,
+) -> bool:
+    if not _has_search_tool_result(tool_call_events):
+        return False
+    routing_meta = state.get("routing_metadata") if isinstance(state, dict) else {}
+    routing_intent = str((routing_meta or {}).get("intent") or "").strip().lower()
+    explicit_web = routing_intent == "web_search" or _looks_explicit_web_search_query(query)
+    if not explicit_web:
+        return False
+    search_result_chars = sum(
+        len(str(event.get("result") or ""))
+        for event in tool_call_events or []
+        if event.get("type") == "result" and _is_search_tool_name(str(event.get("name") or ""))
+    )
+    return (
+        _has_fetch_tool_result(tool_call_events)
+        or tool_round >= 1
+        or search_result_chars >= _RICH_SEARCH_RESULT_CHAR_FLOOR
+    )
+
+
+def _is_explicit_web_search_turn(query: str, state: AgentState | None) -> bool:
+    routing_meta = state.get("routing_metadata") if isinstance(state, dict) else {}
+    routing_intent = str((routing_meta or {}).get("intent") or "").strip().lower()
+    return (
+        "web-search" in _force_skills_for_turn(state)
+        or routing_intent == "web_search"
+        or _looks_explicit_web_search_query(query)
+    )
+
+
+def _should_use_search_template_for_empty_response(
+    *,
+    query: str,
+    state: AgentState | None,
+    tool_call_events: list[dict],
+) -> bool:
+    return (
+        _is_explicit_web_search_turn(query, state)
+        and _has_search_tool_result(tool_call_events)
+    )
+
+
+def _clean_forced_web_search_query(query: str) -> str:
+    """Convert an explicit @web-search turn into a clean tool query."""
+    text = str(query or "").strip()
+    text = re.sub(r"(?i)@web-search\b", "", text).strip()
+    text = re.split(
+        r"(?i)\b(?:trả\s+lời|tra\s+loi|answer|respond|reply)\b",
+        text,
+        maxsplit=1,
+    )[0].strip()
+    text = text.strip(" .:-–—")
+    return text or str(query or "").strip()

--- a/maritime-ai-service/tests/unit/test_code_studio_template_scaffold.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_template_scaffold.py
@@ -27,6 +27,12 @@ from app.engine.multi_agent.code_studio_scaffold_contract import (
     legacy_kind_for_primitive,
     primitive_for_legacy_kind,
 )
+from app.engine.multi_agent.code_studio_scaffold_captions import (
+    caption_for_scaffold_primitive,
+)
+from app.engine.multi_agent.code_studio_scaffold_registry import (
+    ScaffoldRendererRegistry,
+)
 from app.engine.multi_agent.code_studio_template_scaffold import (
     build_code_studio_scaffold,
     build_scaffold_visible_caption,
@@ -50,6 +56,33 @@ def test_scaffold_contract_maps_legacy_kinds_without_renderer_imports() -> None:
     assert primitive_for_legacy_kind("unknown") is None
     assert legacy_kind_for_primitive(PRIMITIVE_SCENE) == "literary"
     assert legacy_kind_for_primitive("unknown") == "default"
+
+
+def test_scaffold_renderer_registry_falls_back_to_data_band_renderer() -> None:
+    """Unknown primitive names must have exactly one safe fallback path."""
+    calls: list[dict] = []
+
+    def fallback_renderer(spec: dict) -> str:
+        calls.append(spec)
+        return "fallback-html"
+
+    registry = ScaffoldRendererRegistry(
+        renderers={},
+        fallback_renderer=fallback_renderer,
+    )
+
+    spec = {"primitive": "unknown"}
+    assert registry.render(spec) == "fallback-html"
+    assert calls == [spec]
+
+
+def test_scaffold_caption_contract_is_primitive_based() -> None:
+    """Caption copy can be audited without importing the large renderer."""
+    scene_caption = caption_for_scaffold_primitive(PRIMITIVE_SCENE)
+    fallback_caption = caption_for_scaffold_primitive("unknown")
+
+    assert "scene" in scene_caption.lower()
+    assert "canvas" in fallback_caption.lower()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #413

## Summary
- Extracted direct Pointy selector/inventory policy into `direct_pointy_runtime.py`.
- Extracted explicit web-search forcing and fallback gating into `direct_web_search_policy.py`.
- Extracted direct current-session memory fast paths into `direct_session_memory_runtime.py` with shared direct text folding in `direct_text_utils.py`.
- Extracted Code Studio scaffold renderer dispatch and Vietnamese captions into small audited contracts.
- Updated runtime cleanup audit and codebase map so the architecture map matches the new module boundaries.

## Verification
- `cd maritime-ai-service; uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_code_studio_template_scaffold.py tests/unit/test_conservative_evolution.py tests/unit/test_direct_node_provider_errors.py -q --tb=short` -> 205 passed
- `cd maritime-ai-service; uv run --with ruff ruff check app/engine/multi_agent/direct_node_runtime.py app/engine/multi_agent/direct_session_memory_runtime.py app/engine/multi_agent/direct_text_utils.py app/engine/multi_agent/direct_tool_rounds_runtime.py app/engine/multi_agent/direct_pointy_runtime.py app/engine/multi_agent/direct_web_search_policy.py app/engine/multi_agent/code_studio_template_scaffold.py app/engine/multi_agent/code_studio_scaffold_registry.py app/engine/multi_agent/code_studio_scaffold_captions.py tests/unit/test_code_studio_template_scaffold.py` -> passed
- `cd maritime-ai-service; uv run --with ruff ruff check app/ --select=E9,F63,F7` -> passed
- `git diff --check` -> passed, CRLF normalization warnings only

## Full-suite note
- `cd maritime-ai-service; uv run --extra dev --with openai --with PyJWT --with minio --with structlog --with PyMuPDF pytest tests/unit/ -q --tb=short` -> 12880 passed, 39 skipped, 21 failed.
- Observed failures are outside this refactor surface: `test_sprint160b_hardening` mocked session expectations, `test_sprint196_*`/`test_sprint197_query_planner` missing `duckduckgo_search`, and `test_sprint30_semantic_memory_repo` embedding metadata expectation when embedding backend is unavailable.

## Risk
- Refactor-only change, but it touches direct response/tool-loop runtime import boundaries, so risk is accidental import drift or behavior mismatch in direct fast paths.
- No auth, LMS mutation, migration, or provider-default changes.

## Rollback
- Revert this PR to restore inline helper definitions in `direct_node_runtime.py`, `direct_tool_rounds_runtime.py`, and `code_studio_template_scaffold.py`.
- No data migration or deployment configuration rollback is required.