### PR TITLE
refactor(backend): extract direct follow-up invocation

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -70,6 +70,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   `direct_tool_followup_runtime.py`, keeping default `llm_auto` continuation,
   visual-only rebinding, forced visual tool choice, and fallback source metadata
   behind a focused helper.
+- Follow-up #435 moved post-tool follow-up invocation into
+  `direct_tool_followup_runtime.py`, keeping heartbeat lifecycle,
+  provider-target propagation, runtime-tier resolution, fallback invocation, and
+  shutdown logging behind a focused helper.
 
 ## Preserved Intentionally
 
@@ -104,9 +108,9 @@ backups, data PDFs, or local skill folders.
   web-search policy plus deterministic document host-action execution, message
   builders, generic tool dispatch, final synthesis helper construction, and
   final synthesis execution plus post-tool convergence policy have moved out.
-  Follow-up LLM selection has also moved out. The next durable step is
-  separating post-tool heartbeat/follow-up invocation execution from the main
-  loop.
+  Follow-up LLM selection and invocation have also moved out. The next durable
+  step is separating remaining round-completion/search-template response
+  finalization from the main loop.
 - `code_studio_template_scaffold.py` is still a large deterministic fallback,
   but contract, renderer dispatch, caption copy, and explicit-simulation
   quality policy are no longer embedded in the renderer body. Scene and
@@ -163,3 +167,6 @@ In follow-up #433, the direct tool-round command passed with 67 tests after
 moving follow-up LLM/tool selection into `direct_tool_followup_runtime.py`.
 Targeted ruff checks, repository `ruff check app/ --select=E9,F63,F7`, and
 `git diff --check` also passed for the follow-up selection extraction.
