### PR TITLE
refactor(backend): extract document host-action shortcuts

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_document_host_action_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_document_host_action_runtime.py
@@ -14,6 +14,11 @@ PushEvent = Callable[[dict[str, Any]], Awaitable[None]]
 InvokeTool = Callable[..., Awaitable[Any]]
 EmitHostAction = Callable[..., Awaitable[None]]
 SummarizeToolResult = Callable[[str, Any], Any]
+ShouldRequestPreview = Callable[..., bool]
+FindHostActionTool = Callable[[list[Any]], Any | None]
+BuildHostActionParams = Callable[[str, AgentState | None], dict[str, Any]]
+BuildAssistantMessage = Callable[..., Any]
+UploadedDocumentAttachments = Callable[[AgentState | None], list[Any]]
 
 
 @dataclass(frozen=True)
@@ -27,6 +32,61 @@ class DocumentHostActionShortcut:
     thinking_provenance: str
     response: str
     failure_log_message: str
+
+
+@dataclass(frozen=True)
+class RequestedDocumentHostActionShortcut:
+    """Resolved preview-only shortcut selected for the current user turn."""
+
+    shortcut: DocumentHostActionShortcut
+    tool: Any
+    args: dict[str, Any]
+    log_message: str
+
+
+def resolve_requested_document_host_action_shortcut(
+    *,
+    query: str,
+    state: AgentState,
+    tools: list[Any],
+    should_request_course_preview: ShouldRequestPreview,
+    find_course_host_action_tool: FindHostActionTool,
+    build_course_params: BuildHostActionParams,
+    course_shortcut: DocumentHostActionShortcut,
+    should_request_lesson_preview: ShouldRequestPreview,
+    find_lesson_host_action_tool: FindHostActionTool,
+    build_lesson_params: BuildHostActionParams,
+    lesson_shortcut: DocumentHostActionShortcut,
+) -> RequestedDocumentHostActionShortcut | None:
+    """Resolve the deterministic uploaded-document preview shortcut for a turn."""
+
+    if should_request_course_preview(query=query, state=state, tools=tools):
+        course_tool = find_course_host_action_tool(tools)
+        if course_tool is not None:
+            return RequestedDocumentHostActionShortcut(
+                shortcut=course_shortcut,
+                tool=course_tool,
+                args=build_course_params(query, state),
+                log_message=(
+                    "[DIRECT] Deterministic document course host action requested "
+                    "(attachments=%d, source_refs=%d)"
+                ),
+            )
+
+    if should_request_lesson_preview(query=query, state=state, tools=tools):
+        preview_tool = find_lesson_host_action_tool(tools)
+        if preview_tool is not None:
+            return RequestedDocumentHostActionShortcut(
+                shortcut=lesson_shortcut,
+                tool=preview_tool,
+                args=build_lesson_params(query, state),
+                log_message=(
+                    "[DIRECT] Deterministic document preview host action requested "
+                    "(attachments=%d, source_refs=%d)"
+                ),
+            )
+
+    return None
 
 
 async def execute_document_host_action_shortcut(
@@ -139,3 +199,70 @@ async def execute_document_host_action_shortcut(
         }
     )
     return shortcut.response
