### PR TITLE
refactor(backend): extract direct prompt turn contracts

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_prompt_turn_contracts.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompt_turn_contracts.py
@@ -1,0 +1,168 @@
+"""Direct prompt turn-contract and force-skill helpers."""
+
+from __future__ import annotations
+
+from app.engine.multi_agent.state import AgentState
+
+
+def _build_force_skill_directive(state: AgentState) -> str:
+    """High-priority TOP-of-system-prompt directive for @-mention force-bind.
+
+    Phase F5 (2026-05-06) — when user typed `@wiii-pointy ...` or `@web-search ...`
+    in chat input, frontend parses + sets `force_skills` in chat request.
+    Tools are bound + pruned to honour the explicit invocation, but NVIDIA
+    DeepSeek (and other smaller models) still occasionally generate prose
+    instead of calling the tool. This directive plus `tool_choice="any"`
+    (set in bind_direct_tools when force_tools=True) gives the LLM
+    near-deterministic guidance on what to do FIRST.
+
+    Pattern follows Anthropic Computer Use 2026:
+      - Lead with positive imperative ("YOU MUST call ... NOW")
+      - List the exact tool names available
+      - Inject the page inventory inline so LLM has the data to pick
+        the right `selector` without round-tripping through
+        ``tool_pointy_inventory``.
+    """
+    if not isinstance(state, dict):
+        return ""
+    try:
+        from app.engine.multi_agent.tool_collection import (
+            _force_skills_from_state,
+        )
+    except Exception:
+        return ""
+    forced = _force_skills_from_state(state)
+    if not forced:
+        return ""
+
+    lines: list[str] = ["[USER FORCE-BOUND PLUGINS via @-mention — bắt buộc invoke]"]
+
+    if "wiii-pointy" in forced:
+        # Inline inventory so LLM does NOT need to call tool_pointy_inventory
+        # first. Saves a round-trip on host_ui_navigation queries.
+        targets = _extract_pointy_inventory(state)
+        target_lines = []
+        for t in targets[:12]:
+            tid = t.get("id", "")
+            label = t.get("label", "") or ""
+            role = t.get("role", "") or ""
+            if not tid:
+                continue
+            target_lines.append(
+                f'  - id="{tid}" role={role} label="{label}"'
+                f'\n    → call: tool_pointy_show(selector="{tid}", caption="...")'
+            )
+        if target_lines:
+            lines.append(
+                "User invoked **@wiii-pointy** — bạn PHẢI gọi `tool_pointy_show` "
+                "NGAY trong response này (KHÔNG được trả prose 'mình đang trỏ' "
+                "mà không invoke). Inventory hiện có trên màn hình:"
+            )
+            lines.extend(target_lines)
+            lines.append(
+                "Chọn 1 id phù hợp nhất với câu hỏi (ví dụ 'nút gửi tin nhắn' "
+                "→ id chứa 'send' hoặc 'chat-send', hoặc id `auto:...` có label khớp)."
+            )
+        else:
+            lines.append(
+                "User invoked **@wiii-pointy** nhưng inventory hiện trống. "
+                "Gọi `tool_pointy_inventory()` trước để refresh, rồi gọi "
+                "`tool_pointy_show()` với id từ kết quả."
+            )
+        lines.append(
+            "Selector PHẢI là exact id nguyên văn từ inventory. Synthetic ids "
+            "dạng `auto:button:...` là HỢP LỆ. KHÔNG thêm `#`, KHÔNG generate "
+            "CSS selector, KHÔNG dùng `[aria-label=...]`, và KHÔNG dịch/đổi id."
+        )
+
+    if "web-search" in forced:
+        lines.append(
+            "User invoked **@web-search** — bạn PHẢI gọi `tool_web_search` với "
+            "query phù hợp NGAY trong response này, KHÔNG dùng kiến thức training "
+            "thuần (user explicit chọn realtime web)."
+        )
+
+    if "visual-code-gen" in forced:
+        lines.append(
+            "User invoked **@visual-code-gen** — bạn PHẢI gọi "
+            "`tool_create_visual_code` với code_html phù hợp NGAY, KHÔNG mô tả "
+            "bằng prose thuần (user explicit chọn visual artifact)."
+        )
+
+    return "\n".join(lines)
+
+
+def _extract_pointy_inventory(state: AgentState) -> list[dict]:
+    """Pull `available_targets` from host_context.page.metadata.
+
+    Returns ordered list of target dicts với keys: id, label, role,
+    click_safe, click_kind, visible. Empty list when no inventory
+    published (no PageScanner running or empty DOM).
+    """
+    if not isinstance(state, dict):
+        return []
+    ctx = state.get("context") or {}
+    if not isinstance(ctx, dict):
+        return []
+    host = ctx.get("host_context") or state.get("host_context") or {}
+    if not isinstance(host, dict):
+        return []
+    page = host.get("page") or {}
+    if not isinstance(page, dict):
+        return []
+    metadata = page.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        return []
+    targets = metadata.get("available_targets") or []
+    if not isinstance(targets, list):
+        return []
+    return [t for t in targets if isinstance(t, dict)]
+
+
+def _force_skills_for_turn(state: AgentState) -> set[str]:
+    """Read force-bound skill ids from the current turn context."""
+    if not isinstance(state, dict):
+        return set()
+    force_skills = state.get("force_skills")
+    if not force_skills:
+        ctx = state.get("context")
+        if isinstance(ctx, dict):
+            force_skills = ctx.get("force_skills")
+    if isinstance(force_skills, (list, tuple, set)):
+        return {str(skill).strip().lower() for skill in force_skills if skill}
+    return set()
+
+
+def _build_direct_turn_contract(state: AgentState) -> str:
+    """UI-TARS-inspired discipline layer for direct turns.
+
+    Wiii has many context blocks (memory, host UI, skills, tools). This
+    lightweight envelope makes their priority explicit without flattening
+    Wiii's voice into a rigid state machine.
+    """
+    targets = _extract_pointy_inventory(state)
+    forced = _force_skills_for_turn(state)
+    lines = [
+        "## WIII DIRECT TURN CONTRACT",
+        "- Current turn wins: treat the final user message as the active instruction.",
+        "- Use history, memory, RAG, host context, and capability notes as evidence/continuity, not as competing tasks.",
+        "- If old context conflicts with the current turn, follow the current turn and mention the assumption only when useful.",
+        "- Tool discipline: call a tool only when this turn needs live data, retrieval, file/UI action, visual artifact work, or an explicit force-bound skill.",
+        "- Never carry a previous turn's tool route into a simple social/emotional turn.",
+    ]
+    if forced:
+        lines.append(
+            "- Force-bound skills for THIS turn: "
+            + ", ".join(sorted(forced))
+            + ". Satisfy those first, then keep the visible answer concise."
+        )
+    if targets:
+        lines.extend(
+            [
+                f"- Pointy inventory is available ({len(targets)} targets). Use exact ids from available_targets only; synthetic `auto:...` ids are valid.",
+                "- Normal Wiii Desktop/Web UI-location route: answer briefly, then append `[POINT:<exact-id>]` once.",
+                "- If a higher-priority @wiii-pointy/tool directive is present, call `tool_pointy_show` instead and do not add a duplicate `[POINT:...]` tag.",
+                "- Do not invent CSS selectors, `#id`, `[aria-label=...]`, translated ids, or ids that are not in inventory.",
+            ]
+        )
+    return "\n".join(lines)

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
@@ -12,6 +12,12 @@ from typing import Optional
 from app.core.config import settings
 from app.engine.multi_agent.state import AgentState
 
