### PR TITLE
refactor(backend): extract forced web-search shortcut

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -81,6 +81,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
 - Follow-up #439 moved post-tool source-backed search-template early returns
   into `direct_search_template_runtime.py`, keeping forced `@web-search` and
   explicit web-search evidence exits behind a focused helper.
+- Follow-up #441 moved the initial deterministic forced `@web-search`
+  shortcut into `direct_forced_web_search_runtime.py`, keeping tool-call/result
+  SSE events, runtime invocation options, thinking trace emission, and fallback
+  response construction behind a focused helper.
 
 ## Preserved Intentionally
 
@@ -116,8 +120,9 @@ backups, data PDFs, or local skill folders.
   builders, generic tool dispatch, final synthesis helper construction, and
   final synthesis execution plus post-tool convergence policy have moved out.
   Follow-up LLM selection, invocation, response finalization, and post-tool
-  search-template returns have also moved out. The next durable step is
-  separating remaining deterministic shortcut branches from the main loop.
+  search-template returns and forced web-search shortcuts have also moved out.
+  The next durable step is separating remaining deterministic document/visual
+  shortcut branches from the main loop.
 - `code_studio_template_scaffold.py` is still a large deterministic fallback,
   but contract, renderer dispatch, caption copy, and explicit-simulation
   quality policy are no longer embedded in the renderer body. Scene and
@@ -185,3 +190,7 @@ In follow-up #439, the direct tool-round command passed with 74 tests after
 moving post-tool source-backed search-template returns into
 `direct_search_template_runtime.py`. Targeted ruff checks also passed for the
 search-template return extraction.
+In follow-up #441, the direct tool-round command passed with 76 tests after
+moving the deterministic forced web-search shortcut into
+`direct_forced_web_search_runtime.py`. Targeted ruff checks also passed for the
+forced web-search shortcut extraction.