+
+
+async def execute_requested_document_host_action_shortcut(
+    *,
+    query: str,
+    state: AgentState,
+    tools: list[Any],
+    tool_call_events: list[dict[str, Any]],
+    push_event: PushEvent,
+    native_tool_messages: bool,
+    runtime_context_base: Any,
+    invoke_tool_with_runtime: InvokeTool,
+    maybe_emit_host_action_event: EmitHostAction,
+    summarize_tool_result_for_stream: SummarizeToolResult,
+    should_request_course_preview: ShouldRequestPreview,
+    find_course_host_action_tool: FindHostActionTool,
+    build_course_params: BuildHostActionParams,
+    course_shortcut: DocumentHostActionShortcut,
+    should_request_lesson_preview: ShouldRequestPreview,
+    find_lesson_host_action_tool: FindHostActionTool,
+    build_lesson_params: BuildHostActionParams,
+    lesson_shortcut: DocumentHostActionShortcut,
+    build_assistant_message: BuildAssistantMessage,
+    uploaded_document_attachments_from_state: UploadedDocumentAttachments,
+    logger_obj: logging.Logger,
+) -> Any | None:
+    """Execute the requested uploaded-document preview shortcut, if any."""
+
+    request = resolve_requested_document_host_action_shortcut(
+        query=query,
+        state=state,
+        tools=tools,
+        should_request_course_preview=should_request_course_preview,
+        find_course_host_action_tool=find_course_host_action_tool,
+        build_course_params=build_course_params,
+        course_shortcut=course_shortcut,
+        should_request_lesson_preview=should_request_lesson_preview,
+        find_lesson_host_action_tool=find_lesson_host_action_tool,
+        build_lesson_params=build_lesson_params,
+        lesson_shortcut=lesson_shortcut,
+    )
+    if request is None:
+        return None
+
+    response = await execute_document_host_action_shortcut(
+        shortcut=request.shortcut,
+        tool=request.tool,
+        args=request.args,
+        state=state,
+        tool_call_events=tool_call_events,
+        push_event=push_event,
+        invoke_tool_with_runtime=invoke_tool_with_runtime,
+        maybe_emit_host_action_event=maybe_emit_host_action_event,
+        summarize_tool_result_for_stream=summarize_tool_result_for_stream,
+        runtime_context_base=runtime_context_base,
+        query_snippet=str(request.args.get("title", ""))[:100],
+        logger_obj=logger_obj,
+    )
+    logger_obj.info(
+        request.log_message,
+        len(uploaded_document_attachments_from_state(state)),
+        len(request.args.get("source_references") or []),
+    )
+    return build_assistant_message(
+        response,
+        native_tool_messages=native_tool_messages,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -55,7 +55,7 @@ from app.engine.multi_agent.direct_forced_web_search_runtime import (
 )
 from app.engine.multi_agent.direct_document_host_action_runtime import (
     DocumentHostActionShortcut,
-    execute_document_host_action_shortcut,
+    execute_requested_document_host_action_shortcut,
 )
 from app.engine.multi_agent.direct_pointy_runtime import (
     _format_pointy_inventory,
@@ -2664,71 +2664,31 @@ async def execute_direct_tool_rounds_impl(
         if forced_web_response is not None:
             return forced_web_response, messages, tool_call_events
 
-        if _should_request_uploaded_doc_course_preview(query=query, state=state, tools=tools):
-            forced_course_tool = _find_doc_course_host_action_tool(tools)
-            if forced_course_tool is not None:
-                tc_args = _build_uploaded_doc_course_params(query, state)
-                response = await execute_document_host_action_shortcut(
-                    shortcut=_DOC_COURSE_HOST_ACTION_SHORTCUT,
-                    tool=forced_course_tool,
-                    args=tc_args,
-                    state=state,
-                    tool_call_events=tool_call_events,
-                    push_event=push_event,
-                    invoke_tool_with_runtime=graph_invoke_tool_with_runtime,
-                    maybe_emit_host_action_event=graph_maybe_emit_host_action_event,
-                    summarize_tool_result_for_stream=_summarize_tool_result_for_stream,
-                    runtime_context_base=runtime_context_base,
-                    query_snippet=str(tc_args.get("title", ""))[:100],
-                    logger_obj=logger,
-                )
-                logger.info(
-                    "[DIRECT] Deterministic document course host action requested "
-                    "(attachments=%d, source_refs=%d)",
-                    len(_uploaded_document_attachments_from_state(state)),
-                    len(tc_args.get("source_references") or []),
-                )
-                return (
-                    _build_assistant_message(
-                        response,
-                        native_tool_messages=native_tool_messages,
-                    ),
-                    messages,
-                    tool_call_events,
-                )
-
-        if _should_request_uploaded_doc_preview(query=query, state=state, tools=tools):
-            forced_preview_tool = _find_doc_preview_host_action_tool(tools)
-            if forced_preview_tool is not None:
-                tc_args = _build_uploaded_doc_preview_params(query, state)
-                response = await execute_document_host_action_shortcut(
-                    shortcut=_DOC_PREVIEW_HOST_ACTION_SHORTCUT,
-                    tool=forced_preview_tool,
-                    args=tc_args,
-                    state=state,
-                    tool_call_events=tool_call_events,
-                    push_event=push_event,
-                    invoke_tool_with_runtime=graph_invoke_tool_with_runtime,
-                    maybe_emit_host_action_event=graph_maybe_emit_host_action_event,
-                    summarize_tool_result_for_stream=_summarize_tool_result_for_stream,
-                    runtime_context_base=runtime_context_base,
-                    query_snippet=str(tc_args.get("title", ""))[:100],
-                    logger_obj=logger,
-                )
-                logger.info(
-                    "[DIRECT] Deterministic document preview host action requested "
-                    "(attachments=%d, source_refs=%d)",
-                    len(_uploaded_document_attachments_from_state(state)),
-                    len(tc_args.get("source_references") or []),
-                )
-                return (
-                    _build_assistant_message(
-                        response,
-                        native_tool_messages=native_tool_messages,
-                    ),
-                    messages,
-                    tool_call_events,
-                )
+        document_shortcut_response = await execute_requested_document_host_action_shortcut(
+            query=query,
+            state=state,
+            tools=tools,
+            tool_call_events=tool_call_events,
+            push_event=push_event,
+            native_tool_messages=native_tool_messages,
+            runtime_context_base=runtime_context_base,
+            invoke_tool_with_runtime=graph_invoke_tool_with_runtime,
+            maybe_emit_host_action_event=graph_maybe_emit_host_action_event,
+            summarize_tool_result_for_stream=_summarize_tool_result_for_stream,
+            should_request_course_preview=_should_request_uploaded_doc_course_preview,
+            find_course_host_action_tool=_find_doc_course_host_action_tool,
+            build_course_params=_build_uploaded_doc_course_params,
+            course_shortcut=_DOC_COURSE_HOST_ACTION_SHORTCUT,
+            should_request_lesson_preview=_should_request_uploaded_doc_preview,
+            find_lesson_host_action_tool=_find_doc_preview_host_action_tool,
+            build_lesson_params=_build_uploaded_doc_preview_params,
+            lesson_shortcut=_DOC_PREVIEW_HOST_ACTION_SHORTCUT,
+            build_assistant_message=_build_assistant_message,
+            uploaded_document_attachments_from_state=_uploaded_document_attachments_from_state,
+            logger_obj=logger,
+        )
+        if document_shortcut_response is not None:
+            return document_shortcut_response, messages, tool_call_events
 
         if tools and forced_tool_choice:
             # Forced tool choice — use ainvoke to ensure tool calls happen
@@ -2857,7 +2817,7 @@ async def execute_direct_tool_rounds_impl(
                         pointy_payload = build_pointy_event(mode="clear")
                         validation_error = None
                     else:
-                        pointy_args = tc.get("args", {}) or {}
+                        pointy_args = tc_args or {}
                         raw_selector = str(pointy_args.get("selector", "")).strip()
                         # Validate selector vs inventory.
                         validation_error = _validate_pointy_selector(

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -8,6 +8,7 @@ import pytest
 from app.engine.multi_agent.direct_document_host_action_runtime import (
     DocumentHostActionShortcut,
     execute_document_host_action_shortcut,
+    execute_requested_document_host_action_shortcut,
 )
 
 
@@ -2747,6 +2748,8 @@ def test_extract_inventory_ids_from_state_nested_context():
     }
     ids = extract_inventory_ids_from_state(state)
     assert ids == ["btn-x"]
+
+
 @pytest.mark.asyncio
 async def test_document_host_action_shortcut_emits_preview_event_contract() -> None:
     pushed_events: list[dict] = []
@@ -2814,3 +2817,160 @@ async def test_document_host_action_shortcut_emits_preview_event_contract() -> N
     assert tool_call_events[1]["result"] == str(
         {"host_action": "preview", "approval_required": True}
     )
+
+
+@pytest.mark.asyncio
+async def test_requested_document_host_action_shortcut_prefers_course_preview() -> None:
+    course_tool = object()
+    lesson_tool = object()
+    pushed_events: list[dict] = []
+    tool_call_events: list[dict] = []
+    invoked: dict = {}
+    lesson_checked = False
+    state: dict = {"document_context": {"attachments": [{"id": "doc-1"}]}}
+
+    course_shortcut = DocumentHostActionShortcut(
+        tool_name="tool_preview_course_plan",
+        tool_call_id="forced_doc_course_preview_0",
+        thinking="Course preview only.",
+        thinking_summary="Course preview",
+        thinking_provenance="test_course_preview",
+        response="Course preview sent.",
+        failure_log_message="failed: %s",
+    )
+    lesson_shortcut = DocumentHostActionShortcut(
+        tool_name="tool_preview_lesson_patch",
+        tool_call_id="forced_doc_preview_0",
+        thinking="Lesson preview only.",
+        thinking_summary="Lesson preview",
+        thinking_provenance="test_lesson_preview",
+        response="Lesson preview sent.",
+        failure_log_message="failed: %s",
+    )
+
+    async def push_event(event: dict) -> None:
+        pushed_events.append(event)
+
+    async def invoke_tool(tool, args, **kwargs):
+        invoked.update({"tool": tool, "args": args, "kwargs": kwargs})
+        return {"host_action": "preview-course", "approval_required": True}
+
+    async def emit_host_action(**kwargs) -> None:
+        pushed_events.append({"type": "host_action", "content": kwargs["result"]})
+
+    def build_assistant_message(content: str, **kwargs) -> dict:
+        return {"content": content, "native_tool_messages": kwargs["native_tool_messages"]}
+
+    def should_request_lesson_preview(**kwargs) -> bool:
+        nonlocal lesson_checked
+        lesson_checked = True
+        return True
+
+    response = await execute_requested_document_host_action_shortcut(
+        query="tạo cho mình bài học",
+        state=state,
+        tools=[course_tool, lesson_tool],
+        tool_call_events=tool_call_events,
+        push_event=push_event,
+        native_tool_messages=True,
+        runtime_context_base={"request_id": "req-1"},
+        invoke_tool_with_runtime=invoke_tool,
+        maybe_emit_host_action_event=emit_host_action,
+        summarize_tool_result_for_stream=lambda name, result: "summary",
+        should_request_course_preview=lambda **kwargs: True,
+        find_course_host_action_tool=lambda tools: course_tool,
+        build_course_params=lambda query, state: {
+            "title": "Course",
+            "source_references": [{"document_id": "doc-1"}],
+        },
+        course_shortcut=course_shortcut,
+        should_request_lesson_preview=should_request_lesson_preview,
+        find_lesson_host_action_tool=lambda tools: lesson_tool,
+        build_lesson_params=lambda query, state: {"title": "Lesson"},
+        lesson_shortcut=lesson_shortcut,
+        build_assistant_message=build_assistant_message,
+        uploaded_document_attachments_from_state=lambda state: [{"id": "doc-1"}],
+        logger_obj=__import__("logging").getLogger(__name__),
+    )
+
+    assert response == {
+        "content": "Course preview sent.",
+        "native_tool_messages": True,
+    }
+    assert lesson_checked is False
+    assert invoked["tool"] is course_tool
+    assert invoked["kwargs"]["tool_name"] == "tool_preview_course_plan"
+    assert invoked["args"]["source_references"] == [{"document_id": "doc-1"}]
+    assert [event["type"] for event in tool_call_events] == ["call", "result"]
+    assert [event["type"] for event in pushed_events] == [
+        "tool_call",
+        "tool_result",
+        "host_action",
+        "thinking_start",
+        "thinking_delta",
+        "thinking_end",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_requested_document_host_action_shortcut_uses_lesson_preview() -> None:
+    lesson_tool = object()
+    invoked: dict = {}
+    state: dict = {"document_context": {"attachments": [{"id": "doc-1"}]}}
+    shortcut = DocumentHostActionShortcut(
+        tool_name="tool_preview_lesson_patch",
+        tool_call_id="forced_doc_preview_0",
+        thinking="Lesson preview only.",
+        thinking_summary="Lesson preview",
+        thinking_provenance="test_lesson_preview",
+        response="Lesson preview sent.",
+        failure_log_message="failed: %s",
+    )
+
+    async def push_event(event: dict) -> None:
+        return None
+
+    async def invoke_tool(tool, args, **kwargs):
+        invoked.update({"tool": tool, "args": args, "kwargs": kwargs})
+        return {"host_action": "preview-lesson", "approval_required": True}
+
+    async def emit_host_action(**kwargs) -> None:
+        return None
+
+    response = await execute_requested_document_host_action_shortcut(
+        query="tạo cho mình bài học",
+        state=state,
+        tools=[lesson_tool],
+        tool_call_events=[],
+        push_event=push_event,
+        native_tool_messages=False,
+        runtime_context_base={"request_id": "req-2"},
+        invoke_tool_with_runtime=invoke_tool,
+        maybe_emit_host_action_event=emit_host_action,
+        summarize_tool_result_for_stream=lambda name, result: "summary",
+        should_request_course_preview=lambda **kwargs: False,
+        find_course_host_action_tool=lambda tools: None,
+        build_course_params=lambda query, state: {"title": "Course"},
+        course_shortcut=shortcut,
+        should_request_lesson_preview=lambda **kwargs: True,
+        find_lesson_host_action_tool=lambda tools: lesson_tool,
+        build_lesson_params=lambda query, state: {
+            "title": "Lesson",
+            "source_references": [{"document_id": "doc-1"}],
+        },
+        lesson_shortcut=shortcut,
+        build_assistant_message=lambda content, **kwargs: {
+            "content": content,
+            "native_tool_messages": kwargs["native_tool_messages"],
+        },
+        uploaded_document_attachments_from_state=lambda state: [{"id": "doc-1"}],
+        logger_obj=__import__("logging").getLogger(__name__),
+    )
+
+    assert response == {
+        "content": "Lesson preview sent.",
+        "native_tool_messages": False,
+    }
+    assert invoked["tool"] is lesson_tool
+    assert invoked["kwargs"]["tool_name"] == "tool_preview_lesson_patch"
+    assert invoked["args"]["source_references"] == [{"document_id": "doc-1"}]


### PR DESCRIPTION
## Summary
- Extract deterministic uploaded-document host-action selection into `direct_document_host_action_runtime.py`.
- Keep the direct tool loop responsible for orchestration only, while the document runtime now resolves course-vs-lesson preview shortcuts and executes the existing preview-only host action contract.
- Add unit coverage for course priority and lesson fallback so LMS document turns keep the preview/apply boundary.

Fixes #443

## Scope
In scope:
- Backend direct runtime refactor only.
- Uploaded document course/lesson preview shortcut routing.
- Pointy normalized tool args cleanup found by ruff in the touched runtime.

Out of scope:
- No LMS apply mutation changes.
- No frontend, voice, deployment, provider, or migration changes.
- No generated artifacts committed.

## Verification
- `cd maritime-ai-service && uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short` -> `78 passed in 6.38s`
- `cd maritime-ai-service && uv run --with ruff ruff check app/engine/multi_agent/direct_document_host_action_runtime.py app/engine/multi_agent/direct_tool_rounds_runtime.py tests/unit/test_direct_tool_rounds_runtime.py` -> `All checks passed!`
- `cd maritime-ai-service && uv run --with ruff ruff check app/ --select=E9,F63,F7` -> `All checks passed!`
- `git diff --check` -> passed

## Risk and rollback
Risk: medium. This touches backend direct runtime routing for LMS uploaded-document preview paths, a high-value contract surface.

Safety notes:
- The existing preview executor remains the single path that emits tool_call/tool_result/host_action/thinking events.
- The helper still prefers course preview when both course and lesson intents match, matching previous branch order.
- Apply/mutation behavior is unchanged and still depends on the downstream approval_token flow.

Rollback: revert this PR. No migrations, persistent data writes, or deployment config changes.

## Reviewer focus
- Uploaded-document preview routing preserves course-before-lesson behavior.
- Host action still emits preview-only events before any LMS apply path.
- Unit tests cover both deterministic routing branches.