### PR TITLE
refactor(backend): extract direct tool-call response normalization

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_call_response_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_call_response_runtime.py
@@ -1,0 +1,58 @@
+"""Direct LLM response tool-call recovery and logging."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+ExtractRawToolCalls = Callable[..., list[dict[str, Any]]]
+ToolNamesFromTools = Callable[[list[Any]], list[str]]
+BuildAssistantToolCallMessage = Callable[..., Any]
+
+
+@dataclass(frozen=True)
+class DirectToolCallResponse:
+    """LLM response plus the tool calls the direct loop should process."""
+
+    llm_response: Any
+    tool_calls: list[Any]
+
+
+def prepare_direct_tool_call_response(
+    *,
+    llm_response: Any,
+    tools: list[Any],
+    native_tool_messages: bool,
+    extract_raw_tool_calls_from_text: ExtractRawToolCalls,
+    tool_names_from_tools: ToolNamesFromTools,
+    build_assistant_tool_call_message: BuildAssistantToolCallMessage,
+    logger_obj: logging.Logger,
+) -> DirectToolCallResponse:
+    """Recover raw text tool calls and log direct LLM tool-call shape."""
+
+    tool_calls = list(getattr(llm_response, "tool_calls", []) or [])
+    if tools and not tool_calls:
+        raw_tool_calls = extract_raw_tool_calls_from_text(
+            getattr(llm_response, "content", ""),
+            allowed_tool_names=tool_names_from_tools(tools) or None,
+        )
+        if raw_tool_calls:
+            logger_obj.warning(
+                "[DIRECT] Converted raw JSON assistant content into %d structured tool call(s): %s",
+                len(raw_tool_calls),
+                [call.get("name") for call in raw_tool_calls],
+            )
+            llm_response = build_assistant_tool_call_message(
+                raw_tool_calls,
+                native_tool_messages=native_tool_messages,
+            )
+            tool_calls = list(getattr(llm_response, "tool_calls", raw_tool_calls) or [])
+
+    logger_obj.warning(
+        "[DIRECT] LLM response: tool_calls=%d, content_len=%d",
+        len(tool_calls) if tool_calls else 0,
+        len(str(getattr(llm_response, "content", ""))),
+    )
+    return DirectToolCallResponse(llm_response=llm_response, tool_calls=tool_calls)

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -29,6 +29,9 @@ from app.engine.multi_agent.direct_tool_message_runtime import (
 from app.engine.multi_agent.direct_tool_post_dispatch_runtime import (
     process_direct_tool_post_dispatch,
 )
+from app.engine.multi_agent.direct_tool_call_response_runtime import (
+    prepare_direct_tool_call_response,
+)
 from app.engine.multi_agent.direct_tool_dispatch_runtime import (
     dispatch_direct_tool_call,
     normalize_tool_call as _normalize_tool_call,
@@ -2741,28 +2744,16 @@ async def execute_direct_tool_rounds_impl(
             logger_obj=logger,
         )
 
-    tool_calls = getattr(llm_response, "tool_calls", [])
-    if tools and not tool_calls:
-        raw_tool_calls = extract_raw_tool_calls_from_text(
-            getattr(llm_response, "content", ""),
-            allowed_tool_names=tool_names_from_tools(tools) or None,
-        )
-        if raw_tool_calls:
-            logger.warning(
-                "[DIRECT] Converted raw JSON assistant content into %d structured tool call(s): %s",
-                len(raw_tool_calls),
-                [call.get("name") for call in raw_tool_calls],
-            )
-            llm_response = _build_assistant_tool_call_message(
-                raw_tool_calls,
-                native_tool_messages=native_tool_messages,
-            )
-            tool_calls = getattr(llm_response, "tool_calls", raw_tool_calls)
-    logger.warning(
-        "[DIRECT] LLM response: tool_calls=%d, content_len=%d",
-        len(tool_calls) if tool_calls else 0,
-        len(str(llm_response.content)),
+    tool_call_response = prepare_direct_tool_call_response(
+        llm_response=llm_response,
+        tools=tools,
+        native_tool_messages=native_tool_messages,
+        extract_raw_tool_calls_from_text=extract_raw_tool_calls_from_text,
+        tool_names_from_tools=tool_names_from_tools,
+        build_assistant_tool_call_message=_build_assistant_tool_call_message,
+        logger_obj=logger,
     )
+    llm_response = tool_call_response.llm_response
     if not streamed_direct_answer and opening_thinking_started:
         await push_event({"type": "thinking_end", "content": "", "node": "direct"})
 

--- a/maritime-ai-service/tests/unit/test_direct_tool_call_response_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_call_response_runtime.py
@@ -1,0 +1,80 @@
+import logging
+from types import SimpleNamespace
+
+from app.engine.multi_agent.direct_tool_call_response_runtime import (
+    prepare_direct_tool_call_response,
+)
+
+
+def test_prepare_direct_tool_call_response_converts_raw_text_tool_call() -> None:
+    raw_calls = [{"name": "tool_demo", "args": {"query": "x"}, "id": "call-1"}]
+    captured: dict = {}
+
+    def extract_raw(content, *, allowed_tool_names):
+        captured["content"] = content
+        captured["allowed_tool_names"] = allowed_tool_names
+        return raw_calls
+
+    def build_message(tool_calls, **kwargs):
+        captured["native_tool_messages"] = kwargs["native_tool_messages"]
+        return SimpleNamespace(content="", tool_calls=tool_calls)
+
+    response = prepare_direct_tool_call_response(
+        llm_response=SimpleNamespace(
+            content='{"name":"tool_demo","arguments":{"query":"x"}}',
+            tool_calls=[],
+        ),
+        tools=[object()],
+        native_tool_messages=True,
+        extract_raw_tool_calls_from_text=extract_raw,
+        tool_names_from_tools=lambda tools: ["tool_demo"],
+        build_assistant_tool_call_message=build_message,
+        logger_obj=logging.getLogger(__name__),
+    )
+
+    assert response.llm_response.tool_calls == raw_calls
+    assert response.tool_calls == raw_calls
+    assert captured == {
+        "content": '{"name":"tool_demo","arguments":{"query":"x"}}',
+        "allowed_tool_names": ["tool_demo"],
+        "native_tool_messages": True,
+    }
+
+
+def test_prepare_direct_tool_call_response_keeps_structured_tool_calls() -> None:
+    structured_calls = [{"name": "tool_demo", "args": {}, "id": "call-1"}]
+
+    response = prepare_direct_tool_call_response(
+        llm_response=SimpleNamespace(content="", tool_calls=structured_calls),
+        tools=[object()],
+        native_tool_messages=False,
+        extract_raw_tool_calls_from_text=lambda *args, **kwargs: [],
+        tool_names_from_tools=lambda tools: ["tool_demo"],
+        build_assistant_tool_call_message=lambda *args, **kwargs: None,
+        logger_obj=logging.getLogger(__name__),
+    )
+
+    assert response.llm_response.tool_calls == structured_calls
+    assert response.tool_calls == structured_calls
+
+
+def test_prepare_direct_tool_call_response_skips_raw_parse_without_tools() -> None:
+    parsed = False
+
+    def extract_raw(*args, **kwargs):
+        nonlocal parsed
+        parsed = True
+        return []
+
+    response = prepare_direct_tool_call_response(
+        llm_response=SimpleNamespace(content='{"name":"tool_demo"}', tool_calls=[]),
+        tools=[],
+        native_tool_messages=False,
+        extract_raw_tool_calls_from_text=extract_raw,
+        tool_names_from_tools=lambda tools: [],
+        build_assistant_tool_call_message=lambda *args, **kwargs: None,
+        logger_obj=logging.getLogger(__name__),
+    )
+
+    assert parsed is False
+    assert response.tool_calls == []


### PR DESCRIPTION
## Summary
- Extract direct LLM tool-call response normalization into `direct_tool_call_response_runtime.py`.
- Preserve recovery of raw JSON assistant-content tool calls before dispatch, so provider text leaks still become structured tool calls.
- Add focused unit coverage for raw conversion, structured no-op, and no-tools skip paths.

Fixes #451

## Scope
In scope:
- Backend direct runtime refactor only.
- Tool-call response normalization and logging.

Out of scope:
- No tool dispatch behavior changes.
- No provider/model routing changes.
- No frontend, LMS, document, voice, deployment, or migration changes.
- No generated artifacts committed.

## Verification
- `cd maritime-ai-service && uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_call_response_runtime.py tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short` -> `84 passed in 2.19s`
- `cd maritime-ai-service && uv run --with ruff ruff check app/engine/multi_agent/direct_tool_call_response_runtime.py app/engine/multi_agent/direct_tool_rounds_runtime.py tests/unit/test_direct_tool_call_response_runtime.py` -> `All checks passed!`
- `cd maritime-ai-service && uv run --with ruff ruff check app/ --select=E9,F63,F7` -> `All checks passed!`
- `git diff --check` -> passed

## Risk and rollback
Risk: medium. This preserves a safety path that prevents raw provider tool-call JSON from rendering as chat text. The helper keeps the same raw-tool recovery order and logging.

Rollback: revert this PR. No migrations, persistent data writes, deployment config, or frontend changes.

## Reviewer focus
- Raw assistant content still converts to an assistant tool-call message only when tools exist and structured tool_calls are absent.
- Structured tool_calls remain untouched.
- No-tools responses skip raw parsing.