### PR TITLE
refactor(backend): extract direct search-template returns

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -78,6 +78,9 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   `direct_tool_response_finalization_runtime.py`, keeping empty-response
   search-template fallback, forced no-tool synthesis, provider propagation, and
   widget injection behind a focused helper.
+- Follow-up #439 moved post-tool source-backed search-template early returns
+  into `direct_search_template_runtime.py`, keeping forced `@web-search` and
+  explicit web-search evidence exits behind a focused helper.
 
 ## Preserved Intentionally
 
@@ -112,9 +115,9 @@ backups, data PDFs, or local skill folders.
   web-search policy plus deterministic document host-action execution, message
   builders, generic tool dispatch, final synthesis helper construction, and
   final synthesis execution plus post-tool convergence policy have moved out.
-  Follow-up LLM selection, invocation, and response finalization have also
-  moved out. The next durable step is separating remaining round-loop branch
-  decisions and early-return shortcuts from the main loop.
+  Follow-up LLM selection, invocation, response finalization, and post-tool
+  search-template returns have also moved out. The next durable step is
+  separating remaining deterministic shortcut branches from the main loop.
 - `code_studio_template_scaffold.py` is still a large deterministic fallback,
   but contract, renderer dispatch, caption copy, and explicit-simulation
   quality policy are no longer embedded in the renderer body. Scene and
@@ -178,3 +181,7 @@ In follow-up #437, the direct tool-round command passed with 71 tests after
 moving post-tool response finalization into
 `direct_tool_response_finalization_runtime.py`. Targeted ruff checks also
 passed for the response finalization extraction.
+In follow-up #439, the direct tool-round command passed with 74 tests after
+moving post-tool source-backed search-template returns into
+`direct_search_template_runtime.py`. Targeted ruff checks also passed for the
+search-template return extraction.

