### PR TITLE
refactor(backend): extract direct uploaded context guards

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -58,6 +58,20 @@ from app.engine.multi_agent.direct_node_meta_fast_paths import (
     _build_wiii_capability_inventory_thinking,
     _looks_self_feeling_probe_turn,
 )
+from app.engine.multi_agent.direct_node_uploaded_context import (
+    _build_image_input_answer,
+    _build_uploaded_document_context_fallback_answer,
+    _build_uploaded_document_visual_guard_answer,
+    _first_markdown_line,
+    _image_payload_attr,
+    _looks_uploaded_context_fact_query,
+    _looks_uploaded_document_preview_request,
+    _looks_uploaded_file_metadata_query,
+    _looks_uploaded_file_visual_inspection_query,
+    _plain_markdown_excerpt,
+    _provider_likely_supports_image_blocks,
+    _uploaded_context_has_video,
+)
 from app.engine.multi_agent.direct_node_visible_thought import (
     _DIRECT_ENGLISH_PLANNER_MARKERS,
     _DIRECT_INTERNAL_THOUGHT_MARKERS,
@@ -119,6 +133,16 @@ _DIRECT_VISIBLE_THOUGHT_COMPAT_EXPORTS = (
     _extract_direct_woven_thought,
     _looks_like_direct_english_planner_thought,
     _trim_direct_visible_thought_answer_draft,
+)
+
+_DIRECT_UPLOADED_CONTEXT_COMPAT_EXPORTS = (
+    _uploaded_document_attachments,
+    _image_payload_attr,
+    _first_markdown_line,
+    _plain_markdown_excerpt,
+    _uploaded_context_has_video,
+    _looks_uploaded_file_metadata_query,
+    _provider_likely_supports_image_blocks,
 )
 
 
@@ -530,345 +554,6 @@ def _build_codebase_analysis_fallback_answer(query: str) -> str:
         "> Sơ đồ lớp chỉ mô tả các entity nghiệp vụ chính, không liệt kê toàn bộ bảng vật lý. Database có thêm bảng junction, bảng hạ tầng và bảng phát sinh qua migration. JWT thì stateless: token không lưu như session DB, nhưng mỗi request vẫn verify token rồi load user mới nhất để role/enabled có hiệu lực ngay."
     )
     return "\n\n".join(sections)
