### PR TITLE
refactor(backend): extract direct response finalization

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -74,6 +74,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   `direct_tool_followup_runtime.py`, keeping heartbeat lifecycle,
   provider-target propagation, runtime-tier resolution, fallback invocation, and
   shutdown logging behind a focused helper.
+- Follow-up #437 moved post-tool response finalization into
+  `direct_tool_response_finalization_runtime.py`, keeping empty-response
+  search-template fallback, forced no-tool synthesis, provider propagation, and
+  widget injection behind a focused helper.
 
 ## Preserved Intentionally
 
@@ -108,9 +112,9 @@ backups, data PDFs, or local skill folders.
   web-search policy plus deterministic document host-action execution, message
   builders, generic tool dispatch, final synthesis helper construction, and
   final synthesis execution plus post-tool convergence policy have moved out.
-  Follow-up LLM selection and invocation have also moved out. The next durable
-  step is separating remaining round-completion/search-template response
-  finalization from the main loop.
+  Follow-up LLM selection, invocation, and response finalization have also
+  moved out. The next durable step is separating remaining round-loop branch
+  decisions and early-return shortcuts from the main loop.
 - `code_studio_template_scaffold.py` is still a large deterministic fallback,
   but contract, renderer dispatch, caption copy, and explicit-simulation
   quality policy are no longer embedded in the renderer body. Scene and
@@ -170,3 +174,7 @@ Targeted ruff checks, repository `ruff check app/ --select=E9,F63,F7`, and
 In follow-up #435, the direct tool-round command passed with 69 tests after
 moving post-tool follow-up invocation into `direct_tool_followup_runtime.py`.
 Targeted ruff checks also passed for the follow-up invocation extraction.
