### PR TITLE
Refactor Code Studio scaffold quality gate

### DIFF
--- a/docs/architecture/WIII_CODEBASE_MAP.md
+++ b/docs/architecture/WIII_CODEBASE_MAP.md
@@ -82,7 +82,7 @@ The normal chat turn should be read in this order:
 | Host bridge | `wiii-desktop/src/lib/embed-bridge.ts`, `wiii-desktop/src/lib/context-bridge.ts` |
 | Pointy | `wiii-desktop/src/pointy-host/**` and `wiii-desktop/src/components/chat/PointyModeToggle.tsx` |
 | Voice | `wiii-desktop/src/api/voice.ts`, voice mode/toggle components |
-| Visual artifacts | `wiii-desktop/src/components/chat/VisualArtifactCard.tsx`, `wiii-desktop/src/components/common/InlineVisualFrame.tsx`; deterministic Code Studio fallback contracts live in backend `code_studio_scaffold_*` modules |
+| Visual artifacts | `wiii-desktop/src/components/chat/VisualArtifactCard.tsx`, `wiii-desktop/src/components/common/InlineVisualFrame.tsx`; deterministic Code Studio fallback contracts, captions, registry, and quality gates live in backend `code_studio_scaffold_*` modules |
 
 ## Canonical Contracts
 

--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415
+Follow-up issues: #413, #415, #417
 
 ## Purpose
 
@@ -37,6 +37,9 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   into `direct_document_host_action_runtime.py`, keeping preview-only
   tool-call/result, host-action emission, thinking trace, and user response as
   one tested contract.
+- Follow-up #417 added `code_studio_scaffold_quality.py` so explicit
+  simulation/canvas requests cannot silently fall back to generic data-band
+  templates when no topic classifier matches.
 
 ## Preserved Intentionally
 
@@ -72,9 +75,10 @@ backups, data PDFs, or local skill folders.
   moved out. The next durable step is separating generic tool-dispatch
   execution from final synthesis.
 - `code_studio_template_scaffold.py` is still a large deterministic fallback,
-  but contract, renderer dispatch, and caption copy are no longer embedded in
-  the renderer body. The next durable step is scaffold-quality gates that
-  reject generic templates for simulation requests.
+  but contract, renderer dispatch, caption copy, and explicit-simulation
+  quality policy are no longer embedded in the renderer body. The next durable
+  step is splitting large primitive renderer bodies into focused modules behind
+  the existing registry.
 - Some tests still import compatibility `graph.py` modules. Move tests toward
   `runtime.py` imports when the external import window can close.
 
@@ -97,3 +101,5 @@ with 54 tests, the direct tool-round command passed with 56 tests, and the
 combined direct-runtime regression set passed with 205 tests.
 In follow-up #415, the direct tool-round command passed with 57 tests after
 adding the document host-action shortcut contract test.
+In follow-up #417, the Code Studio scaffold command passed with 56 tests after
+adding the explicit-simulation quality gate.

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_quality.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_quality.py
@@ -1,0 +1,75 @@
+"""Quality gates for deterministic Code Studio scaffold fallbacks."""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Any
+
+from app.engine.multi_agent.code_studio_scaffold_contract import (
+    PRIMITIVE_DATA_BAND,
+    PRIMITIVE_SCENE,
+)
+
+
+_EXPLICIT_SIMULATION_MARKERS = (
+    "canvas",
+    "mo phong",
+    "simulation",
+    "simulate",
+    "tao mo phong",
+    "truc quan hoa",
+    "visualization",
+    "visualize",
+)
+
+
+def _fold_scaffold_quality_text(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", str(value or ""))
+    stripped = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    return " ".join(stripped.lower().replace("đ", "d").split())
+
+
+def looks_explicit_scaffold_simulation_request(query: str) -> bool:
+    """Return True when the user explicitly asks for a visual simulation."""
+    folded = _fold_scaffold_quality_text(query)
+    return bool(folded and any(marker in folded for marker in _EXPLICIT_SIMULATION_MARKERS))
+
+
+def apply_scaffold_quality_gate(query: str, spec: dict[str, Any]) -> dict[str, Any]:
+    """Upgrade generic fallbacks when the user explicitly asked for simulation."""
+    if spec.get("primitive") != PRIMITIVE_DATA_BAND:
+        return spec
+    if not looks_explicit_scaffold_simulation_request(query):
+        return spec
+
+    upgraded = dict(spec)
+    upgraded.update(
+        {
+            "primitive": PRIMITIVE_SCENE,
+            "slider_label": "Nhịp cảnh",
+            "scene_figure": "character",
+            "moments": [
+                {
+                    "key": "Khởi tạo",
+                    "quote": "Bắt đầu dựng cảnh tương tác.",
+                    "sky_blend": 0.0,
+                },
+                {
+                    "key": "Biến chuyển",
+                    "quote": "Kéo thanh trượt để thấy trạng thái và quan hệ trong cảnh thay đổi.",
+                    "sky_blend": 0.5,
+                },
+                {
+                    "key": "Kết quả",
+                    "quote": "Cảnh giữ được nhịp tương tác tối thiểu thay vì chỉ là template dữ liệu.",
+                    "sky_blend": 1.0,
+                },
+            ],
+            "quality_gate": {
+                "name": "explicit_simulation_not_generic_data_band",
+                "from": PRIMITIVE_DATA_BAND,
+                "to": PRIMITIVE_SCENE,
+            },
+        }
+    )
+    return upgraded

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_template_scaffold.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_template_scaffold.py
@@ -114,6 +114,9 @@ from app.engine.multi_agent.code_studio_scaffold_contract import (
 from app.engine.multi_agent.code_studio_scaffold_captions import (
     caption_for_scaffold_primitive,
 )
+from app.engine.multi_agent.code_studio_scaffold_quality import (
+    apply_scaffold_quality_gate,
+)
 from app.engine.multi_agent.code_studio_scaffold_registry import (
     ScaffoldRendererRegistry,
 )
@@ -893,13 +896,13 @@ def _build_default_spec(query: str) -> dict:
             "primitive": PRIMITIVE_PARTICLE_FIELD,
             "drift_direction": inferred_drift,
         }, query)