+In follow-up #435, the direct tool-round command passed with 69 tests after
+moving post-tool follow-up invocation into `direct_tool_followup_runtime.py`.
+Targeted ruff checks also passed for the follow-up invocation extraction.

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_followup_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_followup_runtime.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
-from typing import Any
+import logging
+from typing import Any, Awaitable, Callable
 
 from app.engine.multi_agent.direct_prompts import _resolve_tool_choice, _tool_name
 from app.engine.multi_agent.visual_intent_resolver import (
@@ -19,6 +21,14 @@ class DirectToolFollowupSelection:
     tools: list[Any]
     tool_choice: Any | None
     fallback_source: Any | None
+
+
+@dataclass(slots=True)
+class DirectToolFollowupInvocation:
+    """Post-tool LLM response and provider metadata."""
+
+    llm_response: Any
+    resolved_provider: str | None
 
 
 def select_direct_tool_followup(
@@ -70,3 +80,91 @@ def select_direct_tool_followup(
         tool_choice=followup_tool_choice,
         fallback_source=bind_source or llm_base,
     )
+
+
+async def invoke_direct_tool_followup(
+    *,
+    llm_auto: Any,
+    llm_base: Any,
+    llm_with_tools: Any,
+    tools: list[Any],
+    messages: list[Any],
+    query: str,
+    push_event: Callable[[dict[str, Any]], Awaitable[Any]],
+    requires_visual_commit: bool,
+    visual_emitted_any: bool,
+    visual_decision: Any,
+    resolved_provider: str | None,
+    provider: str | None,
+    request_failover_mode: str,
+    followup_timeout_profile: str,
+    state: dict[str, Any],
+    allowed_fallback_providers: tuple[str, ...] | list[str] | set[str] | None,
+    ainvoke_with_fallback: Callable[..., Awaitable[Any]],
+    stream_direct_wait_heartbeats: Callable[..., Awaitable[Any]],
+    remember_execution_target: Callable[..., tuple[str | None, str | None]],
+    runtime_tier_for: Callable[..., str],
+    round_cue: str,
+    round_tool_names: list[str],
+    logger_obj: logging.Logger | None = None,
+) -> DirectToolFollowupInvocation:
+    """Run the post-tool follow-up LLM call with heartbeat lifecycle handling."""
+    log = logger_obj or logging.getLogger(__name__)
+    post_tool_heartbeat = asyncio.create_task(
+        stream_direct_wait_heartbeats(
+            push_event,
+            query=query,
+            phase="ground",
+            cue=round_cue,
+            tool_names=round_tool_names,
+        )
+    )
+    try:
+        followup_selection = select_direct_tool_followup(
+            llm_auto=llm_auto,
+            llm_base=llm_base,
+            llm_with_tools=llm_with_tools,
+            tools=tools,
+            requires_visual_commit=requires_visual_commit,
+            visual_emitted_any=visual_emitted_any,
+            visual_decision=visual_decision,
+            resolved_provider=resolved_provider,
+            provider=provider,
+        )
+        candidate_provider, _candidate_model = remember_execution_target(
+            followup_selection.llm,
+            fallback_source=followup_selection.fallback_source,
+        )
+        next_resolved_provider = candidate_provider or resolved_provider
+        llm_response = await ainvoke_with_fallback(
+            followup_selection.llm,
+            messages,
+            tools=followup_selection.tools,
+            tool_choice=followup_selection.tool_choice,
+            tier=runtime_tier_for(
+                followup_selection.llm,
+                followup_selection.fallback_source,
+            ),
+            provider=provider,
+            resolved_provider=next_resolved_provider,
+            failover_mode=request_failover_mode,
+            push_event=push_event,
+            timeout_profile=followup_timeout_profile,
+            state=state,
+            allowed_fallback_providers=allowed_fallback_providers,
+        )
+        return DirectToolFollowupInvocation(
+            llm_response=llm_response,
+            resolved_provider=next_resolved_provider,
+        )
+    finally:
+        post_tool_heartbeat.cancel()
+        try:
+            await post_tool_heartbeat
+        except asyncio.CancelledError:
+            pass
+        except Exception as heartbeat_error:
+            log.debug(
+                "[DIRECT] Post-tool heartbeat shutdown skipped: %s",
+                heartbeat_error,
+            )

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -34,7 +34,7 @@ from app.engine.multi_agent.direct_tool_convergence_runtime import (
     append_direct_tool_convergence_hint,
 )
 from app.engine.multi_agent.direct_tool_followup_runtime import (
-    select_direct_tool_followup,
+    invoke_direct_tool_followup,
 )
 from app.engine.multi_agent.direct_prompts import _tool_name
 from app.engine.multi_agent.direct_reasoning import (
@@ -3179,60 +3179,33 @@ async def execute_direct_tool_rounds_impl(
             native_tool_messages=native_tool_messages,
             logger_obj=logger,
         )
-        post_tool_heartbeat = asyncio.create_task(
-            graph_stream_direct_wait_heartbeats(
-                push_event,
-                query=query,
-                phase="ground",
-                cue=round_cue,
-                tool_names=round_tool_names,
-            )
+        followup_invocation = await invoke_direct_tool_followup(
+            llm_auto=llm_auto,
+            llm_base=llm_base,
+            llm_with_tools=llm_with_tools,
+            tools=tools,
+            messages=messages,
+            query=query,
+            push_event=push_event,
+            requires_visual_commit=requires_visual_commit,
+            visual_emitted_any=visual_emitted_any,
+            visual_decision=visual_decision,
+            resolved_provider=resolved_provider,
+            provider=provider,
+            request_failover_mode=request_failover_mode,
+            followup_timeout_profile=followup_timeout_profile,
+            state=state,
+            allowed_fallback_providers=allowed_fallback_providers,
+            ainvoke_with_fallback=graph_ainvoke_with_fallback,
+            stream_direct_wait_heartbeats=graph_stream_direct_wait_heartbeats,
+            remember_execution_target=remember_execution_target,
+            runtime_tier_for=runtime_tier_for,
+            round_cue=round_cue,
+            round_tool_names=round_tool_names,
+            logger_obj=logger,
         )
-        try:
-            followup_selection = select_direct_tool_followup(
-                llm_auto=llm_auto,
-                llm_base=llm_base,
-                llm_with_tools=llm_with_tools,
-                tools=tools,
-                requires_visual_commit=requires_visual_commit,
-                visual_emitted_any=visual_emitted_any,
-                visual_decision=visual_decision,
-                resolved_provider=resolved_provider,
-                provider=provider,
-            )
-            candidate_provider, _candidate_model = remember_execution_target(
-                followup_selection.llm,
-                fallback_source=followup_selection.fallback_source,
-            )
-            resolved_provider = candidate_provider or resolved_provider
-            llm_response = await graph_ainvoke_with_fallback(
-                followup_selection.llm,
-                messages,
-                tools=followup_selection.tools,
-                tool_choice=followup_selection.tool_choice,
-                tier=runtime_tier_for(
-                    followup_selection.llm,
-                    followup_selection.fallback_source,
-                ),
-                provider=provider,
-                resolved_provider=resolved_provider,
-                failover_mode=request_failover_mode,
-                push_event=push_event,
-                timeout_profile=followup_timeout_profile,
-                state=state,
-                allowed_fallback_providers=allowed_fallback_providers,
-            )
-        finally:
-            post_tool_heartbeat.cancel()
-            try:
-                await post_tool_heartbeat
-            except asyncio.CancelledError:
-                pass
-            except Exception as heartbeat_error:
-                logger.debug(
-                    "[DIRECT] Post-tool heartbeat shutdown skipped: %s",
-                    heartbeat_error,
-                )
+        llm_response = followup_invocation.llm_response
+        resolved_provider = followup_invocation.resolved_provider
     if streamed_direct_answer and not tool_call_events:
         state["_answer_streamed_via_bus"] = True
         return llm_response, messages, tool_call_events

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -519,6 +519,102 @@ def test_select_direct_tool_followup_keeps_auto_llm_after_visual_emits():
 
 
 @pytest.mark.asyncio
+async def test_invoke_direct_tool_followup_cancels_heartbeat_and_updates_provider():
+    from app.engine.multi_agent.direct_tool_followup_runtime import (
+        invoke_direct_tool_followup,
+    )
+    from app.engine.multi_agent.visual_intent_resolver import VisualIntentDecision
+
+    llm_auto = object()
+    llm_base = object()
+    response = SimpleNamespace(content="done")
+    messages = [{"role": "user", "content": "xin chao"}]
+    tools = [SimpleNamespace(name="tool_web_search")]
+    state: dict = {"request_id": "req-1"}
+    heartbeat_started = asyncio.Event()
+    heartbeat_cancelled = False
+    heartbeat_call: dict = {}
+    invoke_call: dict = {}
+
+    async def push_event(event):
+        return event
+
+    async def fake_heartbeats(push_event_arg, **kwargs):
+        nonlocal heartbeat_cancelled
+        heartbeat_call["push_event"] = push_event_arg
+        heartbeat_call.update(kwargs)
+        heartbeat_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            heartbeat_cancelled = True
+            raise
+
+    async def fake_ainvoke(llm, messages_arg, **kwargs):
+        await heartbeat_started.wait()
+        invoke_call["llm"] = llm
+        invoke_call["messages"] = messages_arg
+        invoke_call.update(kwargs)
+        return response
+
+    def remember_execution_target(candidate_llm, fallback_source=None):
+        assert candidate_llm is llm_auto
+        assert fallback_source is llm_base
+        return "qwen", "qwen3-next"
+
+    def runtime_tier_for(candidate_llm, fallback_source=None):
+        assert candidate_llm is llm_auto
+        assert fallback_source is llm_base
+        return "balanced"
+
+    result = await invoke_direct_tool_followup(
+        llm_auto=llm_auto,
+        llm_base=llm_base,
+        llm_with_tools=object(),
+        tools=tools,
+        messages=messages,
+        query="xin chao",
+        push_event=push_event,
+        requires_visual_commit=False,
+        visual_emitted_any=False,
+        visual_decision=VisualIntentDecision(mode="text"),
+        resolved_provider="zhipu",
+        provider="auto",
+        request_failover_mode="auto",
+        followup_timeout_profile="structured",
+        state=state,
+        allowed_fallback_providers=("zhipu",),
+        ainvoke_with_fallback=fake_ainvoke,
+        stream_direct_wait_heartbeats=fake_heartbeats,
+        remember_execution_target=remember_execution_target,
+        runtime_tier_for=runtime_tier_for,
+        round_cue="tool-cue",
+        round_tool_names=["tool_web_search"],
+    )
+
+    assert result.llm_response is response
+    assert result.resolved_provider == "qwen"
+    assert heartbeat_cancelled is True
+    assert heartbeat_call["push_event"] is push_event
+    assert heartbeat_call["query"] == "xin chao"
+    assert heartbeat_call["phase"] == "ground"
+    assert heartbeat_call["cue"] == "tool-cue"
+    assert heartbeat_call["tool_names"] == ["tool_web_search"]
+    assert invoke_call["llm"] is llm_auto
+    assert invoke_call["messages"] is messages
+    assert invoke_call["tools"] is tools
+    assert invoke_call["tool_choice"] is None
+    assert invoke_call["tier"] == "balanced"
+    assert invoke_call["provider"] == "auto"
+    assert invoke_call["resolved_provider"] == "qwen"
+    assert invoke_call["failover_mode"] == "auto"
+    assert invoke_call["push_event"] is push_event
+    assert invoke_call["timeout_profile"] == "structured"
+    assert invoke_call["state"] is state
+    assert invoke_call["allowed_fallback_providers"] == ("zhipu",)
+
+
+@pytest.mark.asyncio
 async def test_execute_direct_tool_rounds_does_not_emit_authored_public_thinking_for_tool_rounds():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (
         execute_direct_tool_rounds_impl,


### PR DESCRIPTION
## Summary

- Extracts post-tool follow-up invocation from `direct_tool_rounds_runtime.py` into `direct_tool_followup_runtime.py`.
- Preserves follow-up LLM/tool selection, heartbeat lifecycle, provider target propagation, runtime-tier resolution, and fallback invocation behavior behind a focused helper.
- Adds regression coverage for heartbeat cancellation and resolved-provider propagation, and updates the runtime cleanup audit for follow-up #435.

Closes #435.

## In Scope

- Backend direct runtime cleanup only.
- Post-tool follow-up invocation after direct tool rounds.

## Out of Scope

- No LMS preview/apply behavior changes.
- No desktop UI, Pointy, visual output, provider catalog, auth, tenant, memory, migration, or deployment changes.
- No prompt text changes.

## Verification

From `maritime-ai-service`:

```powershell
uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short
# 69 passed in 1.67s

uv run --with ruff ruff check app/engine/multi_agent/direct_tool_rounds_runtime.py app/engine/multi_agent/direct_tool_followup_runtime.py tests/unit/test_direct_tool_rounds_runtime.py
# All checks passed!

uv run --with ruff ruff check app/ --select=E9,F63,F7
# All checks passed!
```

From repo root:

```powershell
git diff --check
# passed
```

## Risk / Rollback

Risk is moderate because this touches provider/tool routing after tool execution. Intended behavior is preserved as a focused extraction with direct unit coverage. Rollback is to revert this PR; no schema, data, LMS, UI, or deployment state migration is involved.

## Reviewer Focus

- Confirm post-tool heartbeat start/cancel behavior is unchanged.
- Confirm provider resolution still uses `remember_execution_target()` and keeps previous provider when no candidate provider is found.
- Confirm visual follow-up selection still filters/rebinds visual-only tools through the existing helper.