### PR TITLE
refactor(backend): extract direct follow-up selection

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -66,6 +66,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   `direct_tool_convergence_runtime.py`, keeping sparse-result self-eval,
   rich-result stop hints, native message handling, and log metadata behind a
   focused helper.
+- Follow-up #433 moved post-tool follow-up LLM/tool selection into
+  `direct_tool_followup_runtime.py`, keeping default `llm_auto` continuation,
+  visual-only rebinding, forced visual tool choice, and fallback source metadata
+  behind a focused helper.
 
 ## Preserved Intentionally
 
@@ -100,7 +104,9 @@ backups, data PDFs, or local skill folders.
   web-search policy plus deterministic document host-action execution, message
   builders, generic tool dispatch, final synthesis helper construction, and
   final synthesis execution plus post-tool convergence policy have moved out.
-  The next durable step is separating follow-up LLM selection from the main loop.
+  Follow-up LLM selection has also moved out. The next durable step is
+  separating post-tool heartbeat/follow-up invocation execution from the main
+  loop.
 - `code_studio_template_scaffold.py` is still a large deterministic fallback,
   but contract, renderer dispatch, caption copy, and explicit-simulation
   quality policy are no longer embedded in the renderer body. Scene and
@@ -153,3 +159,7 @@ moving post-tool convergence hint policy into
 `direct_tool_convergence_runtime.py`. Targeted ruff checks, repository
 `ruff check app/ --select=E9,F63,F7`, and `git diff --check` also passed for
 the convergence policy extraction.