-    return _enrich_spec({
+    return apply_scaffold_quality_gate(query, _enrich_spec({
         "primitive": PRIMITIVE_DATA_BAND,
         "slider_label": "Tham số chính",
         "slider_min": 10,
         "slider_max": 100,
         "slider_default": 50,
-    }, query)
+    }, query))
 
 
 def extract_scaffold_spec(query: str) -> dict:

--- a/maritime-ai-service/tests/unit/test_code_studio_template_scaffold.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_template_scaffold.py
@@ -37,6 +37,7 @@ from app.engine.multi_agent.code_studio_template_scaffold import (
     build_code_studio_scaffold,
     build_scaffold_visible_caption,
     detect_scaffold_kind,
+    extract_scaffold_spec,
 )
 
 
@@ -166,6 +167,33 @@ def test_scaffold_kind_override() -> None:
 
     literary_html = build_code_studio_scaffold("anything", kind="literary")
     assert "wiii-scene-stage" in literary_html
+
+
+def test_explicit_unknown_simulation_avoids_generic_data_band() -> None:
+    """Unmatched simulation prompts should still render a real scene surface.
+
+    This is the long-term guard against the "slop template" failure mode:
+    when Wiii cannot classify a novel simulation topic, the deterministic
+    fallback must not degrade to a generic data dashboard.
+    """
+    query = "tạo mô phỏng hảo hán đối ẩm xem"
+
+    spec = extract_scaffold_spec(query)
+
+    assert spec["primitive"] == PRIMITIVE_SCENE
+    assert spec["quality_gate"]["name"] == "explicit_simulation_not_generic_data_band"
+    html = build_code_studio_scaffold(query)
+    assert 'data-scaffold-primitive="scene"' in html
+    assert "wiii-scene-stage" in html
+    assert "wiii-default-stage" not in html
+
+
+def test_unknown_non_simulation_still_uses_data_band() -> None:
+    """The quality gate should not over-route ordinary widget requests."""
+    spec = extract_scaffold_spec("widget bất kỳ")
+
+    assert spec["primitive"] == PRIMITIVE_DATA_BAND
+    assert "quality_gate" not in spec
 
 
 def test_scaffold_renders_distinct_html_per_kind() -> None:


### PR DESCRIPTION
## Summary
- Add a deterministic Code Studio scaffold quality gate for explicit simulation/canvas requests that otherwise fall through to the generic data-band fallback.
- Preserve ordinary unknown widget requests on the data-band fallback.
- Update runtime cleanup audit and codebase map with the new quality-policy boundary.

## Verification
- `cd maritime-ai-service && uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_code_studio_template_scaffold.py -q --tb=short` -> 56 passed
- `cd maritime-ai-service && uv run --with ruff ruff check app/engine/multi_agent/code_studio_template_scaffold.py app/engine/multi_agent/code_studio_scaffold_quality.py tests/unit/test_code_studio_template_scaffold.py` -> pass
- `cd maritime-ai-service && uv run --with ruff ruff check app/ --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk
- Low-to-medium runtime behavior risk: only affects deterministic Code Studio fallback when no richer topic/concept route matches and the prompt explicitly asks for simulation/canvas/visualization.
- Security note: existing XSS regression test caught raw-title propagation through the new scene moments during development; the final gate uses static moment copy and the full scaffold test now passes.

## Rollback
- Revert this PR to restore prior behavior where unmatched explicit simulation requests can fall through to the generic data-band scaffold.

Closes #417