### PR TITLE
refactor(backend): extract direct Pointy post-dispatch

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_pointy_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_pointy_runtime.py
@@ -7,7 +7,21 @@ carrying Pointy policy inline.
 
 from __future__ import annotations
 
-from typing import Any
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+
+PushEvent = Callable[[dict[str, Any]], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class DirectPointyPostDispatchResult:
+    """Result after Pointy-specific post-dispatch handling."""
+
+    result: Any
+    pointy_action_emitted: bool = False
+    inventory_served: bool = False
 
 
 def _validate_pointy_selector(selector: str, state: Any) -> str | None:
@@ -208,3 +222,78 @@ def _format_pointy_inventory(state: Any) -> str:
             lines.append(f'User selected text: "{preview}"')
 
     return "\n".join(lines)
+
+
+async def handle_direct_pointy_post_dispatch(
+    *,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    result: Any,
+    state: Any,
+    push_event: PushEvent,
+    logger_obj: logging.Logger,
+) -> DirectPointyPostDispatchResult:
+    """Apply Pointy post-dispatch side effects and result rewriting."""
+
+    updated_result = result
+    pointy_action_emitted = False
+    inventory_served = False
+
+    if tool_name in ("tool_pointy_show", "tool_pointy_clear"):
+        try:
+            from app.engine.tools.pointy_tools import build_pointy_event
+
+            if tool_name == "tool_pointy_clear":
+                pointy_payload = build_pointy_event(mode="clear")
+            else:
+                raw_selector = str((tool_args or {}).get("selector", "")).strip()
+                validation_error = _validate_pointy_selector(raw_selector, state)
+                if validation_error:
+                    updated_result = validation_error
+                    logger_obj.warning(
+                        "[POINTY] selector validation FAILED: %s | raw=%r",
+                        validation_error[:120],
+                        raw_selector[:80],
+                    )
+                    pointy_payload = None
+                else:
+                    pointy_payload = build_pointy_event(
+                        selector=raw_selector,
+                        caption=str((tool_args or {}).get("caption", "")),
+                        duration_ms=int((tool_args or {}).get("duration_ms", 4500) or 4500),
+                        mode=str((tool_args or {}).get("mode", "highlight") or "highlight"),
+                    )
+            if pointy_payload is not None:
+                await push_event(
+                    {
+                        "type": "pointy_action",
+                        "content": pointy_payload,
+                        "node": "direct",
+                    }
+                )
+                pointy_action_emitted = True
+                logger_obj.info(
+                    "[POINTY] dispatched action=%s selector=%r (direct)",
+                    pointy_payload.get("action"),
+                    pointy_payload.get("params", {}).get("selector"),
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger_obj.warning("[POINTY] direct emit failed: %s", exc)
+
+    if tool_name == "tool_pointy_inventory":
+        try:
+            inventory_text = _format_pointy_inventory(state)
+            updated_result = inventory_text
+            inventory_served = True
+            logger_obj.info(
+                "[POINTY] inventory served (%d chars)",
+                len(inventory_text),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger_obj.warning("[POINTY] inventory format failed: %s", exc)
+
+    return DirectPointyPostDispatchResult(
+        result=updated_result,
+        pointy_action_emitted=pointy_action_emitted,
+        inventory_served=inventory_served,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -58,8 +58,9 @@ from app.engine.multi_agent.direct_document_host_action_runtime import (
     execute_requested_document_host_action_shortcut,
 )
 from app.engine.multi_agent.direct_pointy_runtime import (
-    _format_pointy_inventory,
-    _validate_pointy_selector,
+    _format_pointy_inventory,  # noqa: F401 - compatibility alias
+    _validate_pointy_selector,  # noqa: F401 - compatibility alias
+    handle_direct_pointy_post_dispatch,
 )
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.tool_call_text_parser import (
@@ -2803,73 +2804,15 @@ async def execute_direct_tool_rounds_impl(
             tc_name = dispatch_result.tool_name
             tc_args = dispatch_result.tool_args
             result = dispatch_result.result
-            # Wiii Pointy — agent invoked tool_pointy_show / clear.
-            #
-            # v3.0 anti-hallucination: validate selector vs available_targets
-            # BEFORE emit SSE. Khi LLM hallucinate (compound CSS, aria-label
-            # patterns, .class selectors) → return structured error trong
-            # tool_result. AI nhận error message → tự correct round tiếp với
-            # exact id từ inventory.
-            if tc_name in ("tool_pointy_show", "tool_pointy_clear"):
-                try:
-                    from app.engine.tools.pointy_tools import build_pointy_event
-                    if tc_name == "tool_pointy_clear":
-                        pointy_payload = build_pointy_event(mode="clear")
-                        validation_error = None
-                    else:
-                        pointy_args = tc_args or {}
-                        raw_selector = str(pointy_args.get("selector", "")).strip()
-                        # Validate selector vs inventory.
-                        validation_error = _validate_pointy_selector(
-                            raw_selector, state
-                        )
-                        if validation_error:
-                            # Hallucinated → override result với error message
-                            # cho LLM thấy. Skip SSE dispatch.
-                            result = validation_error
-                            logger.warning(
-                                "[POINTY] selector validation FAILED: %s | raw=%r",
-                                validation_error[:120],
-                                raw_selector[:80],
-                            )
-                            pointy_payload = None
-                        else:
-                            pointy_payload = build_pointy_event(
-                                selector=raw_selector,
-                                caption=str(pointy_args.get("caption", "")),
-                                duration_ms=int(pointy_args.get("duration_ms", 4500) or 4500),
-                                mode=str(pointy_args.get("mode", "highlight") or "highlight"),
-                            )
-                    if pointy_payload is not None:
-                        await push_event({
-                            "type": "pointy_action",
-                            "content": pointy_payload,
-                            "node": "direct",
-                        })
-                        logger.info(
-                            "[POINTY] dispatched action=%s selector=%r (direct)",
-                            pointy_payload.get("action"),
-                            pointy_payload.get("params", {}).get("selector"),
-                        )
-                except Exception as exc:  # noqa: BLE001
-                    logger.warning("[POINTY] direct emit failed: %s", exc)
-
-            # Wiii Pointy inventory query — replace the tool's [POINTY:
-            # inventory] ack with the actual list of available_targets
-            # from host context so the LLM has something useful to read
-            # in its next round.
-            if tc_name == "tool_pointy_inventory":
-                try:
-                    inventory_text = _format_pointy_inventory(state)
-                    # Replace the result the LLM will see with the
-                    # actual inventory (overwrite the ack string).
-                    result = inventory_text
-                    logger.info(
-                        "[POINTY] inventory served (%d chars)",
-                        len(inventory_text),
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    logger.warning("[POINTY] inventory format failed: %s", exc)
+            pointy_post_dispatch = await handle_direct_pointy_post_dispatch(
+                tool_name=tc_name,
+                tool_args=tc_args or {},
+                result=result,
+                state=state,
+                push_event=push_event,
+                logger_obj=logger,
+            )
+            result = pointy_post_dispatch.result
             await graph_maybe_emit_host_action_event(
                 push_event=push_event,
                 tool_name=tc_name,

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -2470,6 +2470,86 @@ def test_pointy_validator_accepts_bare_id_in_inventory():
     assert _validate_pointy_selector("chat-send-button", state) is None
 
 
+@pytest.mark.asyncio
+async def test_direct_pointy_post_dispatch_emits_show_action() -> None:
+    from app.engine.multi_agent.direct_pointy_runtime import (
+        handle_direct_pointy_post_dispatch,
+    )
+
+    pushed_events: list[dict] = []
+
+    async def push_event(event: dict) -> None:
+        pushed_events.append(event)
+
+    result = await handle_direct_pointy_post_dispatch(
+        tool_name="tool_pointy_show",
+        tool_args={
+            "selector": "chat-send-button",
+            "caption": "Nút gửi",
+            "duration_ms": 3000,
+        },
+        result="[POINTY:highlight]",
+        state=_state_with_targets("chat-send-button"),
+        push_event=push_event,
+        logger_obj=__import__("logging").getLogger(__name__),
+    )
+
+    assert result.result == "[POINTY:highlight]"
+    assert result.pointy_action_emitted is True
+    assert result.inventory_served is False
+    assert [event["type"] for event in pushed_events] == ["pointy_action"]
+    assert pushed_events[0]["content"]["action"] == "ui.highlight"
+    assert pushed_events[0]["content"]["params"]["selector"] == "chat-send-button"
+
+
+@pytest.mark.asyncio
+async def test_direct_pointy_post_dispatch_rewrites_invalid_selector_result() -> None:
+    from app.engine.multi_agent.direct_pointy_runtime import (
+        handle_direct_pointy_post_dispatch,
+    )
+
+    pushed_events: list[dict] = []
+
+    async def push_event(event: dict) -> None:
+        pushed_events.append(event)
+
+    result = await handle_direct_pointy_post_dispatch(
+        tool_name="tool_pointy_show",
+        tool_args={"selector": ".send-button"},
+        result="[POINTY:highlight]",
+        state=_state_with_targets("chat-send-button"),
+        push_event=push_event,
+        logger_obj=__import__("logging").getLogger(__name__),
+    )
+
+    assert "NOT a valid Wiii Pointy id" in result.result
+    assert result.pointy_action_emitted is False
+    assert pushed_events == []
+
+
+@pytest.mark.asyncio
+async def test_direct_pointy_post_dispatch_rewrites_inventory_result() -> None:
+    from app.engine.multi_agent.direct_pointy_runtime import (
+        handle_direct_pointy_post_dispatch,
+    )
+
+    async def push_event(event: dict) -> None:
+        return None
+
+    result = await handle_direct_pointy_post_dispatch(
+        tool_name="tool_pointy_inventory",
+        tool_args={},
+        result="[POINTY:inventory]",
+        state=_state_with_targets("chat-send-button"),
+        push_event=push_event,
+        logger_obj=__import__("logging").getLogger(__name__),
+    )
+
+    assert result.inventory_served is True
+    assert "Pointable elements" in result.result
+    assert 'tool_pointy_show(selector="chat-send-button"' in result.result
+
+
 def test_pointy_validator_accepts_auto_id_in_inventory():
     from app.engine.multi_agent.direct_tool_rounds_runtime import (
         _validate_pointy_selector,


### PR DESCRIPTION
## Summary
- Extract direct Pointy post-dispatch handling into `direct_pointy_runtime.py`.
- Keep the direct tool loop focused on dispatch flow while Pointy now owns selector validation result rewriting, pointy_action SSE emission, and inventory result replacement.
- Add focused unit coverage for valid Pointy show events, invalid selector correction, and inventory injection.

Fixes #445

## Scope
In scope:
- Backend direct runtime refactor only.
- Pointy show/clear post-dispatch action emission.
- Pointy inventory result rewriting for LLM correction rounds.

Out of scope:
- No frontend Pointy bridge changes.
- No LMS, document, voice, provider, deployment, or migration changes.
- No generated artifacts committed.

## Verification
- `cd maritime-ai-service && uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short` -> `81 passed in 2.88s` (uv emitted package-index warnings for old greenlet distribution files; tests passed)
- `cd maritime-ai-service && uv run --with ruff ruff check app/engine/multi_agent/direct_pointy_runtime.py app/engine/multi_agent/direct_tool_rounds_runtime.py tests/unit/test_direct_tool_rounds_runtime.py` -> `All checks passed!`
- `cd maritime-ai-service && uv run --with ruff ruff check app/ --select=E9,F63,F7` -> `All checks passed!`
- `git diff --check` -> passed

## Risk and rollback
Risk: medium. Pointy tool results are used both for realtime UI events and LLM self-correction, so the helper preserves previous order: validate/rewrite Pointy result before host-action/visual/reflection handling.

Rollback: revert this PR. No migrations, persistent data writes, deployment config, or frontend changes.

## Reviewer focus
- Invalid selectors still become the tool result that the LLM sees.
- Valid show/clear calls still emit `pointy_action` SSE events.
- Inventory calls still replace the tool ack with formatted available_targets.