### PR TITLE
refactor(backend): extract direct tool post-dispatch pipeline

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_post_dispatch_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_post_dispatch_runtime.py
@@ -1,0 +1,133 @@
+"""Post-dispatch side effects for direct tool results."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from app.engine.multi_agent.direct_handoff_runtime import record_direct_handoff_request
+from app.engine.multi_agent.direct_pointy_runtime import handle_direct_pointy_post_dispatch
+from app.engine.multi_agent.state import AgentState
+
+
+PushEvent = Callable[[dict[str, Any]], Awaitable[None]]
+MaybeEmitHostAction = Callable[..., Awaitable[None]]
+MaybeEmitVisualEvent = Callable[..., Awaitable[tuple[list[str], list[str]]]]
+BuildDirectToolReflection = Callable[[Any, str, Any], Awaitable[str]]
+PushStatusOnlyProgress = Callable[..., Awaitable[None]]
+BuildToolResultMessage = Callable[..., Any]
+
+
+@dataclass(frozen=True)
+class DirectToolPostDispatchState:
+    """Updated direct tool-loop state after a tool result is processed."""
+
+    result: Any
+    active_visual_session_ids: list[str]
+    visual_emitted_any: bool
+
+
+async def process_direct_tool_post_dispatch(
+    *,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    tool_call_id: str,
+    result: Any,
+    state: AgentState,
+    messages: list[Any],
+    tool_call_events: list[dict[str, Any]],
+    push_event: PushEvent,
+    native_tool_messages: bool,
+    active_visual_session_ids: list[str],
+    visual_session_ids: list[str],
+    visual_emitted_any: bool,
+    handoffs_enabled: bool,
+    maybe_emit_host_action_event: MaybeEmitHostAction,
+    maybe_emit_visual_event: MaybeEmitVisualEvent,
+    build_direct_tool_reflection: BuildDirectToolReflection,
+    push_status_only_progress: PushStatusOnlyProgress,
+    build_tool_result_message: BuildToolResultMessage,
+    logger_obj: logging.Logger,
+) -> DirectToolPostDispatchState:
+    """Run the ordered post-dispatch side effects for one direct tool result."""
+
+    pointy_post_dispatch = await handle_direct_pointy_post_dispatch(
+        tool_name=tool_name,
+        tool_args=tool_args or {},
+        result=result,
+        state=state,
+        push_event=push_event,
+        logger_obj=logger_obj,
+    )
+    updated_result = pointy_post_dispatch.result
+
+    await maybe_emit_host_action_event(
+        push_event=push_event,
+        tool_name=tool_name,
+        result=updated_result,
+        node="direct",
+        tool_call_events=tool_call_events,
+    )
+    emitted_visual_session_ids, disposed_visual_session_ids = await maybe_emit_visual_event(
+        push_event=push_event,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        result=updated_result,
+        node="direct",
+        tool_call_events=tool_call_events,
+        previous_visual_session_ids=active_visual_session_ids,
+    )
+
+    next_active_visual_session_ids = active_visual_session_ids
+    next_visual_emitted_any = visual_emitted_any
+    if emitted_visual_session_ids:
+        visual_session_ids.extend(emitted_visual_session_ids)
+        next_active_visual_session_ids = list(dict.fromkeys(emitted_visual_session_ids))
+        next_visual_emitted_any = True
+    elif disposed_visual_session_ids:
+        disposed = set(disposed_visual_session_ids)
+        next_active_visual_session_ids = [
+            session_id
+            for session_id in active_visual_session_ids
+            if session_id not in disposed
+        ]
+
+    reflection = await build_direct_tool_reflection(state, tool_name, updated_result)
+    if reflection:
+        await push_status_only_progress(
+            push_event,
+            node="direct",
+            content=reflection,
+            subtype="tool_reflection",
+        )
+
+    tool_call_events.append(
+        {
+            "type": "result",
+            "name": tool_name,
+            "result": str(updated_result),
+            "id": tool_call_id,
+        }
+    )
+    messages.append(
+        build_tool_result_message(
+            str(updated_result),
+            tool_call_id=tool_call_id,
+            native_tool_messages=native_tool_messages,
+        )
+    )
+
+    record_direct_handoff_request(
+        state=state,
+        tool_name=tool_name,
+        tool_args=tool_args or {},
+        enabled=handoffs_enabled,
+        logger_obj=logger_obj,
+    )
+
+    return DirectToolPostDispatchState(
+        result=updated_result,
+        active_visual_session_ids=next_active_visual_session_ids,
+        visual_emitted_any=next_visual_emitted_any,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -26,6 +26,9 @@ from app.engine.multi_agent.direct_tool_message_runtime import (
     build_assistant_tool_call_message as _build_assistant_tool_call_message,
     build_tool_result_message as _build_tool_result_message,
 )
+from app.engine.multi_agent.direct_tool_post_dispatch_runtime import (
+    process_direct_tool_post_dispatch,
+)
 from app.engine.multi_agent.direct_tool_dispatch_runtime import (
     dispatch_direct_tool_call,
     normalize_tool_call as _normalize_tool_call,
@@ -53,7 +56,6 @@ from app.engine.multi_agent.direct_search_template_runtime import (
 from app.engine.multi_agent.direct_forced_web_search_runtime import (
     execute_forced_web_search_shortcut,
 )
-from app.engine.multi_agent.direct_handoff_runtime import record_direct_handoff_request
 from app.engine.multi_agent.direct_document_host_action_runtime import (
     DocumentHostActionShortcut,
     execute_requested_document_host_action_shortcut,
@@ -61,7 +63,6 @@ from app.engine.multi_agent.direct_document_host_action_runtime import (
 from app.engine.multi_agent.direct_pointy_runtime import (
     _format_pointy_inventory,  # noqa: F401 - compatibility alias
     _validate_pointy_selector,  # noqa: F401 - compatibility alias
-    handle_direct_pointy_post_dispatch,
 )
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.tool_call_text_parser import (
@@ -2804,74 +2805,29 @@ async def execute_direct_tool_rounds_impl(
             tc_id = dispatch_result.tool_call_id
             tc_name = dispatch_result.tool_name
             tc_args = dispatch_result.tool_args
-            result = dispatch_result.result
-            pointy_post_dispatch = await handle_direct_pointy_post_dispatch(
+            post_dispatch = await process_direct_tool_post_dispatch(
                 tool_name=tc_name,
                 tool_args=tc_args or {},
-                result=result,
-                state=state,
-                push_event=push_event,
-                logger_obj=logger,
-            )
-            result = pointy_post_dispatch.result
-            await graph_maybe_emit_host_action_event(
-                push_event=push_event,
-                tool_name=tc_name,
-                result=result,
-                node="direct",
-                tool_call_events=tool_call_events,
-            )
-            emitted_visual_session_ids, disposed_visual_session_ids = await graph_maybe_emit_visual_event(
-                push_event=push_event,
-                tool_name=tc_name,
                 tool_call_id=tc_id,
-                result=result,
-                node="direct",
-                tool_call_events=tool_call_events,
-                previous_visual_session_ids=active_visual_session_ids,
-            )
-            if emitted_visual_session_ids:
-                visual_session_ids.extend(emitted_visual_session_ids)
-                active_visual_session_ids = list(dict.fromkeys(emitted_visual_session_ids))
-                visual_emitted_any = True
-            elif disposed_visual_session_ids:
-                disposed = set(disposed_visual_session_ids)
-                active_visual_session_ids = [
-                    session_id
-                    for session_id in active_visual_session_ids
-                    if session_id not in disposed
-                ]
-            reflection = await graph_build_direct_tool_reflection(state, tc_name, result)
-            if reflection:
-                await push_status_only_progress(
-                    push_event,
-                    node="direct",
-                    content=reflection,
-                    subtype="tool_reflection",
-                )
-            tool_call_events.append(
-                {
-                    "type": "result",
-                    "name": tc_name,
-                    "result": str(result),
-                    "id": tc_id,
-                }
-            )
-            messages.append(
-                _build_tool_result_message(
-                    str(result),
-                    tool_call_id=tc_id,
-                    native_tool_messages=native_tool_messages,
-                )
-            )
-
-            record_direct_handoff_request(
+                result=dispatch_result.result,
                 state=state,
-                tool_name=tc_name,
-                tool_args=tc_args or {},
-                enabled=settings.enable_agent_handoffs,
+                messages=messages,
+                tool_call_events=tool_call_events,
+                push_event=push_event,
+                native_tool_messages=native_tool_messages,
+                active_visual_session_ids=active_visual_session_ids,
+                visual_session_ids=visual_session_ids,
+                visual_emitted_any=visual_emitted_any,
+                handoffs_enabled=settings.enable_agent_handoffs,
+                maybe_emit_host_action_event=graph_maybe_emit_host_action_event,
+                maybe_emit_visual_event=graph_maybe_emit_visual_event,
+                build_direct_tool_reflection=graph_build_direct_tool_reflection,
+                push_status_only_progress=push_status_only_progress,
+                build_tool_result_message=_build_tool_result_message,
                 logger_obj=logger,
             )
+            active_visual_session_ids = post_dispatch.active_visual_session_ids
+            visual_emitted_any = post_dispatch.visual_emitted_any
         await graph_emit_visual_commit_events(
             push_event=push_event,
             node="direct",

--- a/maritime-ai-service/tests/unit/test_direct_tool_post_dispatch_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_post_dispatch_runtime.py
@@ -1,0 +1,161 @@
+import logging
+
+import pytest
+
+from app.engine.multi_agent.direct_tool_post_dispatch_runtime import (
+    process_direct_tool_post_dispatch,
+)
+
+
+@pytest.mark.asyncio
+async def test_process_direct_tool_post_dispatch_appends_events_and_reflection() -> None:
+    pushed_events: list[dict] = []
+    messages: list[dict] = []
+    tool_call_events: list[dict] = []
+    visual_session_ids: list[str] = []
+
+    async def push_event(event: dict) -> None:
+        pushed_events.append(event)
+
+    async def maybe_emit_host_action_event(**kwargs) -> None:
+        pushed_events.append({"type": "host_action_checked", "tool": kwargs["tool_name"]})
+
+    async def maybe_emit_visual_event(**kwargs) -> tuple[list[str], list[str]]:
+        pushed_events.append({"type": "visual_checked", "tool": kwargs["tool_name"]})
+        return ["vs-1"], []
+
+    async def build_reflection(state, tool_name, result) -> str:
+        return f"{tool_name}: reflected {result}"
+
+    async def push_status_only_progress(push_event, **kwargs) -> None:
+        await push_event({"type": "status", "content": kwargs["content"]})
+
+    state = await process_direct_tool_post_dispatch(
+        tool_name="tool_web_search",
+        tool_args={"query": "maritime"},
+        tool_call_id="call-1",
+        result="search result",
+        state={},
+        messages=messages,
+        tool_call_events=tool_call_events,
+        push_event=push_event,
+        native_tool_messages=False,
+        active_visual_session_ids=[],
+        visual_session_ids=visual_session_ids,
+        visual_emitted_any=False,
+        handoffs_enabled=True,
+        maybe_emit_host_action_event=maybe_emit_host_action_event,
+        maybe_emit_visual_event=maybe_emit_visual_event,
+        build_direct_tool_reflection=build_reflection,
+        push_status_only_progress=push_status_only_progress,
+        build_tool_result_message=lambda content, **kwargs: {
+            "content": content,
+            "tool_call_id": kwargs["tool_call_id"],
+        },
+        logger_obj=logging.getLogger(__name__),
+    )
+
+    assert state.result == "search result"
+    assert state.active_visual_session_ids == ["vs-1"]
+    assert state.visual_emitted_any is True
+    assert visual_session_ids == ["vs-1"]
+    assert tool_call_events == [
+        {
+            "type": "result",
+            "name": "tool_web_search",
+            "result": "search result",
+            "id": "call-1",
+        }
+    ]
+    assert messages == [{"content": "search result", "tool_call_id": "call-1"}]
+    assert pushed_events == [
+        {"type": "host_action_checked", "tool": "tool_web_search"},
+        {"type": "visual_checked", "tool": "tool_web_search"},
+        {"type": "status", "content": "tool_web_search: reflected search result"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_direct_tool_post_dispatch_updates_visual_disposals() -> None:
+    async def noop_push_event(event: dict) -> None:
+        return None
+
+    async def noop_host_action(**kwargs) -> None:
+        return None
+
+    async def dispose_visual(**kwargs) -> tuple[list[str], list[str]]:
+        return [], ["drop-me"]
+
+    async def no_reflection(state, tool_name, result) -> str:
+        return ""
+
+    async def noop_progress(*args, **kwargs) -> None:
+        return None
+
+    state = await process_direct_tool_post_dispatch(
+        tool_name="tool_visual_dispose",
+        tool_args={},
+        tool_call_id="call-2",
+        result="disposed",
+        state={},
+        messages=[],
+        tool_call_events=[],
+        push_event=noop_push_event,
+        native_tool_messages=False,
+        active_visual_session_ids=["keep-me", "drop-me"],
+        visual_session_ids=[],
+        visual_emitted_any=False,
+        handoffs_enabled=True,
+        maybe_emit_host_action_event=noop_host_action,
+        maybe_emit_visual_event=dispose_visual,
+        build_direct_tool_reflection=no_reflection,
+        push_status_only_progress=noop_progress,
+        build_tool_result_message=lambda content, **kwargs: content,
+        logger_obj=logging.getLogger(__name__),
+    )
+
+    assert state.active_visual_session_ids == ["keep-me"]
+    assert state.visual_emitted_any is False
+
+
+@pytest.mark.asyncio
+async def test_process_direct_tool_post_dispatch_records_handoff_target() -> None:
+    async def noop_push_event(event: dict) -> None:
+        return None
+
+    async def noop_host_action(**kwargs) -> None:
+        return None
+
+    async def no_visual(**kwargs) -> tuple[list[str], list[str]]:
+        return [], []
+
+    async def no_reflection(state, tool_name, result) -> str:
+        return ""
+
+    async def noop_progress(*args, **kwargs) -> None:
+        return None
+
+    graph_state: dict = {}
+    await process_direct_tool_post_dispatch(
+        tool_name="handoff_to_agent",
+        tool_args={"target_agent": "rag_agent"},
+        tool_call_id="call-3",
+        result="handoff requested",
+        state=graph_state,
+        messages=[],
+        tool_call_events=[],
+        push_event=noop_push_event,
+        native_tool_messages=False,
+        active_visual_session_ids=[],
+        visual_session_ids=[],
+        visual_emitted_any=False,
+        handoffs_enabled=True,
+        maybe_emit_host_action_event=noop_host_action,
+        maybe_emit_visual_event=no_visual,
+        build_direct_tool_reflection=no_reflection,
+        push_status_only_progress=noop_progress,
+        build_tool_result_message=lambda content, **kwargs: content,
+        logger_obj=logging.getLogger(__name__),
+    )
+
+    assert graph_state["_handoff_target"] == "rag_agent"


### PR DESCRIPTION
## Summary
- Extract the direct tool post-dispatch pipeline into `direct_tool_post_dispatch_runtime.py`.
- Preserve ordered side effects after each direct tool result: Pointy rewrite/action, host-action event, visual event state, reflection progress, tool result message, and handoff recording.
- Add focused unit coverage for visual emission, visual disposal, reflection/message append, and handoff state propagation.

Fixes #449

## Scope
In scope:
- Backend direct runtime refactor only.
- Post-tool result side-effect ordering and state return.

Out of scope:
- No visual runtime contract changes.
- No frontend, LMS, document, voice, provider, deployment, or migration changes.
- No generated artifacts committed.

## Verification
- `cd maritime-ai-service && uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_post_dispatch_runtime.py tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_direct_handoff_runtime.py -q --tb=short` -> `88 passed in 4.52s`
- `cd maritime-ai-service && uv run --with ruff ruff check app/engine/multi_agent/direct_tool_post_dispatch_runtime.py app/engine/multi_agent/direct_tool_rounds_runtime.py tests/unit/test_direct_tool_post_dispatch_runtime.py` -> `All checks passed!`
- `cd maritime-ai-service && uv run --with ruff ruff check app/ --select=E9,F63,F7` -> `All checks passed!`
- `git diff --check` -> passed

## Risk and rollback
Risk: medium. This consolidates the ordered side effects after each direct tool result. The helper keeps the previous order intact and returns only the visual session state that the loop needs to continue.

Rollback: revert this PR. No migrations, persistent data writes, deployment config, or frontend changes.

## Reviewer focus
- Pointy result rewriting still occurs before host-action/visual/reflection handling.
- Tool result events/messages still use the final rewritten result.
- Visual session activation/disposal updates match previous loop behavior.
- Handoff recording still happens after the tool result message is appended.