### PR TITLE
refactor(runtime): extract direct final synthesis helpers

### DIFF
--- a/docs/architecture/WIII_CODEBASE_MAP.md
+++ b/docs/architecture/WIII_CODEBASE_MAP.md
@@ -59,7 +59,7 @@ The normal chat turn should be read in this order:
 |---|---|
 | Sync chat behavior | `maritime-ai-service/app/api/v1/chat.py`, then `maritime-ai-service/app/services/chat_orchestrator.py` |
 | Streaming behavior | `maritime-ai-service/app/api/v1/chat_stream.py`, then `maritime-ai-service/app/services/chat_stream_coordinator.py` |
-| Direct tool loop | `maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py` (main orchestration)<br>Generic dispatch: `direct_tool_dispatch_runtime.py`<br>Pointy policy: `direct_pointy_runtime.py`<br>Web-search policy: `direct_web_search_policy.py`<br>Document host-action shortcuts: `direct_document_host_action_runtime.py`<br>Message builders: `direct_tool_message_runtime.py`<br>Session-memory fast paths: `direct_session_memory_runtime.py` |
+| Direct tool loop | `maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py` (main orchestration)<br>Generic dispatch: `direct_tool_dispatch_runtime.py`<br>Final synthesis helpers: `direct_final_synthesis_runtime.py`<br>Pointy policy: `direct_pointy_runtime.py`<br>Web-search policy: `direct_web_search_policy.py`<br>Document host-action shortcuts: `direct_document_host_action_runtime.py`<br>Message builders: `direct_tool_message_runtime.py`<br>Session-memory fast paths: `direct_session_memory_runtime.py` |
 | Native stream/provider quirks | `maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py` |
 | Routing and supervisor behavior | `maritime-ai-service/app/engine/multi_agent/supervisor*.py` |
 | Tool registry | `maritime-ai-service/app/engine/tools/registry.py` and `maritime-ai-service/app/engine/multi_agent/tool_collection.py` |

--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -54,6 +54,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   event shape, runtime invocation options, search-query adjustment, and
   unknown-tool recovery while leaving Pointy, visual, reflection, handoff, and
   final synthesis orchestration in the main loop.
+- Follow-up #427 moved visible-answer extraction and final synthesis
+  instruction construction into `direct_final_synthesis_runtime.py`, preserving
+  compatibility aliases in the main tool-round module while leaving final
+  synthesis execution and provider fallback unchanged.
 
 ## Preserved Intentionally
 
@@ -86,8 +90,9 @@ backups, data PDFs, or local skill folders.
   response-finalization, and SSE V3 parity modules with narrow contract tests.
 - `direct_tool_rounds_runtime.py` remains large, but Pointy and explicit
   web-search policy plus deterministic document host-action execution, message
-  builders, and generic tool dispatch have moved out. The next durable step is
-  separating final synthesis and post-tool convergence policy.
+  builders, generic tool dispatch, and final synthesis helper construction have
+  moved out. The next durable step is separating final synthesis execution and
+  post-tool convergence policy.
 - `code_studio_template_scaffold.py` is still a large deterministic fallback,
   but contract, renderer dispatch, caption copy, and explicit-simulation
   quality policy are no longer embedded in the renderer body. Scene and
@@ -128,3 +133,5 @@ moving direct message builders out of the main tool loop.
 In follow-up #425, the direct tool-round command passed with 60 tests after
 moving generic dispatch out of the main tool loop and adding focused
 `direct_tool_dispatch_runtime.py` tests.
+In follow-up #427, the direct tool-round command passed with 57 tests after
+moving final synthesis helper bodies out of the main tool loop.

