### PR TITLE
refactor(runtime): isolate document host-action shortcut

### DIFF
--- a/docs/architecture/WIII_CODEBASE_MAP.md
+++ b/docs/architecture/WIII_CODEBASE_MAP.md
@@ -59,7 +59,7 @@ The normal chat turn should be read in this order:
 |---|---|
 | Sync chat behavior | `maritime-ai-service/app/api/v1/chat.py`, then `maritime-ai-service/app/services/chat_orchestrator.py` |
 | Streaming behavior | `maritime-ai-service/app/api/v1/chat_stream.py`, then `maritime-ai-service/app/services/chat_stream_coordinator.py` |
-| Direct tool loop | `maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py`; Pointy policy lives in `direct_pointy_runtime.py`; explicit web-search policy lives in `direct_web_search_policy.py`; current-session memory fast paths live in `direct_session_memory_runtime.py` |
+| Direct tool loop | `maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py`; Pointy policy lives in `direct_pointy_runtime.py`; explicit web-search policy lives in `direct_web_search_policy.py`; uploaded-document host-action shortcuts live in `direct_document_host_action_runtime.py`; current-session memory fast paths live in `direct_session_memory_runtime.py` |
 | Native stream/provider quirks | `maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py` |
 | Routing and supervisor behavior | `maritime-ai-service/app/engine/multi_agent/supervisor*.py` |
 | Tool registry | `maritime-ai-service/app/engine/tools/registry.py` and `maritime-ai-service/app/engine/multi_agent/tool_collection.py` |

--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issue: #413
+Follow-up issues: #413, #415
 
 ## Purpose
 
@@ -33,6 +33,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
 - Follow-up #413 moved Code Studio scaffold renderer dispatch into
   `code_studio_scaffold_registry.py` and visible Vietnamese fallback copy into
   `code_studio_scaffold_captions.py`.
+- Follow-up #415 moved deterministic uploaded-document host-action execution
+  into `direct_document_host_action_runtime.py`, keeping preview-only
+  tool-call/result, host-action emission, thinking trace, and user response as
+  one tested contract.
 
 ## Preserved Intentionally
 
@@ -64,8 +68,9 @@ backups, data PDFs, or local skill folders.
   has moved out. The long-term cleanup direction is lifecycle,
   response-finalization, and SSE V3 parity modules with narrow contract tests.
 - `direct_tool_rounds_runtime.py` remains large, but Pointy and explicit
-  web-search policy have moved out. The next durable step is separating
-  tool-dispatch execution from deterministic host-action shortcuts.
+  web-search policy plus deterministic document host-action execution have
+  moved out. The next durable step is separating generic tool-dispatch
+  execution from final synthesis.
 - `code_studio_template_scaffold.py` is still a large deterministic fallback,
   but contract, renderer dispatch, and caption copy are no longer embedded in
   the renderer body. The next durable step is scaffold-quality gates that
@@ -90,3 +95,5 @@ tests after adding the required `pytest-asyncio` test plugin to the temporary
 uv environment. In follow-up #413, the Code Studio scaffold command passed
 with 54 tests, the direct tool-round command passed with 56 tests, and the
 combined direct-runtime regression set passed with 205 tests.
+In follow-up #415, the direct tool-round command passed with 57 tests after
+adding the document host-action shortcut contract test.

