### PR TITLE
Extract direct tool-round message builders

### DIFF
--- a/docs/architecture/WIII_CODEBASE_MAP.md
+++ b/docs/architecture/WIII_CODEBASE_MAP.md
@@ -59,7 +59,7 @@ The normal chat turn should be read in this order:
 |---|---|
 | Sync chat behavior | `maritime-ai-service/app/api/v1/chat.py`, then `maritime-ai-service/app/services/chat_orchestrator.py` |
 | Streaming behavior | `maritime-ai-service/app/api/v1/chat_stream.py`, then `maritime-ai-service/app/services/chat_stream_coordinator.py` |
-| Direct tool loop | `maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py`; Pointy policy lives in `direct_pointy_runtime.py`; explicit web-search policy lives in `direct_web_search_policy.py`; uploaded-document host-action shortcuts live in `direct_document_host_action_runtime.py`; current-session memory fast paths live in `direct_session_memory_runtime.py` |
+| Direct tool loop | `maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py`; Pointy policy lives in `direct_pointy_runtime.py`; explicit web-search policy lives in `direct_web_search_policy.py`; uploaded-document host-action shortcuts live in `direct_document_host_action_runtime.py`; direct message builders live in `direct_tool_message_runtime.py`; current-session memory fast paths live in `direct_session_memory_runtime.py` |
 | Native stream/provider quirks | `maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py` |
 | Routing and supervisor behavior | `maritime-ai-service/app/engine/multi_agent/supervisor*.py` |
 | Tool registry | `maritime-ai-service/app/engine/tools/registry.py` and `maritime-ai-service/app/engine/multi_agent/tool_collection.py` |

--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -46,6 +46,9 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
 - Follow-up #421 moved particle-field, oscillation, function-plot, and
   timeline renderer bodies into `code_studio_scaffold_core_renderers.py`,
   completing the Code Studio primitive renderer split behind the registry.
+- Follow-up #423 moved direct tool-round message construction into
+  `direct_tool_message_runtime.py`, reducing provider/tool message-shape logic
+  inside the main tool loop before larger dispatch/synthesis extraction.
 
 ## Preserved Intentionally
 
@@ -77,9 +80,9 @@ backups, data PDFs, or local skill folders.
   has moved out. The long-term cleanup direction is lifecycle,
   response-finalization, and SSE V3 parity modules with narrow contract tests.
 - `direct_tool_rounds_runtime.py` remains large, but Pointy and explicit
-  web-search policy plus deterministic document host-action execution have
-  moved out. The next durable step is separating generic tool-dispatch
-  execution from final synthesis.
+  web-search policy plus deterministic document host-action execution and
+  message builders have moved out. The next durable step is separating generic
+  tool-dispatch execution from final synthesis.
 - `code_studio_template_scaffold.py` is still a large deterministic fallback,
   but contract, renderer dispatch, caption copy, and explicit-simulation
   quality policy are no longer embedded in the renderer body. Scene and
@@ -115,3 +118,5 @@ In follow-up #419, the same scaffold command passed with 56 tests after moving
 scene and data-band renderer bodies out of the monolithic scaffold module.
 In follow-up #421, the same scaffold command passed with 57 tests after moving
 the remaining primitive renderer bodies out of the monolithic scaffold module.