--- a/maritime-ai-service/app/engine/multi_agent/direct_final_synthesis_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_final_synthesis_runtime.py
@@ -1,0 +1,75 @@
+"""Final synthesis helpers for direct tool-round execution."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.engine.multi_agent.direct_reasoning import (
+    _build_direct_analytical_axes,
+    _build_direct_evidence_plan,
+    _infer_direct_thinking_mode,
+)
+from app.engine.multi_agent.state import AgentState
+
+
+def extract_direct_visible_text(content: Any) -> str:
+    """Return the answer text that would be visible to the user."""
+    try:
+        from app.services.output_processor import extract_thinking_from_response
+
+        text_content, _thinking_content = extract_thinking_from_response(content)
+        return str(text_content or "").strip()
+    except Exception:
+        return str(content or "").strip()
+
+
+def build_direct_final_synthesis_instruction(
+    query: str,
+    state: AgentState,
+    tool_names: list[str],
+) -> str:
+    """Build a mode-aware final synthesis instruction after tool rounds."""
+    thinking_mode = _infer_direct_thinking_mode(query, state, tool_names)
+    axes = _build_direct_analytical_axes(query, state, tool_names)
+    plan = _build_direct_evidence_plan(query, state, tool_names)
+
+    base = (
+        "Du lieu da du cho luot nay. Khong goi them cong cu. "
+        "Hay tong hop ngay thanh cau tra loi cuoi cung bang tieng Viet, "
+        "dua tren cac ket qua cong cu da co."
+    )
+
+    if thinking_mode == "analytical_market":
+        return (
+            base
+            + " Mo dau bang mot cau thesis ve mat bang thi truong hien tai, sau do tach cac luc keo chinh "
+            + "(cung-cau, OPEC+, ton kho, dia chinh tri) thay vi liet ke tin tuc. "
+            + "Neu cac tin hieu xung nhau, hay noi ro truc nao dang giu mat bang gia va truc nao chi tao nhieu ngan han. "
+            + "Mac dinh uu tien 2-3 doan chat; chi dung bullet ngan neu can tach watchlist. "
+            + "KHONG dung heading Markdown nhu #, ##, ###, va KHONG dung bullet/bold kieu ban tin tong hop. "
+            + "Ket bang takeaway hoac dieu can theo doi tiep theo."
+        )
+    if thinking_mode == "analytical_math":
+        return (
+            base
+            + " Mo dau bang mot cau thesis ve mo hinh dang dung, roi trinh bay theo nhip mo hinh/gia dinh -> phuong trinh hoac suy dan -> y nghia vat ly. "
+            + "Noi ro cac gia dinh nhu "
+            + (", ".join(axes[:3]) if axes else "mo hinh, goc nho, va phuong trinh")
+            + ". Neu ket luan phu thuoc gan dung, noi ro pham vi ma gan dung do con hop le. "
+            + "Mac dinh uu tien 2-3 doan chat; KHONG dung heading Markdown nhu #, ##, ### neu user khong yeu cau."
+        )
+    if thinking_mode == "analytical_general":
+        plan_hint = (
+            ", ".join(plan[:2])
+            if plan
+            else "cac bien so chinh va chung cu manh nhat"
+        )
+        return (
+            base
+            + " Mo dau bang mot cau thesis co the kiem cheo, di thang vao luan diem, tach dieu chac khoi dieu con nhieu, va neo lai "
+            + plan_hint
+            + ". Neu co tin hieu trai chieu, noi ro cai nao dang nang ky hon. "
+            + "Mac dinh uu tien 2-3 doan chat; chi dung bullet ngan khi user can tach checklist/watchlist. "
+            + "KHONG dung heading Markdown nhu #, ##, ###."
+        )
+    return base

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -33,11 +33,12 @@ from app.engine.multi_agent.direct_tool_dispatch_runtime import (
 )
 from app.engine.multi_agent.direct_prompts import _resolve_tool_choice, _tool_name
 from app.engine.multi_agent.direct_reasoning import (
-    _build_direct_analytical_axes,
-    _build_direct_evidence_plan,
     _build_direct_tool_reflection,
     _infer_direct_reasoning_cue,
-    _infer_direct_thinking_mode,
+)
+from app.engine.multi_agent.direct_final_synthesis_runtime import (
+    build_direct_final_synthesis_instruction as _build_direct_final_synthesis_instruction,
+    extract_direct_visible_text as _extract_direct_visible_text,
 )
 from app.engine.multi_agent.direct_search_synthesis_fallback import (
     build_search_template_fallback,
@@ -2494,65 +2495,6 @@ def _build_uploaded_doc_preview_params(query: str, state: AgentState | None) -> 
     if lesson_id:
         params["lesson_id"] = lesson_id
     return params
-
-
-def _extract_direct_visible_text(content: Any) -> str:
-    """Return the answer text that would be visible to the user."""
-    try:
-        from app.services.output_processor import extract_thinking_from_response
-
-        text_content, _thinking_content = extract_thinking_from_response(content)
-        return str(text_content or "").strip()
-    except Exception:
-        return str(content or "").strip()
-
-
-def _build_direct_final_synthesis_instruction(
-    query: str,
-    state: AgentState,
-    tool_names: list[str],
-) -> str:
-    """Build a mode-aware final synthesis instruction after tool rounds."""
-    thinking_mode = _infer_direct_thinking_mode(query, state, tool_names)
-    axes = _build_direct_analytical_axes(query, state, tool_names)
-    plan = _build_direct_evidence_plan(query, state, tool_names)
-
-    base = (
-        "Du lieu da du cho luot nay. Khong goi them cong cu. "
-        "Hay tong hop ngay thanh cau tra loi cuoi cung bang tieng Viet, "
-        "dua tren cac ket qua cong cu da co."
-    )
-
-    if thinking_mode == "analytical_market":
-        return (
-            base
-            + " Mo dau bang mot cau thesis ve mat bang thi truong hien tai, sau do tach cac luc keo chinh "
-            + "(cung-cau, OPEC+, ton kho, dia chinh tri) thay vi liet ke tin tuc. "
-            + "Neu cac tin hieu xung nhau, hay noi ro truc nao dang giu mat bang gia va truc nao chi tao nhieu ngan han. "
-            + "Mac dinh uu tien 2-3 doan chat; chi dung bullet ngan neu can tach watchlist. "
-            + "KHONG dung heading Markdown nhu #, ##, ###, va KHONG dung bullet/bold kieu ban tin tong hop. "
-            + "Ket bang takeaway hoac dieu can theo doi tiep theo."
-        )
-    if thinking_mode == "analytical_math":
-        return (
-            base
-            + " Mo dau bang mot cau thesis ve mo hinh dang dung, roi trinh bay theo nhip mo hinh/gia dinh -> phuong trinh hoac suy dan -> y nghia vat ly. "
-            + "Noi ro cac gia dinh nhu "
-            + (", ".join(axes[:3]) if axes else "mo hinh, goc nho, va phuong trinh")
-            + ". Neu ket luan phu thuoc gan dung, noi ro pham vi ma gan dung do con hop le. "
-            + "Mac dinh uu tien 2-3 doan chat; KHONG dung heading Markdown nhu #, ##, ### neu user khong yeu cau."
-        )
-    if thinking_mode == "analytical_general":
-        plan_hint = ", ".join(plan[:2]) if plan else "cac bien so chinh va chung cu manh nhat"
-        return (
-            base
-            + " Mo dau bang mot cau thesis co the kiem cheo, di thang vao luan diem, tach dieu chac khoi dieu con nhieu, va neo lai "
-            + plan_hint
-            + ". Neu co tin hieu trai chieu, noi ro cai nao dang nang ky hon. "
-            + "Mac dinh uu tien 2-3 doan chat; chi dung bullet ngan khi user can tach checklist/watchlist. "
-            + "KHONG dung heading Markdown nhu #, ##, ###."
-        )
-    return base
 
 
 async def execute_direct_tool_rounds_impl(


### PR DESCRIPTION
## Summary

- Moves visible-answer extraction and final synthesis instruction construction into `direct_final_synthesis_runtime.py`.
- Keeps compatibility aliases in `direct_tool_rounds_runtime.py` so existing tests/callers continue working.
- Updates the runtime cleanup audit and codebase map.

Closes #427.

## Scope

In scope:
- Final-synthesis helper movement only.
- Runtime docs for this cleanup boundary.

Out of scope:
- No prompt text changes beyond moving existing strings.
- No final synthesis execution/provider fallback changes.
- No LMS preview/apply, Pointy, visual, or frontend changes.

## Owner / Agents

Owner: Codex
Agents: Codex only
Owned paths: `maritime-ai-service/app/engine/multi_agent/direct_final_synthesis_runtime.py`, `direct_tool_rounds_runtime.py`, runtime docs
Conflict risk: low; behavior-preserving helper extraction.

## Verification

```powershell
cd maritime-ai-service
uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short
# 57 passed

uv run --with ruff ruff check app/engine/multi_agent/direct_tool_rounds_runtime.py app/engine/multi_agent/direct_final_synthesis_runtime.py tests/unit/test_direct_tool_rounds_runtime.py
# All checks passed!

uv run --with ruff ruff check app/ --select=E9,F63,F7
# All checks passed!

git diff --check
# passed
```

## Risk / Rollback

Risk is low to medium because this touches backend runtime final-response helper code, but execution and provider fallback remain unchanged. Rollback is to revert this PR, restoring helper bodies inline.

## Reviewer Focus

- Confirm helper aliases preserve existing imports from `direct_tool_rounds_runtime.py`.
- Confirm no synthesis prompt text or provider fallback behavior changed.