### PR TITLE
docs(architecture): record latest runtime cleanup boundaries

### DIFF
--- a/docs/architecture/WIII_CODEBASE_MAP.md
+++ b/docs/architecture/WIII_CODEBASE_MAP.md
@@ -62,6 +62,7 @@ The normal chat turn should be read in this order:
 | Direct tool loop | `maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py` (main orchestration)<br>Generic dispatch: `direct_tool_dispatch_runtime.py`<br>Final synthesis helpers: `direct_final_synthesis_runtime.py`<br>Pointy policy: `direct_pointy_runtime.py`<br>Web-search policy: `direct_web_search_policy.py`<br>Document host-action shortcuts: `direct_document_host_action_runtime.py`<br>Uploaded-document preview/course payloads: `direct_document_preview_payloads.py`<br>Message builders: `direct_tool_message_runtime.py`<br>Session-memory fast paths: `direct_session_memory_runtime.py` |
 | Native stream/provider quirks | `maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py` |
 | Routing and supervisor behavior | `maritime-ai-service/app/engine/multi_agent/supervisor*.py` |
+| Direct prompt assembly | `maritime-ai-service/app/engine/multi_agent/direct_prompts.py` (main assembly)<br>Turn contract and forced-skill prompt helpers: `direct_prompt_turn_contracts.py` |
 | Tool registry | `maritime-ai-service/app/engine/tools/registry.py` and `maritime-ai-service/app/engine/multi_agent/tool_collection.py` |
 | LMS host actions | `maritime-ai-service/app/engine/context/action_tools.py`, `maritime-ai-service/app/engine/tools/lms_tools.py` |
 | Document context | `maritime-ai-service/app/api/v1/document_context.py`, document runtime helpers |

--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -112,9 +112,15 @@ backups, data PDFs, or local skill folders.
 
 ## Remaining Debt
 
-- `direct_node_runtime.py` remains large, but session-memory parsing/recall
-  has moved out. The long-term cleanup direction is lifecycle,
-  response-finalization, and SSE V3 parity modules with narrow contract tests.
+- `direct_node_runtime.py` remains large, but session-memory parsing/recall,
+  thinking-effort policy, emergency fallback/salvage helpers, uploaded-context
+  guards, operational fast paths, meta fast paths, chatter fast paths, visible
+  thought helpers, and document-preview host-action rebinding have moved out.
+  The long-term cleanup direction is lifecycle, response-finalization, and SSE
+  V3 parity modules with narrow contract tests.
+- `direct_prompts.py` remains the main direct prompt assembly surface, but
+  force-bound skill directives, Pointy inventory prompt injection, and the
+  direct turn contract now live in `direct_prompt_turn_contracts.py`.
 - `direct_tool_rounds_runtime.py` is now a smaller orchestration shell. Pointy,
   explicit web-search policy, deterministic document host-action execution,
   uploaded-document preview/course payload builders, message builders, generic
@@ -194,7 +200,18 @@ In follow-up #441, the direct tool-round command passed with 76 tests after
 moving the deterministic forced web-search shortcut into
 `direct_forced_web_search_runtime.py`. Targeted ruff checks also passed for the
 forced web-search shortcut extraction.
+In follow-up #466, targeted direct-node reasoning tests passed after moving
+direct thinking-effort policy into `direct_node_thinking_effort.py`.
+In follow-up #468, targeted direct-node provider error tests passed after
+moving emergency search fallback, synthetic tool event emission, and salvage
+helpers into `direct_node_emergency_fallbacks.py`.
 In follow-up #469, the direct tool-round command passed with 81 tests after
 moving uploaded-document preview/course payload builders into
 `direct_document_preview_payloads.py`. Targeted ruff checks also passed for the
 payload extraction.
+In follow-up #471, targeted direct-node document preview/provider tests passed
+after moving LMS document-preview host-action rebinding into
+`direct_node_document_preview_rebind.py`.
+In follow-up #473, direct prompt contract tests passed after moving
+force-bound skill directives, Pointy inventory prompt injection, and direct
+turn-contract helpers into `direct_prompt_turn_contracts.py`.


### PR DESCRIPTION
## Summary
- Updates the runtime cleanup audit with the latest direct-node, direct-tool, and direct-prompt extraction boundaries.
- Adds `direct_prompt_turn_contracts.py` to the codebase map.
- Keeps future cleanup guidance aligned with current `main`.

Closes #475

## Scope
In scope:
- Documentation-only updates to cleanup audit and codebase map.

Out of scope:
- Runtime code changes.
- Test or CI configuration changes.

## Owner / Agents
- Owner: Codex
- Agents involved: Codex only
- Owned paths: `docs/architecture/WIII_CODEBASE_MAP.md`, `docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md`
- Conflict risk: Low.

## Verification
- `git diff --check` -> passed

## Risk / Rollback
Docs-only. Rollback by reverting this PR.

## Reviewer Focus
- Confirm module boundary names match current code.
- Confirm remaining-debt notes no longer point at completed cleanup slices.