-
-
-def _image_payload_attr(image: Any, key: str, default: Any = None) -> Any:
-    if isinstance(image, dict):
-        return image.get(key, default)
-    return getattr(image, key, default)
-
-
-def _first_markdown_line(markdown: str, label: str) -> str:
-    pattern = re.compile(rf"^\s*-\s*{re.escape(label)}:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
-    match = pattern.search(markdown or "")
-    return match.group(1).strip() if match else ""
-
-
-def _plain_markdown_excerpt(markdown: str, *, limit: int = 700) -> str:
-    lines: list[str] = []
-    for raw_line in (markdown or "").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("[Transcript unavailable:"):
-            continue
-        line = re.sub(r"^#{1,6}\s+", "", line)
-        line = re.sub(r"^\s*[-*]\s+", "", line)
-        line = line.replace("\\_", "_")
-        if line:
-            lines.append(line)
-        if sum(len(item) for item in lines) >= limit:
-            break
-    return " ".join(lines)[:limit].strip()
-
-
-def _build_uploaded_document_context_fallback_answer(
-    query: str,
-    ctx: dict[str, Any],
-    *,
-    provider_unstable: bool = True,
-) -> str:
-    """Provider-failure or deterministic answer for per-turn uploaded file context."""
-    attachments = _uploaded_document_attachments(ctx)
-    if not attachments:
-        return ""
-
-    lines = [
-        (
-            "Mình vẫn đọc được phần file đã parse trong lượt này, dù provider LLM/vision đang chưa ổn định."
-            if provider_unstable
-            else "Mình đọc được phần file đã parse trong lượt này."
-        ),
-    ]
-    for index, item in enumerate(attachments[:3], start=1):
-        markdown = str(item.get("markdown") or "")
-        file_name = str(item.get("file_name") or f"file-{index}")
-        media_kind = str(item.get("media_kind") or "document")
-        parser = str(item.get("parser") or "markitdown")
-        provenance_level = str(item.get("provenance_level") or "")
-        char_count = item.get("char_count")
-        extracted_image_count = item.get("extracted_image_count")
-        embedded_asset_count = item.get("embedded_asset_count")
-
-        lines.append("")
-        provenance_text = f", provenance={provenance_level}" if provenance_level else ""
-        lines.append(f"- File: `{file_name}` ({media_kind}, parser={parser}{provenance_text})")
-        if isinstance(char_count, int):
-            lines.append(f"- Nội dung parse được: khoảng {char_count} ký tự.")
-        if isinstance(embedded_asset_count, int) and embedded_asset_count > 0:
-            lines.append(
-                f"- Parser phát hiện {embedded_asset_count} asset nhúng (hình/bảng); "
-                "cần citation/vision rõ ràng trước khi mô tả chi tiết hình ảnh."
-            )
-
-        if media_kind == "video":
-            duration = _first_markdown_line(markdown, "Duration")
-            resolution = _first_markdown_line(markdown, "Resolution")
-            has_audio = _first_markdown_line(markdown, "Has audio")
-            if duration:
-                lines.append(f"- Thời lượng video: {duration}.")
-            if resolution:
-                lines.append(f"- Độ phân giải: {resolution}.")
-            if isinstance(extracted_image_count, int):
-                lines.append(f"- Wiii đã trích {extracted_image_count} khung hình đại diện để gửi vào vision context.")
-            if has_audio:
-                lines.append(f"- Có audio: {has_audio}.")
-            if "Transcript unavailable" in markdown:
-                lines.append(
-                    "- Transcript audio hiện chưa có; điều này chỉ nói rằng audio chưa được chuyển lời/ASR chưa khả dụng, "
-                    "không chứng minh video không có giọng nói."
-                )
-        else:
-            excerpt = _plain_markdown_excerpt(markdown)
-            if excerpt:
-                lines.append(f"- Trích đoạn đầu: {excerpt}")
-
-    return _with_requested_response_marker(query, "\n".join(lines).strip())
-
-
-def _uploaded_context_has_video(ctx: dict[str, Any]) -> bool:
-    return any(
-        str(item.get("media_kind") or "").strip().lower() == "video"
-        for item in _uploaded_document_attachments(ctx)
-    )
-
-
-def _looks_uploaded_document_preview_request(query: str) -> bool:
-    """Route document-to-course preview requests away from fact fast-paths."""
-    folded = _fold_direct_text(query)
-    if not folded:
-        return False
-    preview_markers = (
-        "approval_token",
-        "ban nhap",
-        "ban xem truoc",
-        "citation",
-        "diff",
-        "lesson patch",
-        "preview",
-        "preview_lesson_patch",
-        "source references",
-        "source_references",
-        "lap bai giang",
-        "soan bai giang",
-        "soan giao an",
-        "tao bai giang",
-        "tao giao an",
-        "tao hoc lieu",
-        "tao ban xem truoc",
-        "tao khoa hoc",
-        "thiet ke bai giang",
-        "thiet ke khoa hoc",
-        "xay dung bai giang",
-        "cau truc khoa hoc",
-        "toan bo khoa",
-        "cay khoa",
-        "chia khoa",
-        "course architect",
-        "course outline",
-        "course syllabus",
-        "curriculum",
-        "de cuong khoa",
-        "de cuong mon",
-        "giao trinh",
-        "ke hoach giang day",
-        "learning path",
-        "lo trinh hoc",
-        "syllabus",
-        "generate_course_from_document",
-        "trich dan",
-        "xem truoc",
-    )
-    return any(marker in folded for marker in preview_markers)
-
-
-def _looks_uploaded_context_fact_query(query: str, ctx: dict[str, Any]) -> bool:
-    """Keep direct fact extraction from uploaded markdown off the slow LLM path."""
-    if not _has_uploaded_document_context(ctx):
-        return False
-    folded = _fold_direct_text(query)
-    if not folded:
-        return False
-    if _looks_uploaded_document_preview_request(query):
-        return False
-    if len([token for token in folded.split() if token]) > 90:
-        return False
-    fact_markers = (
-        "bang",
-        "char count",
-        "csv",
-        "doc vua upload",
-        "docx",
-        "eta",
-        "file vua upload",
-        "kpi",
-        "latencybudget",
-        "marker",
-        "noi dung parse",
-        "priority",
-        "risk",
-        "tom tat",
-        "trich",
-        "upload",
-        "uu tien",
-        "xlsx",
-    )
-    if any(marker in folded for marker in fact_markers):
-        return True
-    return _looks_uploaded_file_metadata_query(query, ctx)
-
-
-def _looks_uploaded_file_metadata_query(query: str, ctx: dict[str, Any]) -> bool:
-    """Keep simple uploaded-video fact questions deterministic and low-latency."""
-    if not _uploaded_context_has_video(ctx):
-        return False
-    folded = _fold_direct_text(query)
-    if not folded:
-        return False
-    metadata_markers = (
-        "bao lau",
-        "dai may",
-        "dai bao",
-        "thoi luong",
-        "duration",
-        "metadata",
-        "do phan giai",
-        "resolution",
-        "fps",
-        "frame",
-        "khung hinh",
-        "keyframe",
-        "trich duoc",
-        "bao nhieu khung",
-        "may khung",
-        "audio",
-        "am thanh",
-        "transcript",
-    )
-    return any(marker in folded for marker in metadata_markers)
-
-
-def _looks_uploaded_file_visual_inspection_query(query: str) -> bool:
-    folded = _fold_direct_text(query)
-    frame_hint = any(
-        marker in folded
-        for marker in (
-            "khung hinh",
-            "keyframe",
-            "frame",
-            "anh trong video",
-            "hinh anh",
-            "video nay",
-            "trong video",
-        )
-    )
-    visual_action = any(
-        marker in folded
-        for marker in (
-            "nhin",
-            "thay gi",
-            "mo ta",
-            "kieu hinh",
-            "noi dung",
-            "trong do co gi",
-            "co gi",
-        )
-    )
-    return frame_hint and visual_action
-
-
-def _provider_likely_supports_image_blocks(provider: str | None, model: str | None = None) -> bool:
-    normalized_provider = str(provider or "").strip().lower()
-    normalized_model = str(model or "").strip().lower()
-    if normalized_provider in {"google", "zhipu"}:
-        return True
-    if normalized_provider == "openai":
-        return any(marker in normalized_model for marker in ("gpt-4o", "gpt-4.1", "gpt-5", "vision"))
-    if normalized_provider == "openrouter":
-        return any(marker in normalized_model for marker in ("vision", "vl", "gpt-4o", "gpt-4.1", "gpt-5"))
-    if normalized_provider == "nvidia":
-        return any(
-            marker in normalized_model
-            for marker in (
-                "vision",
-                "vl",
-                "neva",
-                "paligemma",
-                "gemma-3-",
-                "gemma-3n-",
-                "gemma-4-",
-                "llama-4-maverick",
-                "phi-4-multimodal",
-                "ministral-14b-instruct",
-                "mistral-large-3",
-                "mistral-medium-3",
-                "mistral-small-4",
-                "kimi-k2.6",
-                "qwen3.5-",
-            )
-        )
-    return False
-
-
-def _build_uploaded_document_visual_guard_answer(query: str, ctx: dict[str, Any]) -> str:
-    base = _build_uploaded_document_context_fallback_answer(query, ctx)
-    if not base:
-        return ""
-    guard = (
-        "- Mình chưa mô tả nội dung thật bên trong các khung hình vì lượt này chưa chạy qua "
-        "vision provider hợp lệ; nói khác đi, Wiii biết video đã có frame, nhưng không được đoán "
-        "frame đó trông như thế nào."
-    )
-    if guard in base:
-        return base
-    return f"{base}\n{guard}"
-
-
-async def _build_image_input_answer(query: str, images: list[Any]) -> str:
-    first_base64 = next(
-        (
-            image
-            for image in images
-            if _image_payload_attr(image, "type", "base64") == "base64"
-            and _image_payload_attr(image, "data", "")
-        ),
-        None,
-    )
-    if first_base64 is None:
-        return _with_requested_response_marker(
-            query,
-            (
-                "Mình thấy cậu đã gửi ảnh, nhưng hiện tại Wiii chỉ xử lý trực tiếp ảnh base64 "
-                "trong chat. Hãy đính kèm lại ảnh trực tiếp trong khung chat để mình phân tích cho chắc."
-            ),
-        )
-
-    try:
-        from app.engine.vision_runtime import analyze_image_for_query
-
-        result = await analyze_image_for_query(
-            image_base64=_image_payload_attr(first_base64, "data", ""),
-            query=query,
-            media_type=_image_payload_attr(first_base64, "media_type", "image/jpeg"),
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("[DIRECT] Vision image analysis failed: %s", exc)
-        return _with_requested_response_marker(
-            query,
-            (
-                "Mình đã nhận được ảnh, nhưng Vision runtime hiện bị lỗi khi phân tích. "
-                "Mình không nên đoán nội dung ảnh; cậu thử gửi lại hoặc bật provider vision khả dụng nhé."
-            ),
-        )
-
-    if getattr(result, "success", False) and str(getattr(result, "text", "")).strip():
-        return _with_requested_response_marker(query, str(result.text).strip())
-
-    return _with_requested_response_marker(
-        query,
-        (
-            "Mình đã nhận được ảnh, nhưng hiện chưa có provider vision khả dụng để đọc ảnh này. "
-            "Mình sẽ không đoán nội dung ảnh; hãy bật Vision runtime/provider vision rồi thử lại nhé."
-        ),
-    )
 
 
 def _canonicalize_direct_thinking_effort(value: str | None) -> str | None:

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_uploaded_context.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_uploaded_context.py
@@ -1,0 +1,356 @@
+"""Uploaded document/video and image-input guards for the direct node."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from app.engine.multi_agent.document_preview_contract import (
+    has_uploaded_document_context as _has_uploaded_document_context,
+    uploaded_document_attachments_from_context as _uploaded_document_attachments,
+)
+from app.engine.multi_agent.direct_session_memory_runtime import (
+    _with_requested_response_marker,
+)
+from app.engine.multi_agent.direct_text_utils import _fold_direct_text
+
+logger = logging.getLogger(__name__)
+
+def _image_payload_attr(image: Any, key: str, default: Any = None) -> Any:
+    if isinstance(image, dict):
+        return image.get(key, default)
+    return getattr(image, key, default)
+
+
+def _first_markdown_line(markdown: str, label: str) -> str:
+    pattern = re.compile(rf"^\s*-\s*{re.escape(label)}:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+    match = pattern.search(markdown or "")
+    return match.group(1).strip() if match else ""
+
+
+def _plain_markdown_excerpt(markdown: str, *, limit: int = 700) -> str:
+    lines: list[str] = []
+    for raw_line in (markdown or "").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("[Transcript unavailable:"):
+            continue
+        line = re.sub(r"^#{1,6}\s+", "", line)
+        line = re.sub(r"^\s*[-*]\s+", "", line)
+        line = line.replace("\\_", "_")
+        if line:
+            lines.append(line)
+        if sum(len(item) for item in lines) >= limit:
+            break
+    return " ".join(lines)[:limit].strip()
+
+
+def _build_uploaded_document_context_fallback_answer(
+    query: str,
+    ctx: dict[str, Any],
+    *,
+    provider_unstable: bool = True,
+) -> str:
+    """Provider-failure or deterministic answer for per-turn uploaded file context."""
+    attachments = _uploaded_document_attachments(ctx)
+    if not attachments:
+        return ""
+
+    lines = [
+        (
+            "Mình vẫn đọc được phần file đã parse trong lượt này, dù provider LLM/vision đang chưa ổn định."
+            if provider_unstable
+            else "Mình đọc được phần file đã parse trong lượt này."
+        ),
+    ]
+    for index, item in enumerate(attachments[:3], start=1):
+        markdown = str(item.get("markdown") or "")
+        file_name = str(item.get("file_name") or f"file-{index}")
+        media_kind = str(item.get("media_kind") or "document")
+        parser = str(item.get("parser") or "markitdown")
+        provenance_level = str(item.get("provenance_level") or "")
+        char_count = item.get("char_count")
+        extracted_image_count = item.get("extracted_image_count")
+        embedded_asset_count = item.get("embedded_asset_count")
+
+        lines.append("")
+        provenance_text = f", provenance={provenance_level}" if provenance_level else ""
+        lines.append(f"- File: `{file_name}` ({media_kind}, parser={parser}{provenance_text})")
+        if isinstance(char_count, int):
+            lines.append(f"- Nội dung parse được: khoảng {char_count} ký tự.")
+        if isinstance(embedded_asset_count, int) and embedded_asset_count > 0:
+            lines.append(
+                f"- Parser phát hiện {embedded_asset_count} asset nhúng (hình/bảng); "
+                "cần citation/vision rõ ràng trước khi mô tả chi tiết hình ảnh."
+            )
+
+        if media_kind == "video":
+            duration = _first_markdown_line(markdown, "Duration")
+            resolution = _first_markdown_line(markdown, "Resolution")
+            has_audio = _first_markdown_line(markdown, "Has audio")
+            if duration:
+                lines.append(f"- Thời lượng video: {duration}.")
+            if resolution:
+                lines.append(f"- Độ phân giải: {resolution}.")
+            if isinstance(extracted_image_count, int):
+                lines.append(f"- Wiii đã trích {extracted_image_count} khung hình đại diện để gửi vào vision context.")
+            if has_audio:
+                lines.append(f"- Có audio: {has_audio}.")
+            if "Transcript unavailable" in markdown:
+                lines.append(
+                    "- Transcript audio hiện chưa có; điều này chỉ nói rằng audio chưa được chuyển lời/ASR chưa khả dụng, "
+                    "không chứng minh video không có giọng nói."
+                )
+        else:
+            excerpt = _plain_markdown_excerpt(markdown)
+            if excerpt:
+                lines.append(f"- Trích đoạn đầu: {excerpt}")
+
+    return _with_requested_response_marker(query, "\n".join(lines).strip())
+
+
+def _uploaded_context_has_video(ctx: dict[str, Any]) -> bool:
+    return any(
+        str(item.get("media_kind") or "").strip().lower() == "video"
+        for item in _uploaded_document_attachments(ctx)
+    )
+
+
+def _looks_uploaded_document_preview_request(query: str) -> bool:
+    """Route document-to-course preview requests away from fact fast-paths."""
+    folded = _fold_direct_text(query)
+    if not folded:
+        return False
+    preview_markers = (
+        "approval_token",
+        "ban nhap",
+        "ban xem truoc",
+        "citation",
+        "diff",
+        "lesson patch",
+        "preview",
+        "preview_lesson_patch",
+        "source references",
+        "source_references",
+        "lap bai giang",
+        "soan bai giang",
+        "soan giao an",
+        "tao bai giang",
+        "tao giao an",
+        "tao hoc lieu",
+        "tao ban xem truoc",
+        "tao khoa hoc",
+        "thiet ke bai giang",
+        "thiet ke khoa hoc",
+        "xay dung bai giang",
+        "cau truc khoa hoc",
+        "toan bo khoa",
+        "cay khoa",
+        "chia khoa",
+        "course architect",
+        "course outline",
+        "course syllabus",
+        "curriculum",
+        "de cuong khoa",
+        "de cuong mon",
+        "giao trinh",
+        "ke hoach giang day",
+        "learning path",
+        "lo trinh hoc",
+        "syllabus",
+        "generate_course_from_document",
+        "trich dan",
+        "xem truoc",
+    )
+    return any(marker in folded for marker in preview_markers)
+
+
+def _looks_uploaded_context_fact_query(query: str, ctx: dict[str, Any]) -> bool:
+    """Keep direct fact extraction from uploaded markdown off the slow LLM path."""
+    if not _has_uploaded_document_context(ctx):
+        return False
+    folded = _fold_direct_text(query)
+    if not folded:
+        return False
+    if _looks_uploaded_document_preview_request(query):
+        return False
+    if len([token for token in folded.split() if token]) > 90:
+        return False
+    fact_markers = (
+        "bang",
+        "char count",
+        "csv",
+        "doc vua upload",
+        "docx",
+        "eta",
+        "file vua upload",
+        "kpi",
+        "latencybudget",
+        "marker",
+        "noi dung parse",
+        "priority",
+        "risk",
+        "tom tat",
+        "trich",
+        "upload",
+        "uu tien",
+        "xlsx",
+    )
+    if any(marker in folded for marker in fact_markers):
+        return True
+    return _looks_uploaded_file_metadata_query(query, ctx)
+
+
+def _looks_uploaded_file_metadata_query(query: str, ctx: dict[str, Any]) -> bool:
+    """Keep simple uploaded-video fact questions deterministic and low-latency."""
+    if not _uploaded_context_has_video(ctx):
+        return False
+    folded = _fold_direct_text(query)
+    if not folded:
+        return False
+    metadata_markers = (
+        "bao lau",
+        "dai may",
+        "dai bao",
+        "thoi luong",
+        "duration",
+        "metadata",
+        "do phan giai",
+        "resolution",
+        "fps",
+        "frame",
+        "khung hinh",
+        "keyframe",
+        "trich duoc",
+        "bao nhieu khung",
+        "may khung",
+        "audio",
+        "am thanh",
+        "transcript",
+    )
+    return any(marker in folded for marker in metadata_markers)
+
+
+def _looks_uploaded_file_visual_inspection_query(query: str) -> bool:
+    folded = _fold_direct_text(query)
+    frame_hint = any(
+        marker in folded
+        for marker in (
+            "khung hinh",
+            "keyframe",
+            "frame",
+            "anh trong video",
+            "hinh anh",
+            "video nay",
+            "trong video",
+        )
+    )
+    visual_action = any(
+        marker in folded
+        for marker in (
+            "nhin",
+            "thay gi",
+            "mo ta",
+            "kieu hinh",
+            "noi dung",
+            "trong do co gi",
+            "co gi",
+        )
+    )
+    return frame_hint and visual_action
+
+
+def _provider_likely_supports_image_blocks(provider: str | None, model: str | None = None) -> bool:
+    normalized_provider = str(provider or "").strip().lower()
+    normalized_model = str(model or "").strip().lower()
+    if normalized_provider in {"google", "zhipu"}:
+        return True
+    if normalized_provider == "openai":
+        return any(marker in normalized_model for marker in ("gpt-4o", "gpt-4.1", "gpt-5", "vision"))
+    if normalized_provider == "openrouter":
+        return any(marker in normalized_model for marker in ("vision", "vl", "gpt-4o", "gpt-4.1", "gpt-5"))
+    if normalized_provider == "nvidia":
+        return any(
+            marker in normalized_model
+            for marker in (
+                "vision",
+                "vl",
+                "neva",
+                "paligemma",
+                "gemma-3-",
+                "gemma-3n-",
+                "gemma-4-",
+                "llama-4-maverick",
+                "phi-4-multimodal",
+                "ministral-14b-instruct",
+                "mistral-large-3",
+                "mistral-medium-3",
+                "mistral-small-4",
+                "kimi-k2.6",
+                "qwen3.5-",
+            )
+        )
+    return False
+
+
+def _build_uploaded_document_visual_guard_answer(query: str, ctx: dict[str, Any]) -> str:
+    base = _build_uploaded_document_context_fallback_answer(query, ctx)
+    if not base:
+        return ""
+    guard = (
+        "- Mình chưa mô tả nội dung thật bên trong các khung hình vì lượt này chưa chạy qua "
+        "vision provider hợp lệ; nói khác đi, Wiii biết video đã có frame, nhưng không được đoán "
+        "frame đó trông như thế nào."
+    )
+    if guard in base:
+        return base
+    return f"{base}\n{guard}"
+
+
+async def _build_image_input_answer(query: str, images: list[Any]) -> str:
+    first_base64 = next(
+        (
+            image
+            for image in images
+            if _image_payload_attr(image, "type", "base64") == "base64"
+            and _image_payload_attr(image, "data", "")
+        ),
+        None,
+    )
+    if first_base64 is None:
+        return _with_requested_response_marker(
+            query,
+            (
+                "Mình thấy cậu đã gửi ảnh, nhưng hiện tại Wiii chỉ xử lý trực tiếp ảnh base64 "
+                "trong chat. Hãy đính kèm lại ảnh trực tiếp trong khung chat để mình phân tích cho chắc."
+            ),
+        )
+
+    try:
+        from app.engine.vision_runtime import analyze_image_for_query
+
+        result = await analyze_image_for_query(
+            image_base64=_image_payload_attr(first_base64, "data", ""),
+            query=query,
+            media_type=_image_payload_attr(first_base64, "media_type", "image/jpeg"),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[DIRECT] Vision image analysis failed: %s", exc)
+        return _with_requested_response_marker(
+            query,
+            (
+                "Mình đã nhận được ảnh, nhưng Vision runtime hiện bị lỗi khi phân tích. "
+                "Mình không nên đoán nội dung ảnh; cậu thử gửi lại hoặc bật provider vision khả dụng nhé."
+            ),
+        )
+
+    if getattr(result, "success", False) and str(getattr(result, "text", "")).strip():
+        return _with_requested_response_marker(query, str(result.text).strip())
+
+    return _with_requested_response_marker(
+        query,
+        (
+            "Mình đã nhận được ảnh, nhưng hiện chưa có provider vision khả dụng để đọc ảnh này. "
+            "Mình sẽ không đoán nội dung ảnh; hãy bật Vision runtime/provider vision rồi thử lại nhé."
+        ),
+    )


### PR DESCRIPTION
Fixes #461.

## Scope
- Extract uploaded document/video context fallback, preview/fact/metadata intent checks, visual-inspection guard copy, provider image-block detection, and image-input deterministic answer helper into `direct_node_uploaded_context.py`.
- Keep private compatibility aliases from `direct_node_runtime.py` for existing tests and call sites.
- Preserve behavior; no prompt, LMS approval/host-action, provider routing, auth, deployment, schema, or UI changes intended.

## Verification
- `cd maritime-ai-service; uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_document_context_api.py tests/unit/test_direct_node_provider_errors.py::test_direct_response_node_handles_image_input_with_vision_before_llm tests/unit/test_conservative_evolution.py::TestConservativeFastRouting::test_image_input_error_routes_direct_before_rag_or_llm tests/unit/test_conservative_evolution.py::TestConservativeFastRouting::test_image_input_routes_direct_vision_lane_before_rag_or_llm -q --tb=short` -> 18 passed
- `cd maritime-ai-service; uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_node_provider_errors.py tests/unit/test_document_context_api.py -q --tb=short` -> 50 passed
- `cd maritime-ai-service; uv run --with ruff ruff check app/engine/multi_agent/direct_node_uploaded_context.py app/engine/multi_agent/direct_node_runtime.py tests/unit/test_document_context_api.py tests/unit/test_direct_node_provider_errors.py` -> All checks passed
- `cd maritime-ai-service; uv run --with ruff ruff check app/ --select=E9,F63,F7` -> All checks passed
- `git diff --check` -> passed
- `git diff --check HEAD~1..HEAD` -> passed

## Risk / Rollback
- Risk is isolated to direct-lane uploaded context fallback and image-input guard behavior.
- Rollback is a normal revert; no data, config, schema, or deployment changes.

## Reviewer Focus
- Confirm document/video preview/fact/metadata routing remains unchanged and direct runtime compatibility aliases are sufficient for existing private imports.