### PR TITLE
refactor(backend): extract direct final synthesis runtime

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -58,6 +58,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   instruction construction into `direct_final_synthesis_runtime.py`, preserving
   compatibility aliases in the main tool-round module while leaving final
   synthesis execution and provider fallback unchanged.
+- Follow-up #429 moved direct final synthesis execution into
+  `direct_final_synthesis_runtime.py`, keeping the no-tool synthesis pass,
+  heartbeat lifecycle, provider resolution, moderate timeout profile, and
+  message insertion behind a focused helper.
 
 ## Preserved Intentionally
 
@@ -90,8 +94,8 @@ backups, data PDFs, or local skill folders.
   response-finalization, and SSE V3 parity modules with narrow contract tests.
 - `direct_tool_rounds_runtime.py` remains large, but Pointy and explicit
   web-search policy plus deterministic document host-action execution, message
-  builders, generic tool dispatch, and final synthesis helper construction have
-  moved out. The next durable step is separating final synthesis execution and
+  builders, generic tool dispatch, final synthesis helper construction, and
+  final synthesis execution have moved out. The next durable step is separating
   post-tool convergence policy.
 - `code_studio_template_scaffold.py` is still a large deterministic fallback,
   but contract, renderer dispatch, caption copy, and explicit-simulation

--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -139,3 +139,8 @@ moving generic dispatch out of the main tool loop and adding focused
 `direct_tool_dispatch_runtime.py` tests.
 In follow-up #427, the direct tool-round command passed with 57 tests after
 moving final synthesis helper bodies out of the main tool loop.
+In follow-up #429, the direct tool-round command passed with 59 tests after
+moving direct final synthesis execution into
+`direct_final_synthesis_runtime.py`. Targeted ruff checks, repository
+`ruff check app/ --select=E9,F63,F7`, and `git diff --check` also passed for
+the no-tool synthesis, heartbeat, provider-resolution helper refactor.

--- a/maritime-ai-service/app/engine/multi_agent/direct_final_synthesis_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_final_synthesis_runtime.py
@@ -130,7 +130,11 @@ async def run_direct_final_synthesis(
             native_tool_messages=native_tool_messages,
         )
     )