+In follow-up #437, the direct tool-round command passed with 71 tests after
+moving post-tool response finalization into
+`direct_tool_response_finalization_runtime.py`. Targeted ruff checks also
+passed for the response finalization extraction.

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_response_finalization_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_response_finalization_runtime.py
@@ -1,0 +1,146 @@
+"""Response finalization after direct tool-round execution."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from app.engine.multi_agent.direct_final_synthesis_runtime import (
+    extract_direct_visible_text,
+    run_direct_final_synthesis,
+)
+from app.engine.multi_agent.direct_tool_message_runtime import (
+    build_assistant_message,
+)
+from app.engine.multi_agent.direct_web_search_policy import (
+    _should_use_search_template_for_empty_response,
+)
+from app.engine.multi_agent.direct_search_synthesis_fallback import (
+    build_search_template_fallback,
+)
+
+
+@dataclass(slots=True)
+class DirectToolResponseFinalization:
+    """Final direct response state after tool evidence has been reconciled."""
+
+    llm_response: Any
+    messages: list[Any]
+    resolved_provider: str | None
+
+
+async def finalize_direct_tool_response(
+    *,
+    llm_response: Any,
+    messages: list[Any],
+    tools: list[Any],
+    tool_call_events: list[dict[str, Any]],
+    query: str,
+    state: dict[str, Any],
+    push_event: Callable[[dict[str, Any]], Awaitable[Any]],
+    native_tool_messages: bool,
+    llm_base: Any,
+    llm_auto: Any,
+    llm_with_tools: Any,
+    provider: str | None,
+    resolved_provider: str | None,
+    request_failover_mode: str,
+    allowed_fallback_providers: tuple[str, ...] | list[str] | set[str] | None,
+    ainvoke_with_fallback: Callable[..., Awaitable[Any]],
+    stream_direct_wait_heartbeats: Callable[..., Awaitable[Any]],
+    remember_execution_target: Callable[..., tuple[str | None, str | None]],
+    runtime_tier_for: Callable[..., str],
+    inject_widget_blocks_from_tool_results: Callable[..., Any],
+    structured_visuals_enabled: bool,
+    logger_obj: logging.Logger | None = None,
+) -> DirectToolResponseFinalization:
+    """Finalize a post-tool response with search fallback, synthesis, and widgets."""
+    log = logger_obj or logging.getLogger(__name__)
+    next_response = llm_response
+    next_messages = messages
+    next_resolved_provider = resolved_provider
+
+    remaining_tool_calls = bool(
+        tools and hasattr(next_response, "tool_calls") and next_response.tool_calls
+    )
+    visible_response_text = extract_direct_visible_text(
+        getattr(next_response, "content", "")
+    )
+
+    if (
+        tool_call_events
+        and not visible_response_text
+        and _should_use_search_template_for_empty_response(
+            query=query,
+            state=state,
+            tool_call_events=tool_call_events,
+        )
+    ):
+        template_response = ""
+        try:
+            template_response = build_search_template_fallback(
+                query=query,
+                tool_call_events=tool_call_events,
+            )
+        except Exception as template_error:  # noqa: BLE001
+            log.warning(
+                "[DIRECT] Web-search empty-response template synthesis failed: %s",
+                template_error,
+            )
+        if template_response:
+            log.info(
+                "[DIRECT] Web-search returning source-backed template "
+                "without slow synthesis LLM (events=%d, len=%d)",
+                len(tool_call_events),
+                len(template_response),
+            )
+            next_response = build_assistant_message(
+                template_response,
+                native_tool_messages=native_tool_messages,
+            )
+            visible_response_text = template_response
+            remaining_tool_calls = False
+
+    if tool_call_events and (remaining_tool_calls or not visible_response_text):
+        log.warning(
+            "[DIRECT] Tool loop ended without final prose "
+            "(remaining_tool_calls=%s, visible_len=%d) -> forcing no-tool synthesis",
+            remaining_tool_calls,
+            len(visible_response_text),
+        )
+        synthesis_result = await run_direct_final_synthesis(
+            messages=next_messages,
+            query=query,
+            state=state,
+            tool_call_events=tool_call_events,
+            push_event=push_event,
+            native_tool_messages=native_tool_messages,
+            llm_base=llm_base,
+            llm_auto=llm_auto,
+            llm_with_tools=llm_with_tools,
+            provider=provider,
+            resolved_provider=next_resolved_provider,
+            request_failover_mode=request_failover_mode,
+            allowed_fallback_providers=allowed_fallback_providers,
+            ainvoke_with_fallback=ainvoke_with_fallback,
+            stream_direct_wait_heartbeats=stream_direct_wait_heartbeats,
+            remember_execution_target=remember_execution_target,
+            runtime_tier_for=runtime_tier_for,
+        )
+        next_response = synthesis_result.llm_response
+        next_messages = synthesis_result.messages
+        next_resolved_provider = synthesis_result.resolved_provider
+
+    next_response = inject_widget_blocks_from_tool_results(
+        next_response,
+        tool_call_events,
+        query=query,
+        structured_visuals_enabled=structured_visuals_enabled,
+    )
+
+    return DirectToolResponseFinalization(
+        llm_response=next_response,
+        messages=next_messages,
+        resolved_provider=next_resolved_provider,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -36,6 +36,9 @@ from app.engine.multi_agent.direct_tool_convergence_runtime import (
 from app.engine.multi_agent.direct_tool_followup_runtime import (
     invoke_direct_tool_followup,
 )
+from app.engine.multi_agent.direct_tool_response_finalization_runtime import (
+    finalize_direct_tool_response,
+)
 from app.engine.multi_agent.direct_prompts import _tool_name
 from app.engine.multi_agent.direct_reasoning import (
     _build_direct_tool_reflection,
@@ -43,8 +46,6 @@ from app.engine.multi_agent.direct_reasoning import (
 )
 from app.engine.multi_agent.direct_final_synthesis_runtime import (
     build_direct_final_synthesis_instruction,
-    extract_direct_visible_text as _extract_direct_visible_text,
-    run_direct_final_synthesis,
 )
 from app.engine.multi_agent.direct_search_synthesis_fallback import (
     build_search_template_fallback,
@@ -70,7 +71,7 @@ from app.engine.multi_agent.direct_web_search_policy import (
     _is_search_tool_name,
     _prefer_official_query_for_known_docs,
     _should_return_search_template_after_tool_round,
-    _should_use_search_template_for_empty_response,
+    _should_use_search_template_for_empty_response,  # noqa: F401 - compatibility alias
 )
 from app.engine.multi_agent.visual_events import (
     _collect_active_visual_session_ids,
@@ -3210,81 +3211,29 @@ async def execute_direct_tool_rounds_impl(
         state["_answer_streamed_via_bus"] = True
         return llm_response, messages, tool_call_events
 
-    remaining_tool_calls = bool(
-        tools and hasattr(llm_response, "tool_calls") and llm_response.tool_calls
-    )
-    visible_response_text = _extract_direct_visible_text(
-        getattr(llm_response, "content", "")
-    )
-    if (
-        tool_call_events
-        and not visible_response_text
-        and _should_use_search_template_for_empty_response(
-            query=query,
-            state=state,
-            tool_call_events=tool_call_events,
-        )
-    ):
-        template_response = ""
-        try:
-            template_response = build_search_template_fallback(
-                query=query,
-                tool_call_events=tool_call_events,
-            )
-        except Exception as template_error:  # noqa: BLE001
-            logger.warning(
-                "[DIRECT] Web-search empty-response template synthesis failed: %s",
-                template_error,
-            )
-        if template_response:
-            logger.info(
-                "[DIRECT] Web-search returning source-backed template "
-                "without slow synthesis LLM (events=%d, len=%d)",
-                len(tool_call_events),
-                len(template_response),
-            )
-            llm_response = _build_assistant_message(
-                template_response,
-                native_tool_messages=native_tool_messages,
-            )
-            visible_response_text = template_response
-            remaining_tool_calls = False
-
-    if tool_call_events and (remaining_tool_calls or not visible_response_text):
-        logger.warning(
-            "[DIRECT] Tool loop ended without final prose "
-            "(remaining_tool_calls=%s, visible_len=%d) -> forcing no-tool synthesis",
-            remaining_tool_calls,
-            len(visible_response_text),
-        )
-        synthesis_result = await run_direct_final_synthesis(
-            messages=messages,
-            query=query,
-            state=state,
-            tool_call_events=tool_call_events,
-            push_event=push_event,
-            native_tool_messages=native_tool_messages,
-            llm_base=llm_base,
-            llm_auto=llm_auto,
-            llm_with_tools=llm_with_tools,
-            provider=provider,
-            resolved_provider=resolved_provider,
-            request_failover_mode=request_failover_mode,
-            allowed_fallback_providers=allowed_fallback_providers,
-            ainvoke_with_fallback=graph_ainvoke_with_fallback,
-            stream_direct_wait_heartbeats=graph_stream_direct_wait_heartbeats,
-            remember_execution_target=remember_execution_target,
-            runtime_tier_for=runtime_tier_for,
-        )
-        llm_response = synthesis_result.llm_response
-        messages = synthesis_result.messages
-        resolved_provider = synthesis_result.resolved_provider
-
-    llm_response = _inject_widget_blocks_from_tool_results(
-        llm_response,
-        tool_call_events,
+    finalization = await finalize_direct_tool_response(
+        llm_response=llm_response,
+        messages=messages,
+        tools=tools,
+        tool_call_events=tool_call_events,
         query=query,
+        state=state,
+        push_event=push_event,
+        native_tool_messages=native_tool_messages,
+        llm_base=llm_base,
+        llm_auto=llm_auto,
+        llm_with_tools=llm_with_tools,
+        provider=provider,
+        resolved_provider=resolved_provider,
+        request_failover_mode=request_failover_mode,
+        allowed_fallback_providers=allowed_fallback_providers,
+        ainvoke_with_fallback=graph_ainvoke_with_fallback,
+        stream_direct_wait_heartbeats=graph_stream_direct_wait_heartbeats,
+        remember_execution_target=remember_execution_target,
+        runtime_tier_for=runtime_tier_for,
+        inject_widget_blocks_from_tool_results=_inject_widget_blocks_from_tool_results,
         structured_visuals_enabled=getattr(settings, "enable_structured_visuals", False),
+        logger_obj=logger,
     )
 
-    return llm_response, messages, tool_call_events
+    return finalization.llm_response, finalization.messages, tool_call_events

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -615,6 +615,134 @@ async def test_invoke_direct_tool_followup_cancels_heartbeat_and_updates_provide
 
 
 @pytest.mark.asyncio
+async def test_finalize_direct_tool_response_uses_empty_search_template(monkeypatch):
+    from app.engine.multi_agent import direct_tool_response_finalization_runtime as runtime
+
+    messages = [{"role": "user", "content": "gia dau"}]
+    tool_events = [{"type": "result", "name": "tool_web_search", "content": "evidence"}]
+    inject_call: dict = {}
+
+    monkeypatch.setattr(
+        runtime,
+        "_should_use_search_template_for_empty_response",
+        lambda **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "build_search_template_fallback",
+        lambda **_kwargs: "Bản tổng hợp có nguồn.",
+    )
+
+    async def fail_synthesis(**_kwargs):
+        raise AssertionError("final synthesis should not run after template fallback")
+
+    def inject_widget_blocks(response, events, **kwargs):
+        inject_call["response"] = response
+        inject_call["events"] = events
+        inject_call.update(kwargs)
+        return response
+
+    monkeypatch.setattr(runtime, "run_direct_final_synthesis", fail_synthesis)
+
+    result = await runtime.finalize_direct_tool_response(
+        llm_response=SimpleNamespace(content=""),
+        messages=messages,
+        tools=[SimpleNamespace(name="tool_web_search")],
+        tool_call_events=tool_events,
+        query="giá dầu hôm nay",
+        state={"force_search": True},
+        push_event=lambda _event: None,
+        native_tool_messages=False,
+        llm_base=object(),
+        llm_auto=object(),
+        llm_with_tools=object(),
+        provider="auto",
+        resolved_provider="zhipu",
+        request_failover_mode="auto",
+        allowed_fallback_providers=("zhipu",),
+        ainvoke_with_fallback=lambda *_args, **_kwargs: None,
+        stream_direct_wait_heartbeats=lambda *_args, **_kwargs: None,
+        remember_execution_target=lambda *_args, **_kwargs: (None, None),
+        runtime_tier_for=lambda *_args, **_kwargs: "moderate",
+        inject_widget_blocks_from_tool_results=inject_widget_blocks,
+        structured_visuals_enabled=True,
+    )
+
+    assert result.llm_response.content == "Bản tổng hợp có nguồn."
+    assert result.messages is messages
+    assert result.resolved_provider == "zhipu"
+    assert inject_call["response"] is result.llm_response
+    assert inject_call["events"] is tool_events
+    assert inject_call["query"] == "giá dầu hôm nay"
+    assert inject_call["structured_visuals_enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_finalize_direct_tool_response_forces_no_tool_synthesis(monkeypatch):
+    from app.engine.multi_agent import direct_tool_response_finalization_runtime as runtime
+
+    response = SimpleNamespace(content="final")
+    messages = [{"role": "user", "content": "hoc hang hai"}]
+    synthesized_messages = [*messages, {"role": "assistant", "content": "final"}]
+    tool_events = [{"type": "call", "name": "tool_knowledge_search"}]
+    synthesis_call: dict = {}
+
+    monkeypatch.setattr(
+        runtime,
+        "_should_use_search_template_for_empty_response",
+        lambda **_kwargs: False,
+    )
+
+    async def fake_synthesis(**kwargs):
+        synthesis_call.update(kwargs)
+        return SimpleNamespace(
+            llm_response=response,
+            messages=synthesized_messages,
+            resolved_provider="qwen",
+        )
+
+    def inject_widget_blocks(response_arg, events, **kwargs):
+        assert response_arg is response
+        assert events is tool_events
+        assert kwargs["structured_visuals_enabled"] is False
+        return response_arg
+
+    monkeypatch.setattr(runtime, "run_direct_final_synthesis", fake_synthesis)
+
+    result = await runtime.finalize_direct_tool_response(
+        llm_response=SimpleNamespace(content="", tool_calls=[{"name": "tool_demo"}]),
+        messages=messages,
+        tools=[SimpleNamespace(name="tool_demo")],
+        tool_call_events=tool_events,
+        query="mình muốn học hàng hải",
+        state={"request_id": "req-2"},
+        push_event=lambda _event: None,
+        native_tool_messages=False,
+        llm_base="base",
+        llm_auto="auto",
+        llm_with_tools="with_tools",
+        provider="auto",
+        resolved_provider="zhipu",
+        request_failover_mode="auto",
+        allowed_fallback_providers=("zhipu",),
+        ainvoke_with_fallback=lambda *_args, **_kwargs: None,
+        stream_direct_wait_heartbeats=lambda *_args, **_kwargs: None,
+        remember_execution_target=lambda *_args, **_kwargs: (None, None),
+        runtime_tier_for=lambda *_args, **_kwargs: "moderate",
+        inject_widget_blocks_from_tool_results=inject_widget_blocks,
+        structured_visuals_enabled=False,
+    )
+
+    assert result.llm_response is response
+    assert result.messages is synthesized_messages
+    assert result.resolved_provider == "qwen"
+    assert synthesis_call["messages"] is messages
+    assert synthesis_call["query"] == "mình muốn học hàng hải"
+    assert synthesis_call["tool_call_events"] is tool_events
+    assert synthesis_call["resolved_provider"] == "zhipu"
+
+
+@pytest.mark.asyncio
 async def test_execute_direct_tool_rounds_does_not_emit_authored_public_thinking_for_tool_rounds():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (
         execute_direct_tool_rounds_impl,


### PR DESCRIPTION
## Summary

- Extracts post-tool response finalization from `direct_tool_rounds_runtime.py` into `direct_tool_response_finalization_runtime.py`.
- Preserves empty-response search-template fallback, forced no-tool synthesis, provider propagation, and widget-block injection behavior.
- Adds focused finalization tests and updates the runtime cleanup audit for follow-up #437.

Closes #437.

## In Scope

- Backend direct runtime cleanup only.
- Response finalization after direct tool rounds.

## Out of Scope

- No LMS preview/apply behavior changes.
- No desktop UI, Pointy, visual renderer, provider catalog, auth, tenant, memory, migration, or deployment changes.
- No prompt text changes.

## Verification

From `maritime-ai-service`:

```powershell
uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short
# 71 passed in 1.61s

uv run --with ruff ruff check app/engine/multi_agent/direct_tool_rounds_runtime.py app/engine/multi_agent/direct_tool_followup_runtime.py app/engine/multi_agent/direct_tool_response_finalization_runtime.py tests/unit/test_direct_tool_rounds_runtime.py
# All checks passed!

uv run --with ruff ruff check app/ --select=E9,F63,F7
# All checks passed!
```

From repo root:

```powershell
git diff --check
# passed
```

## Risk / Rollback

Risk is moderate because this touches response finalization after tool execution. Intended behavior is preserved as a focused extraction with direct unit coverage. Rollback is to revert this PR; no schema, data, LMS, UI, or deployment state migration is involved.

## Reviewer Focus

- Confirm empty search-template fallback still prevents a slow extra synthesis call.
- Confirm no-prose/remaining-tool-call responses still force no-tool final synthesis.
- Confirm widget injection still runs after template or synthesis finalization with the existing structured-visuals flag.