### PR TITLE
refactor(runtime): extract direct tool dispatch

### DIFF
--- a/docs/architecture/WIII_CODEBASE_MAP.md
+++ b/docs/architecture/WIII_CODEBASE_MAP.md
@@ -59,7 +59,7 @@ The normal chat turn should be read in this order:
 |---|---|
 | Sync chat behavior | `maritime-ai-service/app/api/v1/chat.py`, then `maritime-ai-service/app/services/chat_orchestrator.py` |
 | Streaming behavior | `maritime-ai-service/app/api/v1/chat_stream.py`, then `maritime-ai-service/app/services/chat_stream_coordinator.py` |
-| Direct tool loop | `maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py`; generic dispatch helpers live in `direct_tool_dispatch_runtime.py`; Pointy policy lives in `direct_pointy_runtime.py`; explicit web-search policy lives in `direct_web_search_policy.py`; uploaded-document host-action shortcuts live in `direct_document_host_action_runtime.py`; direct message builders live in `direct_tool_message_runtime.py`; current-session memory fast paths live in `direct_session_memory_runtime.py` |
+| Direct tool loop | `maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py` (main orchestration)<br>Generic dispatch: `direct_tool_dispatch_runtime.py`<br>Pointy policy: `direct_pointy_runtime.py`<br>Web-search policy: `direct_web_search_policy.py`<br>Document host-action shortcuts: `direct_document_host_action_runtime.py`<br>Message builders: `direct_tool_message_runtime.py`<br>Session-memory fast paths: `direct_session_memory_runtime.py` |
 | Native stream/provider quirks | `maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py` |
 | Routing and supervisor behavior | `maritime-ai-service/app/engine/multi_agent/supervisor*.py` |
 | Tool registry | `maritime-ai-service/app/engine/tools/registry.py` and `maritime-ai-service/app/engine/multi_agent/tool_collection.py` |

--- a/docs/architecture/WIII_CODEBASE_MAP.md
+++ b/docs/architecture/WIII_CODEBASE_MAP.md
@@ -59,7 +59,7 @@ The normal chat turn should be read in this order:
 |---|---|
 | Sync chat behavior | `maritime-ai-service/app/api/v1/chat.py`, then `maritime-ai-service/app/services/chat_orchestrator.py` |
 | Streaming behavior | `maritime-ai-service/app/api/v1/chat_stream.py`, then `maritime-ai-service/app/services/chat_stream_coordinator.py` |
-| Direct tool loop | `maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py`; Pointy policy lives in `direct_pointy_runtime.py`; explicit web-search policy lives in `direct_web_search_policy.py`; uploaded-document host-action shortcuts live in `direct_document_host_action_runtime.py`; direct message builders live in `direct_tool_message_runtime.py`; current-session memory fast paths live in `direct_session_memory_runtime.py` |
+| Direct tool loop | `maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py`; generic dispatch helpers live in `direct_tool_dispatch_runtime.py`; Pointy policy lives in `direct_pointy_runtime.py`; explicit web-search policy lives in `direct_web_search_policy.py`; uploaded-document host-action shortcuts live in `direct_document_host_action_runtime.py`; direct message builders live in `direct_tool_message_runtime.py`; current-session memory fast paths live in `direct_session_memory_runtime.py` |
 | Native stream/provider quirks | `maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py` |
 | Routing and supervisor behavior | `maritime-ai-service/app/engine/multi_agent/supervisor*.py` |
 | Tool registry | `maritime-ai-service/app/engine/tools/registry.py` and `maritime-ai-service/app/engine/multi_agent/tool_collection.py` |

--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -125,6 +125,6 @@ In follow-up #421, the same scaffold command passed with 57 tests after moving
 the remaining primitive renderer bodies out of the monolithic scaffold module.
 In follow-up #423, the direct tool-round command passed with 57 tests after
 moving direct message builders out of the main tool loop.