+In follow-up #433, the direct tool-round command passed with 67 tests after
+moving follow-up LLM/tool selection into `direct_tool_followup_runtime.py`.
+Targeted ruff checks, repository `ruff check app/ --select=E9,F63,F7`, and
+`git diff --check` also passed for the follow-up selection extraction.

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_followup_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_followup_runtime.py
@@ -45,7 +45,7 @@ def select_direct_tool_followup(
             tool for tool in tools if _tool_name(tool) in required_visual_tool_name_set
         ]
         bind_source = (
-            llm_base
+            (llm_base if hasattr(llm_base, "bind_tools") else None)
             or (llm_auto if hasattr(llm_auto, "bind_tools") else None)
             or (llm_with_tools if hasattr(llm_with_tools, "bind_tools") else None)
         )

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_followup_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_followup_runtime.py
@@ -1,0 +1,72 @@
+"""Follow-up LLM/tool selection after direct tool execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.engine.multi_agent.direct_prompts import _resolve_tool_choice, _tool_name
+from app.engine.multi_agent.visual_intent_resolver import (
+    required_visual_tool_names,
+)
+
+
+@dataclass(slots=True)
+class DirectToolFollowupSelection:
+    """Invocation target and metadata for the next post-tool LLM call."""
+
+    llm: Any
+    tools: list[Any]
+    tool_choice: Any | None
+    fallback_source: Any | None
+
+
+def select_direct_tool_followup(
+    *,
+    llm_auto: Any,
+    llm_base: Any,
+    llm_with_tools: Any,
+    tools: list[Any],
+    requires_visual_commit: bool,
+    visual_emitted_any: bool,
+    visual_decision: Any,
+    resolved_provider: str | None,
+    provider: str | None,
+) -> DirectToolFollowupSelection:
+    """Choose the follow-up LLM and tool declarations after one tool round."""
+    followup_llm = llm_auto
+    followup_tool_choice = None
+    followup_tools = tools
+    bind_source = None
+
+    if requires_visual_commit and not visual_emitted_any:
+        required_visual_tool_name_set = set(required_visual_tool_names(visual_decision))
+        visual_only_tools = [
+            tool for tool in tools if _tool_name(tool) in required_visual_tool_name_set
+        ]
+        bind_source = (
+            llm_base
+            or (llm_auto if hasattr(llm_auto, "bind_tools") else None)
+            or (llm_with_tools if hasattr(llm_with_tools, "bind_tools") else None)
+        )
+        if bind_source is not None and visual_only_tools:
+            followup_tools = visual_only_tools
+            followup_tool_choice = _resolve_tool_choice(
+                True,
+                visual_only_tools,
+                resolved_provider or provider,
+            )
+            if followup_tool_choice:
+                followup_llm = bind_source.bind_tools(
+                    visual_only_tools,
+                    tool_choice=followup_tool_choice,
+                )
+            else:
+                followup_llm = bind_source.bind_tools(visual_only_tools)
+
+    return DirectToolFollowupSelection(
+        llm=followup_llm,
+        tools=followup_tools,
+        tool_choice=followup_tool_choice,
+        fallback_source=bind_source or llm_base,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -33,7 +33,10 @@ from app.engine.multi_agent.direct_tool_dispatch_runtime import (
 from app.engine.multi_agent.direct_tool_convergence_runtime import (
     append_direct_tool_convergence_hint,
 )
-from app.engine.multi_agent.direct_prompts import _resolve_tool_choice, _tool_name
+from app.engine.multi_agent.direct_tool_followup_runtime import (
+    select_direct_tool_followup,
+)
+from app.engine.multi_agent.direct_prompts import _tool_name
 from app.engine.multi_agent.direct_reasoning import (
     _build_direct_tool_reflection,
     _infer_direct_reasoning_cue,
@@ -77,7 +80,6 @@ from app.engine.multi_agent.visual_events import (
     _summarize_tool_result_for_stream,
 )
 from app.engine.multi_agent.visual_intent_resolver import (
-    required_visual_tool_names,
     resolve_visual_intent,
 )
 from app.engine.reasoning import record_thinking_snapshot
@@ -3187,52 +3189,31 @@ async def execute_direct_tool_rounds_impl(
             )
         )
         try:
-            # After the first forced call, keep tool declarations via llm_auto
-            # but do not force another tool call; otherwise current/news turns
-            # can loop through tools until max_rounds before synthesizing.
-            followup_llm = llm_auto
-            followup_tool_choice = None
-            followup_tools = tools
-            bind_source = None
-            if requires_visual_commit and not visual_emitted_any:
-                required_visual_tool_name_set = set(
-                    required_visual_tool_names(visual_decision)
-                )
-                visual_only_tools = [
-                    tool
-                    for tool in tools
-                    if _tool_name(tool) in required_visual_tool_name_set
-                ]
-                bind_source = (
-                    llm_base
-                    or (llm_auto if hasattr(llm_auto, "bind_tools") else None)
-                    or (llm_with_tools if hasattr(llm_with_tools, "bind_tools") else None)
-                )
-                if bind_source is not None and visual_only_tools:
-                    followup_tools = visual_only_tools
-                    followup_tool_choice = _resolve_tool_choice(
-                        True,
-                        visual_only_tools,
-                        resolved_provider or provider,
-                    )
-                    if followup_tool_choice:
-                        followup_llm = bind_source.bind_tools(
-                            visual_only_tools,
-                            tool_choice=followup_tool_choice,
-                        )
-                    else:
-                        followup_llm = bind_source.bind_tools(visual_only_tools)
+            followup_selection = select_direct_tool_followup(
+                llm_auto=llm_auto,
+                llm_base=llm_base,
+                llm_with_tools=llm_with_tools,
+                tools=tools,
+                requires_visual_commit=requires_visual_commit,
+                visual_emitted_any=visual_emitted_any,
+                visual_decision=visual_decision,
+                resolved_provider=resolved_provider,
+                provider=provider,
+            )
             candidate_provider, _candidate_model = remember_execution_target(
-                followup_llm,
-                fallback_source=bind_source or llm_base,
+                followup_selection.llm,
+                fallback_source=followup_selection.fallback_source,
             )
             resolved_provider = candidate_provider or resolved_provider
             llm_response = await graph_ainvoke_with_fallback(
-                followup_llm,
+                followup_selection.llm,
                 messages,
-                tools=followup_tools,
-                tool_choice=followup_tool_choice,
-                tier=runtime_tier_for(followup_llm, bind_source or llm_base),
+                tools=followup_selection.tools,
+                tool_choice=followup_selection.tool_choice,
+                tier=runtime_tier_for(
+                    followup_selection.llm,
+                    followup_selection.fallback_source,
+                ),
                 provider=provider,
                 resolved_provider=resolved_provider,
                 failover_mode=request_failover_mode,

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -361,6 +361,115 @@ def test_append_direct_tool_convergence_hint_skips_non_convergence_cases(
     assert messages == []
 
 
+def test_select_direct_tool_followup_uses_auto_llm_for_non_visual_turn():
+    from app.engine.multi_agent.direct_tool_followup_runtime import (
+        select_direct_tool_followup,
+    )
+    from app.engine.multi_agent.visual_intent_resolver import VisualIntentDecision
+
+    llm_auto = object()
+    llm_base = object()
+    llm_with_tools = object()
+    tools = [SimpleNamespace(name="tool_web_search")]
+
+    selection = select_direct_tool_followup(
+        llm_auto=llm_auto,
+        llm_base=llm_base,
+        llm_with_tools=llm_with_tools,
+        tools=tools,
+        requires_visual_commit=False,
+        visual_emitted_any=False,
+        visual_decision=VisualIntentDecision(mode="text"),
+        resolved_provider="zhipu",
+        provider="auto",
+    )
+
+    assert selection.llm is llm_auto
+    assert selection.tools is tools
+    assert selection.tool_choice is None
+    assert selection.fallback_source is llm_base
+
+
+def test_select_direct_tool_followup_rebinds_visual_only_tools():
+    from app.engine.multi_agent.direct_tool_followup_runtime import (
+        select_direct_tool_followup,
+    )
+    from app.engine.multi_agent.visual_intent_resolver import VisualIntentDecision
+
+    bound_llm = object()
+
+    class FakeBaseLLM:
+        def __init__(self):
+            self.calls: list[dict] = []
+
+        def bind_tools(self, tools, tool_choice=None):
+            self.calls.append({"tools": list(tools), "tool_choice": tool_choice})
+            return bound_llm
+
+    llm_base = FakeBaseLLM()
+    tools = [
+        SimpleNamespace(name="tool_web_search"),
+        SimpleNamespace(name="tool_generate_visual"),
+        SimpleNamespace(name="tool_generate_mermaid"),
+    ]
+
+    selection = select_direct_tool_followup(
+        llm_auto=object(),
+        llm_base=llm_base,
+        llm_with_tools=object(),
+        tools=tools,
+        requires_visual_commit=True,
+        visual_emitted_any=False,
+        visual_decision=VisualIntentDecision(
+            mode="template",
+            force_tool=True,
+            presentation_intent="article_figure",
+        ),
+        resolved_provider="zhipu",
+        provider="auto",
+    )
+
+    assert selection.llm is bound_llm
+    assert [tool.name for tool in selection.tools] == ["tool_generate_visual"]
+    assert selection.tool_choice == "tool_generate_visual"
+    assert selection.fallback_source is llm_base
+    assert len(llm_base.calls) == 1
+    assert [tool.name for tool in llm_base.calls[0]["tools"]] == ["tool_generate_visual"]
+    assert llm_base.calls[0]["tool_choice"] == "tool_generate_visual"
+
+
+def test_select_direct_tool_followup_keeps_auto_llm_after_visual_emits():
+    from app.engine.multi_agent.direct_tool_followup_runtime import (
+        select_direct_tool_followup,
+    )
+    from app.engine.multi_agent.visual_intent_resolver import VisualIntentDecision
+
+    llm_auto = object()
+    llm_base = object()
+    tools = [SimpleNamespace(name="tool_generate_visual")]
+
+    selection = select_direct_tool_followup(
+        llm_auto=llm_auto,
+        llm_base=llm_base,
+        llm_with_tools=object(),
+        tools=tools,
+        requires_visual_commit=True,
+        visual_emitted_any=True,
+        visual_decision=VisualIntentDecision(
+            mode="template",
+            force_tool=True,
+            presentation_intent="article_figure",
+        ),
+        resolved_provider="zhipu",
+        provider="auto",
+    )
+
+    assert selection.llm is llm_auto
+    assert selection.tools is tools
+    assert selection.tool_choice is None
+    assert selection.fallback_source is llm_base
+
+
 @pytest.mark.asyncio
 async def test_execute_direct_tool_rounds_does_not_emit_authored_public_thinking_for_tool_rounds():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -438,6 +438,54 @@ def test_select_direct_tool_followup_rebinds_visual_only_tools():
     assert llm_base.calls[0]["tool_choice"] == "tool_generate_visual"
 
 
+def test_select_direct_tool_followup_skips_non_bindable_base_llm():
+    from app.engine.multi_agent.direct_tool_followup_runtime import (
+        select_direct_tool_followup,
+    )
+    from app.engine.multi_agent.visual_intent_resolver import VisualIntentDecision
+
+    bound_llm = object()
+
+    class FakeAutoLLM:
+        def __init__(self):
+            self.calls: list[dict] = []
+
+        def bind_tools(self, tools, tool_choice=None):
+            self.calls.append({"tools": list(tools), "tool_choice": tool_choice})
+            return bound_llm
+
+    llm_auto = FakeAutoLLM()
+    llm_base = object()
+    tools = [
+        SimpleNamespace(name="tool_web_search"),
+        SimpleNamespace(name="tool_generate_visual"),
+    ]
+
+    selection = select_direct_tool_followup(
+        llm_auto=llm_auto,
+        llm_base=llm_base,
+        llm_with_tools=object(),
+        tools=tools,
+        requires_visual_commit=True,
+        visual_emitted_any=False,
+        visual_decision=VisualIntentDecision(
+            mode="template",
+            force_tool=True,
+            presentation_intent="article_figure",
+        ),
+        resolved_provider="zhipu",
+        provider="auto",
+    )
+
+    assert selection.llm is bound_llm
+    assert [tool.name for tool in selection.tools] == ["tool_generate_visual"]
+    assert selection.tool_choice == "tool_generate_visual"
+    assert selection.fallback_source is llm_auto
+    assert len(llm_auto.calls) == 1
+    assert [tool.name for tool in llm_auto.calls[0]["tools"]] == ["tool_generate_visual"]
+    assert llm_auto.calls[0]["tool_choice"] == "tool_generate_visual"
+
+
 def test_select_direct_tool_followup_keeps_auto_llm_after_visual_emits():
     from app.engine.multi_agent.direct_tool_followup_runtime import (
         select_direct_tool_followup,


### PR DESCRIPTION
## Summary

- Extracts post-tool follow-up LLM/tool selection into `direct_tool_followup_runtime.py`.
- Preserves default `llm_auto` continuation and visual-only rebinding/forced visual tool-choice behavior.
- Adds focused selection tests, including non-bindable base LLM fallback coverage, and updates the runtime cleanup audit for follow-up #433.

Closes #433.

## In Scope

- Backend direct runtime cleanup only.
- Follow-up LLM/tool declaration selection after a direct tool round.

## Out of Scope

- No LMS preview/apply behavior changes.
- No desktop UI, Pointy, visual runtime behavior, provider catalog, auth, tenant, memory, or migration changes.
- No prompt text changes.

## Verification

From `maritime-ai-service`:

```powershell
uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short
# 68 passed in 2.00s

uv run --with ruff ruff check app/engine/multi_agent/direct_tool_rounds_runtime.py app/engine/multi_agent/direct_tool_followup_runtime.py tests/unit/test_direct_tool_rounds_runtime.py
# All checks passed!

uv run --with ruff ruff check app/ --select=E9,F63,F7
# All checks passed!
```

From repo root:

```powershell
git diff --check
# passed
```

## Risk / Rollback

Risk is moderate because this touches provider/tool routing after tool execution. Intended behavior is preserved as a focused extraction with direct unit coverage. Rollback is to revert this PR; no schema, data, deployment, LMS, or UI state migration is involved.

## Reviewer Focus

- Confirm the non-visual path still continues on `llm_auto` with the full tool set.
- Confirm visual-commit follow-up still filters to required visual tools and binds a forced tool choice.
- Confirm fallback source metadata remains available for provider resolution/runtime tiering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated runtime cleanup audit documentation with follow-up implementation details.

* **Refactor**
  * Reorganized tool follow-up selection logic into a dedicated module for improved code maintainability and clarity.

* **Tests**
  * Added comprehensive unit tests covering tool follow-up selection behavior for visual and non-visual execution paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