+In follow-up #423, the direct tool-round command passed with 57 tests after
+moving direct message builders out of the main tool loop.

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_message_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_message_runtime.py
@@ -1,0 +1,82 @@
+"""Message builders for direct tool-round execution."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_tool_result_message(
+    content: str,
+    *,
+    tool_call_id: str,
+    native_tool_messages: bool,
+) -> Any:
+    """Create the post-tool message without depending on LangChain."""
+    if native_tool_messages:
+        from app.engine.native_chat_runtime import make_tool_message
+
+        return make_tool_message(content, tool_call_id=tool_call_id)
+
+    from app.engine.messages import Message
+
+    return Message(role="tool", content=content, tool_call_id=tool_call_id)
+
+
+def build_user_instruction_message(
+    content: str,
+    *,
+    native_tool_messages: bool,
+) -> Any:
+    """Create a user instruction message for final synthesis."""
+    if native_tool_messages:
+        from app.engine.native_chat_runtime import make_user_message
+
+        return make_user_message(content)
+
+    from app.engine.messages import Message
+
+    return Message(role="user", content=content)
+
+
+def build_assistant_message(
+    content: str,
+    *,
+    native_tool_messages: bool,
+) -> Any:
+    """Create an assistant message for direct tool-round control flow."""
+    if native_tool_messages:
+        from app.engine.native_chat_runtime import make_assistant_message
+
+        return make_assistant_message(content)
+
+    from app.engine.messages import Message
+
+    return Message(role="assistant", content=content)
+
+
+def build_assistant_tool_call_message(
+    tool_calls: list[dict[str, Any]],
+    *,
+    native_tool_messages: bool,
+) -> Any:
+    """Create an assistant message containing normalized tool calls."""
+    if native_tool_messages:
+        from app.engine.native_chat_runtime import make_assistant_message
+
+        return make_assistant_message("", tool_calls=tool_calls)
+
+    from app.engine.messages import Message, ToolCall
+
+    return Message(
+        role="assistant",
+        content="",
+        tool_calls=[
+            ToolCall(
+                id=str(call.get("id") or f"raw_tool_call_{index}"),
+                name=str(call.get("name") or ""),
+                arguments=dict(call.get("args") or call.get("arguments") or {}),
+            )
+            for index, call in enumerate(tool_calls)
+            if str(call.get("name") or "").strip()
+        ],
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -21,6 +21,12 @@ from app.engine.multi_agent.direct_opening_runtime import (
     finalize_direct_opening_phase_impl,
     start_direct_opening_phase_impl,
 )
+from app.engine.multi_agent.direct_tool_message_runtime import (
+    build_assistant_message as _build_assistant_message,
+    build_assistant_tool_call_message as _build_assistant_tool_call_message,
+    build_tool_result_message as _build_tool_result_message,
+    build_user_instruction_message as _build_user_instruction_message,
+)
 from app.engine.multi_agent.direct_prompts import _resolve_tool_choice, _tool_name
 from app.engine.multi_agent.direct_reasoning import (
     _build_direct_analytical_axes,
@@ -2543,81 +2549,6 @@ def _build_direct_final_synthesis_instruction(
             + "KHONG dung heading Markdown nhu #, ##, ###."
         )
     return base
-
-
-def _build_tool_result_message(
-    content: str,
-    *,
-    tool_call_id: str,
-    native_tool_messages: bool,
-) -> Any:
-    """Create the post-tool message without depending on LangChain."""
-    if native_tool_messages:
-        from app.engine.native_chat_runtime import make_tool_message
-
-        return make_tool_message(content, tool_call_id=tool_call_id)
-
-    from app.engine.messages import Message
-
-    return Message(role="tool", content=content, tool_call_id=tool_call_id)
-
-
-def _build_user_instruction_message(
-    content: str,
-    *,
-    native_tool_messages: bool,
-) -> Any:
-    """Create a user instruction message for final synthesis."""
-    if native_tool_messages:
-        from app.engine.native_chat_runtime import make_user_message
-
-        return make_user_message(content)
-
-    from app.engine.messages import Message
-
-    return Message(role="user", content=content)
-
-
-def _build_assistant_message(
-    content: str,
-    *,
-    native_tool_messages: bool,
-) -> Any:
-    if native_tool_messages:
-        from app.engine.native_chat_runtime import make_assistant_message
-
-        return make_assistant_message(content)
-
-    from app.engine.messages import Message
-
-    return Message(role="assistant", content=content)
-
-
-def _build_assistant_tool_call_message(
-    tool_calls: list[dict[str, Any]],
-    *,
-    native_tool_messages: bool,
-) -> Any:
-    if native_tool_messages:
-        from app.engine.native_chat_runtime import make_assistant_message
-
-        return make_assistant_message("", tool_calls=tool_calls)
-
-    from app.engine.messages import Message, ToolCall
-
-    return Message(
-        role="assistant",
-        content="",
-        tool_calls=[
-            ToolCall(
-                id=str(call.get("id") or f"raw_tool_call_{index}"),
-                name=str(call.get("name") or ""),
-                arguments=dict(call.get("args") or call.get("arguments") or {}),
-            )
-            for index, call in enumerate(tool_calls)
-            if str(call.get("name") or "").strip()
-        ],
-    )
 
 
 async def execute_direct_tool_rounds_impl(


### PR DESCRIPTION
## Summary
- Move direct tool-round message construction into `direct_tool_message_runtime.py`.
- Keep existing `_build_*` call sites stable through alias imports in `direct_tool_rounds_runtime.py`.
- Update cleanup audit and codebase map with the new direct-tool boundary.

## Verification
- `cd maritime-ai-service && uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short` -> 57 passed
- `cd maritime-ai-service && uv run --with ruff ruff check app/engine/multi_agent/direct_tool_rounds_runtime.py app/engine/multi_agent/direct_tool_message_runtime.py tests/unit/test_direct_tool_rounds_runtime.py` -> pass
- `cd maritime-ai-service && uv run --with ruff ruff check app/ --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk
- Low-to-medium provider/tool-loop compatibility risk: this moves message shape helpers but keeps call sites and behavior stable for native chat messages and legacy `Message` objects.

## Rollback
- Revert this PR to restore the helper functions inside `direct_tool_rounds_runtime.py`.

Closes #423