### PR TITLE
refactor(backend): extract direct tool round execution

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_round_execution_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_round_execution_runtime.py
@@ -1,0 +1,128 @@
+"""Execution of one direct tool round."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from app.engine.multi_agent.state import AgentState
+
+
+PushEvent = Callable[[dict[str, Any]], Awaitable[None]]
+NormalizeToolCall = Callable[[Any], dict[str, Any]]
+InferDirectReasoningCue = Callable[[str, AgentState, list[str]], str]
+CollectActiveVisualSessionIds = Callable[[AgentState], list[str]]
+DispatchDirectToolCall = Callable[..., Awaitable[Any]]
+ProcessDirectToolPostDispatch = Callable[..., Awaitable[Any]]
+EmitVisualCommitEvents = Callable[..., Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class DirectToolRoundExecution:
+    """State emitted by one direct tool round."""
+
+    round_tool_names: list[str]
+    round_cue: str
+    visual_emitted_any: bool
+
+
+async def execute_direct_tool_round(
+    *,
+    llm_response: Any,
+    tool_round: int,
+    tools: list[Any],
+    query: str,
+    state: AgentState,
+    messages: list[Any],
+    tool_call_events: list[dict[str, Any]],
+    push_event: PushEvent,
+    native_tool_messages: bool,
+    visual_emitted_any: bool,
+    runtime_context_base: Any,
+    handoffs_enabled: bool,
+    get_tool_by_name: Callable[..., Any],
+    invoke_tool_with_runtime: Callable[..., Awaitable[Any]],
+    is_search_tool_name: Callable[[str], bool],
+    prefer_official_query_for_known_docs: Callable[..., dict[str, Any]],
+    summarize_tool_result_for_stream: Callable[[str, Any], Any],
+    maybe_emit_host_action_event: Callable[..., Awaitable[None]],
+    maybe_emit_visual_event: Callable[..., Awaitable[tuple[list[str], list[str]]]],
+    emit_visual_commit_events: EmitVisualCommitEvents,
+    build_direct_tool_reflection: Callable[[Any, str, Any], Awaitable[str]],
+    push_status_only_progress: Callable[..., Awaitable[None]],
+    build_tool_result_message: Callable[..., Any],
+    normalize_tool_call: NormalizeToolCall,
+    infer_direct_reasoning_cue: InferDirectReasoningCue,
+    collect_active_visual_session_ids: CollectActiveVisualSessionIds,
+    dispatch_direct_tool_call: DispatchDirectToolCall,
+    process_direct_tool_post_dispatch: ProcessDirectToolPostDispatch,
+    logger_obj: logging.Logger,
+) -> DirectToolRoundExecution:
+    """Normalize, dispatch, and finalize all tool calls for one round."""
+
+    normalized_tool_calls = [
+        normalize_tool_call(tool_call) for tool_call in llm_response.tool_calls
+    ]
+    round_tool_names = [
+        str(tool_call.get("name", "unknown"))
+        for tool_call in normalized_tool_calls
+        if tool_call.get("name")
+    ]
+    round_cue = infer_direct_reasoning_cue(query, state, round_tool_names)
+    messages.append(llm_response)
+    visual_session_ids: list[str] = []
+    active_visual_session_ids = collect_active_visual_session_ids(state)
+
+    next_visual_emitted_any = visual_emitted_any
+    for tool_call in normalized_tool_calls:
+        dispatch_result = await dispatch_direct_tool_call(
+            tool_call=tool_call,
+            tool_round=tool_round,
+            tools=tools,
+            query=query,
+            push_event=push_event,
+            tool_call_events=tool_call_events,
+            get_tool_by_name=get_tool_by_name,
+            invoke_tool_with_runtime=invoke_tool_with_runtime,
+            runtime_context_base=runtime_context_base,
+            is_search_tool_name=is_search_tool_name,
+            prefer_official_query_for_known_docs=prefer_official_query_for_known_docs,
+            summarize_tool_result_for_stream=summarize_tool_result_for_stream,
+            logger_obj=logger_obj,
+        )
+        post_dispatch = await process_direct_tool_post_dispatch(
+            tool_name=dispatch_result.tool_name,
+            tool_args=dispatch_result.tool_args or {},
+            tool_call_id=dispatch_result.tool_call_id,
+            result=dispatch_result.result,
+            state=state,
+            messages=messages,
+            tool_call_events=tool_call_events,
+            push_event=push_event,
+            native_tool_messages=native_tool_messages,
+            active_visual_session_ids=active_visual_session_ids,
+            visual_session_ids=visual_session_ids,
+            visual_emitted_any=next_visual_emitted_any,
+            handoffs_enabled=handoffs_enabled,
+            maybe_emit_host_action_event=maybe_emit_host_action_event,
+            maybe_emit_visual_event=maybe_emit_visual_event,
+            build_direct_tool_reflection=build_direct_tool_reflection,
+            push_status_only_progress=push_status_only_progress,
+            build_tool_result_message=build_tool_result_message,
+            logger_obj=logger_obj,
+        )
+        active_visual_session_ids = post_dispatch.active_visual_session_ids
+        next_visual_emitted_any = post_dispatch.visual_emitted_any
+
+    await emit_visual_commit_events(
+        push_event=push_event,
+        node="direct",
+        visual_session_ids=visual_session_ids,
+        tool_call_events=tool_call_events,
+    )
+    return DirectToolRoundExecution(
+        round_tool_names=round_tool_names,
+        round_cue=round_cue,
+        visual_emitted_any=next_visual_emitted_any,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -32,6 +32,9 @@ from app.engine.multi_agent.direct_tool_post_dispatch_runtime import (
 from app.engine.multi_agent.direct_tool_call_response_runtime import (
     prepare_direct_tool_call_response,
 )
+from app.engine.multi_agent.direct_tool_round_execution_runtime import (
+    execute_direct_tool_round,
+)
 from app.engine.multi_agent.direct_tool_dispatch_runtime import (
     dispatch_direct_tool_call,
     normalize_tool_call as _normalize_tool_call,
@@ -2765,66 +2768,40 @@ async def execute_direct_tool_rounds_impl(
     for tool_round in range(max_rounds):
         if not (tools and hasattr(llm_response, "tool_calls") and llm_response.tool_calls):
             break
-        normalized_tool_calls = [
-            _normalize_tool_call(tc) for tc in llm_response.tool_calls
-        ]
-        round_tool_names = [
-            str(tc.get("name", "unknown"))
-            for tc in normalized_tool_calls
-            if tc.get("name")
-        ]
-        round_cue = _infer_direct_reasoning_cue(query, state, round_tool_names)
-        messages.append(llm_response)
-        visual_session_ids: list[str] = []
-        active_visual_session_ids = _collect_active_visual_session_ids(state)
-        for tc in normalized_tool_calls:
-            dispatch_result = await dispatch_direct_tool_call(
-                tool_call=tc,
-                tool_round=tool_round,
-                tools=tools,
-                query=query,
-                push_event=push_event,
-                tool_call_events=tool_call_events,
-                get_tool_by_name=graph_get_tool_by_name,
-                invoke_tool_with_runtime=graph_invoke_tool_with_runtime,
-                runtime_context_base=runtime_context_base,
-                is_search_tool_name=_is_search_tool_name,
-                prefer_official_query_for_known_docs=_prefer_official_query_for_known_docs,
-                summarize_tool_result_for_stream=_summarize_tool_result_for_stream,
-                logger_obj=logger,
-            )
-            tc_id = dispatch_result.tool_call_id
-            tc_name = dispatch_result.tool_name
-            tc_args = dispatch_result.tool_args
-            post_dispatch = await process_direct_tool_post_dispatch(
-                tool_name=tc_name,
-                tool_args=tc_args or {},
-                tool_call_id=tc_id,
-                result=dispatch_result.result,
-                state=state,
-                messages=messages,
-                tool_call_events=tool_call_events,
-                push_event=push_event,
-                native_tool_messages=native_tool_messages,
-                active_visual_session_ids=active_visual_session_ids,
-                visual_session_ids=visual_session_ids,
-                visual_emitted_any=visual_emitted_any,
-                handoffs_enabled=settings.enable_agent_handoffs,
-                maybe_emit_host_action_event=graph_maybe_emit_host_action_event,
-                maybe_emit_visual_event=graph_maybe_emit_visual_event,
-                build_direct_tool_reflection=graph_build_direct_tool_reflection,
-                push_status_only_progress=push_status_only_progress,
-                build_tool_result_message=_build_tool_result_message,
-                logger_obj=logger,
-            )
-            active_visual_session_ids = post_dispatch.active_visual_session_ids
-            visual_emitted_any = post_dispatch.visual_emitted_any
-        await graph_emit_visual_commit_events(
-            push_event=push_event,
-            node="direct",
-            visual_session_ids=visual_session_ids,
+        round_execution = await execute_direct_tool_round(
+            llm_response=llm_response,
+            tool_round=tool_round,
+            tools=tools,
+            query=query,
+            state=state,
+            messages=messages,
             tool_call_events=tool_call_events,
+            push_event=push_event,
+            native_tool_messages=native_tool_messages,
+            visual_emitted_any=visual_emitted_any,
+            runtime_context_base=runtime_context_base,
+            handoffs_enabled=settings.enable_agent_handoffs,
+            get_tool_by_name=graph_get_tool_by_name,
+            invoke_tool_with_runtime=graph_invoke_tool_with_runtime,
+            is_search_tool_name=_is_search_tool_name,
+            prefer_official_query_for_known_docs=_prefer_official_query_for_known_docs,
+            summarize_tool_result_for_stream=_summarize_tool_result_for_stream,
+            maybe_emit_host_action_event=graph_maybe_emit_host_action_event,
+            maybe_emit_visual_event=graph_maybe_emit_visual_event,
+            emit_visual_commit_events=graph_emit_visual_commit_events,
+            build_direct_tool_reflection=graph_build_direct_tool_reflection,
+            push_status_only_progress=push_status_only_progress,
+            build_tool_result_message=_build_tool_result_message,
+            normalize_tool_call=_normalize_tool_call,
+            infer_direct_reasoning_cue=_infer_direct_reasoning_cue,
+            collect_active_visual_session_ids=_collect_active_visual_session_ids,
+            dispatch_direct_tool_call=dispatch_direct_tool_call,
+            process_direct_tool_post_dispatch=process_direct_tool_post_dispatch,
+            logger_obj=logger,
         )
+        round_tool_names = round_execution.round_tool_names
+        round_cue = round_execution.round_cue
+        visual_emitted_any = round_execution.visual_emitted_any
 
         search_template_response = build_direct_post_tool_search_template_response(
             query=query,

--- a/maritime-ai-service/tests/unit/test_direct_tool_round_execution_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_round_execution_runtime.py
@@ -1,0 +1,162 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from app.engine.multi_agent.direct_tool_dispatch_runtime import (
+    DirectToolDispatchResult,
+    normalize_tool_call,
+)
+from app.engine.multi_agent.direct_tool_post_dispatch_runtime import (
+    DirectToolPostDispatchState,
+)
+from app.engine.multi_agent.direct_tool_round_execution_runtime import (
+    execute_direct_tool_round,
+)
+
+
+@pytest.mark.asyncio
+async def test_execute_direct_tool_round_dispatches_and_commits_visuals() -> None:
+    llm_response = SimpleNamespace(
+        tool_calls=[
+            SimpleNamespace(id="call-1", name="tool_demo", arguments={"query": "x"})
+        ]
+    )
+    messages: list = []
+    tool_call_events: list[dict] = []
+    captured: dict = {}
+
+    async def push_event(event: dict) -> None:
+        return None
+
+    async def dispatch_tool_call(**kwargs):
+        captured["dispatch_tool_call"] = kwargs["tool_call"]
+        return DirectToolDispatchResult(
+            tool_call_id="call-1",
+            tool_name="tool_demo",
+            tool_args={"query": "x"},
+            result="demo result",
+            matched=True,
+        )
+
+    async def process_post_dispatch(**kwargs):
+        captured["post_tool_name"] = kwargs["tool_name"]
+        captured["post_active_visuals"] = kwargs["active_visual_session_ids"]
+        kwargs["visual_session_ids"].append("vs-1")
+        messages.append({"role": "tool", "content": kwargs["result"]})
+        tool_call_events.append({"type": "result", "name": kwargs["tool_name"]})
+        return DirectToolPostDispatchState(
+            result=kwargs["result"],
+            active_visual_session_ids=["vs-1"],
+            visual_emitted_any=True,
+        )
+
+    async def emit_visual_commit_events(**kwargs):
+        captured["committed_visuals"] = kwargs["visual_session_ids"]
+
+    result = await execute_direct_tool_round(
+        llm_response=llm_response,
+        tool_round=0,
+        tools=[object()],
+        query="demo",
+        state={},
+        messages=messages,
+        tool_call_events=tool_call_events,
+        push_event=push_event,
+        native_tool_messages=False,
+        visual_emitted_any=False,
+        runtime_context_base={"request_id": "req-1"},
+        handoffs_enabled=True,
+        get_tool_by_name=lambda tools, name: object(),
+        invoke_tool_with_runtime=lambda *args, **kwargs: None,
+        is_search_tool_name=lambda name: False,
+        prefer_official_query_for_known_docs=lambda args, query: args,
+        summarize_tool_result_for_stream=lambda name, value: value,
+        maybe_emit_host_action_event=lambda **kwargs: None,
+        maybe_emit_visual_event=lambda **kwargs: ([], []),
+        emit_visual_commit_events=emit_visual_commit_events,
+        build_direct_tool_reflection=lambda state, name, value: "",
+        push_status_only_progress=lambda *args, **kwargs: None,
+        build_tool_result_message=lambda content, **kwargs: content,
+        normalize_tool_call=normalize_tool_call,
+        infer_direct_reasoning_cue=lambda query, state, names: f"cue:{','.join(names)}",
+        collect_active_visual_session_ids=lambda state: ["active-before"],
+        dispatch_direct_tool_call=dispatch_tool_call,
+        process_direct_tool_post_dispatch=process_post_dispatch,
+        logger_obj=logging.getLogger(__name__),
+    )
+
+    assert result.round_tool_names == ["tool_demo"]
+    assert result.round_cue == "cue:tool_demo"
+    assert result.visual_emitted_any is True
+    assert messages[0] is llm_response
+    assert messages[1] == {"role": "tool", "content": "demo result"}
+    assert captured["dispatch_tool_call"] == {
+        "id": "call-1",
+        "name": "tool_demo",
+        "args": {"query": "x"},
+    }
+    assert captured["post_tool_name"] == "tool_demo"
+    assert captured["post_active_visuals"] == ["active-before"]
+    assert captured["committed_visuals"] == ["vs-1"]
+
+
+@pytest.mark.asyncio
+async def test_execute_direct_tool_round_preserves_existing_visual_emission_state() -> None:
+    llm_response = SimpleNamespace(tool_calls=[{"id": "call-1", "name": "tool_demo"}])
+
+    async def push_event(event: dict) -> None:
+        return None
+
+    async def dispatch_tool_call(**kwargs):
+        return DirectToolDispatchResult(
+            tool_call_id="call-1",
+            tool_name="tool_demo",
+            tool_args={},
+            result="demo result",
+            matched=True,
+        )
+
+    async def process_post_dispatch(**kwargs):
+        return DirectToolPostDispatchState(
+            result=kwargs["result"],
+            active_visual_session_ids=[],
+            visual_emitted_any=kwargs["visual_emitted_any"],
+        )
+
+    async def emit_visual_commit_events(**kwargs):
+        return None
+
+    result = await execute_direct_tool_round(
+        llm_response=llm_response,
+        tool_round=1,
+        tools=[object()],
+        query="demo",
+        state={},
+        messages=[],
+        tool_call_events=[],
+        push_event=push_event,
+        native_tool_messages=False,
+        visual_emitted_any=True,
+        runtime_context_base={},
+        handoffs_enabled=True,
+        get_tool_by_name=lambda tools, name: object(),
+        invoke_tool_with_runtime=lambda *args, **kwargs: None,
+        is_search_tool_name=lambda name: False,
+        prefer_official_query_for_known_docs=lambda args, query: args,
+        summarize_tool_result_for_stream=lambda name, value: value,
+        maybe_emit_host_action_event=lambda **kwargs: None,
+        maybe_emit_visual_event=lambda **kwargs: ([], []),
+        emit_visual_commit_events=emit_visual_commit_events,
+        build_direct_tool_reflection=lambda state, name, value: "",
+        push_status_only_progress=lambda *args, **kwargs: None,
+        build_tool_result_message=lambda content, **kwargs: content,
+        normalize_tool_call=normalize_tool_call,
+        infer_direct_reasoning_cue=lambda query, state, names: "cue",
+        collect_active_visual_session_ids=lambda state: [],
+        dispatch_direct_tool_call=dispatch_tool_call,
+        process_direct_tool_post_dispatch=process_post_dispatch,
+        logger_obj=logging.getLogger(__name__),
+    )
+
+    assert result.visual_emitted_any is True


### PR DESCRIPTION
## Summary
- Extract execution of one direct tool round into `direct_tool_round_execution_runtime.py`.
- Keep `direct_tool_rounds_runtime.py` focused on the high-level lifecycle: prepare response, execute round, search-template return, convergence hint, follow-up.
- Add focused unit coverage for tool-call normalization, round cue/tool names, dispatch/post-dispatch integration, visual commit emission, and preservation of visual-emitted state.

Fixes #453

## Scope
In scope:
- Backend direct runtime refactor only.
- Per-round direct tool execution and visual commit orchestration.

Out of scope:
- No tool implementation changes.
- No provider/model routing changes.
- No frontend, LMS, document, voice, deployment, or migration changes.
- No generated artifacts committed.

## Verification
- `cd maritime-ai-service && uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_round_execution_runtime.py tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_direct_tool_post_dispatch_runtime.py -q --tb=short` -> `86 passed in 3.28s`
- `cd maritime-ai-service && uv run --with ruff ruff check app/engine/multi_agent/direct_tool_round_execution_runtime.py app/engine/multi_agent/direct_tool_rounds_runtime.py tests/unit/test_direct_tool_round_execution_runtime.py` -> `All checks passed!`
- `cd maritime-ai-service && uv run --with ruff ruff check app/ --select=E9,F63,F7` -> `All checks passed!`
- `git diff --check` -> passed

## Risk and rollback
Risk: medium. This moves the core per-round dispatch loop, but all side-effect dependency functions are injected and the direct loop consumes the same returned round cue/tool names/visual-emitted state.

Rollback: revert this PR. No migrations, persistent data writes, deployment config, or frontend changes.

## Reviewer focus
- `messages.append(llm_response)` still occurs before per-tool dispatch processing.
- Normalized tool names still feed `round_cue` and follow-up invocation.
- Visual commit events still emit after all tool calls in the round.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured tool execution pipeline into a dedicated runtime module for improved code organization and maintainability
  * Centralized tool dispatch and visual event handling into a single execution pathway

* **Tests**
  * Added unit tests validating tool call normalization, dispatch processing, and visual event handling
  * Tests verify proper tracking of visual sessions and event emission workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->