### PR TITLE
refactor(backend): extract direct document preview rebind

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_document_preview_rebind.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_document_preview_rebind.py
@@ -1,0 +1,108 @@
+"""Document preview host-action rebinding helpers for direct turns."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.engine.multi_agent.document_preview_contract import (
+    as_plain_mapping as _as_plain_direct_mapping,
+    document_preview_forced_tool_choice as _document_preview_forced_tool_choice,
+    extract_document_preview_capabilities as _extract_document_preview_capabilities,
+    has_document_preview_host_action_tool as _has_document_preview_host_action_tool,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _direct_role_candidates(state: dict[str, Any], ctx: dict[str, Any]) -> list[str]:
+    state_context = state.get("context") if isinstance(state.get("context"), dict) else {}
+    host_context = _as_plain_direct_mapping(
+        ctx.get("host_context")
+        or (state_context.get("host_context") if isinstance(state_context, dict) else None)
+        or state.get("host_context")
+    )
+    candidates = [
+        ctx.get("user_role"),
+        state_context.get("user_role") if isinstance(state_context, dict) else None,
+        state.get("user_role"),
+        state.get("role"),
+        host_context.get("user_role"),
+        host_context.get("host_role"),
+    ]
+    roles: list[str] = []
+    for candidate in candidates:
+        value = getattr(candidate, "value", candidate)
+        role = str(value or "").strip().lower()
+        if role and role not in roles:
+            roles.append(role)
+    return roles
+
+
+def _rebind_document_preview_host_action_tool(
+    *,
+    tools: list[Any],
+    force_tools: bool,
+    query: str,
+    state: dict[str, Any],
+    ctx: dict[str, Any],
+) -> tuple[list[Any], bool, dict[str, Any]]:
+    """Bind only the declared, non-mutating LMS preview action if collection lost it."""
+
+    if _has_document_preview_host_action_tool(tools):
+        return tools, True, {
+            "status": "already_bound",
+            "tool_count": len(tools),
+        }
+
+    preview_capabilities = _extract_document_preview_capabilities(state, ctx)
+    debug: dict[str, Any] = {
+        "status": "missing_capability",
+        "tool_count": len(tools),
+        "preview_capability_count": len(preview_capabilities),
+    }
+    if not preview_capabilities:
+        return tools, force_tools, debug
+
+    roles = _direct_role_candidates(state, ctx)
+    debug["role_candidates"] = roles[:4]
+    for role in roles or ["student"]:
+        try:
+            from app.engine.context.action_tools import generate_host_action_tools
+
+            generated = generate_host_action_tools(
+                preview_capabilities,
+                role,
+                event_bus_id=state.get("_event_bus_id") or state.get("session_id") or "",
+                approval_context={
+                    "query": query,
+                    "host_action_feedback": (ctx.get("host_action_feedback") or {}),
+                },
+            )
+        except Exception as exc:
+            debug.update({"status": "generation_failed", "error": type(exc).__name__})
+            logger.debug("[DIRECT] Document preview host action rebind failed: %s", exc)
+            return tools, force_tools, debug
+
+        wanted_tool = _document_preview_forced_tool_choice(query, generated)
+        preview_tools = [
+            tool
+            for tool in generated
+            if str(getattr(tool, "name", "") or getattr(tool, "__name__", "")).strip().lower()
+            == wanted_tool
+        ]
+        if preview_tools:
+            debug.update(
+                {
+                    "status": "rebound",
+                    "role": role,
+                    "tool_count": len(preview_tools),
+                }
+            )
+            logger.info(
+                "[DIRECT] Rebound LMS document preview host action from runtime capabilities"
+            )
+            return preview_tools[:1], True, debug
+
+    debug["status"] = "role_filtered"
+    return tools, force_tools, debug

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -11,12 +11,14 @@ from app.core.exceptions import ProviderUnavailableError
 from app.engine.llm_failover_runtime import classify_failover_reason_impl
 from app.engine.multi_agent.document_preview_contract import (
     DOC_PREVIEW_HOST_ACTION_TOOL as _DOC_PREVIEW_HOST_ACTION_TOOL,
-    as_plain_mapping as _as_plain_direct_mapping,
     document_preview_forced_tool_choice as _document_preview_forced_tool_choice,
-    extract_document_preview_capabilities as _extract_document_preview_capabilities,
     has_document_preview_host_action_tool as _has_document_preview_host_action_tool,
     has_uploaded_document_context as _has_uploaded_document_context,
     uploaded_document_attachments_from_context as _uploaded_document_attachments,
+)
+from app.engine.multi_agent.direct_node_document_preview_rebind import (
+    _direct_role_candidates,
+    _rebind_document_preview_host_action_tool,
 )
 from app.engine.multi_agent.direct_intent import (
     _looks_emotional_support_turn,
@@ -195,96 +197,10 @@ _DIRECT_THINKING_EFFORT_COMPAT_EXPORTS = (
     _canonicalize_direct_thinking_effort,
 )
 
-
-def _direct_role_candidates(state: dict[str, Any], ctx: dict[str, Any]) -> list[str]:
-    state_context = state.get("context") if isinstance(state.get("context"), dict) else {}
-    host_context = _as_plain_direct_mapping(
-        ctx.get("host_context")
-        or (state_context.get("host_context") if isinstance(state_context, dict) else None)
-        or state.get("host_context")
-    )
-    candidates = [
-        ctx.get("user_role"),
-        state_context.get("user_role") if isinstance(state_context, dict) else None,
-        state.get("user_role"),
-        state.get("role"),
-        host_context.get("user_role"),
-        host_context.get("host_role"),
-    ]
-    roles: list[str] = []
-    for candidate in candidates:
-        value = getattr(candidate, "value", candidate)
-        role = str(value or "").strip().lower()
-        if role and role not in roles:
-            roles.append(role)
-    return roles
-
-
-def _rebind_document_preview_host_action_tool(
-    *,
-    tools: list[Any],
-    force_tools: bool,
-    query: str,
-    state: dict[str, Any],
-    ctx: dict[str, Any],
-) -> tuple[list[Any], bool, dict[str, Any]]:
-    """Bind only the declared, non-mutating LMS preview action if collection lost it."""
-
-    if _has_document_preview_host_action_tool(tools):
-        return tools, True, {
-            "status": "already_bound",
-            "tool_count": len(tools),
-        }
-
-    preview_capabilities = _extract_document_preview_capabilities(state, ctx)
-    debug: dict[str, Any] = {
-        "status": "missing_capability",
-        "tool_count": len(tools),
-        "preview_capability_count": len(preview_capabilities),
-    }
-    if not preview_capabilities:
-        return tools, force_tools, debug
-
-    roles = _direct_role_candidates(state, ctx)
-    debug["role_candidates"] = roles[:4]
-    for role in roles or ["student"]:
-        try:
-            from app.engine.context.action_tools import generate_host_action_tools
-
-            generated = generate_host_action_tools(
-                preview_capabilities,
-                role,
-                event_bus_id=state.get("_event_bus_id") or state.get("session_id") or "",
-                approval_context={
-                    "query": query,
-                    "host_action_feedback": (ctx.get("host_action_feedback") or {}),
-                },
-            )
-        except Exception as exc:
-            debug.update({"status": "generation_failed", "error": type(exc).__name__})
-            logger.debug("[DIRECT] Document preview host action rebind failed: %s", exc)
-            return tools, force_tools, debug
-
-        wanted_tool = _document_preview_forced_tool_choice(query, generated)
-        preview_tools = [
-            tool
-            for tool in generated
-            if str(getattr(tool, "name", "") or getattr(tool, "__name__", "")).strip().lower()
-            == wanted_tool
-        ]
-        if preview_tools:
-            debug.update({
-                "status": "rebound",
-                "role": role,
-                "tool_count": len(preview_tools),
-            })
-            logger.info(
-                "[DIRECT] Rebound LMS document preview host action from runtime capabilities"
-            )
-            return preview_tools[:1], True, debug
-
-    debug["status"] = "role_filtered"
-    return tools, force_tools, debug
+_DIRECT_DOCUMENT_PREVIEW_REBIND_COMPAT_EXPORTS = (
+    _direct_role_candidates,
+    _rebind_document_preview_host_action_tool,
+)
 
 _HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS = 45.0  # Phase F3 (2026-05-06): bumped 24→45s. NVIDIA DeepSeek tool-heavy pointy turns (inventory + show + synthesis) regularly hit 25-35s; 24s caused canned fallback even when LLM was actively succeeding.
 


### PR DESCRIPTION
## Summary
- Extracts direct-node document preview host-action rebinding helpers into `direct_node_document_preview_rebind.py`.
- Keeps compatibility exports in `direct_node_runtime.py`.
- Preserves preview-only forced host-action behavior and LMS preview tool selection.

Closes #471

## Scope
In scope:
- Backend direct-node LMS document preview rebind helper extraction.

Out of scope:
- LMS apply mutation behavior.
- Provider, prompt, frontend, voice, or payload-shape changes.

## Owner / Agents
- Owner: Codex
- Agents involved: Codex only
- Owned paths: `maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py`, `maritime-ai-service/app/engine/multi_agent/direct_node_document_preview_rebind.py`
- Conflict risk: Low; narrow helper extraction.

## Verification
- `uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_node_provider_errors.py tests/unit/test_document_preview_contract.py -q --tb=short` -> 39 passed
- `uv run --with ruff ruff check app/engine/multi_agent/direct_node_document_preview_rebind.py app/engine/multi_agent/direct_node_runtime.py tests/unit/test_direct_node_provider_errors.py tests/unit/test_document_preview_contract.py` -> All checks passed
- `uv run --with ruff ruff check app/ --select=E9,F63,F7` -> All checks passed
- `git diff --check` -> passed

## Risk / Rollback
Risk is backend LMS preview tool rebinding if runtime host capabilities are missing from collected tools. The change is intended as behavior-preserving extraction.

Rollback: revert this PR to restore the helper implementation inside `direct_node_runtime.py`.

## Reviewer Focus
- Confirm preview-only host action rebinding preserves role candidate order and debug statuses.
- Confirm direct runtime still uses forced document preview host-action choice unchanged.