--- a/maritime-ai-service/app/engine/multi_agent/direct_document_host_action_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_document_host_action_runtime.py
@@ -1,0 +1,141 @@
+"""Deterministic uploaded-document host-action execution for direct turns."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from app.engine.multi_agent.state import AgentState
+from app.engine.reasoning import record_thinking_snapshot
+
+
+PushEvent = Callable[[dict[str, Any]], Awaitable[None]]
+InvokeTool = Callable[..., Awaitable[Any]]
+EmitHostAction = Callable[..., Awaitable[None]]
+SummarizeToolResult = Callable[[str, Any], Any]
+
+
+@dataclass(frozen=True)
+class DocumentHostActionShortcut:
+    """Immutable contract for a preview-only uploaded-document host action."""
+
+    tool_name: str
+    tool_call_id: str
+    thinking: str
+    thinking_summary: str
+    thinking_provenance: str
+    response: str
+    failure_log_message: str
+
+
+async def execute_document_host_action_shortcut(
+    *,
+    shortcut: DocumentHostActionShortcut,
+    tool: Any,
+    args: dict[str, Any],
+    state: AgentState,
+    tool_call_events: list[dict[str, Any]],
+    push_event: PushEvent,
+    invoke_tool_with_runtime: InvokeTool,
+    maybe_emit_host_action_event: EmitHostAction,
+    summarize_tool_result_for_stream: SummarizeToolResult,
+    runtime_context_base: Any,
+    query_snippet: str,
+    logger_obj: logging.Logger,
+) -> str:
+    """Execute a preview host action and return the user-visible response."""
+
+    await push_event(
+        {
+            "type": "tool_call",
+            "content": {
+                "name": shortcut.tool_name,
+                "args": args,
+                "id": shortcut.tool_call_id,
+            },
+            "node": "direct",
+        }
+    )
+    tool_call_events.append(
+        {
+            "type": "call",
+            "name": shortcut.tool_name,
+            "args": args,
+            "id": shortcut.tool_call_id,
+        }
+    )
+
+    try:
+        result = await invoke_tool_with_runtime(
+            tool,
+            args,
+            tool_name=shortcut.tool_name,
+            runtime_context_base=runtime_context_base,
+            tool_call_id=shortcut.tool_call_id,
+            query_snippet=query_snippet,
+            prefer_async=False,
+            run_sync_in_thread=True,
+        )
+    except Exception as tool_error:  # noqa: BLE001
+        logger_obj.warning(shortcut.failure_log_message, tool_error)
+        result = "Tool unavailable"
+
+    await push_event(
+        {
+            "type": "tool_result",
+            "content": {
+                "name": shortcut.tool_name,
+                "result": summarize_tool_result_for_stream(shortcut.tool_name, result),
+                "id": shortcut.tool_call_id,
+            },
+            "node": "direct",
+        }
+    )
+    await maybe_emit_host_action_event(
+        push_event=push_event,
+        tool_name=shortcut.tool_name,
+        result=result,
+        node="direct",
+        tool_call_events=tool_call_events,
+    )
+    tool_call_events.append(
+        {
+            "type": "result",
+            "name": shortcut.tool_name,
+            "result": str(result),
+            "id": shortcut.tool_call_id,
+        }
+    )
+
+    state["thinking"] = shortcut.thinking
+    state["thinking_content"] = shortcut.thinking
+    record_thinking_snapshot(
+        state,
+        shortcut.thinking,
+        node="direct",
+        provenance=shortcut.thinking_provenance,
+    )
+    await push_event(
+        {
+            "type": "thinking_start",
+            "content": "",
+            "node": "direct",
+            "summary": shortcut.thinking_summary,
+        }
+    )
+    await push_event(
+        {
+            "type": "thinking_delta",
+            "content": shortcut.thinking,
+            "node": "direct",
+        }
+    )
+    await push_event(
+        {
+            "type": "thinking_end",
+            "content": "",
+            "node": "direct",
+        }
+    )
+    return shortcut.response

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -32,6 +32,10 @@ from app.engine.multi_agent.direct_reasoning import (
 from app.engine.multi_agent.direct_search_synthesis_fallback import (
     build_search_template_fallback,
 )
+from app.engine.multi_agent.direct_document_host_action_runtime import (
+    DocumentHostActionShortcut,
+    execute_document_host_action_shortcut,
+)
 from app.engine.multi_agent.direct_pointy_runtime import (
     _format_pointy_inventory,
     _validate_pointy_selector,
@@ -66,6 +70,42 @@ from app.engine.reasoning import record_thinking_snapshot
 
 
 logger = logging.getLogger(__name__)
+
+_DOC_COURSE_HOST_ACTION_SHORTCUT = DocumentHostActionShortcut(
+    tool_name=_DOC_COURSE_HOST_ACTION_TOOL,
+    tool_call_id="forced_doc_course_preview_0",
+    thinking=(
+        "Mình nhận đây là flow tạo cấu trúc khóa học từ tài liệu upload. "
+        "Vì thao tác này có thể sinh nhiều chương/bài trong LMS, mình dựng "
+        "course_plan có nguồn trích dẫn trước và chỉ gửi host action preview; LMS sẽ "
+        "yêu cầu giáo viên bấm Áp dụng để cấp approval_token trước khi ghi dữ liệu."
+    ),
+    thinking_summary="Tạo cây khóa học từ tài liệu",
+    thinking_provenance="deterministic_document_course_host_action",
+    response=(
+        "Mình đã gửi bản thiết kế khóa học từ tài liệu sang LMS. "
+        "Bạn xem cây chương/bài và nguồn trích dẫn trong hộp xem trước, rồi chỉ bấm Áp dụng "
+        "nếu muốn LMS tạo các chương/bài draft tương ứng."
+    ),
+    failure_log_message="[DIRECT] Deterministic document course host action failed: %s",
+)
+
+_DOC_PREVIEW_HOST_ACTION_SHORTCUT = DocumentHostActionShortcut(
+    tool_name=_DOC_PREVIEW_HOST_ACTION_TOOL,
+    tool_call_id="forced_doc_preview_0",
+    thinking=(
+        "Mình nhận đây là flow upload tài liệu -> tạo preview bài học. "
+        "Vì đây là đường ghi LMS có ràng buộc an toàn, mình không chờ model tự gọi tool; "
+        "mình dựng payload preview từ document_context và gửi host action preview-only để LMS mở phần so sánh thay đổi và nguồn trích dẫn trước."
+    ),
+    thinking_summary="Tao preview bai hoc tu tai lieu",
+    thinking_provenance="deterministic_document_preview_host_action",
+    response=(
+        "Mình đã gửi bản preview từ tài liệu sang LMS. "
+        "Bạn kiểm tra phần so sánh thay đổi và nguồn trích dẫn trong hộp xem trước, rồi chỉ bấm Áp dụng nếu nội dung đúng."
+    ),
+    failure_log_message="[DIRECT] Deterministic document preview host action failed: %s",
+)
 
 _DOC_PREVIEW_LOW_VALUE_LABELS = {
     "buoc",
@@ -2865,114 +2905,20 @@ async def execute_direct_tool_rounds_impl(
         if _should_request_uploaded_doc_course_preview(query=query, state=state, tools=tools):
             forced_course_tool = _find_doc_course_host_action_tool(tools)
             if forced_course_tool is not None:
-                tc_id = "forced_doc_course_preview_0"
                 tc_args = _build_uploaded_doc_course_params(query, state)
-                await push_event(
-                    {
-                        "type": "tool_call",
-                        "content": {
-                            "name": _DOC_COURSE_HOST_ACTION_TOOL,
-                            "args": tc_args,
-                            "id": tc_id,
-                        },
-                        "node": "direct",
-                    }
-                )
-                tool_call_events.append(
-                    {
-                        "type": "call",
-                        "name": _DOC_COURSE_HOST_ACTION_TOOL,
-                        "args": tc_args,
-                        "id": tc_id,
-                    }
-                )
-                try:
-                    result = await graph_invoke_tool_with_runtime(
-                        forced_course_tool,
-                        tc_args,
-                        tool_name=_DOC_COURSE_HOST_ACTION_TOOL,
-                        runtime_context_base=runtime_context_base,
-                        tool_call_id=tc_id,
-                        query_snippet=str(tc_args.get("title", ""))[:100],
-                        prefer_async=False,
-                        run_sync_in_thread=True,
-                    )
-                except Exception as tool_error:
-                    logger.warning(
-                        "[DIRECT] Deterministic document course host action failed: %s",
-                        tool_error,
-                    )
-                    result = "Tool unavailable"
-
-                await push_event(
-                    {
-                        "type": "tool_result",
-                        "content": {
-                            "name": _DOC_COURSE_HOST_ACTION_TOOL,
-                            "result": _summarize_tool_result_for_stream(
-                                _DOC_COURSE_HOST_ACTION_TOOL,
-                                result,
-                            ),
-                            "id": tc_id,
-                        },
-                        "node": "direct",
-                    }
-                )
-                await graph_maybe_emit_host_action_event(
-                    push_event=push_event,
-                    tool_name=_DOC_COURSE_HOST_ACTION_TOOL,
-                    result=result,
-                    node="direct",
+                response = await execute_document_host_action_shortcut(
+                    shortcut=_DOC_COURSE_HOST_ACTION_SHORTCUT,
+                    tool=forced_course_tool,
+                    args=tc_args,
+                    state=state,
                     tool_call_events=tool_call_events,
-                )
-                tool_call_events.append(
-                    {
-                        "type": "result",
-                        "name": _DOC_COURSE_HOST_ACTION_TOOL,
-                        "result": str(result),
-                        "id": tc_id,
-                    }
-                )
-                doc_course_thinking = (
-                    "Mình nhận đây là flow tạo cấu trúc khóa học từ tài liệu upload. "
-                    "Vì thao tác này có thể sinh nhiều chương/bài trong LMS, mình dựng "
-                    "course_plan có nguồn trích dẫn trước và chỉ gửi host action preview; LMS sẽ "
-                    "yêu cầu giáo viên bấm Áp dụng để cấp approval_token trước khi ghi dữ liệu."
-                )
-                state["thinking"] = doc_course_thinking
-                state["thinking_content"] = doc_course_thinking
-                record_thinking_snapshot(
-                    state,
-                    doc_course_thinking,
-                    node="direct",
-                    provenance="deterministic_document_course_host_action",
-                )
-                await push_event(
-                    {
-                        "type": "thinking_start",
-                        "content": "",
-                        "node": "direct",
-                        "summary": "Tạo cây khóa học từ tài liệu",
-                    }
-                )
-                await push_event(
-                    {
-                        "type": "thinking_delta",
-                        "content": doc_course_thinking,
-                        "node": "direct",
-                    }
-                )
-                await push_event(
-                    {
-                        "type": "thinking_end",
-                        "content": "",
-                        "node": "direct",
-                    }
-                )
-                response = (
-                    "Mình đã gửi bản thiết kế khóa học từ tài liệu sang LMS. "
-                    "Bạn xem cây chương/bài và nguồn trích dẫn trong hộp xem trước, rồi chỉ bấm Áp dụng "
-                    "nếu muốn LMS tạo các chương/bài draft tương ứng."
+                    push_event=push_event,
+                    invoke_tool_with_runtime=graph_invoke_tool_with_runtime,
+                    maybe_emit_host_action_event=graph_maybe_emit_host_action_event,
+                    summarize_tool_result_for_stream=_summarize_tool_result_for_stream,
+                    runtime_context_base=runtime_context_base,
+                    query_snippet=str(tc_args.get("title", ""))[:100],
+                    logger_obj=logger,
                 )
                 logger.info(
                     "[DIRECT] Deterministic document course host action requested "
@@ -2992,112 +2938,20 @@ async def execute_direct_tool_rounds_impl(
         if _should_request_uploaded_doc_preview(query=query, state=state, tools=tools):
             forced_preview_tool = _find_doc_preview_host_action_tool(tools)
             if forced_preview_tool is not None:
-                tc_id = "forced_doc_preview_0"
                 tc_args = _build_uploaded_doc_preview_params(query, state)
-                await push_event(
-                    {
-                        "type": "tool_call",
-                        "content": {
-                            "name": _DOC_PREVIEW_HOST_ACTION_TOOL,
-                            "args": tc_args,
-                            "id": tc_id,
-                        },
-                        "node": "direct",
-                    }
-                )
-                tool_call_events.append(
-                    {
-                        "type": "call",
-                        "name": _DOC_PREVIEW_HOST_ACTION_TOOL,
-                        "args": tc_args,
-                        "id": tc_id,
-                    }
-                )
-                try:
-                    result = await graph_invoke_tool_with_runtime(
-                        forced_preview_tool,
-                        tc_args,
-                        tool_name=_DOC_PREVIEW_HOST_ACTION_TOOL,
-                        runtime_context_base=runtime_context_base,
-                        tool_call_id=tc_id,
-                        query_snippet=str(tc_args.get("title", ""))[:100],
-                        prefer_async=False,
-                        run_sync_in_thread=True,
-                    )
-                except Exception as tool_error:
-                    logger.warning(
-                        "[DIRECT] Deterministic document preview host action failed: %s",
-                        tool_error,
-                    )
-                    result = "Tool unavailable"
-
-                await push_event(
-                    {
-                        "type": "tool_result",
-                        "content": {
-                            "name": _DOC_PREVIEW_HOST_ACTION_TOOL,
-                            "result": _summarize_tool_result_for_stream(
-                                _DOC_PREVIEW_HOST_ACTION_TOOL,
-                                result,
-                            ),
-                            "id": tc_id,
-                        },
-                        "node": "direct",
-                    }
-                )
-                await graph_maybe_emit_host_action_event(
-                    push_event=push_event,
-                    tool_name=_DOC_PREVIEW_HOST_ACTION_TOOL,
-                    result=result,
-                    node="direct",
+                response = await execute_document_host_action_shortcut(
+                    shortcut=_DOC_PREVIEW_HOST_ACTION_SHORTCUT,
+                    tool=forced_preview_tool,
+                    args=tc_args,
+                    state=state,
                     tool_call_events=tool_call_events,
-                )
-                tool_call_events.append(
-                    {
-                        "type": "result",
-                        "name": _DOC_PREVIEW_HOST_ACTION_TOOL,
-                        "result": str(result),
-                        "id": tc_id,
-                    }
-                )
-                doc_preview_thinking = (
-                    "Mình nhận đây là flow upload tài liệu -> tạo preview bài học. "
-                    "Vì đây là đường ghi LMS có ràng buộc an toàn, mình không chờ model tự gọi tool; "
-                    "mình dựng payload preview từ document_context và gửi host action preview-only để LMS mở phần so sánh thay đổi và nguồn trích dẫn trước."
-                )
-                state["thinking"] = doc_preview_thinking
-                state["thinking_content"] = doc_preview_thinking
-                record_thinking_snapshot(
-                    state,
-                    doc_preview_thinking,
-                    node="direct",
-                    provenance="deterministic_document_preview_host_action",
-                )
-                await push_event(
-                    {
-                        "type": "thinking_start",
-                        "content": "",
-                        "node": "direct",
-                        "summary": "Tao preview bai hoc tu tai lieu",
-                    }
-                )
-                await push_event(
-                    {
-                        "type": "thinking_delta",
-                        "content": doc_preview_thinking,
-                        "node": "direct",
-                    }
-                )
-                await push_event(
-                    {
-                        "type": "thinking_end",
-                        "content": "",
-                        "node": "direct",
-                    }
-                )
-                response = (
-                    "Mình đã gửi bản preview từ tài liệu sang LMS. "
-                    "Bạn kiểm tra phần so sánh thay đổi và nguồn trích dẫn trong hộp xem trước, rồi chỉ bấm Áp dụng nếu nội dung đúng."
+                    push_event=push_event,
+                    invoke_tool_with_runtime=graph_invoke_tool_with_runtime,
+                    maybe_emit_host_action_event=graph_maybe_emit_host_action_event,
+                    summarize_tool_result_for_stream=_summarize_tool_result_for_stream,
+                    runtime_context_base=runtime_context_base,
+                    query_snippet=str(tc_args.get("title", ""))[:100],
+                    logger_obj=logger,
                 )
                 logger.info(
                     "[DIRECT] Deterministic document preview host action requested "

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -5,6 +5,11 @@ from unittest.mock import patch
 
 import pytest
 
+from app.engine.multi_agent.direct_document_host_action_runtime import (
+    DocumentHostActionShortcut,
+    execute_document_host_action_shortcut,
+)
+
 
 def test_build_direct_final_synthesis_instruction_is_mode_aware_for_market_turn():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (
@@ -1996,3 +2001,70 @@ def test_extract_inventory_ids_from_state_nested_context():
     }
     ids = extract_inventory_ids_from_state(state)
     assert ids == ["btn-x"]
+@pytest.mark.asyncio
+async def test_document_host_action_shortcut_emits_preview_event_contract() -> None:
+    pushed_events: list[dict] = []
+    tool_call_events: list[dict] = []
+    invoke_kwargs: dict = {}
+    state: dict = {}
+
+    shortcut = DocumentHostActionShortcut(
+        tool_name="tool_preview_lesson_patch",
+        tool_call_id="forced_doc_preview_0",
+        thinking="Preview only; wait for approval_token before apply.",
+        thinking_summary="Preview document lesson",
+        thinking_provenance="test_document_preview",
+        response="Preview sent.",
+        failure_log_message="failed: %s",
+    )
+
+    async def push_event(event: dict) -> None:
+        pushed_events.append(event)
+
+    async def invoke_tool(tool, args, **kwargs):
+        invoke_kwargs.update(kwargs)
+        return {"host_action": "preview", "approval_required": True}
+
+    async def emit_host_action(**kwargs) -> None:
+        pushed_events.append(
+            {
+                "type": "host_action",
+                "content": kwargs["result"],
+                "node": kwargs["node"],
+            }
+        )
+
+    response = await execute_document_host_action_shortcut(
+        shortcut=shortcut,
+        tool=object(),
+        args={"title": "Bản nháp"},
+        state=state,
+        tool_call_events=tool_call_events,
+        push_event=push_event,
+        invoke_tool_with_runtime=invoke_tool,
+        maybe_emit_host_action_event=emit_host_action,
+        summarize_tool_result_for_stream=lambda name, result: "summary",
+        runtime_context_base={"request_id": "req-1"},
+        query_snippet="Bản nháp",
+        logger_obj=__import__("logging").getLogger(__name__),
+    )
+
+    assert response == "Preview sent."
+    assert state["thinking_content"] == shortcut.thinking
+    assert invoke_kwargs["tool_name"] == shortcut.tool_name
+    assert invoke_kwargs["tool_call_id"] == shortcut.tool_call_id
+    assert invoke_kwargs["prefer_async"] is False
+    assert invoke_kwargs["run_sync_in_thread"] is True
+    assert [event["type"] for event in pushed_events] == [
+        "tool_call",
+        "tool_result",
+        "host_action",
+        "thinking_start",
+        "thinking_delta",
+        "thinking_end",
+    ]
+    assert [event["type"] for event in tool_call_events] == ["call", "result"]
+    assert tool_call_events[0]["name"] == shortcut.tool_name
+    assert tool_call_events[1]["result"] == str(
+        {"host_action": "preview", "approval_required": True}
+    )


### PR DESCRIPTION
Closes #415

## Summary
- Extracted deterministic uploaded-document host-action execution into `direct_document_host_action_runtime.py`.
- Kept preview-only tool call/result emission, host-action forwarding, thinking trace, and user-visible response under one typed shortcut contract.
- Reduced duplicated document preview/course shortcut code inside `direct_tool_rounds_runtime.py`.
- Added a regression test for document host-action event order and invocation options.
- Updated the cleanup audit and codebase map.

## Verification
- `cd maritime-ai-service; uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short` -> 57 passed
- `cd maritime-ai-service; uv run --with ruff ruff check app/engine/multi_agent/direct_tool_rounds_runtime.py app/engine/multi_agent/direct_document_host_action_runtime.py tests/unit/test_direct_tool_rounds_runtime.py` -> passed
- `cd maritime-ai-service; uv run --with ruff ruff check app/ --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
- Refactor-only path, but it touches the deterministic LMS preview shortcut used for uploaded documents. Main risk is event ordering drift; the new unit test pins tool_call -> tool_result -> host_action -> thinking events.
- No LMS apply mutation, auth, migration, provider default, or deployment config change.

## Rollback
- Revert this PR to restore inline deterministic document host-action execution in `direct_tool_rounds_runtime.py`.
- No database or deployment rollback required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated document preview and course planning execution logic into a unified, reusable handler with improved event streaming and error management.

* **Documentation**
  * Updated architecture and audit documentation to reflect completed refactoring of document host-action processing.

* **Tests**
  * Added test coverage for document host-action shortcut execution, including event emission and state mutations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->