-In follow-up #425, the direct dispatch focused tests were added alongside the
-direct tool-round command after moving generic dispatch out of the main tool
-loop.
+In follow-up #425, the direct tool-round command passed with 60 tests after
+moving generic dispatch out of the main tool loop and adding focused
+`direct_tool_dispatch_runtime.py` tests.

--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -49,6 +49,11 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
 - Follow-up #423 moved direct tool-round message construction into
   `direct_tool_message_runtime.py`, reducing provider/tool message-shape logic
   inside the main tool loop before larger dispatch/synthesis extraction.
+- Follow-up #425 moved generic direct tool dispatch into
+  `direct_tool_dispatch_runtime.py`, preserving SSE `tool_call`/`tool_result`
+  event shape, runtime invocation options, search-query adjustment, and
+  unknown-tool recovery while leaving Pointy, visual, reflection, handoff, and
+  final synthesis orchestration in the main loop.
 
 ## Preserved Intentionally
 
@@ -80,9 +85,9 @@ backups, data PDFs, or local skill folders.
   has moved out. The long-term cleanup direction is lifecycle,
   response-finalization, and SSE V3 parity modules with narrow contract tests.
 - `direct_tool_rounds_runtime.py` remains large, but Pointy and explicit
-  web-search policy plus deterministic document host-action execution and
-  message builders have moved out. The next durable step is separating generic
-  tool-dispatch execution from final synthesis.
+  web-search policy plus deterministic document host-action execution, message
+  builders, and generic tool dispatch have moved out. The next durable step is
+  separating final synthesis and post-tool convergence policy.
 - `code_studio_template_scaffold.py` is still a large deterministic fallback,
   but contract, renderer dispatch, caption copy, and explicit-simulation
   quality policy are no longer embedded in the renderer body. Scene and
@@ -120,3 +125,6 @@ In follow-up #421, the same scaffold command passed with 57 tests after moving
 the remaining primitive renderer bodies out of the monolithic scaffold module.
 In follow-up #423, the direct tool-round command passed with 57 tests after
 moving direct message builders out of the main tool loop.
