### PR TITLE
refactor(backend): extract direct emergency fallbacks

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_emergency_fallbacks.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_emergency_fallbacks.py
@@ -1,0 +1,208 @@
+"""Emergency fallback helpers for the direct response node."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from typing import Any
+
+from app.engine.multi_agent.direct_node_operational_fast_paths import (
+    _clean_emergency_web_search_query,
+)
+from app.engine.multi_agent.direct_node_visible_thought import (
+    _align_direct_visible_thought,
+    _best_effort_direct_visible_thought_raw,
+    _compact_basic_identity_answer,
+    _should_surface_direct_visible_thought,
+    _strip_direct_inline_private_asides,
+)
+from app.engine.multi_agent.visual_events import _summarize_tool_result_for_stream
+
+logger = logging.getLogger(__name__)
+
+
+async def _emergency_search_fallback(
+    *,
+    query: str,
+    tools: list[Any],
+    timeout_seconds: float = 30.0,
+) -> list[dict[str, Any]]:
+    """Run a bounded LLM-free search fallback when direct planning times out."""
+    if not tools or not query.strip():
+        return []
+
+    target_names = (
+        "tool_web_search",
+        "web_search",
+        "tool_search_news",
+        "search_news",
+    )
+    chosen = None
+    for tool_obj in tools:
+        name = (
+            getattr(tool_obj, "name", None)
+            or getattr(tool_obj, "__name__", None)
+            or ""
+        )
+        if str(name).lower() in target_names:
+            chosen = tool_obj
+            break
+    if chosen is None:
+        return []
+
+    chosen_name = getattr(chosen, "name", None) or getattr(chosen, "__name__", "tool_web_search")
+    invoker = getattr(chosen, "ainvoke", None)
+    search_query = _clean_emergency_web_search_query(query)
+    payload = {"query": search_query}
+    try:
+        if invoker is not None and inspect.iscoroutinefunction(invoker):
+            result = await asyncio.wait_for(invoker(payload), timeout=timeout_seconds)
+        else:
+            sync_invoker = getattr(chosen, "invoke", None)
+            if sync_invoker is None:
+                return []
+            result = await asyncio.wait_for(
+                asyncio.to_thread(sync_invoker, payload),
+                timeout=timeout_seconds,
+            )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "[DIRECT] Emergency %s exceeded %.1fs - abandoning fallback",
+            chosen_name,
+            timeout_seconds,
+        )
+        return []
+    except Exception as exc:
+        logger.warning("[DIRECT] Emergency %s raised %s - abandoning", chosen_name, exc)
+        return []
+
+    if not result or not str(result).strip():
+        return []
+
+    return [
+        {
+            "type": "call",
+            "id": "emergency-1",
+            "name": chosen_name,
+            "args": {"query": search_query},
+        },
+        {
+            "type": "result",
+            "id": "emergency-1",
+            "name": chosen_name,
+            "result": str(result),
+        },
+    ]
+
+
+async def _emit_synthetic_tool_events(
+    events: list[dict[str, Any]],
+    *,
+    push_event,
+) -> None:
+    """Surface LLM-free emergency tool work through the same SSE tool strip."""
+    for event in events or []:
+        event_type = event.get("type")
+        name = str(event.get("name") or "")
+        event_id = str(event.get("id") or "")
+        if event_type == "call":
+            await push_event(
+                {
+                    "type": "tool_call",
+                    "content": {
+                        "name": name,
+                        "args": event.get("args") or {},
+                        "id": event_id,
+                    },
+                    "node": "direct",
+                }
+            )
+        elif event_type == "result":
+            result = str(event.get("result") or "")
+            await push_event(
+                {
+                    "type": "tool_result",
+                    "content": {
+                        "name": name,
+                        "result": _summarize_tool_result_for_stream(name, result),
+                        "id": event_id,
+                    },
+                    "node": "direct",
+                }
+            )
+
+
+async def _salvage_direct_turn_from_final_result(
+    *,
+    llm_response: Any,
+    messages: list[Any],
+    extract_direct_response,
+    sanitize_structured_visual_answer_text,
+    sanitize_wiii_house_text,
+    tool_call_events: list[dict[str, Any]],
+    query: str,
+    is_identity_turn: bool,
+    routing_intent: str,
+    response_language: str,
+    llm: Any,
+) -> tuple[str, str, list[dict[str, Any]]] | None:
+    """Recover a usable response if post-processing fails after an LLM result."""
+    if llm_response is None:
+        return None
+
+    try:
+        response, thinking_content, tools_used = extract_direct_response(
+            llm_response,
+            messages or [],
+        )
+    except Exception as exc:
+        logger.warning("[DIRECT] Salvage extraction failed: %s", exc)
+        return None
+
+    response = str(response or "").strip()
+    if not response:
+        return None
+
+    try:
+        response = sanitize_structured_visual_answer_text(
+            response,
+            tool_call_events=tool_call_events,
+        )
+    except Exception as exc:
+        logger.debug("[DIRECT] Salvage skipped visual sanitize: %s", exc)
+
+    try:
+        response = sanitize_wiii_house_text(response, query=query)
+    except Exception as exc:
+        logger.debug("[DIRECT] Salvage skipped house sanitize: %s", exc)
+
+    response = _strip_direct_inline_private_asides(response)
+    if is_identity_turn:
+        try:
+            response = _compact_basic_identity_answer(response, query=query)
+        except Exception as exc:
+            logger.debug("[DIRECT] Salvage skipped identity compaction: %s", exc)
+
+    response = str(response or "").strip()
+    if not response:
+        return None
+
+    visible_thought = ""
+    if _should_surface_direct_visible_thought(
+        thinking_content,
+        routing_intent=routing_intent,
+        response=response,
+    ):
+        try:
+            visible_thought = await _align_direct_visible_thought(
+                thinking_content,
+                response_language=response_language,
+                llm=llm,
+            )
+        except Exception as exc:
+            logger.debug("[DIRECT] Salvage alignment skipped: %s", exc)
+        if not visible_thought:
+            visible_thought = _best_effort_direct_visible_thought_raw(thinking_content)
+
+    return response, visible_thought, tools_used

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import logging
 from typing import Any
 
@@ -55,6 +54,11 @@ from app.engine.multi_agent.direct_node_meta_fast_paths import (
     _build_wiii_capability_inventory_answer,
     _build_wiii_capability_inventory_thinking,
     _looks_self_feeling_probe_turn,
+)
+from app.engine.multi_agent.direct_node_emergency_fallbacks import (
+    _emergency_search_fallback,
+    _emit_synthetic_tool_events,
+    _salvage_direct_turn_from_final_result,
 )
 from app.engine.multi_agent.direct_node_operational_fast_paths import (
     _DSML_BLOCK_RE,
@@ -109,7 +113,6 @@ from app.engine.multi_agent.direct_node_visible_thought import (
     _IDENTITY_LORE_MARKERS,
     _IDENTITY_ORIGIN_QUERY_MARKERS,
     _align_direct_visible_thought,
-    _best_effort_direct_visible_thought_raw,
     _build_emotional_rescue_visible_thought,
     _compact_basic_identity_answer,
     _contains_direct_internal_thought_leak,
@@ -121,7 +124,6 @@ from app.engine.multi_agent.direct_node_visible_thought import (
 )
 from app.engine.runtime.runtime_metrics import inc_counter
 from app.engine.multi_agent.state import AgentState
-from app.engine.multi_agent.visual_events import _summarize_tool_result_for_stream
 from app.engine.reasoning import (
     align_visible_thinking_language,
     record_thinking_snapshot,
@@ -285,194 +287,6 @@ def _rebind_document_preview_host_action_tool(
     return tools, force_tools, debug
 
 _HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS = 45.0  # Phase F3 (2026-05-06): bumped 24→45s. NVIDIA DeepSeek tool-heavy pointy turns (inventory + show + synthesis) regularly hit 25-35s; 24s caused canned fallback even when LLM was actively succeeding.
-
-async def _emergency_search_fallback(
-    *,
-    query: str,
-    tools: list[Any],
-    timeout_seconds: float = 30.0,
-) -> list[dict[str, Any]]:
-    """LLM-free emergency search invoked when planning timed out.
-
-    Picks ``tool_web_search`` from the bound tool list and runs it directly
-    against the user query, then returns a synthetic ``tool_call_events`` list
-    that can be fed into ``build_search_template_fallback``. Bounded by a
-    short timeout so a slow search engine cannot stall the fallback path.
-    """
-    if not tools or not query.strip():
-        return []
-
-    target_names = (
-        "tool_web_search",
-        "web_search",
-        "tool_search_news",
-        "search_news",
-    )
-    chosen = None
-    for tool_obj in tools:
-        name = (
-            getattr(tool_obj, "name", None)
-            or getattr(tool_obj, "__name__", None)
-            or ""
-        )
-        if str(name).lower() in target_names:
-            chosen = tool_obj
-            break
-    if chosen is None:
-        return []
-
-    chosen_name = getattr(chosen, "name", None) or getattr(chosen, "__name__", "tool_web_search")
-    invoker = getattr(chosen, "ainvoke", None)
-    search_query = _clean_emergency_web_search_query(query)
-    payload = {"query": search_query}
-    try:
-        if invoker is not None and inspect.iscoroutinefunction(invoker):
-            result = await asyncio.wait_for(invoker(payload), timeout=timeout_seconds)
-        else:
-            sync_invoker = getattr(chosen, "invoke", None)
-            if sync_invoker is None:
-                return []
-            result = await asyncio.wait_for(
-                asyncio.to_thread(sync_invoker, payload),
-                timeout=timeout_seconds,
-            )
-    except asyncio.TimeoutError:
-        logger.warning(
-            "[DIRECT] Emergency %s exceeded %.1fs — abandoning fallback",
-            chosen_name,
-            timeout_seconds,
-        )
-        return []
-    except Exception as exc:
-        logger.warning("[DIRECT] Emergency %s raised %s — abandoning", chosen_name, exc)
-        return []
-
-    if not result or not str(result).strip():
-        return []
-
-    return [
-        {
-            "type": "call",
-            "id": "emergency-1",
-            "name": chosen_name,
-            "args": {"query": search_query},
-        },
-        {
-            "type": "result",
-            "id": "emergency-1",
-            "name": chosen_name,
-            "result": str(result),
-        },
-    ]
-
-
-async def _emit_synthetic_tool_events(
-    events: list[dict[str, Any]],
-    *,
-    push_event,
-) -> None:
-    """Surface LLM-free emergency tool work through the same SSE tool strip."""
-    for event in events or []:
-        event_type = event.get("type")
-        name = str(event.get("name") or "")
-        event_id = str(event.get("id") or "")
-        if event_type == "call":
-            await push_event(
-                {
-                    "type": "tool_call",
-                    "content": {
-                        "name": name,
-                        "args": event.get("args") or {},
-                        "id": event_id,
-                    },
-                    "node": "direct",
-                }
-            )
-        elif event_type == "result":
-            result = str(event.get("result") or "")
-            await push_event(
-                {
-                    "type": "tool_result",
-                    "content": {
-                        "name": name,
-                        "result": _summarize_tool_result_for_stream(name, result),
-                        "id": event_id,
-                    },
-                    "node": "direct",
-                }
-            )
-
-
-async def _salvage_direct_turn_from_final_result(
-    *,
-    llm_response: Any,
-    messages: list[Any],
-    extract_direct_response,
-    sanitize_structured_visual_answer_text,
-    sanitize_wiii_house_text,
-    tool_call_events: list[dict[str, Any]],
-    query: str,
-    is_identity_turn: bool,
-    routing_intent: str,
-    response_language: str,
-    llm: Any,
-) -> tuple[str, str, list[dict[str, Any]]] | None:
-    if llm_response is None:
-        return None
-
-    try:
-        response, thinking_content, tools_used = extract_direct_response(llm_response, messages or [])
-    except Exception as exc:
-        logger.warning("[DIRECT] Salvage extraction failed: %s", exc)
-        return None
-
-    response = str(response or "").strip()
-    if not response:
-        return None
-
-    try:
-        response = sanitize_structured_visual_answer_text(
-            response,
-            tool_call_events=tool_call_events,
-        )
-    except Exception as exc:
-        logger.debug("[DIRECT] Salvage skipped visual sanitize: %s", exc)
-
-    try:
-        response = sanitize_wiii_house_text(response, query=query)
-    except Exception as exc:
-        logger.debug("[DIRECT] Salvage skipped house sanitize: %s", exc)
-
-    response = _strip_direct_inline_private_asides(response)
-    if is_identity_turn:
-        try:
-            response = _compact_basic_identity_answer(response, query=query)
-        except Exception as exc:
-            logger.debug("[DIRECT] Salvage skipped identity compaction: %s", exc)
-
-    response = str(response or "").strip()
-    if not response:
-        return None
-
-    visible_thought = ""
-    if _should_surface_direct_visible_thought(
-        thinking_content,
-        routing_intent=routing_intent,
-        response=response,
-    ):
-        try:
-            visible_thought = await _align_direct_visible_thought(
-                thinking_content,
-                response_language=response_language,
-                llm=llm,
-            )
-        except Exception as exc:
-            logger.debug("[DIRECT] Salvage alignment skipped: %s", exc)
-        if not visible_thought:
-            visible_thought = _best_effort_direct_visible_thought_raw(thinking_content)
-
-    return response, visible_thought, tools_used
-
 
 async def direct_response_node_impl(
     state: AgentState,


### PR DESCRIPTION
## Summary
- Extracts the direct-node emergency search fallback, synthetic tool SSE emission, and final-result salvage helpers into `direct_node_emergency_fallbacks.py`.
- Leaves `direct_node_runtime.py` as the orchestration caller, with existing private helper names imported for compatibility.
- No intentional behavior change.

Closes #467

## Scope
In scope:
- Backend direct-node fallback helper extraction.
- Runtime imports/call sites only.

Out of scope:
- Provider routing behavior changes.
- LMS, voice, frontend, prompt, or deployment behavior.
- Broad cleanup outside this fallback path.

## Owner / Agents
- Owner: Codex
- Agents involved: Codex only
- Owned paths: `maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py`, `maritime-ai-service/app/engine/multi_agent/direct_node_emergency_fallbacks.py`
- Conflict risk: Low; narrow backend refactor.

## Verification
- `uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_node_provider_errors.py -q --tb=short` -> 35 passed
- `uv run --with ruff ruff check app/engine/multi_agent/direct_node_emergency_fallbacks.py app/engine/multi_agent/direct_node_runtime.py tests/unit/test_direct_node_provider_errors.py` -> All checks passed
- `uv run --with ruff ruff check app/ --select=E9,F63,F7` -> All checks passed
- `git diff --check` -> passed

## Risk / Rollback
Risk is backend runtime fallback regressions during provider timeout or post-processing failures. The implementation only moves existing logic into a focused module and keeps call sites intact.

Rollback: revert this PR to restore helper implementations inside `direct_node_runtime.py`.

## Reviewer Focus
- Confirm emergency search fallback event shape is unchanged.
- Confirm salvage path still applies visual/house sanitizers and visible thought alignment in the same order.
- Confirm no unrelated direct runtime behavior changed.