### PR TITLE
refactor(backend): extract direct convergence policy

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -62,6 +62,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   `direct_final_synthesis_runtime.py`, keeping the no-tool synthesis pass,
   heartbeat lifecycle, provider resolution, moderate timeout profile, and
   message insertion behind a focused helper.
+- Follow-up #431 moved round-0 search convergence hint policy into
+  `direct_tool_convergence_runtime.py`, keeping sparse-result self-eval,
+  rich-result stop hints, native message handling, and log metadata behind a
+  focused helper.
 
 ## Preserved Intentionally
 
@@ -95,8 +99,8 @@ backups, data PDFs, or local skill folders.
 - `direct_tool_rounds_runtime.py` remains large, but Pointy and explicit
   web-search policy plus deterministic document host-action execution, message
   builders, generic tool dispatch, final synthesis helper construction, and
-  final synthesis execution have moved out. The next durable step is separating
-  post-tool convergence policy.
+  final synthesis execution plus post-tool convergence policy have moved out.
+  The next durable step is separating follow-up LLM selection from the main loop.
 - `code_studio_template_scaffold.py` is still a large deterministic fallback,
   but contract, renderer dispatch, caption copy, and explicit-simulation
   quality policy are no longer embedded in the renderer body. Scene and
@@ -144,3 +148,8 @@ moving direct final synthesis execution into
 `direct_final_synthesis_runtime.py`. Targeted ruff checks, repository
 `ruff check app/ --select=E9,F63,F7`, and `git diff --check` also passed for
 the no-tool synthesis, heartbeat, provider-resolution helper refactor.