+In follow-up #425, the direct dispatch focused tests were added alongside the
+direct tool-round command after moving generic dispatch out of the main tool
+loop.

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_dispatch_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_dispatch_runtime.py
@@ -1,0 +1,121 @@
+"""Generic tool dispatch helpers for direct tool-round execution."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class DirectToolDispatchResult:
+    """Result of one normalized direct tool call dispatch."""
+
+    tool_call_id: str
+    tool_name: str
+    tool_args: dict[str, Any]
+    result: Any
+    matched: bool
+
+
+def normalize_tool_call(tool_call: Any) -> dict[str, Any]:
+    """Normalize provider-specific tool call objects to Wiii's dict shape."""
+    if isinstance(tool_call, dict):
+        return tool_call
+    return {
+        "id": getattr(tool_call, "id", "") or "",
+        "name": getattr(tool_call, "name", "") or "",
+        "args": getattr(tool_call, "arguments", None)
+        or getattr(tool_call, "args", None)
+        or {},
+    }
+
+
+async def dispatch_direct_tool_call(
+    *,
+    tool_call: dict[str, Any],
+    tool_round: int,
+    tools: list[Any],
+    query: str,
+    push_event,
+    tool_call_events: list[dict[str, Any]],
+    get_tool_by_name,
+    invoke_tool_with_runtime,
+    runtime_context_base: Any,
+    is_search_tool_name,
+    prefer_official_query_for_known_docs,
+    summarize_tool_result_for_stream,
+    logger_obj: logging.Logger,
+) -> DirectToolDispatchResult:
+    """Run one tool call and emit the stable SSE call/result event pair."""
+    tool_call_id = str(tool_call.get("id", f"tc_{tool_round}"))
+    tool_name = str(tool_call.get("name", "unknown"))
+    tool_args = tool_call.get("args", {}) or {}
+    if not isinstance(tool_args, dict):
+        tool_args = {"value": tool_args}
+        tool_call["args"] = tool_args
+
+    if is_search_tool_name(tool_name):
+        tool_args = prefer_official_query_for_known_docs(tool_args, query)
+        tool_call["args"] = tool_args
+
+    await push_event(
+        {
+            "type": "tool_call",
+            "content": {"name": tool_name, "args": tool_args, "id": tool_call_id},
+            "node": "direct",
+        }
+    )
+    tool_call_events.append(
+        {
+            "type": "call",
+            "name": tool_name,
+            "args": tool_args,
+            "id": tool_call_id,
+        }
+    )
+
+    matched = get_tool_by_name(tools, tool_name.strip())
+    try:
+        if matched:
+            result = await invoke_tool_with_runtime(
+                matched,
+                tool_args,
+                tool_name=tool_name,
+                runtime_context_base=runtime_context_base,
+                tool_call_id=tool_call_id,
+                query_snippet=str(tool_args.get("query", ""))[:100],
+                prefer_async=False,
+                run_sync_in_thread=True,
+            )
+        else:
+            logger_obj.warning(
+                "[DIRECT] LLM called unknown tool name=%r - skipping",
+                tool_name,
+            )
+            result = (
+                f"Lỗi: không tìm thấy tool `{tool_name}` trong registry. "
+                "Hãy gọi đúng tên tool có sẵn."
+            )
+    except Exception as tool_error:  # noqa: BLE001
+        logger_obj.warning("[DIRECT] Tool %s failed: %s", tool_name, tool_error)
+        result = "Tool unavailable"
+
+    await push_event(
+        {
+            "type": "tool_result",
+            "content": {
+                "name": tool_name,
+                "result": summarize_tool_result_for_stream(tool_name, result),
+                "id": tool_call_id,
+            },
+            "node": "direct",
+        }
+    )
+    return DirectToolDispatchResult(
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        tool_args=tool_args,
+        result=result,
+        matched=bool(matched),
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_dispatch_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_dispatch_runtime.py
@@ -48,7 +48,7 @@ async def dispatch_direct_tool_call(
     logger_obj: logging.Logger,
 ) -> DirectToolDispatchResult:
     """Run one tool call and emit the stable SSE call/result event pair."""
-    tool_call_id = str(tool_call.get("id", f"tc_{tool_round}"))
+    tool_call_id = str(tool_call.get("id") or f"tc_{tool_round}")
     tool_name = str(tool_call.get("name", "unknown"))
     tool_args = tool_call.get("args", {}) or {}
     if not isinstance(tool_args, dict):

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -27,6 +27,10 @@ from app.engine.multi_agent.direct_tool_message_runtime import (
     build_tool_result_message as _build_tool_result_message,
     build_user_instruction_message as _build_user_instruction_message,
 )
+from app.engine.multi_agent.direct_tool_dispatch_runtime import (
+    dispatch_direct_tool_call,
+    normalize_tool_call as _normalize_tool_call,
+)
 from app.engine.multi_agent.direct_prompts import _resolve_tool_choice, _tool_name
 from app.engine.multi_agent.direct_reasoning import (
     _build_direct_analytical_axes,
@@ -2977,21 +2981,12 @@ async def execute_direct_tool_rounds_impl(
     # `from_openai_response` → pydantic `ToolCall(id, name, arguments)`.
     # Existing loop body assumes dict access (`tc.get("args")`). Normalize
     # here so both shapes work without rewriting 50+ lines downstream.
-    def _normalize_tc(tc) -> dict:
-        if isinstance(tc, dict):
-            return tc
-        return {
-            "id": getattr(tc, "id", "") or "",
-            "name": getattr(tc, "name", "") or "",
-            "args": getattr(tc, "arguments", None)
-                    or getattr(tc, "args", None)
-                    or {},
-        }
-
     for tool_round in range(max_rounds):
         if not (tools and hasattr(llm_response, "tool_calls") and llm_response.tool_calls):
             break
-        normalized_tool_calls = [_normalize_tc(tc) for tc in llm_response.tool_calls]
+        normalized_tool_calls = [
+            _normalize_tool_call(tc) for tc in llm_response.tool_calls
+        ]
         round_tool_names = [
             str(tc.get("name", "unknown"))
             for tc in normalized_tool_calls
@@ -3002,67 +2997,25 @@ async def execute_direct_tool_rounds_impl(
         visual_session_ids: list[str] = []
         active_visual_session_ids = _collect_active_visual_session_ids(state)
         for tc in normalized_tool_calls:
-            tc_id = tc.get("id", f"tc_{tool_round}")
-            tc_name = tc.get("name", "unknown")
-            tc_args = tc.get("args", {}) or {}
-            if _is_search_tool_name(str(tc_name)):
-                tc_args = _prefer_official_query_for_known_docs(tc_args, query)
-                tc["args"] = tc_args
-            await push_event(
-                {
-                    "type": "tool_call",
-                    "content": {"name": tc_name, "args": tc_args, "id": tc_id},
-                    "node": "direct",
-                }
+            dispatch_result = await dispatch_direct_tool_call(
+                tool_call=tc,
+                tool_round=tool_round,
+                tools=tools,
+                query=query,
+                push_event=push_event,
+                tool_call_events=tool_call_events,
+                get_tool_by_name=graph_get_tool_by_name,
+                invoke_tool_with_runtime=graph_invoke_tool_with_runtime,
+                runtime_context_base=runtime_context_base,
+                is_search_tool_name=_is_search_tool_name,
+                prefer_official_query_for_known_docs=_prefer_official_query_for_known_docs,
+                summarize_tool_result_for_stream=_summarize_tool_result_for_stream,
+                logger_obj=logger,
             )
-            tool_call_events.append(
-                {
-                    "type": "call",
-                    "name": tc_name,
-                    "args": tc_args,
-                    "id": tc_id,
-                }
-            )
-            matched = graph_get_tool_by_name(tools, str(tc_name).strip())
-            try:
-                if matched:
-                    result = await graph_invoke_tool_with_runtime(
-                        matched,
-                        tc_args,
-                        tool_name=tc_name,
-                        runtime_context_base=runtime_context_base,
-                        tool_call_id=tc_id,
-                        query_snippet=str(tc_args.get("query", ""))[:100],
-                        prefer_async=False,
-                        run_sync_in_thread=True,
-                    )
-                else:
-                    # Phase 35 — when LLM hallucinates a tool name (or DSML
-                    # parser extracts a bad name), don't surface "Unknown tool"
-                    # to the user's source list. Log warning + return a
-                    # structured error result so the model can recover.
-                    logger.warning(
-                        "[DIRECT] LLM called unknown tool name=%r — skipping",
-                        tc_name,
-                    )
-                    result = (
-                        f"Lỗi: không tìm thấy tool `{tc_name}` trong registry. "
-                        "Hãy gọi đúng tên tool có sẵn."
-                    )
-            except Exception as tool_error:
-                logger.warning("[DIRECT] Tool %s failed: %s", tc_name, tool_error)
-                result = "Tool unavailable"
-            await push_event(
-                {
-                    "type": "tool_result",
-                    "content": {
-                        "name": tc_name,
-                        "result": _summarize_tool_result_for_stream(tc_name, result),
-                        "id": tc_id,
-                    },
-                    "node": "direct",
-                }
-            )
+            tc_id = dispatch_result.tool_call_id
+            tc_name = dispatch_result.tool_name
+            tc_args = dispatch_result.tool_args
+            result = dispatch_result.result
             # Wiii Pointy — agent invoked tool_pointy_show / clear.
             #
             # v3.0 anti-hallucination: validate selector vs available_targets

--- a/maritime-ai-service/tests/unit/test_direct_tool_dispatch_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_dispatch_runtime.py
@@ -1,0 +1,138 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.engine.multi_agent.direct_tool_dispatch_runtime import (
+    dispatch_direct_tool_call,
+    normalize_tool_call,
+)
+
+
+def test_normalize_tool_call_preserves_dicts_and_provider_objects():
+    raw = {"id": "call_1", "name": "tool_demo", "args": {"query": "abc"}}
+    provider_call = SimpleNamespace(
+        id="call_2",
+        name="tool_other",
+        arguments={"query": "xyz"},
+    )
+
+    assert normalize_tool_call(raw) is raw
+    assert normalize_tool_call(provider_call) == {
+        "id": "call_2",
+        "name": "tool_other",
+        "args": {"query": "xyz"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_dispatch_direct_tool_call_emits_stable_call_and_result_events():
+    class FakeTool:
+        name = "tool_web_search"
+
+    events: list[dict] = []
+    tool_call_events: list[dict] = []
+    captured_invocation: dict[str, object] = {}
+    tool_call = {
+        "id": "call_1",
+        "name": "tool_web_search",
+        "args": {"query": "openai docs"},
+    }
+
+    async def push_event(event):
+        events.append(event)
+
+    def get_tool_by_name(tools, name):
+        return next((tool for tool in tools if tool.name == name), None)
+
+    async def invoke_tool_with_runtime(tool, args, **kwargs):
+        captured_invocation.update({"tool": tool, "args": args, **kwargs})
+        return {"answer": "ok"}
+
+    result = await dispatch_direct_tool_call(
+        tool_call=tool_call,
+        tool_round=0,
+        tools=[FakeTool()],
+        query="Tìm nguồn chính thức OpenAI",
+        push_event=push_event,
+        tool_call_events=tool_call_events,
+        get_tool_by_name=get_tool_by_name,
+        invoke_tool_with_runtime=invoke_tool_with_runtime,
+        runtime_context_base={"request_id": "req_1"},
+        is_search_tool_name=lambda name: name == "tool_web_search",
+        prefer_official_query_for_known_docs=lambda args, _query: {
+            **args,
+            "query": "OpenAI API Reference",
+        },
+        summarize_tool_result_for_stream=lambda _name, value: value,
+        logger_obj=SimpleNamespace(warning=lambda *args, **kwargs: None),
+    )
+
+    assert result.matched is True
+    assert result.tool_call_id == "call_1"
+    assert result.tool_name == "tool_web_search"
+    assert result.tool_args == {"query": "OpenAI API Reference"}
+    assert result.result == {"answer": "ok"}
+    assert tool_call["args"] == {"query": "OpenAI API Reference"}
+    assert tool_call_events == [
+        {
+            "type": "call",
+            "name": "tool_web_search",
+            "args": {"query": "OpenAI API Reference"},
+            "id": "call_1",
+        }
+    ]
+    assert [event["type"] for event in events] == ["tool_call", "tool_result"]
+    assert events[0]["content"] == {
+        "name": "tool_web_search",
+        "args": {"query": "OpenAI API Reference"},
+        "id": "call_1",
+    }
+    assert events[1]["content"] == {
+        "name": "tool_web_search",
+        "result": {"answer": "ok"},
+        "id": "call_1",
+    }
+    assert captured_invocation["runtime_context_base"] == {"request_id": "req_1"}
+    assert captured_invocation["tool_call_id"] == "call_1"
+    assert captured_invocation["query_snippet"] == "OpenAI API Reference"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_direct_tool_call_returns_structured_unknown_tool_error():
+    events: list[dict] = []
+    tool_call_events: list[dict] = []
+
+    async def push_event(event):
+        events.append(event)
+
+    async def invoke_tool_with_runtime(*_args, **_kwargs):
+        raise AssertionError("Unknown tools must not be invoked")
+
+    result = await dispatch_direct_tool_call(
+        tool_call={"name": "tool_missing", "args": {"query": "abc"}},
+        tool_round=3,
+        tools=[],
+        query="abc",
+        push_event=push_event,
+        tool_call_events=tool_call_events,
+        get_tool_by_name=lambda _tools, _name: None,
+        invoke_tool_with_runtime=invoke_tool_with_runtime,
+        runtime_context_base=None,
+        is_search_tool_name=lambda _name: False,
+        prefer_official_query_for_known_docs=lambda args, _query: args,
+        summarize_tool_result_for_stream=lambda _name, value: value,
+        logger_obj=SimpleNamespace(warning=lambda *args, **kwargs: None),
+    )
+
+    assert result.matched is False
+    assert result.tool_call_id == "tc_3"
+    assert "không tìm thấy tool `tool_missing`" in result.result
+    assert tool_call_events == [
+        {
+            "type": "call",
+            "name": "tool_missing",
+            "args": {"query": "abc"},
+            "id": "tc_3",
+        }
+    ]
+    assert events[1]["content"]["result"] == result.result

--- a/maritime-ai-service/tests/unit/test_direct_tool_dispatch_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_dispatch_runtime.py
@@ -109,7 +109,7 @@ async def test_dispatch_direct_tool_call_returns_structured_unknown_tool_error()
         raise AssertionError("Unknown tools must not be invoked")
 
     result = await dispatch_direct_tool_call(
-        tool_call={"name": "tool_missing", "args": {"query": "abc"}},
+        tool_call={"id": "", "name": "tool_missing", "args": {"query": "abc"}},
         tool_round=3,
         tools=[],
         query="abc",


### PR DESCRIPTION
## Summary

- Moves normalized direct tool dispatch into `direct_tool_dispatch_runtime.py`.
- Keeps `direct_tool_rounds_runtime.py` responsible for orchestration, Pointy validation, visual events, reflection, handoff state, and final synthesis.
- Adds focused dispatch regression tests for provider-object normalization, SSE `tool_call`/`tool_result` event shape, search-query adjustment, invocation options, and unknown-tool recovery.
- Updates the runtime cleanup audit and codebase map.

Closes #425.

## Scope

In scope:
- Generic direct tool call dispatch only.
- Backend runtime docs for this cleanup boundary.

Out of scope:
- No provider routing changes.
- No LMS preview/apply behavior changes.
- No prompt/persona or frontend UI changes.

## Owner / Agents

Owner: Codex
Agents: Codex only
Owned paths: `maritime-ai-service/app/engine/multi_agent/direct_tool_*`, `maritime-ai-service/tests/unit/test_direct_tool_dispatch_runtime.py`, runtime docs
Conflict risk: low; behavior-preserving extraction in direct runtime.

## Verification

```powershell
cd maritime-ai-service
uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_dispatch_runtime.py tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short
# 60 passed

uv run --with ruff ruff check app/engine/multi_agent/direct_tool_rounds_runtime.py app/engine/multi_agent/direct_tool_dispatch_runtime.py tests/unit/test_direct_tool_dispatch_runtime.py tests/unit/test_direct_tool_rounds_runtime.py
# All checks passed!

uv run --with ruff ruff check app/ --select=E9,F63,F7
# All checks passed!

git diff --check
# passed
```

## Risk / Rollback

Risk is medium-low because direct backend tool dispatch is a runtime path, but the PR preserves SSE event shape and invocation options with targeted tests. Rollback is to revert this PR, restoring the inline dispatch block in `direct_tool_rounds_runtime.py`.

## Reviewer Focus

- Confirm `tool_call_events` ordering remains compatible: dispatch appends the call event, while the orchestration layer still appends final result/host/visual events in the existing order.
- Confirm Pointy, visual, reflection, handoff, and synthesis behavior stayed outside this extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation and runtime cleanup audit notes to reflect recent infrastructure changes.

* **Tests**
  * Added new test coverage for tool call normalization and execution logic.

* **Refactor**
  * Centralized and improved direct tool dispatch logic for enhanced reliability and consistency in tool execution, including improved handling of unknown tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->