--- a/maritime-ai-service/app/engine/multi_agent/direct_search_template_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_search_template_runtime.py
@@ -1,0 +1,84 @@
+"""Search-template early returns for direct tool rounds."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.engine.multi_agent.direct_search_synthesis_fallback import (
+    build_search_template_fallback,
+)
+from app.engine.multi_agent.direct_tool_message_runtime import (
+    build_assistant_message,
+)
+from app.engine.multi_agent.direct_web_search_policy import (
+    _force_skills_for_turn,
+    _has_search_tool_result,
+    _should_return_search_template_after_tool_round,
+)
+
+
+def build_direct_post_tool_search_template_response(
+    *,
+    query: str,
+    state: dict[str, Any],
+    tool_call_events: list[dict[str, Any]],
+    tool_round: int,
+    native_tool_messages: bool,
+    logger_obj: logging.Logger | None = None,
+) -> Any | None:
+    """Return a source-backed search template when another LLM round is wasteful."""
+    log = logger_obj or logging.getLogger(__name__)
+    forced_web_search = "web-search" in _force_skills_for_turn(
+        state
+    ) and _has_search_tool_result(tool_call_events)
+    explicit_web_search = _should_return_search_template_after_tool_round(
+        query=query,
+        state=state,
+        tool_call_events=tool_call_events,
+        tool_round=tool_round,
+    )
+    if not forced_web_search and not explicit_web_search:
+        return None
+
+    template_response = ""
+    try:
+        template_response = build_search_template_fallback(
+            query=query,
+            tool_call_events=tool_call_events,
+        )
+    except Exception as template_error:  # noqa: BLE001
+        if forced_web_search:
+            log.warning(
+                "[DIRECT] Forced @web-search template synthesis failed: %s",
+                template_error,
+            )
+        else:
+            log.warning(
+                "[DIRECT] Explicit web-search template synthesis failed: %s",
+                template_error,
+            )
+        return None
+
+    if not template_response:
+        return None
+
+    if forced_web_search:
+        log.info(
+            "[DIRECT] Forced @web-search returning source-backed template "
+            "immediately after tool result (events=%d, len=%d)",
+            len(tool_call_events),
+            len(template_response),
+        )
+    else:
+        log.info(
+            "[DIRECT] Explicit web-search returning source-backed template "
+            "after tool evidence (round=%d, events=%d, len=%d)",
+            tool_round,
+            len(tool_call_events),
+            len(template_response),
+        )
+    return build_assistant_message(
+        template_response,
+        native_tool_messages=native_tool_messages,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -50,6 +50,9 @@ from app.engine.multi_agent.direct_final_synthesis_runtime import (
 from app.engine.multi_agent.direct_search_synthesis_fallback import (
     build_search_template_fallback,
 )
+from app.engine.multi_agent.direct_search_template_runtime import (
+    build_direct_post_tool_search_template_response,
+)
 from app.engine.multi_agent.direct_document_host_action_runtime import (
     DocumentHostActionShortcut,
     execute_document_host_action_shortcut,
@@ -67,10 +70,10 @@ from app.engine.multi_agent.direct_web_search_policy import (
     FORCED_WEB_SEARCH_TOOL_NAMES as _FORCED_WEB_SEARCH_TOOL_NAMES,
     _clean_forced_web_search_query,
     _force_skills_for_turn,
-    _has_search_tool_result,
+    _has_search_tool_result,  # noqa: F401 - compatibility alias
     _is_search_tool_name,
     _prefer_official_query_for_known_docs,
-    _should_return_search_template_after_tool_round,
+    _should_return_search_template_after_tool_round,  # noqa: F401 - compatibility alias
     _should_use_search_template_for_empty_response,  # noqa: F401 - compatibility alias
 )
 from app.engine.multi_agent.visual_events import (
@@ -3102,76 +3105,22 @@ async def execute_direct_tool_rounds_impl(
             tool_call_events=tool_call_events,
         )
 
-        if (
-            "web-search" in _force_skills_for_turn(state)
-            and _has_search_tool_result(tool_call_events)
-        ):
-            template_response = ""
-            try:
-                template_response = build_search_template_fallback(
-                    query=query,
-                    tool_call_events=tool_call_events,
-                )
-            except Exception as template_error:  # noqa: BLE001
-                logger.warning(
-                    "[DIRECT] Forced @web-search template synthesis failed: %s",
-                    template_error,
-                )
-            if template_response:
-                logger.info(
-                    "[DIRECT] Forced @web-search returning source-backed template "
-                    "immediately after tool result (events=%d, len=%d)",
-                    len(tool_call_events),
-                    len(template_response),
-                )
-                return (
-                    _build_assistant_message(
-                        template_response,
-                        native_tool_messages=native_tool_messages,
-                    ),
-                    messages,
-                    tool_call_events,
-                )
+        search_template_response = build_direct_post_tool_search_template_response(
+            query=query,
+            state=state,
+            tool_call_events=tool_call_events,
+            tool_round=tool_round,
+            native_tool_messages=native_tool_messages,
+            logger_obj=logger,
+        )
+        if search_template_response is not None:
+            return search_template_response, messages, tool_call_events
 
         # Phase 35 — convergence self-eval rubric injected after round 0.
         # SOTA Anthropic Claude tool-use pattern: explicit "is info sufficient?"
         # check between rounds. ONLY inject when round 0 returned sparse content
         # (< 2500 chars) — when search already rich, avoid extra NVIDIA round
         # (each round adds 30-60s on free tier).
-        if _should_return_search_template_after_tool_round(
-            query=query,
-            state=state,
-            tool_call_events=tool_call_events,
-            tool_round=tool_round,
-        ):
-            template_response = ""
-            try:
-                template_response = build_search_template_fallback(
-                    query=query,
-                    tool_call_events=tool_call_events,
-                )
-            except Exception as template_error:  # noqa: BLE001
-                logger.warning(
-                    "[DIRECT] Explicit web-search template synthesis failed: %s",
-                    template_error,
-                )
-            if template_response:
-                logger.info(
-                    "[DIRECT] Explicit web-search returning source-backed template "
-                    "after tool evidence (round=%d, events=%d, len=%d)",
-                    tool_round,
-                    len(tool_call_events),
-                    len(template_response),
-                )
-                return (
-                    _build_assistant_message(
-                        template_response,
-                        native_tool_messages=native_tool_messages,
-                    ),
-                    messages,
-                    tool_call_events,
-                )
-
         append_direct_tool_convergence_hint(
             messages=messages,
             tool_round=tool_round,

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -107,6 +107,86 @@ def test_explicit_web_search_returns_template_after_fetch_evidence():
     ) is False
 
 
+def test_build_direct_post_tool_search_template_response_for_forced_web(monkeypatch):
+    from app.engine.multi_agent import direct_search_template_runtime as runtime
+
+    monkeypatch.setattr(
+        runtime,
+        "build_search_template_fallback",
+        lambda **_kwargs: "Tổng hợp từ web có nguồn.",
+    )
+
+    response = runtime.build_direct_post_tool_search_template_response(
+        query="giá dầu hôm nay",
+        state={"force_skills": ["web-search"]},
+        tool_call_events=[
+            {
+                "type": "result",
+                "name": "tool_web_search",
+                "result": "URL: https://example.test/oil\nGiá dầu tăng.",
+            }
+        ],
+        tool_round=0,
+        native_tool_messages=False,
+    )
+
+    assert response is not None
+    assert response.content == "Tổng hợp từ web có nguồn."
+
+
+def test_build_direct_post_tool_search_template_response_for_explicit_round(
+    monkeypatch,
+):
+    from app.engine.multi_agent import direct_search_template_runtime as runtime
+
+    monkeypatch.setattr(runtime, "_force_skills_for_turn", lambda _state: set())
+    monkeypatch.setattr(
+        runtime,
+        "_should_return_search_template_after_tool_round",
+        lambda **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "build_search_template_fallback",
+        lambda **_kwargs: "Tổng hợp sau vòng công cụ.",
+    )
+
+    response = runtime.build_direct_post_tool_search_template_response(
+        query="tìm web về responses api",
+        state={"routing_metadata": {"intent": "unknown"}},
+        tool_call_events=[{"type": "result", "name": "tool_fetch_url", "result": "ok"}],
+        tool_round=1,
+        native_tool_messages=False,
+    )
+
+    assert response is not None
+    assert response.content == "Tổng hợp sau vòng công cụ."
+
+
+def test_build_direct_post_tool_search_template_response_skips_empty_template(
+    monkeypatch,
+):
+    from app.engine.multi_agent import direct_search_template_runtime as runtime
+
+    monkeypatch.setattr(
+        runtime,
+        "build_search_template_fallback",
+        lambda **_kwargs: "",
+    )
+
+    response = runtime.build_direct_post_tool_search_template_response(
+        query="giá dầu hôm nay",
+        state={"force_skills": ["web-search"]},
+        tool_call_events=[
+            {"type": "result", "name": "tool_web_search", "result": "source"}
+        ],
+        tool_round=0,
+        native_tool_messages=False,
+    )
+
+    assert response is None
+
+
 def test_direct_public_thinking_dedupe_detects_identical_blocks():
     from app.engine.multi_agent.direct_public_thinking_runtime import (
         remember_direct_public_thinking_chunks,


### PR DESCRIPTION
## Summary

- Extracts post-tool source-backed search-template early returns from `direct_tool_rounds_runtime.py` into `direct_search_template_runtime.py`.
- Preserves forced `@web-search` immediate template responses and explicit web-search evidence exits.
- Adds focused tests for forced, explicit, and empty-template paths, and updates the runtime cleanup audit for follow-up #439.

Closes #439.

## In Scope

- Backend direct runtime cleanup only.
- Post-tool search-template early returns.

## Out of Scope

- No changes to the initial deterministic `@web-search` shortcut.
- No LMS preview/apply behavior changes.
- No desktop UI, Pointy, visual renderer, provider catalog, auth, tenant, memory, migration, or deployment changes.
- No prompt text changes.

## Verification

From `maritime-ai-service`:

```powershell
uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short
# 74 passed in 2.44s

uv run --with ruff ruff check app/engine/multi_agent/direct_tool_rounds_runtime.py app/engine/multi_agent/direct_search_template_runtime.py tests/unit/test_direct_tool_rounds_runtime.py
# All checks passed!

uv run --with ruff ruff check app/ --select=E9,F63,F7
# All checks passed!
```

From repo root:

```powershell
git diff --check
# passed
```

## Risk / Rollback

Risk is moderate because this touches early returns after tool evidence. Intended behavior is preserved as a focused extraction with direct unit coverage. Rollback is to revert this PR; no schema, data, LMS, UI, or deployment state migration is involved.

## Reviewer Focus

- Confirm forced `@web-search` still returns a source-backed template immediately after web-search evidence.
- Confirm explicit web-search/convergence evidence exits still avoid another slow LLM round when a template is available.
- Confirm empty template output falls through to convergence/follow-up as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated logic for handling search template responses after tool execution into a focused helper function, improving code organization and reducing branching complexity.

* **Tests**
  * Added unit tests to validate search template response behavior under different policy conditions.

* **Documentation**
  * Updated runtime cleanup audit documentation to reflect recent refactoring progress.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->