+from app.engine.multi_agent.direct_prompt_turn_contracts import (
+    _build_direct_turn_contract,
+    _build_force_skill_directive,
+    _extract_pointy_inventory,
+    _force_skills_for_turn,
+)
 from app.engine.multi_agent.direct_intent import (
     _looks_identity_selfhood_turn,
     _looks_selfhood_followup_turn,
@@ -31,6 +37,13 @@ from app.engine.multi_agent.graph_runtime_helpers import _copy_runtime_metadata
 from app.prompts.prompt_context_utils import build_response_language_instruction
 
 logger = logging.getLogger(__name__)
+
+_DIRECT_PROMPT_TURN_CONTRACT_COMPAT_EXPORTS = (
+    _build_direct_turn_contract,
+    _build_force_skill_directive,
+    _extract_pointy_inventory,
+    _force_skills_for_turn,
+)
 
 _DIRECT_SELFHOOD_ORIGIN_QUERY_MARKERS = (
     "ra doi",
@@ -69,169 +82,6 @@ def _identity_answer_contract_lines() -> list[str]:
         "- Khong mac dinh bung bullet list, profile list, hay manifesto. Chi mo rong khi nguoi dung muon nghe ky hon.",
         "- Chi nhac ve Bong, thoi diem ra doi, The Wiii Lab, hoac nhung chi tiet lore khac neu nguoi dung hoi sau hon hoac no that su giup cau tra loi nay dung hon.",
     ]
-
-
-def _build_force_skill_directive(state: AgentState) -> str:
-    """High-priority TOP-of-system-prompt directive for @-mention force-bind.
-
-    Phase F5 (2026-05-06) — when user typed `@wiii-pointy ...` or `@web-search ...`
-    in chat input, frontend parses + sets `force_skills` in chat request.
-    Tools are bound + pruned to honour the explicit invocation, but NVIDIA
-    DeepSeek (and other smaller models) still occasionally generate prose
-    instead of calling the tool. This directive plus `tool_choice="any"`
-    (set in bind_direct_tools when force_tools=True) gives the LLM
-    near-deterministic guidance on what to do FIRST.
-
-    Pattern follows Anthropic Computer Use 2026:
-      - Lead with positive imperative ("YOU MUST call ... NOW")
-      - List the exact tool names available
-      - Inject the page inventory inline so LLM has the data to pick
-        the right `selector` without round-tripping through
-        ``tool_pointy_inventory``.
-    """
-    if not isinstance(state, dict):
-        return ""
-    try:
-        from app.engine.multi_agent.tool_collection import (
-            _force_skills_from_state,
-        )
-    except Exception:
-        return ""
-    forced = _force_skills_from_state(state)
-    if not forced:
-        return ""
-
-    lines: list[str] = ["[USER FORCE-BOUND PLUGINS via @-mention — bắt buộc invoke]"]
-
-    if "wiii-pointy" in forced:
-        # Inline inventory so LLM does NOT need to call tool_pointy_inventory
-        # first. Saves a round-trip on host_ui_navigation queries.
-        targets = _extract_pointy_inventory(state)
-        target_lines = []
-        for t in targets[:12]:
-            tid = t.get("id", "")
-            label = t.get("label", "") or ""
-            role = t.get("role", "") or ""
-            if not tid:
-                continue
-            target_lines.append(
-                f'  - id="{tid}" role={role} label="{label}"'
-                f'\n    → call: tool_pointy_show(selector="{tid}", caption="...")'
-            )
-        if target_lines:
-            lines.append(
-                "User invoked **@wiii-pointy** — bạn PHẢI gọi `tool_pointy_show` "
-                "NGAY trong response này (KHÔNG được trả prose 'mình đang trỏ' "
-                "mà không invoke). Inventory hiện có trên màn hình:"
-            )
-            lines.extend(target_lines)
-            lines.append(
-                "Chọn 1 id phù hợp nhất với câu hỏi (ví dụ 'nút gửi tin nhắn' "
-                "→ id chứa 'send' hoặc 'chat-send', hoặc id `auto:...` có label khớp)."
-            )
-        else:
-            lines.append(
-                "User invoked **@wiii-pointy** nhưng inventory hiện trống. "
-                "Gọi `tool_pointy_inventory()` trước để refresh, rồi gọi "
-                "`tool_pointy_show()` với id từ kết quả."
-            )
-        lines.append(
-            "Selector PHẢI là exact id nguyên văn từ inventory. Synthetic ids "
-            "dạng `auto:button:...` là HỢP LỆ. KHÔNG thêm `#`, KHÔNG generate "
-            "CSS selector, KHÔNG dùng `[aria-label=...]`, và KHÔNG dịch/đổi id."
-        )
-
-    if "web-search" in forced:
-        lines.append(
-            "User invoked **@web-search** — bạn PHẢI gọi `tool_web_search` với "
-            "query phù hợp NGAY trong response này, KHÔNG dùng kiến thức training "
-            "thuần (user explicit chọn realtime web)."
-        )
-
-    if "visual-code-gen" in forced:
-        lines.append(
-            "User invoked **@visual-code-gen** — bạn PHẢI gọi "
-            "`tool_create_visual_code` với code_html phù hợp NGAY, KHÔNG mô tả "
-            "bằng prose thuần (user explicit chọn visual artifact)."
-        )
-
-    return "\n".join(lines)
-
-
-def _extract_pointy_inventory(state: AgentState) -> list[dict]:
-    """Pull `available_targets` from host_context.page.metadata.
-
-    Returns ordered list of target dicts với keys: id, label, role,
-    click_safe, click_kind, visible. Empty list when no inventory
-    published (no PageScanner running or empty DOM).
-    """
-    if not isinstance(state, dict):
-        return []
-    ctx = state.get("context") or {}
-    if not isinstance(ctx, dict):
-        return []
-    host = ctx.get("host_context") or state.get("host_context") or {}
-    if not isinstance(host, dict):
-        return []
-    page = host.get("page") or {}
-    if not isinstance(page, dict):
-        return []
-    metadata = page.get("metadata") or {}
-    if not isinstance(metadata, dict):
-        return []
-    targets = metadata.get("available_targets") or []
-    if not isinstance(targets, list):
-        return []
-    return [t for t in targets if isinstance(t, dict)]
-
-
-def _force_skills_for_turn(state: AgentState) -> set[str]:
-    """Read force-bound skill ids from the current turn context."""
-    if not isinstance(state, dict):
-        return set()
-    force_skills = state.get("force_skills")
-    if not force_skills:
-        ctx = state.get("context")
-        if isinstance(ctx, dict):
-            force_skills = ctx.get("force_skills")
-    if isinstance(force_skills, (list, tuple, set)):
-        return {str(skill).strip().lower() for skill in force_skills if skill}
-    return set()
-
-
-def _build_direct_turn_contract(state: AgentState) -> str:
-    """UI-TARS-inspired discipline layer for direct turns.
-
-    Wiii has many context blocks (memory, host UI, skills, tools). This
-    lightweight envelope makes their priority explicit without flattening
-    Wiii's voice into a rigid state machine.
-    """
-    targets = _extract_pointy_inventory(state)
-    forced = _force_skills_for_turn(state)
-    lines = [
-        "## WIII DIRECT TURN CONTRACT",
-        "- Current turn wins: treat the final user message as the active instruction.",
-        "- Use history, memory, RAG, host context, and capability notes as evidence/continuity, not as competing tasks.",
-        "- If old context conflicts with the current turn, follow the current turn and mention the assumption only when useful.",
-        "- Tool discipline: call a tool only when this turn needs live data, retrieval, file/UI action, visual artifact work, or an explicit force-bound skill.",
-        "- Never carry a previous turn's tool route into a simple social/emotional turn.",
-    ]
-    if forced:
-        lines.append(
-            "- Force-bound skills for THIS turn: "
-            + ", ".join(sorted(forced))
-            + ". Satisfy those first, then keep the visible answer concise."
-        )
-    if targets:
-        lines.extend(
-            [
-                f"- Pointy inventory is available ({len(targets)} targets). Use exact ids from available_targets only; synthetic `auto:...` ids are valid.",
-                "- Normal Wiii Desktop/Web UI-location route: answer briefly, then append `[POINT:<exact-id>]` once.",
-                "- If a higher-priority @wiii-pointy/tool directive is present, call `tool_pointy_show` instead and do not add a duplicate `[POINT:...]` tag.",
-                "- Do not invent CSS selectors, `#id`, `[aria-label=...]`, translated ids, or ids that are not in inventory.",
-            ]
-        )
-    return "\n".join(lines)
 
 
 def _build_live_evidence_planner_contract(query: str, state: AgentState) -> str:


### PR DESCRIPTION
## Summary
- Extracts direct prompt turn-contract and force-bound skill helpers into `direct_prompt_turn_contracts.py`.
- Keeps compatibility exports in `direct_prompts.py`.
- Preserves Pointy inventory injection, @-mention force directives, and direct turn contract wording.

Closes #473

## Scope
In scope:
- Backend prompt construction helper extraction for force-bound skills, Pointy inventory, and direct turn contract.

Out of scope:
- Prompt wording changes.
- Tool/provider routing behavior changes.
- Frontend or Pointy runtime changes.

## Owner / Agents
- Owner: Codex
- Agents involved: Codex only
- Owned paths: `maritime-ai-service/app/engine/multi_agent/direct_prompts.py`, `maritime-ai-service/app/engine/multi_agent/direct_prompt_turn_contracts.py`
- Conflict risk: Low to moderate if another branch edits direct prompt construction.

## Verification
- `uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_prompts_analytical_contract.py tests/unit/test_direct_prompts_identity_contract.py tests/unit/test_direct_prompts_turn_contract.py tests/unit/test_direct_codebase_thinking_quality.py tests/unit/test_direct_tool_rounds_runtime.py::test_build_force_skill_directive_pointy_inlines_inventory -q --tb=short` -> 22 passed
- `uv run --with ruff ruff check app/engine/multi_agent/direct_prompt_turn_contracts.py app/engine/multi_agent/direct_prompts.py tests/unit/test_direct_prompts_analytical_contract.py tests/unit/test_direct_prompts_identity_contract.py tests/unit/test_direct_prompts_turn_contract.py tests/unit/test_direct_codebase_thinking_quality.py tests/unit/test_direct_tool_rounds_runtime.py` -> All checks passed
- `uv run --with ruff ruff check app/ --select=E9,F63,F7` -> All checks passed
- `git diff --check` -> passed

## Risk / Rollback
Risk is prompt construction drift for @-mention force-bound skills and Pointy inventory instructions. The change is intended as extraction only.

Rollback: revert this PR to restore these helpers inside `direct_prompts.py`.

## Reviewer Focus
- Confirm prompt wording did not change.
- Confirm compatibility imports cover existing private tests/callers.
- Confirm Pointy force-skill inventory injection remains intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements for enhanced maintainability and modularity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->