-    synthesis_llm = llm_base or llm_auto or llm_with_tools
+    synthesis_llm = llm_base
+    if synthesis_llm is None:
+        raise RuntimeError(
+            "run_direct_final_synthesis requires an unbound LLM for the final no-tool pass"
+        )
     synthesis_heartbeat = asyncio.create_task(
         stream_direct_wait_heartbeats(
             push_event,

--- a/maritime-ai-service/app/engine/multi_agent/direct_final_synthesis_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_final_synthesis_runtime.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from app.engine.multi_agent.direct_reasoning import (
@@ -9,7 +13,21 @@ from app.engine.multi_agent.direct_reasoning import (
     _build_direct_evidence_plan,
     _infer_direct_thinking_mode,
 )
+from app.engine.multi_agent.direct_tool_message_runtime import (
+    build_user_instruction_message,
+)
 from app.engine.multi_agent.state import AgentState
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class DirectFinalSynthesisRunResult:
+    """Result of forcing one no-tool synthesis pass after tool execution."""
+
+    llm_response: Any
+    messages: list[Any]
+    resolved_provider: str | None
 
 
 def extract_direct_visible_text(content: Any) -> str:
@@ -73,3 +91,89 @@ def build_direct_final_synthesis_instruction(
             + "KHONG dung heading Markdown nhu #, ##, ###."
         )
     return base
+
+
+async def run_direct_final_synthesis(
+    *,
+    messages: list[Any],
+    query: str,
+    state: AgentState,
+    tool_call_events: list[dict[str, Any]],
+    push_event,
+    native_tool_messages: bool,
+    llm_base: Any,
+    llm_auto: Any,
+    llm_with_tools: Any,
+    provider: str | None,
+    resolved_provider: str | None,
+    request_failover_mode: Any,
+    allowed_fallback_providers: tuple[str, ...] | list[str] | set[str] | None,
+    ainvoke_with_fallback: Callable[..., Any],
+    stream_direct_wait_heartbeats: Callable[..., Any],
+    remember_execution_target: Callable[..., tuple[str | None, str | None]],
+    runtime_tier_for: Callable[..., str],
+) -> DirectFinalSynthesisRunResult:
+    """Force a final prose answer after tool rounds without exposing tools again."""
+    synthesis_tool_names = [
+        str(event.get("name", ""))
+        for event in tool_call_events
+        if event.get("type") == "call"
+    ]
+    synthesis_messages = list(messages)
+    synthesis_messages.append(
+        build_user_instruction_message(
+            build_direct_final_synthesis_instruction(
+                query,
+                state,
+                synthesis_tool_names,
+            ),
+            native_tool_messages=native_tool_messages,
+        )
+    )
+    synthesis_llm = llm_base or llm_auto or llm_with_tools
+    synthesis_heartbeat = asyncio.create_task(
+        stream_direct_wait_heartbeats(
+            push_event,
+            query=query,
+            phase="synthesize",
+            cue="synthesis",
+            tool_names=synthesis_tool_names,
+        )
+    )
+    try:
+        candidate_provider, _candidate_model = remember_execution_target(
+            synthesis_llm,
+            fallback_source=llm_base,
+        )
+        resolved_provider = candidate_provider or resolved_provider
+        # Synthesis after a successful tool round needs a longer timeout than
+        # tool-bound planning: context is larger and the model must produce
+        # grounded prose from already-collected evidence.
+        llm_response = await ainvoke_with_fallback(
+            synthesis_llm,
+            synthesis_messages,
+            tier=runtime_tier_for(synthesis_llm, llm_base),
+            provider=provider,
+            resolved_provider=resolved_provider,
+            failover_mode=request_failover_mode,
+            push_event=push_event,
+            timeout_profile="moderate",
+            state=state,
+            allowed_fallback_providers=allowed_fallback_providers,
+        )
+        return DirectFinalSynthesisRunResult(
+            llm_response=llm_response,
+            messages=synthesis_messages,
+            resolved_provider=resolved_provider,
+        )
+    finally:
+        synthesis_heartbeat.cancel()
+        try:
+            await synthesis_heartbeat
+        except asyncio.CancelledError:
+            pass
+        except Exception as heartbeat_error:
+            logger.debug(
+                "[DIRECT] Final synthesis heartbeat shutdown skipped: %s",
+                heartbeat_error,
+            )

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -37,8 +37,9 @@ from app.engine.multi_agent.direct_reasoning import (
     _infer_direct_reasoning_cue,
 )
 from app.engine.multi_agent.direct_final_synthesis_runtime import (
-    build_direct_final_synthesis_instruction as _build_direct_final_synthesis_instruction,
+    build_direct_final_synthesis_instruction,
     extract_direct_visible_text as _extract_direct_visible_text,
+    run_direct_final_synthesis,
 )
 from app.engine.multi_agent.direct_search_synthesis_fallback import (
     build_search_template_fallback,
@@ -81,6 +82,9 @@ from app.engine.reasoning import record_thinking_snapshot
 
 
 logger = logging.getLogger(__name__)
+
+# Compatibility alias for older tests and graph imports while synthesis helpers move out.
+_build_direct_final_synthesis_instruction = build_direct_final_synthesis_instruction
 
 _DOC_COURSE_HOST_ACTION_SHORTCUT = DocumentHostActionShortcut(
     tool_name=_DOC_COURSE_HOST_ACTION_TOOL,
@@ -3340,68 +3344,28 @@ async def execute_direct_tool_rounds_impl(
             remaining_tool_calls,
             len(visible_response_text),
         )
-        synthesis_tool_names = [
-            str(event.get("name", ""))
-            for event in tool_call_events
-            if event.get("type") == "call"
-        ]
-        synthesis_messages = list(messages)
-        synthesis_messages.append(
-            _build_user_instruction_message(
-                _build_direct_final_synthesis_instruction(
-                    query,
-                    state,
-                    synthesis_tool_names,
-                ),
-                native_tool_messages=native_tool_messages,
-            )
+        synthesis_result = await run_direct_final_synthesis(
+            messages=messages,
+            query=query,
+            state=state,
+            tool_call_events=tool_call_events,
+            push_event=push_event,
+            native_tool_messages=native_tool_messages,
+            llm_base=llm_base,
+            llm_auto=llm_auto,
+            llm_with_tools=llm_with_tools,
+            provider=provider,
+            resolved_provider=resolved_provider,
+            request_failover_mode=request_failover_mode,
+            allowed_fallback_providers=allowed_fallback_providers,
+            ainvoke_with_fallback=graph_ainvoke_with_fallback,
+            stream_direct_wait_heartbeats=graph_stream_direct_wait_heartbeats,
+            remember_execution_target=remember_execution_target,
+            runtime_tier_for=runtime_tier_for,
         )
-        synthesis_llm = llm_base or llm_auto or llm_with_tools
-        synthesis_heartbeat = asyncio.create_task(
-            graph_stream_direct_wait_heartbeats(
-                push_event,
-                query=query,
-                phase="synthesize",
-                cue=synthesis_cue if "synthesis_cue" in locals() else "synthesis",
-                tool_names=synthesis_tool_names if "synthesis_tool_names" in locals() else None,
-            )
-        )
-        try:
-            candidate_provider, _candidate_model = remember_execution_target(
-                synthesis_llm,
-                fallback_source=llm_base,
-            )
-            resolved_provider = candidate_provider or resolved_provider
-            # Synthesis after a successful tool round needs a longer timeout
-            # than a tool-bound planning call: context is larger (full search
-            # results + fetched URL bodies) and the model must produce prose
-            # that obeys the SKILL Step 4 structure. The "moderate" profile
-            # gives DeepSeek-light enough headroom on long prompts without
-            # needing a full deep-tier model.
-            llm_response = await graph_ainvoke_with_fallback(
-                synthesis_llm,
-                synthesis_messages,
-                tier=runtime_tier_for(synthesis_llm, llm_base),
-                provider=provider,
-                resolved_provider=resolved_provider,
-                failover_mode=request_failover_mode,
-                push_event=push_event,
-                timeout_profile="moderate",
-                state=state,
-                allowed_fallback_providers=allowed_fallback_providers,
-            )
-            messages = synthesis_messages
-        finally:
-            synthesis_heartbeat.cancel()
-            try:
-                await synthesis_heartbeat
-            except asyncio.CancelledError:
-                pass
-            except Exception as heartbeat_error:
-                logger.debug(
-                    "[DIRECT] Final synthesis heartbeat shutdown skipped: %s",
-                    heartbeat_error,
-                )
+        llm_response = synthesis_result.llm_response
+        messages = synthesis_result.messages
+        resolved_provider = synthesis_result.resolved_provider
 
     llm_response = _inject_widget_blocks_from_tool_results(
         llm_response,

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -165,6 +165,87 @@ def test_build_direct_final_synthesis_instruction_is_mode_aware_for_math_turn():
 
 
 @pytest.mark.asyncio
+async def test_run_direct_final_synthesis_uses_no_tool_binding_and_moderate_timeout():
+    from app.engine.multi_agent.direct_final_synthesis_runtime import (
+        run_direct_final_synthesis,
+    )
+
+    llm_base = object()
+    llm_auto = object()
+    llm_with_tools = object()
+    final_response = SimpleNamespace(
+        content="Day la cau tra loi tong hop cuoi cung.",
+        tool_calls=[],
+    )
+    calls: list[dict] = []
+    heartbeat_kwargs: list[dict] = []
+
+    async def push_event(_event):
+        return None
+
+    async def fake_ainvoke_with_fallback(llm, messages, **kwargs):
+        await asyncio.sleep(0)
+        calls.append(
+            {
+                "llm": llm,
+                "messages": list(messages),
+                "kwargs": dict(kwargs),
+            }
+        )
+        return final_response
+
+    async def fake_stream_direct_wait_heartbeats(*_args, **kwargs):
+        heartbeat_kwargs.append(dict(kwargs))
+        await asyncio.Future()
+
+    def remember_execution_target(candidate_llm, fallback_source=None):
+        assert candidate_llm is llm_base
+        assert fallback_source is llm_base
+        return "qwen", "qwen3-next"
+
+    def runtime_tier_for(candidate_llm, fallback_source=None):
+        assert candidate_llm is llm_base
+        assert fallback_source is llm_base
+        return "base-tier"
+
+    result = await run_direct_final_synthesis(
+        messages=[],
+        query="phan tich gia dau",
+        state={},
+        tool_call_events=[
+            {"type": "call", "name": "tool_web_search", "id": "tc-1"},
+            {"type": "result", "name": "tool_web_search", "id": "tc-1"},
+        ],
+        push_event=push_event,
+        native_tool_messages=False,
+        llm_base=llm_base,
+        llm_auto=llm_auto,
+        llm_with_tools=llm_with_tools,
+        provider="auto",
+        resolved_provider=None,
+        request_failover_mode="auto",
+        allowed_fallback_providers=("qwen",),
+        ainvoke_with_fallback=fake_ainvoke_with_fallback,
+        stream_direct_wait_heartbeats=fake_stream_direct_wait_heartbeats,
+        remember_execution_target=remember_execution_target,
+        runtime_tier_for=runtime_tier_for,
+    )
+
+    assert result.llm_response is final_response
+    assert result.resolved_provider == "qwen"
+    assert len(result.messages) == 1
+    assert "Khong goi them cong cu" in result.messages[-1].content
+    assert calls[0]["llm"] is llm_base
+    assert "tools" not in calls[0]["kwargs"]
+    assert calls[0]["kwargs"]["timeout_profile"] == "moderate"
+    assert calls[0]["kwargs"]["tier"] == "base-tier"
+    assert calls[0]["kwargs"]["allowed_fallback_providers"] == ("qwen",)
+    assert heartbeat_kwargs[0]["phase"] == "synthesize"
+    assert heartbeat_kwargs[0]["cue"] == "synthesis"
+    assert heartbeat_kwargs[0]["tool_names"] == ["tool_web_search"]
+
+
+@pytest.mark.asyncio
 async def test_execute_direct_tool_rounds_does_not_emit_authored_public_thinking_for_tool_rounds():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (
         execute_direct_tool_rounds_impl,

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -246,6 +246,43 @@ async def test_run_direct_final_synthesis_uses_no_tool_binding_and_moderate_time
 
 
 @pytest.mark.asyncio
+async def test_run_direct_final_synthesis_requires_unbound_base_llm():
+    from app.engine.multi_agent.direct_final_synthesis_runtime import (
+        run_direct_final_synthesis,
+    )
+
+    async def push_event(_event):
+        return None
+
+    async def fake_ainvoke_with_fallback(*_args, **_kwargs):
+        raise AssertionError("synthesis should fail before invoking a tool-bound model")
+
+    async def fake_stream_direct_wait_heartbeats(*_args, **_kwargs):
+        raise AssertionError("heartbeat should not start without an unbound model")
+
+    with pytest.raises(RuntimeError, match="requires an unbound LLM"):
+        await run_direct_final_synthesis(
+            messages=[],
+            query="phan tich gia dau",
+            state={},
+            tool_call_events=[{"type": "call", "name": "tool_web_search"}],
+            push_event=push_event,
+            native_tool_messages=False,
+            llm_base=None,
+            llm_auto=object(),
+            llm_with_tools=object(),
+            provider="auto",
+            resolved_provider=None,
+            request_failover_mode="auto",
+            allowed_fallback_providers=None,
+            ainvoke_with_fallback=fake_ainvoke_with_fallback,
+            stream_direct_wait_heartbeats=fake_stream_direct_wait_heartbeats,
+            remember_execution_target=lambda *_args, **_kwargs: (None, None),
+            runtime_tier_for=lambda *_args, **_kwargs: "moderate",
+        )
+
+
+@pytest.mark.asyncio
 async def test_execute_direct_tool_rounds_does_not_emit_authored_public_thinking_for_tool_rounds():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (
         execute_direct_tool_rounds_impl,
@@ -1707,6 +1744,7 @@ async def test_execute_direct_tool_rounds_can_use_native_tool_messages():
             push_event=push_event,
             query="Tim du kien roi tong hop lai",
             state={},
+            llm_base=object(),
             forced_tool_choice="tool_demo",
             native_tool_messages=True,
             ainvoke_with_fallback=fake_ainvoke_with_fallback,


### PR DESCRIPTION
## Summary

- Extracts direct tool-round final synthesis execution into `direct_final_synthesis_runtime.py`.
- Keeps the final no-tool synthesis pass, heartbeat lifecycle, provider resolution, failover settings, moderate timeout profile, and message insertion behind a focused helper.
- Tightens the no-tool contract so final synthesis requires the unbound `llm_base` and cannot fall back to `llm_with_tools`.
- Adds focused unit coverage and updates the runtime cleanup audit for follow-up #429.

Closes #429.

## In Scope

- Backend direct runtime cleanup only.
- Direct tool-round synthesis path after tool calls produce no visible prose or still have tool calls at loop cap.

## Out of Scope

- No LMS preview/apply behavior changes.
- No desktop UI, Pointy, visual runtime, provider catalog, auth, tenant, or migration changes.
- No deletion of compatibility shims.

## Verification

From `maritime-ai-service`:

```powershell
uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short
# 59 passed in 1.43s

uv run --with ruff ruff check app/engine/multi_agent/direct_tool_rounds_runtime.py app/engine/multi_agent/direct_final_synthesis_runtime.py tests/unit/test_direct_tool_rounds_runtime.py
# All checks passed!

uv run --with ruff ruff check app/ --select=E9,F63,F7
# All checks passed!
```

From repo root:

```powershell
git diff --check
# passed
```

## Risk / Rollback

Risk is moderate because this touches provider/runtime orchestration after tool execution. Intended behavior is preserved and tightened: final synthesis now requires an explicitly unbound base LLM rather than falling back to a tool-bound model. Rollback is to revert this PR; no schema, data, deployment, LMS, or UI state migration is involved.

## Reviewer Focus

- Confirm final synthesis still runs without tool bindings.
- Confirm provider resolution and heartbeat lifecycle are preserved.
- Confirm compatibility alias remains for older imports/tests while runtime logic moves out.