--- a/maritime-ai-service/app/engine/multi_agent/direct_forced_web_search_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_forced_web_search_runtime.py
@@ -1,0 +1,174 @@
+"""Deterministic forced web-search shortcut for direct turns."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable
+
+from app.engine.multi_agent.direct_search_synthesis_fallback import (
+    build_search_template_fallback,
+)
+from app.engine.multi_agent.direct_tool_message_runtime import (
+    build_assistant_message,
+)
+from app.engine.multi_agent.direct_web_search_policy import (
+    FORCED_WEB_SEARCH_TOOL_NAMES,
+    _clean_forced_web_search_query,
+    _force_skills_for_turn,
+)
+from app.engine.reasoning import record_thinking_snapshot
+
+
+_FORCED_WEB_SEARCH_FALLBACK = (
+    "Mình đã gọi web-search, nhưng chưa lấy được nguồn đủ rõ "
+    "để tổng hợp chắc tay cho lượt này. Cậu thử đổi từ khóa "
+    "hẹp hơn một chút nhé."
+)
+_FORCED_WEB_SEARCH_THINKING = (
+    "Mình nhận đây là lượt @web-search rõ ràng, nên ưu tiên gọi "
+    "tool_web_search trước khi viết câu trả lời. Mình chỉ tổng hợp "
+    "từ URL/snippet tool trả về; nếu synthesizer chậm hoặc rỗng thì "
+    "dùng fallback có nguồn thay vì trả lời bằng lời xin lỗi rỗng."
+)
+
+
+async def execute_forced_web_search_shortcut(
+    *,
+    query: str,
+    state: dict[str, Any],
+    tools: list[Any],
+    messages: list[Any],
+    tool_call_events: list[dict[str, Any]],
+    push_event: Callable[[dict[str, Any]], Awaitable[Any]],
+    native_tool_messages: bool,
+    runtime_context_base: Any,
+    get_tool_by_name: Callable[[list[Any], str], Any],
+    invoke_tool_with_runtime: Callable[..., Awaitable[Any]],
+    summarize_tool_result_for_stream: Callable[[str, Any], Any],
+    logger_obj: logging.Logger | None = None,
+) -> Any | None:
+    """Execute an explicit forced web-search turn without planner LLM routing."""
+    log = logger_obj or logging.getLogger(__name__)
+    if not tools or "web-search" not in _force_skills_for_turn(state):
+        return None
+
+    forced_search_tool = None
+    forced_search_tool_name = ""
+    for candidate_name in FORCED_WEB_SEARCH_TOOL_NAMES:
+        forced_search_tool = get_tool_by_name(tools, candidate_name)
+        if forced_search_tool:
+            forced_search_tool_name = candidate_name
+            break
+    if forced_search_tool is None:
+        return None
+
+    tc_id = "forced_web_search_0"
+    tc_args = {"query": _clean_forced_web_search_query(query)}
+    await push_event(
+        {
+            "type": "tool_call",
+            "content": {
+                "name": forced_search_tool_name,
+                "args": tc_args,
+                "id": tc_id,
+            },
+            "node": "direct",
+        }
+    )
+    tool_call_events.append(
+        {
+            "type": "call",
+            "name": forced_search_tool_name,
+            "args": tc_args,
+            "id": tc_id,
+        }
+    )
+    try:
+        result = await invoke_tool_with_runtime(
+            forced_search_tool,
+            tc_args,
+            tool_name=forced_search_tool_name,
+            runtime_context_base=runtime_context_base,
+            tool_call_id=tc_id,
+            query_snippet=str(tc_args.get("query", ""))[:100],
+            prefer_async=False,
+            run_sync_in_thread=True,
+        )
+    except Exception as tool_error:  # noqa: BLE001
+        log.warning("[DIRECT] Forced @web-search tool failed: %s", tool_error)
+        result = "Tool unavailable"
+
+    await push_event(
+        {
+            "type": "tool_result",
+            "content": {
+                "name": forced_search_tool_name,
+                "result": summarize_tool_result_for_stream(
+                    forced_search_tool_name,
+                    result,
+                ),
+                "id": tc_id,
+            },
+            "node": "direct",
+        }
+    )
+    tool_call_events.append(
+        {
+            "type": "result",
+            "name": forced_search_tool_name,
+            "result": result,
+            "id": tc_id,
+        }
+    )
+
+    template_response = ""
+    try:
+        template_response = build_search_template_fallback(
+            query=query,
+            tool_call_events=tool_call_events,
+        )
+    except Exception as template_error:  # noqa: BLE001
+        log.warning("[DIRECT] Forced @web-search template synthesis failed: %s", template_error)
+    if not template_response:
+        template_response = _FORCED_WEB_SEARCH_FALLBACK
+
+    state["thinking"] = _FORCED_WEB_SEARCH_THINKING
+    state["thinking_content"] = _FORCED_WEB_SEARCH_THINKING
+    record_thinking_snapshot(
+        state,
+        _FORCED_WEB_SEARCH_THINKING,
+        node="direct",
+        provenance="deterministic_forced_web_search",
+    )
+    await push_event(
+        {
+            "type": "thinking_start",
+            "content": "",
+            "node": "direct",
+            "summary": "Tra cứu web có nguồn",
+        }
+    )
+    await push_event(
+        {
+            "type": "thinking_delta",
+            "content": _FORCED_WEB_SEARCH_THINKING,
+            "node": "direct",
+        }
+    )
+    await push_event(
+        {
+            "type": "thinking_end",
+            "content": "",
+            "node": "direct",
+        }
+    )
+    log.info(
+        "[DIRECT] Forced @web-search executed deterministically "
+        "without planner LLM (events=%d, len=%d)",
+        len(tool_call_events),
+        len(template_response),
+    )
+    return build_assistant_message(
+        template_response,
+        native_tool_messages=native_tool_messages,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -47,11 +47,11 @@ from app.engine.multi_agent.direct_reasoning import (
 from app.engine.multi_agent.direct_final_synthesis_runtime import (
     build_direct_final_synthesis_instruction,
 )
-from app.engine.multi_agent.direct_search_synthesis_fallback import (
-    build_search_template_fallback,
-)
 from app.engine.multi_agent.direct_search_template_runtime import (
     build_direct_post_tool_search_template_response,
+)
+from app.engine.multi_agent.direct_forced_web_search_runtime import (
+    execute_forced_web_search_shortcut,
 )
 from app.engine.multi_agent.direct_document_host_action_runtime import (
     DocumentHostActionShortcut,
@@ -67,9 +67,6 @@ from app.engine.multi_agent.tool_call_text_parser import (
     tool_names_from_tools,
 )
 from app.engine.multi_agent.direct_web_search_policy import (
-    FORCED_WEB_SEARCH_TOOL_NAMES as _FORCED_WEB_SEARCH_TOOL_NAMES,
-    _clean_forced_web_search_query,
-    _force_skills_for_turn,
     _has_search_tool_result,  # noqa: F401 - compatibility alias
     _is_search_tool_name,
     _prefer_official_query_for_known_docs,
@@ -86,8 +83,6 @@ from app.engine.multi_agent.visual_events import (
 from app.engine.multi_agent.visual_intent_resolver import (
     resolve_visual_intent,
 )
-from app.engine.reasoning import record_thinking_snapshot
-
 
 logger = logging.getLogger(__name__)
 
@@ -2652,144 +2647,22 @@ async def execute_direct_tool_rounds_impl(
     )
     streamed_direct_answer = False
     try:
-        if tools and "web-search" in _force_skills_for_turn(state):
-            forced_search_tool = None
-            forced_search_tool_name = ""
-            for candidate_name in _FORCED_WEB_SEARCH_TOOL_NAMES:
-                forced_search_tool = graph_get_tool_by_name(tools, candidate_name)
-                if forced_search_tool:
-                    forced_search_tool_name = candidate_name
-                    break
-
-            if forced_search_tool is not None:
-                tc_id = "forced_web_search_0"
-                tc_args = {"query": _clean_forced_web_search_query(query)}
-                await push_event(
-                    {
-                        "type": "tool_call",
-                        "content": {
-                            "name": forced_search_tool_name,
-                            "args": tc_args,
-                            "id": tc_id,
-                        },
-                        "node": "direct",
-                    }
-                )
-                tool_call_events.append(
-                    {
-                        "type": "call",
-                        "name": forced_search_tool_name,
-                        "args": tc_args,
-                        "id": tc_id,
-                    }
-                )
-                try:
-                    result = await graph_invoke_tool_with_runtime(
-                        forced_search_tool,
-                        tc_args,
-                        tool_name=forced_search_tool_name,
-                        runtime_context_base=runtime_context_base,
-                        tool_call_id=tc_id,
-                        query_snippet=str(tc_args.get("query", ""))[:100],
-                        prefer_async=False,
-                        run_sync_in_thread=True,
-                    )
-                except Exception as tool_error:
-                    logger.warning(
-                        "[DIRECT] Forced @web-search tool failed: %s",
-                        tool_error,
-                    )
-                    result = "Tool unavailable"
-
-                await push_event(
-                    {
-                        "type": "tool_result",
-                        "content": {
-                            "name": forced_search_tool_name,
-                            "result": _summarize_tool_result_for_stream(
-                                forced_search_tool_name,
-                                result,
-                            ),
-                            "id": tc_id,
-                        },
-                        "node": "direct",
-                    }
-                )
-                tool_call_events.append(
-                    {
-                        "type": "result",
-                        "name": forced_search_tool_name,
-                        "result": result,
-                        "id": tc_id,
-                    }
-                )
-                template_response = ""
-                try:
-                    template_response = build_search_template_fallback(
-                        query=query,
-                        tool_call_events=tool_call_events,
-                    )
-                except Exception as template_error:  # noqa: BLE001
-                    logger.warning(
-                        "[DIRECT] Forced @web-search template synthesis failed: %s",
-                        template_error,
-                    )
-                if not template_response:
-                    template_response = (
-                        "Mình đã gọi web-search, nhưng chưa lấy được nguồn đủ rõ "
-                        "để tổng hợp chắc tay cho lượt này. Cậu thử đổi từ khóa "
-                        "hẹp hơn một chút nhé."
-                    )
-                web_thinking = (
-                    "Mình nhận đây là lượt @web-search rõ ràng, nên ưu tiên gọi "
-                    "tool_web_search trước khi viết câu trả lời. Mình chỉ tổng hợp "
-                    "từ URL/snippet tool trả về; nếu synthesizer chậm hoặc rỗng thì "
-                    "dùng fallback có nguồn thay vì trả lời bằng lời xin lỗi rỗng."
-                )
-                state["thinking"] = web_thinking
-                state["thinking_content"] = web_thinking
-                record_thinking_snapshot(
-                    state,
-                    web_thinking,
-                    node="direct",
-                    provenance="deterministic_forced_web_search",
-                )
-                await push_event(
-                    {
-                        "type": "thinking_start",
-                        "content": "",
-                        "node": "direct",
-                        "summary": "Tra cứu web có nguồn",
-                    }
-                )
-                await push_event(
-                    {
-                        "type": "thinking_delta",
-                        "content": web_thinking,
-                        "node": "direct",
-                    }
-                )
-                await push_event(
-                    {
-                        "type": "thinking_end",
-                        "content": "",
-                        "node": "direct",
-                    }
-                )
-                logger.info(
-                    "[DIRECT] Forced @web-search executed deterministically "
-                    "without planner LLM (events=%d, len=%d)",
-                    len(tool_call_events),
-                    len(template_response),
-                )
-                return (
-                    _build_assistant_message(
-                        template_response,
-                        native_tool_messages=native_tool_messages,
-                    ),
-                    messages,
-                    tool_call_events,
-                )
+        forced_web_response = await execute_forced_web_search_shortcut(
+            query=query,
+            state=state,
+            tools=tools,
+            messages=messages,
+            tool_call_events=tool_call_events,
+            push_event=push_event,
+            native_tool_messages=native_tool_messages,
+            runtime_context_base=runtime_context_base,
+            get_tool_by_name=graph_get_tool_by_name,
+            invoke_tool_with_runtime=graph_invoke_tool_with_runtime,
+            summarize_tool_result_for_stream=_summarize_tool_result_for_stream,
+            logger_obj=logger,
+        )
+        if forced_web_response is not None:
+            return forced_web_response, messages, tool_call_events
 
         if _should_request_uploaded_doc_course_preview(query=query, state=state, tools=tools):
             forced_course_tool = _find_doc_course_host_action_tool(tools)

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -187,6 +187,93 @@ def test_build_direct_post_tool_search_template_response_skips_empty_template(
     assert response is None
 
 
+@pytest.mark.asyncio
+async def test_execute_forced_web_search_shortcut_emits_events(monkeypatch):
+    from app.engine.multi_agent import direct_forced_web_search_runtime as runtime
+
+    tool = object()
+    emitted: list[dict] = []
+    tool_events: list[dict] = []
+    invoke_call: dict = {}
+
+    monkeypatch.setattr(
+        runtime,
+        "build_search_template_fallback",
+        lambda **_kwargs: "Tổng hợp nhanh có nguồn.",
+    )
+
+    async def push_event(event):
+        emitted.append(event)
+
+    def get_tool_by_name(tools, name):
+        assert tools == [tool]
+        return tool if name == "tool_web_search" else None
+
+    async def invoke_tool_with_runtime(tool_arg, args, **kwargs):
+        invoke_call["tool"] = tool_arg
+        invoke_call["args"] = args
+        invoke_call.update(kwargs)
+        return "URL: https://example.test\nTin mới."
+
+    response = await runtime.execute_forced_web_search_shortcut(
+        query="@web-search giá dầu hôm nay",
+        state={"force_skills": ["web-search"]},
+        tools=[tool],
+        messages=[],
+        tool_call_events=tool_events,
+        push_event=push_event,
+        native_tool_messages=False,
+        runtime_context_base={"tenant": "demo"},
+        get_tool_by_name=get_tool_by_name,
+        invoke_tool_with_runtime=invoke_tool_with_runtime,
+        summarize_tool_result_for_stream=lambda _name, result: f"summary:{result}",
+    )
+
+    assert response is not None
+    assert response.content == "Tổng hợp nhanh có nguồn."
+    assert [event["type"] for event in emitted] == [
+        "tool_call",
+        "tool_result",
+        "thinking_start",
+        "thinking_delta",
+        "thinking_end",
+    ]
+    assert tool_events[0]["type"] == "call"
+    assert tool_events[0]["name"] == "tool_web_search"
+    assert tool_events[1]["type"] == "result"
+    assert tool_events[1]["result"] == "URL: https://example.test\nTin mới."
+    assert invoke_call["tool"] is tool
+    assert invoke_call["args"]["query"] == "giá dầu hôm nay"
+    assert invoke_call["tool_name"] == "tool_web_search"
+    assert invoke_call["runtime_context_base"] == {"tenant": "demo"}
+    assert invoke_call["tool_call_id"] == "forced_web_search_0"
+    assert invoke_call["prefer_async"] is False
+    assert invoke_call["run_sync_in_thread"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_forced_web_search_shortcut_skips_when_not_forced():
+    from app.engine.multi_agent.direct_forced_web_search_runtime import (
+        execute_forced_web_search_shortcut,
+    )
+
+    response = await execute_forced_web_search_shortcut(
+        query="giá dầu hôm nay",
+        state={},
+        tools=[object()],
+        messages=[],
+        tool_call_events=[],
+        push_event=lambda _event: None,
+        native_tool_messages=False,
+        runtime_context_base=None,
+        get_tool_by_name=lambda _tools, _name: object(),
+        invoke_tool_with_runtime=lambda *_args, **_kwargs: None,
+        summarize_tool_result_for_stream=lambda _name, result: result,
+    )
+
+    assert response is None
+
+
 def test_direct_public_thinking_dedupe_detects_identical_blocks():
     from app.engine.multi_agent.direct_public_thinking_runtime import (
         remember_direct_public_thinking_chunks,


### PR DESCRIPTION
## Summary

- Extracts the initial deterministic forced `@web-search` shortcut from `direct_tool_rounds_runtime.py` into `direct_forced_web_search_runtime.py`.
- Preserves tool-call/tool-result SSE events, runtime invocation options, thinking trace emission, fallback template response construction, and assistant-message handling.
- Adds event-level regression coverage and updates the runtime cleanup audit for follow-up #441.

Closes #441.

## In Scope

- Backend direct runtime cleanup only.
- Deterministic forced web-search shortcut before planner/tool-loop branches.

## Out of Scope

- No changes to post-tool search-template returns already extracted in #439.
- No LMS preview/apply behavior changes.
- No desktop UI, Pointy, visual renderer, provider catalog, auth, tenant, memory, migration, or deployment changes.
- No prompt text changes.

## Verification

From `maritime-ai-service`:

```powershell
uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short
# 76 passed in 2.57s

uv run --with ruff ruff check app/engine/multi_agent/direct_tool_rounds_runtime.py app/engine/multi_agent/direct_forced_web_search_runtime.py tests/unit/test_direct_tool_rounds_runtime.py
# All checks passed!

uv run --with ruff ruff check app/ --select=E9,F63,F7
# All checks passed!
```

From repo root:

```powershell
git diff --check
# passed (PowerShell reported CRLF normalization warning for direct_tool_rounds_runtime.py; no whitespace errors)
```

## Risk / Rollback

Risk is moderate because this touches deterministic tool invocation and SSE event shape for forced web-search turns. Intended behavior is preserved as a focused extraction with event-level unit coverage. Rollback is to revert this PR; no schema, data, LMS, UI, or deployment state migration is involved.

## Reviewer Focus

- Confirm forced `@web-search` still emits `tool_call`, `tool_result`, and thinking events in the same order.
- Confirm runtime invocation options and cleaned query are preserved.
- Confirm non-forced turns skip the helper and continue through the normal direct runtime.