+In follow-up #431, the direct tool-round command passed with 64 tests after
+moving post-tool convergence hint policy into
+`direct_tool_convergence_runtime.py`. Targeted ruff checks, repository
+`ruff check app/ --select=E9,F63,F7`, and `git diff --check` also passed for
+the convergence policy extraction.

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_convergence_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_convergence_runtime.py
@@ -1,0 +1,106 @@
+"""Post-tool convergence hints for direct tool-round execution."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from app.engine.multi_agent.direct_tool_message_runtime import (
+    build_user_instruction_message,
+)
+
+logger = logging.getLogger(__name__)
+
+_SEARCH_TOOL_NAMES = {
+    "tool_web_search",
+    "tool_search_news",
+    "tool_search_legal",
+    "tool_search_maritime",
+    "tool_fetch_url",
+}
+
+
+@dataclass(slots=True)
+class DirectToolConvergenceHintResult:
+    """Metadata for a convergence hint inserted after a tool round."""
+
+    inserted: bool
+    total_result_chars: int = 0
+    kind: str | None = None
+
+
+def append_direct_tool_convergence_hint(
+    *,
+    messages: list[Any],
+    tool_round: int,
+    tool_call_events: list[dict[str, Any]],
+    requires_visual_commit: bool,
+    native_tool_messages: bool,
+    logger_obj: logging.Logger | None = None,
+) -> DirectToolConvergenceHintResult:
+    """Append the round-0 search convergence hint when the tool evidence needs it."""
+    if tool_round != 0 or not tool_call_events or requires_visual_commit:
+        return DirectToolConvergenceHintResult(inserted=False)
+
+    had_search_tool = any(
+        str(event.get("name") or "").strip() in _SEARCH_TOOL_NAMES
+        for event in tool_call_events
+        if event.get("type") == "call"
+    )
+    total_result_chars = sum(
+        len(str(event.get("result") or ""))
+        for event in tool_call_events
+        if event.get("type") == "result"
+    )
+    if not had_search_tool:
+        return DirectToolConvergenceHintResult(
+            inserted=False,
+            total_result_chars=total_result_chars,
+        )
+
+    target_logger = logger_obj or logger
+    if total_result_chars < 2500:
+        messages.append(
+            build_user_instruction_message(
+                "Đánh giá nhanh kết quả vừa rồi:\n"
+                "- Số liệu cụ thể (giá / con số / ngày): ĐỦ hay THIẾU?\n"
+                "- Bối cảnh / lý do biến động: ĐỦ hay THIẾU?\n"
+                "- Tin nóng địa chính trị (Iran, OPEC+, Hormuz, Fed) "
+                "có liên quan: đã search chưa?\n\n"
+                "Nếu THIẾU mục nào → gọi 1 tool bổ sung (tool_search_news "
+                "với query KHÁC, hoặc tool_fetch_url trên URL hứa hẹn nhất).\n"
+                "Nếu ĐỦ → trả lời NGAY với cấu trúc: số liệu chính (bold) + "
+                "bối cảnh 2-3 câu + takeaway 1-2 câu. KHÔNG search lại.\n\n"
+                "Định dạng số: '110.01' KHÔNG '110, 01'; '13:18' KHÔNG '13: 18'.",
+                native_tool_messages=native_tool_messages,
+            )
+        )
+        target_logger.info(
+            "[DIRECT] Convergence self-eval injected (round 0 sparse: %d chars)",
+            total_result_chars,
+        )
+        return DirectToolConvergenceHintResult(
+            inserted=True,
+            total_result_chars=total_result_chars,
+            kind="sparse_self_eval",
+        )
+
+    messages.append(
+        build_user_instruction_message(
+            "Kết quả search đã đủ phong phú. Trả lời NGAY (KHÔNG gọi "
+            "thêm tool) với cấu trúc: số liệu chính (bold) + bối cảnh "
+            "2-3 câu + takeaway 1-2 câu.\n"
+            "Định dạng số: '110.01' KHÔNG '110, 01'; '13:18' KHÔNG '13: 18'.",
+            native_tool_messages=native_tool_messages,
+        )
+    )
+    target_logger.info(
+        "[DIRECT] Convergence STOP-hint injected (round 0 rich: %d chars)",
+        total_result_chars,
+    )
+    return DirectToolConvergenceHintResult(
+        inserted=True,
+        total_result_chars=total_result_chars,
+        kind="rich_stop_hint",
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -25,11 +25,13 @@ from app.engine.multi_agent.direct_tool_message_runtime import (
     build_assistant_message as _build_assistant_message,
     build_assistant_tool_call_message as _build_assistant_tool_call_message,
     build_tool_result_message as _build_tool_result_message,
-    build_user_instruction_message as _build_user_instruction_message,
 )
 from app.engine.multi_agent.direct_tool_dispatch_runtime import (
     dispatch_direct_tool_call,
     normalize_tool_call as _normalize_tool_call,
+)
+from app.engine.multi_agent.direct_tool_convergence_runtime import (
+    append_direct_tool_convergence_hint,
 )
 from app.engine.multi_agent.direct_prompts import _resolve_tool_choice, _tool_name
 from app.engine.multi_agent.direct_reasoning import (
@@ -3167,57 +3169,14 @@ async def execute_direct_tool_rounds_impl(
                     tool_call_events,
                 )
 
-        if tool_round == 0 and tool_call_events and not requires_visual_commit:
-            search_tool_names = {
-                "tool_web_search", "tool_search_news",
-                "tool_search_legal", "tool_search_maritime", "tool_fetch_url",
-            }
-            had_search_tool = any(
-                str(ev.get("name") or "").strip() in search_tool_names
-                for ev in tool_call_events
-                if ev.get("type") == "call"
-            )
-            # Compute total content volume from this round's tool results.
-            total_result_chars = sum(
-                len(str(ev.get("result") or ""))
-                for ev in tool_call_events
-                if ev.get("type") == "result"
-            )
-            if had_search_tool and total_result_chars < 2500:
-                messages.append(
-                    _build_user_instruction_message(
-                        "Đánh giá nhanh kết quả vừa rồi:\n"
-                        "- Số liệu cụ thể (giá / con số / ngày): ĐỦ hay THIẾU?\n"
-                        "- Bối cảnh / lý do biến động: ĐỦ hay THIẾU?\n"
-                        "- Tin nóng địa chính trị (Iran, OPEC+, Hormuz, Fed) "
-                        "có liên quan: đã search chưa?\n\n"
-                        "Nếu THIẾU mục nào → gọi 1 tool bổ sung (tool_search_news "
-                        "với query KHÁC, hoặc tool_fetch_url trên URL hứa hẹn nhất).\n"
-                        "Nếu ĐỦ → trả lời NGAY với cấu trúc: số liệu chính (bold) + "
-                        "bối cảnh 2-3 câu + takeaway 1-2 câu. KHÔNG search lại.\n\n"
-                        "Định dạng số: '110.01' KHÔNG '110, 01'; '13:18' KHÔNG '13: 18'.",
-                        native_tool_messages=native_tool_messages,
-                    )
-                )
-                logger.info(
-                    "[DIRECT] Convergence self-eval injected (round 0 sparse: %d chars)",
-                    total_result_chars,
-                )
-            elif had_search_tool:
-                # Round 0 already rich → hint LLM to STOP and synthesize.
-                messages.append(
-                    _build_user_instruction_message(
-                        "Kết quả search đã đủ phong phú. Trả lời NGAY (KHÔNG gọi "
-                        "thêm tool) với cấu trúc: số liệu chính (bold) + bối cảnh "
-                        "2-3 câu + takeaway 1-2 câu.\n"
-                        "Định dạng số: '110.01' KHÔNG '110, 01'; '13:18' KHÔNG '13: 18'.",
-                        native_tool_messages=native_tool_messages,
-                    )
-                )
-                logger.info(
-                    "[DIRECT] Convergence STOP-hint injected (round 0 rich: %d chars)",
-                    total_result_chars,
-                )
+        append_direct_tool_convergence_hint(
+            messages=messages,
+            tool_round=tool_round,
+            tool_call_events=tool_call_events,
+            requires_visual_commit=requires_visual_commit,
+            native_tool_messages=native_tool_messages,
+            logger_obj=logger,
+        )
         post_tool_heartbeat = asyncio.create_task(
             graph_stream_direct_wait_heartbeats(
                 push_event,

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -282,6 +282,85 @@ async def test_run_direct_final_synthesis_requires_unbound_base_llm():
         )
 
 
+def test_append_direct_tool_convergence_hint_inserts_sparse_self_eval():
+    from app.engine.multi_agent.direct_tool_convergence_runtime import (
+        append_direct_tool_convergence_hint,
+    )
+
+    messages = []
+    result = append_direct_tool_convergence_hint(
+        messages=messages,
+        tool_round=0,
+        tool_call_events=[
+            {"type": "call", "name": "tool_web_search", "id": "tc-1"},
+            {"type": "result", "name": "tool_web_search", "result": "short"},
+        ],
+        requires_visual_commit=False,
+        native_tool_messages=False,
+    )
+
+    assert result.inserted is True
+    assert result.kind == "sparse_self_eval"
+    assert result.total_result_chars == len("short")
+    assert len(messages) == 1
+    assert "tool_search_news" in messages[0].content
+    assert "110.01" in messages[0].content
+
+
+def test_append_direct_tool_convergence_hint_inserts_rich_stop_hint():
+    from app.engine.multi_agent.direct_tool_convergence_runtime import (
+        append_direct_tool_convergence_hint,
+    )
+
+    messages = []
+    result = append_direct_tool_convergence_hint(
+        messages=messages,
+        tool_round=0,
+        tool_call_events=[
+            {"type": "call", "name": "tool_fetch_url", "id": "tc-1"},
+            {"type": "result", "name": "tool_fetch_url", "result": "x" * 2500},
+        ],
+        requires_visual_commit=False,
+        native_tool_messages=False,
+    )
+
+    assert result.inserted is True
+    assert result.kind == "rich_stop_hint"
+    assert result.total_result_chars == 2500
+    assert len(messages) == 1
+    assert "110.01" in messages[0].content
+
+
+@pytest.mark.parametrize(
+    ("tool_round", "events", "requires_visual_commit"),
+    [
+        (1, [{"type": "call", "name": "tool_web_search"}], False),
+        (0, [{"type": "call", "name": "tool_demo"}], False),
+        (0, [{"type": "call", "name": "tool_web_search"}], True),
+    ],
+)
+def test_append_direct_tool_convergence_hint_skips_non_convergence_cases(
+    tool_round,
+    events,
+    requires_visual_commit,
+):
+    from app.engine.multi_agent.direct_tool_convergence_runtime import (
+        append_direct_tool_convergence_hint,
+    )
+
+    messages = []
+    result = append_direct_tool_convergence_hint(
+        messages=messages,
+        tool_round=tool_round,
+        tool_call_events=events,
+        requires_visual_commit=requires_visual_commit,
+        native_tool_messages=False,
+    )
+
+    assert result.inserted is False
+    assert messages == []
+
+
 @pytest.mark.asyncio
 async def test_execute_direct_tool_rounds_does_not_emit_authored_public_thinking_for_tool_rounds():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (


### PR DESCRIPTION
## Summary

- Extracts direct post-tool round-0 search convergence hint policy into `direct_tool_convergence_runtime.py`.
- Keeps sparse-result self-eval hints, rich-result stop hints, native message handling, and log metadata behind a focused helper.
- Adds focused policy tests and updates the runtime cleanup audit for follow-up #431.

Closes #431.

## In Scope

- Backend direct runtime cleanup only.
- Post-tool convergence hint insertion after round-0 search/fetch evidence.

## Out of Scope

- No LMS preview/apply behavior changes.
- No desktop UI, Pointy, visual runtime, auth, tenant, memory, provider catalog, or migration changes.
- No broad prompt rewrite; convergence copy was moved into a helper and kept in Vietnamese.

## Verification

From `maritime-ai-service`:

```powershell
uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short
# 64 passed in 1.36s

uv run --with ruff ruff check app/engine/multi_agent/direct_tool_rounds_runtime.py app/engine/multi_agent/direct_tool_convergence_runtime.py tests/unit/test_direct_tool_rounds_runtime.py
# All checks passed!

uv run --with ruff ruff check app/ --select=E9,F63,F7
# All checks passed!
```

From repo root:

```powershell
git diff --check
# passed
```

## Risk / Rollback

Risk is low to moderate because this touches prompt-control policy between tool rounds. Intended behavior is preserved as a focused extraction with policy coverage. Rollback is to revert this PR; no schema, data, deployment, LMS, or UI state migration is involved.

## Reviewer Focus

- Confirm sparse/rich convergence policy conditions match the previous inline behavior.
- Confirm visual-commit turns still skip convergence hints.
- Confirm direct tool loop orchestration is reduced without changing provider/tool dispatch.