### PR TITLE
refactor(backend): extract code studio scaffold shell

### DIFF
--- a/docs/architecture/WIII_CODEBASE_MAP.md
+++ b/docs/architecture/WIII_CODEBASE_MAP.md
@@ -84,7 +84,7 @@ The normal chat turn should be read in this order:
 | Host bridge | `wiii-desktop/src/lib/embed-bridge.ts`, `wiii-desktop/src/lib/context-bridge.ts` |
 | Pointy | `wiii-desktop/src/pointy-host/**` and `wiii-desktop/src/components/chat/PointyModeToggle.tsx` |
 | Voice | `wiii-desktop/src/api/voice.ts`, voice mode/toggle components |
-| Visual artifacts | `wiii-desktop/src/components/chat/VisualArtifactCard.tsx`, `wiii-desktop/src/components/common/InlineVisualFrame.tsx`; deterministic Code Studio fallback contracts, captions, registry, quality gates, and extracted primitive renderers live in backend `code_studio_scaffold_*` modules |
+| Visual artifacts | `wiii-desktop/src/components/chat/VisualArtifactCard.tsx`, `wiii-desktop/src/components/common/InlineVisualFrame.tsx`; deterministic Code Studio fallback contracts, captions, registry, shell helpers, quality gates, and extracted primitive renderers live in backend `code_studio_scaffold_*` modules |
 
 ## Canonical Contracts
 

--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -119,6 +119,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   `direct_document_preview_text.py`, keeping line cleanup, title selection,
   marker extraction, learning-goal shaping, role-focused markdown, and
   source-page parsing separate from host-action payload assembly.
+- Follow-up #493 moved Code Studio scaffold palette, title/ARIA, shared CSS,
+  RAF script wrapper, and shell composition helpers into
+  `code_studio_scaffold_shell.py`, leaving `code_studio_template_scaffold.py`
+  focused on spec inference, renderer registry, and public API.
 
 ## Preserved Intentionally
 
@@ -169,12 +173,12 @@ backups, data PDFs, or local skill folders.
   step is shrinking the compatibility export surface once external imports can
   close.
 - `code_studio_template_scaffold.py` is still a large deterministic fallback,
-  but contract, renderer dispatch, caption copy, and explicit-simulation
-  quality policy are no longer embedded in the renderer body. Scene and
-  data-band bodies plus particle, oscillation, timeline, and function-plot
-  bodies have moved behind the registry boundary. The next durable step is
-  shrinking topic/spec extraction data and helpers if product quality evidence
-  shows that the deterministic fallback remains too broad.
+  but contract, renderer dispatch, caption copy, explicit-simulation quality
+  policy, shared shell helpers, scene/data-band bodies, and particle,
+  oscillation, timeline, and function-plot bodies have moved behind focused
+  boundaries. The next durable step is shrinking topic/spec extraction data and
+  helpers if product quality evidence shows that the deterministic fallback
+  remains too broad.
 - Some tests still import compatibility `graph.py` modules. Move tests toward
   `runtime.py` imports when the external import window can close.
 
@@ -294,3 +298,9 @@ helpers into `direct_document_preview_text.py`. The broader LMS/document
 preview contract regression set passed with 107 tests. Targeted ruff checks,
 repository `ruff check app/ --select=E9,F63,F7`, and `git diff --check` also
 passed for the text helper extraction.
+In follow-up #493, the Code Studio scaffold regression set passed with 57 tests
+after moving palette/title/ARIA/CSS/script/shell helpers into
+`code_studio_scaffold_shell.py`. The broader Code Studio scaffold plus graph
+routing regression set passed with 131 tests. Targeted ruff checks, repository
+`ruff check app/ --select=E9,F63,F7`, and `git diff --check` also passed for
+the shell helper extraction.

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_shell.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_shell.py
@@ -1,0 +1,336 @@
+"""Shared HTML shell helpers for deterministic Code Studio scaffolds."""
+
+from __future__ import annotations
+
+import html
+
+from app.engine.multi_agent.code_studio_scaffold_contract import (
+    PRIMITIVE_DATA_BAND,
+    legacy_kind_for_primitive,
+)
+
+_PALETTES = {
+    "night_sky": {
+        "sky_top": "#02030f", "sky_mid": "#08102a", "sky_bottom": "#1a1f2e",
+        "accent": "#fef9e7", "fg": "#e8e1d0", "fg_muted": "rgba(232,225,208,.85)",
+    },
+    "deep_space": {
+        "sky_top": "#0e0530", "sky_mid": "#241750", "sky_bottom": "#5a3088",
+        "accent": "#ff86d2", "fg": "#e8d5ff", "fg_muted": "rgba(232,213,255,.85)",
+    },
+    "warm_dusk": {
+        "sky_top": "#1f1c33", "sky_mid": "#3b2c4a", "sky_bottom": "#d2a673",
+        "accent": "#ffe5c1", "fg": "#fff8ec", "fg_muted": "rgba(255,248,236,.85)",
+    },
+    "autumn": {
+        "sky_top": "#3a1f0a", "sky_mid": "#7a3a14", "sky_bottom": "#d97744",
+        "accent": "#ffba6b", "fg": "#fff0d6", "fg_muted": "rgba(255,240,214,.85)",
+    },
+    "winter": {
+        "sky_top": "#1a2a3f", "sky_mid": "#3e5878", "sky_bottom": "#a3c5e0",
+        "accent": "#ffffff", "fg": "#e8f0f8", "fg_muted": "rgba(232,240,248,.85)",
+    },
+    "spring": {
+        "sky_top": "#fff5d6", "sky_mid": "#fbe5a6", "sky_bottom": "#a3d495",
+        "accent": "#ff8fa3", "fg": "#3a2a1f", "fg_muted": "rgba(58,42,31,.78)",
+    },
+    "ocean": {
+        "sky_top": "#0a3a5c", "sky_mid": "#1a6b8a", "sky_bottom": "#5fb3c9",
+        "accent": "#fff6a3", "fg": "#e3f2f9", "fg_muted": "rgba(227,242,249,.85)",
+    },
+    "forest": {
+        "sky_top": "#0e2a14", "sky_mid": "#2a5a30", "sky_bottom": "#7ba85c",
+        "accent": "#ffd66b", "fg": "#dff0d2", "fg_muted": "rgba(223,240,210,.85)",
+    },
+    "physics_warm": {
+        "sky_top": "#fff7e8", "sky_mid": "#f4dfae", "sky_bottom": "#dfa667",
+        "accent": "#d97757", "fg": "#3a2a1f", "fg_muted": "rgba(58,42,31,.7)",
+    },
+    "math_cream": {
+        "sky_top": "#fff8f1", "sky_mid": "#fce6c7", "sky_bottom": "#fde9d3",
+        "accent": "#d97757", "fg": "#3a2a1f", "fg_muted": "rgba(58,42,31,.7)",
+    },
+    "historical_dark": {
+        "sky_top": "#0e1230", "sky_mid": "#1f1c33", "sky_bottom": "#1a1f2e",
+        "accent": "#d97757", "fg": "#e8e1d0", "fg_muted": "rgba(232,225,208,.85)",
+    },
+    "lab_bright": {
+        "sky_top": "#fdf6ef", "sky_mid": "#f9e6c5", "sky_bottom": "#f3dcc4",
+        "accent": "#d97757", "fg": "#3a2a1f", "fg_muted": "rgba(58,42,31,.78)",
+    },
+}
+
+
+def _short_title(query: str, max_len: int = 60) -> str:
+    title = (query or "").strip()
+    if len(title) > max_len:
+        title = title[:max_len].rstrip() + "…"
+    return title or "Khung dựng cảnh"
+
+
+def _legacy_kind_for(spec: dict) -> str:
+    primitive = spec.get("primitive", PRIMITIVE_DATA_BAND)
+    return legacy_kind_for_primitive(primitive)
+
+
+def _aria_label(spec: dict, title: str) -> str:
+    legacy = _legacy_kind_for(spec)
+    descriptor = {
+        "literary": "Khung mô phỏng văn học",
+        "physics": "Khung mô phỏng vật lý",
+        "math": "Khung dựng đồ thị",
+        "history": "Khung mô phỏng lịch sử",
+        "celestial": "Khung mô phỏng bầu trời",
+        "default": "Khung mô phỏng",
+    }.get(legacy, "Khung mô phỏng")
+    return (
+        f"{descriptor} cho {title} — màn hình tạm, "
+        "Wiii sẽ mở rộng khi bạn mô tả thêm chi tiết"
+    )
+
+
+# ============================================================================
+# Common HTML/JS helpers shared by every primitive renderer
+# ============================================================================
+
+
+# Kind-specific CSS variable hooks — host theme overrides land via these.
+# Each entry maps legacy_kind → list of var declarations the stage CSS
+# emits so the iframe can inherit ``--wiii-{kind}-*`` from the host.
+# Variable names match Sprint 35e SKILL VISUAL_CODE_GEN.md v6.2.0 §12.
+_KIND_VAR_HOOKS: dict[str, list[tuple[str, str]]] = {
+    "literary": [
+        ("scene-sky-deep", "sky_top"),
+        ("scene-sky-mid", "sky_mid"),
+        ("scene-fg", "fg"),
+    ],
+    "physics": [
+        ("phys-bg-light", "sky_top"),
+        ("phys-fg", "fg"),
+    ],
+    "math": [
+        ("math-bg-light", "sky_top"),
+        ("math-fg", "fg"),
+        ("math-grid", "fg_muted"),
+    ],
+    "history": [
+        ("history-bg-deep", "sky_top"),
+        ("history-fg", "fg"),
+    ],
+    "celestial": [
+        ("celestial-bg-deep", "sky_top"),
+        ("celestial-fg", "fg"),
+    ],
+    "default": [
+        ("default-bg-light", "sky_top"),
+        ("default-fg", "fg"),
+    ],
+}
+
+
+def _common_styles(prefix: str, palette: dict, kind: str = "default") -> str:
+    """Shared stage/controls/slider/readout CSS for any primitive.
+
+    ``prefix`` is the unique CSS class prefix (e.g. ``"wiii-cel"`` for
+    celestial) so each primitive has its own scope. Hardcoded fallbacks
+    pull from ``palette`` so the iframe renders correctly even without
+    host theme overrides.
+
+    ``kind`` is the legacy kind label (literary/physics/math/history/
+    celestial/default) — used to emit kind-specific CSS variable hooks
+    (``var(--wiii-scene-sky-deep, ...)``) so the host theme can override
+    via ``InlineVisualFrame.readHostThemeOverrides``.
+    """
+    sky_top = palette["sky_top"]
+    sky_bottom = palette["sky_bottom"]
+    accent = palette["accent"]
+    fg = palette["fg"]
+    fg_muted = palette["fg_muted"]
+    # Build kind-specific var hook declarations as `--_local: var(--wiii-{kind}-{slot}, fallback);`
+    hooks = _KIND_VAR_HOOKS.get(kind, _KIND_VAR_HOOKS["default"])
+    hook_lines = []
+    slot_to_value = {
+        "sky_top": sky_top, "sky_mid": palette.get("sky_mid", sky_top),
+        "sky_bottom": sky_bottom, "fg": fg, "fg_muted": fg_muted, "accent": accent,
+    }
+    for var_name, slot in hooks:
+        hook_lines.append(
+            f"  --wiii-_kind-{var_name}: var(--wiii-{var_name}, {slot_to_value.get(slot, sky_top)});"
+        )
+    hook_block = "\n".join(hook_lines)
+    return f"""
+.{prefix}-stage{{
+{hook_block}
+  position:relative;width:100%;max-width:100%;border-radius:18px;overflow:hidden;
+  background:{sky_top};
+  box-shadow:0 12px 30px rgba(20,24,38,.25);
+  font-family:var(--wiii-font-sans,"Inter",system-ui,sans-serif);
+  color:{fg};
+}}
+.{prefix}-canvas{{display:block;width:100%;aspect-ratio:16/9;min-height:240px;}}
+.{prefix}-controls{{
+  display:flex;flex-direction:column;gap:10px;padding:14px 18px 16px;
+  background:linear-gradient(180deg,
+    rgba(0,0,0,0) 0%,
+    {sky_bottom} 80%);
+}}
+.{prefix}-row{{display:flex;align-items:center;gap:12px;font-size:12.5px;color:{fg_muted};}}
+.{prefix}-row label{{flex:0 0 auto;letter-spacing:.04em;}}
+.{prefix}-slider{{
+  flex:1;height:4px;-webkit-appearance:none;appearance:none;
+  background:rgba(232,225,208,.18);border-radius:2px;outline:none;
+}}
+.{prefix}-slider::-webkit-slider-thumb{{
+  -webkit-appearance:none;appearance:none;width:14px;height:14px;border-radius:50%;
+  background:var(--wiii-accent,{accent});border:1px solid rgba(255,255,255,.85);cursor:pointer;
+}}
+.{prefix}-slider::-moz-range-thumb{{
+  width:14px;height:14px;border-radius:50%;background:var(--wiii-accent,{accent});
+  border:1px solid rgba(255,255,255,.85);cursor:pointer;
+}}
+.{prefix}-readout{{font-size:12px;color:{fg};letter-spacing:.02em;line-height:1.5;}}
+.{prefix}-readout strong{{color:var(--wiii-accent,{accent});}}
+.{prefix}-hint{{
+  margin-top:12px;font-size:13px;line-height:1.55;
+  color:var(--wiii-text-secondary,#5b4a4a);
+  font-family:var(--wiii-font-sans,"Inter",system-ui,sans-serif);
+}}
+@media (max-width:480px){{
+  .{prefix}-stage{{border-radius:14px;}}
+  .{prefix}-canvas{{aspect-ratio:4/3;}}
+  .{prefix}-controls{{padding:10px 14px 12px;}}
+  .{prefix}-hint{{font-size:12px;line-height:1.45;}}
+}}
+@media (prefers-reduced-motion:reduce){{
+  .{prefix}-canvas{{animation:none !important;}}
+}}
+""".strip()
+
+
+def _common_script_wrapper(
+    canvas_id: str,
+    slider_id: str,
+    readout_id: str,
+    setup_body: str,
+    render_body: str,
+    slider_handler_body: str,
+) -> str:
+    """Shared RAF/slider/reduced-motion JS wrapper for every primitive.
+
+    ``setup_body`` runs once before the loop; ``render_body`` runs every
+    frame; ``slider_handler_body`` runs on slider input. All run inside
+    an IIFE so iframe globals stay clean.
+    """
+    return f"""
+<script>
+(function(){{
+  var canvas = document.getElementById('{canvas_id}');
+  var slider = document.getElementById('{slider_id}');
+  var readout = document.getElementById('{readout_id}');
+  if (!canvas || !slider || !readout) return;
+  var ctx = canvas.getContext('2d');
+  var dpr = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
+  var raf = 0;
+  var startedAt = performance.now();
+
+  function ensureCanvasSize(){{
+    var w = canvas.clientWidth || 640;
+    var h = canvas.clientHeight || 360;
+    if (canvas.width !== w * dpr) canvas.width = w * dpr;
+    if (canvas.height !== h * dpr) canvas.height = h * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    return {{w: w, h: h}};
+  }}
+
+  {setup_body}
+
+  function frame(){{
+    var sz = ensureCanvasSize();
+    var w = sz.w, h = sz.h;
+    var elapsed = (performance.now() - startedAt) / 1000;
+    {render_body}
+    raf = requestAnimationFrame(frame);
+  }}
+
+  function reportProgress(payload, summary){{
+    if (window.WiiiVisualBridge && typeof window.WiiiVisualBridge.reportResult === 'function'){{
+      try {{
+        window.WiiiVisualBridge.reportResult('scaffold_progress', payload || {{}}, summary || '', 'in_progress');
+      }} catch (err) {{}}
+    }}
+  }}
+
+  slider.addEventListener('input', function(){{
+    {slider_handler_body}
+  }});
+  if (window.matchMedia && window.matchMedia('(prefers-reduced-motion:reduce)').matches){{
+    frame(); cancelAnimationFrame(raf);
+  }} else {{
+    raf = requestAnimationFrame(frame);
+  }}
+}})();
+</script>
+""".strip()
+
+
+# Legacy kind → second class prefix (Sprint 35e tests expect these stable
+# names for tooling/CSS hooks).
+_LEGACY_KIND_TO_CLASS_PREFIX: dict[str, str] = {
+    "literary": "scene",
+    "physics": "phys",
+    "math": "math",
+    "history": "hist",
+    "celestial": "cel",
+    "default": "default",
+}
+
+
+_FALLBACK_HINT = (
+    "Đây là khung canvas khởi đầu — kéo thanh trượt để thấy hệ thống "
+    "phản hồi theo tham số. Cho Wiii biết hiện tượng/dữ liệu/tương tác "
+    "cụ thể bạn muốn dựng và mình sẽ thay phần lõi bằng nội dung "
+    "đúng chủ đề."
+)
+
+
+def _build_shell(
+    *,
+    prefix: str,
+    spec: dict,
+    canvas_html: str,
+    controls_html: str,
+    script_html: str,
+) -> str:
+    """Compose stage + canvas + controls + hint + script into final HTML.
+
+    Emits two stage classes: ``wiii-{primitive}-stage`` (for primitive-
+    specific styling) AND ``wiii-{kind}-stage`` (for legacy kind-keyed
+    tooling/tests). Both reference the same shared CSS rules.
+    """
+    palette = _PALETTES.get(spec.get("palette", "lab_bright"), _PALETTES["lab_bright"])
+    aria = html.escape(_aria_label(spec, _short_title(spec.get("title", ""))))
+    legacy_kind = _legacy_kind_for(spec)
+    kind_class_prefix = _LEGACY_KIND_TO_CLASS_PREFIX.get(legacy_kind, "default")
+    hint_text = spec.get("hint") or _FALLBACK_HINT
+    hint_html_escaped = html.escape(hint_text)
+    common_css = _common_styles(prefix, palette, kind=legacy_kind)
+    # Append a kind-aliased CSS rule so `.wiii-{kind}-stage` selector
+    # resolves to the same shared styles. Tests look for the substring
+    # `wiii-{kind}-stage` and tooling can hook on either class.
+    kind_alias_css = (
+        f".wiii-{kind_class_prefix}-stage{{display:contents;}}"
+    )
+    return f"""
+<style>
+{common_css}
+{kind_alias_css}
+</style>
+<div class="{prefix}-stage wiii-{kind_class_prefix}-stage" data-scaffold-kind="{legacy_kind}" data-scaffold-primitive="{spec.get('primitive')}" role="region" aria-label="{aria}">
+  {canvas_html}
+  <div class="{prefix}-controls">
+    {controls_html}
+  </div>
+</div>
+<div class="{prefix}-hint">{hint_html_escaped}</div>
+{script_html}
+""".strip()

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_template_scaffold.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_template_scaffold.py
@@ -97,7 +97,6 @@ Wiii references:
 
 from __future__ import annotations
 
-import html
 import unicodedata
 
 from app.engine.multi_agent.code_studio_scaffold_core_renderers import (
@@ -113,7 +112,6 @@ from app.engine.multi_agent.code_studio_scaffold_contract import (
     PRIMITIVE_PARTICLE_FIELD,
     PRIMITIVE_SCENE,
     PRIMITIVE_TIMELINE,
-    legacy_kind_for_primitive,
     primitive_for_legacy_kind,
 )
 from app.engine.multi_agent.code_studio_scaffold_captions import (
@@ -129,6 +127,13 @@ from app.engine.multi_agent.code_studio_scaffold_scene_renderers import (
     render_data_band_scaffold,
     render_scene_scaffold,
 )
+from app.engine.multi_agent.code_studio_scaffold_shell import (
+    _PALETTES,
+    _build_shell,
+    _common_script_wrapper,
+    _legacy_kind_for,
+    _short_title,
+)
 
 # ============================================================================
 # Primitive identifiers + legacy kind mapping contract
@@ -137,64 +142,6 @@ from app.engine.multi_agent.code_studio_scaffold_scene_renderers import (
 # Primitive and legacy-kind names live in ``code_studio_scaffold_contract``.
 # This renderer imports them so public routing/metrics code can depend on the
 # contract without importing the full HTML scaffold module.
-
-# ============================================================================
-# Palette library (CSS variable-aware, host theme-overridable)
-# ============================================================================
-
-# Each palette is a dict with sky_top, sky_mid, sky_bottom, accent, fg, fg_muted.
-# Hardcoded fallbacks; the iframe inherits ``--wiii-*`` overrides from the
-# host theme bridge (``InlineVisualFrame.readHostThemeOverrides``).
-_PALETTES = {
-    "night_sky": {
-        "sky_top": "#02030f", "sky_mid": "#08102a", "sky_bottom": "#1a1f2e",
-        "accent": "#fef9e7", "fg": "#e8e1d0", "fg_muted": "rgba(232,225,208,.85)",
-    },
-    "deep_space": {
-        "sky_top": "#0e0530", "sky_mid": "#241750", "sky_bottom": "#5a3088",
-        "accent": "#ff86d2", "fg": "#e8d5ff", "fg_muted": "rgba(232,213,255,.85)",
-    },
-    "warm_dusk": {
-        "sky_top": "#1f1c33", "sky_mid": "#3b2c4a", "sky_bottom": "#d2a673",
-        "accent": "#ffe5c1", "fg": "#fff8ec", "fg_muted": "rgba(255,248,236,.85)",
-    },
-    "autumn": {
-        "sky_top": "#3a1f0a", "sky_mid": "#7a3a14", "sky_bottom": "#d97744",
-        "accent": "#ffba6b", "fg": "#fff0d6", "fg_muted": "rgba(255,240,214,.85)",
-    },
-    "winter": {
-        "sky_top": "#1a2a3f", "sky_mid": "#3e5878", "sky_bottom": "#a3c5e0",
-        "accent": "#ffffff", "fg": "#e8f0f8", "fg_muted": "rgba(232,240,248,.85)",
-    },
-    "spring": {
-        "sky_top": "#fff5d6", "sky_mid": "#fbe5a6", "sky_bottom": "#a3d495",
-        "accent": "#ff8fa3", "fg": "#3a2a1f", "fg_muted": "rgba(58,42,31,.78)",
-    },
-    "ocean": {
-        "sky_top": "#0a3a5c", "sky_mid": "#1a6b8a", "sky_bottom": "#5fb3c9",
-        "accent": "#fff6a3", "fg": "#e3f2f9", "fg_muted": "rgba(227,242,249,.85)",
-    },
-    "forest": {
-        "sky_top": "#0e2a14", "sky_mid": "#2a5a30", "sky_bottom": "#7ba85c",
-        "accent": "#ffd66b", "fg": "#dff0d2", "fg_muted": "rgba(223,240,210,.85)",
-    },
-    "physics_warm": {
-        "sky_top": "#fff7e8", "sky_mid": "#f4dfae", "sky_bottom": "#dfa667",
-        "accent": "#d97757", "fg": "#3a2a1f", "fg_muted": "rgba(58,42,31,.7)",
-    },
-    "math_cream": {
-        "sky_top": "#fff8f1", "sky_mid": "#fce6c7", "sky_bottom": "#fde9d3",
-        "accent": "#d97757", "fg": "#3a2a1f", "fg_muted": "rgba(58,42,31,.7)",
-    },
-    "historical_dark": {
-        "sky_top": "#0e1230", "sky_mid": "#1f1c33", "sky_bottom": "#1a1f2e",
-        "accent": "#d97757", "fg": "#e8e1d0", "fg_muted": "rgba(232,225,208,.85)",
-    },
-    "lab_bright": {
-        "sky_top": "#fdf6ef", "sky_mid": "#f9e6c5", "sky_bottom": "#f3dcc4",
-        "accent": "#d97757", "fg": "#3a2a1f", "fg_muted": "rgba(58,42,31,.78)",
-    },
-}
 
 # ============================================================================
 # Topic library — rich content overrides for famous, recurring topics.
@@ -688,37 +635,6 @@ def _normalize(text: str) -> str:
     return "".join(c for c in nfkd if unicodedata.category(c) != "Mn")
 
 
-def _short_title(query: str, max_len: int = 60) -> str:
-    title = (query or "").strip()
-    if len(title) > max_len:
-        title = title[:max_len].rstrip() + "…"
-    return title or "Khung dựng cảnh"
-
-
-def _legacy_kind_for(spec: dict) -> str:
-    primitive = spec.get("primitive", PRIMITIVE_DATA_BAND)
-    return legacy_kind_for_primitive(primitive)
-
-
-def _aria_label(spec: dict, title: str) -> str:
-    legacy = _legacy_kind_for(spec)
-    descriptor = {
-        "literary": "Khung mô phỏng văn học",
-        "physics": "Khung mô phỏng vật lý",
-        "math": "Khung dựng đồ thị",
-        "history": "Khung mô phỏng lịch sử",
-        "celestial": "Khung mô phỏng bầu trời",
-        "default": "Khung mô phỏng",
-    }.get(legacy, "Khung mô phỏng")
-    return (
-        f"{descriptor} cho {title} — màn hình tạm, "
-        "Wiii sẽ mở rộng khi bạn mô tả thêm chi tiết"
-    )
-
-
-# ─── Smart inference helpers (deterministic, microsecond) ──────────────────
-
-
 def _extract_visual_title(query: str, max_len: int = 60) -> str:
     """Strip command words ("mô phỏng", "vẽ", "tạo") iteratively.
 
@@ -957,253 +873,6 @@ def detect_scaffold_kind(query: str) -> str:
         return "default"
     spec = extract_scaffold_spec(query)
     return _legacy_kind_for(spec)
-
-
-# ============================================================================
-# Common HTML/JS helpers shared by every primitive renderer
-# ============================================================================
-
-
-# Kind-specific CSS variable hooks — host theme overrides land via these.
-# Each entry maps legacy_kind → list of var declarations the stage CSS
-# emits so the iframe can inherit ``--wiii-{kind}-*`` from the host.
-# Variable names match Sprint 35e SKILL VISUAL_CODE_GEN.md v6.2.0 §12.
-_KIND_VAR_HOOKS: dict[str, list[tuple[str, str]]] = {
-    "literary": [
-        ("scene-sky-deep", "sky_top"),
-        ("scene-sky-mid", "sky_mid"),
-        ("scene-fg", "fg"),
-    ],
-    "physics": [
-        ("phys-bg-light", "sky_top"),
-        ("phys-fg", "fg"),
-    ],
-    "math": [
-        ("math-bg-light", "sky_top"),
-        ("math-fg", "fg"),
-        ("math-grid", "fg_muted"),
-    ],
-    "history": [
-        ("history-bg-deep", "sky_top"),
-        ("history-fg", "fg"),
-    ],
-    "celestial": [
-        ("celestial-bg-deep", "sky_top"),
-        ("celestial-fg", "fg"),
-    ],
-    "default": [
-        ("default-bg-light", "sky_top"),
-        ("default-fg", "fg"),
-    ],
-}
-
-
-def _common_styles(prefix: str, palette: dict, kind: str = "default") -> str:
-    """Shared stage/controls/slider/readout CSS for any primitive.
-
-    ``prefix`` is the unique CSS class prefix (e.g. ``"wiii-cel"`` for
-    celestial) so each primitive has its own scope. Hardcoded fallbacks
-    pull from ``palette`` so the iframe renders correctly even without
-    host theme overrides.
-
-    ``kind`` is the legacy kind label (literary/physics/math/history/
-    celestial/default) — used to emit kind-specific CSS variable hooks
-    (``var(--wiii-scene-sky-deep, ...)``) so the host theme can override
-    via ``InlineVisualFrame.readHostThemeOverrides``.
-    """
-    sky_top = palette["sky_top"]
-    sky_bottom = palette["sky_bottom"]
-    accent = palette["accent"]
-    fg = palette["fg"]
-    fg_muted = palette["fg_muted"]
-    # Build kind-specific var hook declarations as `--_local: var(--wiii-{kind}-{slot}, fallback);`
-    hooks = _KIND_VAR_HOOKS.get(kind, _KIND_VAR_HOOKS["default"])
-    hook_lines = []
-    slot_to_value = {
-        "sky_top": sky_top, "sky_mid": palette.get("sky_mid", sky_top),
-        "sky_bottom": sky_bottom, "fg": fg, "fg_muted": fg_muted, "accent": accent,
-    }
-    for var_name, slot in hooks:
-        hook_lines.append(
-            f"  --wiii-_kind-{var_name}: var(--wiii-{var_name}, {slot_to_value.get(slot, sky_top)});"
-        )
-    hook_block = "\n".join(hook_lines)
-    return f"""
-.{prefix}-stage{{
-{hook_block}
-  position:relative;width:100%;max-width:100%;border-radius:18px;overflow:hidden;
-  background:{sky_top};
-  box-shadow:0 12px 30px rgba(20,24,38,.25);
-  font-family:var(--wiii-font-sans,"Inter",system-ui,sans-serif);
-  color:{fg};
-}}
-.{prefix}-canvas{{display:block;width:100%;aspect-ratio:16/9;min-height:240px;}}
-.{prefix}-controls{{
-  display:flex;flex-direction:column;gap:10px;padding:14px 18px 16px;
-  background:linear-gradient(180deg,
-    rgba(0,0,0,0) 0%,
-    {sky_bottom} 80%);
-}}
-.{prefix}-row{{display:flex;align-items:center;gap:12px;font-size:12.5px;color:{fg_muted};}}
-.{prefix}-row label{{flex:0 0 auto;letter-spacing:.04em;}}
-.{prefix}-slider{{
-  flex:1;height:4px;-webkit-appearance:none;appearance:none;
-  background:rgba(232,225,208,.18);border-radius:2px;outline:none;
-}}
-.{prefix}-slider::-webkit-slider-thumb{{
-  -webkit-appearance:none;appearance:none;width:14px;height:14px;border-radius:50%;
-  background:var(--wiii-accent,{accent});border:1px solid rgba(255,255,255,.85);cursor:pointer;
-}}
-.{prefix}-slider::-moz-range-thumb{{
-  width:14px;height:14px;border-radius:50%;background:var(--wiii-accent,{accent});
-  border:1px solid rgba(255,255,255,.85);cursor:pointer;
-}}
-.{prefix}-readout{{font-size:12px;color:{fg};letter-spacing:.02em;line-height:1.5;}}
-.{prefix}-readout strong{{color:var(--wiii-accent,{accent});}}
-.{prefix}-hint{{
-  margin-top:12px;font-size:13px;line-height:1.55;
-  color:var(--wiii-text-secondary,#5b4a4a);
-  font-family:var(--wiii-font-sans,"Inter",system-ui,sans-serif);
-}}
-@media (max-width:480px){{
-  .{prefix}-stage{{border-radius:14px;}}
-  .{prefix}-canvas{{aspect-ratio:4/3;}}
-  .{prefix}-controls{{padding:10px 14px 12px;}}
-  .{prefix}-hint{{font-size:12px;line-height:1.45;}}
-}}
-@media (prefers-reduced-motion:reduce){{
-  .{prefix}-canvas{{animation:none !important;}}
-}}
-""".strip()
-
-
-def _common_script_wrapper(
-    canvas_id: str,
-    slider_id: str,
-    readout_id: str,
-    setup_body: str,
-    render_body: str,
-    slider_handler_body: str,
-) -> str:
-    """Shared RAF/slider/reduced-motion JS wrapper for every primitive.
-
-    ``setup_body`` runs once before the loop; ``render_body`` runs every
-    frame; ``slider_handler_body`` runs on slider input. All run inside
-    an IIFE so iframe globals stay clean.
-    """
-    return f"""
-<script>
-(function(){{
-  var canvas = document.getElementById('{canvas_id}');
-  var slider = document.getElementById('{slider_id}');
-  var readout = document.getElementById('{readout_id}');
-  if (!canvas || !slider || !readout) return;
-  var ctx = canvas.getContext('2d');
-  var dpr = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
-  var raf = 0;
-  var startedAt = performance.now();
-
-  function ensureCanvasSize(){{
-    var w = canvas.clientWidth || 640;
-    var h = canvas.clientHeight || 360;
-    if (canvas.width !== w * dpr) canvas.width = w * dpr;
-    if (canvas.height !== h * dpr) canvas.height = h * dpr;
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    return {{w: w, h: h}};
-  }}
-
-  {setup_body}
-
-  function frame(){{
-    var sz = ensureCanvasSize();
-    var w = sz.w, h = sz.h;
-    var elapsed = (performance.now() - startedAt) / 1000;
-    {render_body}
-    raf = requestAnimationFrame(frame);
-  }}
-
-  function reportProgress(payload, summary){{
-    if (window.WiiiVisualBridge && typeof window.WiiiVisualBridge.reportResult === 'function'){{
-      try {{
-        window.WiiiVisualBridge.reportResult('scaffold_progress', payload || {{}}, summary || '', 'in_progress');
-      }} catch (err) {{}}
-    }}
-  }}
-
-  slider.addEventListener('input', function(){{
-    {slider_handler_body}
-  }});
-  if (window.matchMedia && window.matchMedia('(prefers-reduced-motion:reduce)').matches){{
-    frame(); cancelAnimationFrame(raf);
-  }} else {{
-    raf = requestAnimationFrame(frame);
-  }}
-}})();
-</script>
-""".strip()
-
-
-# Legacy kind → second class prefix (Sprint 35e tests expect these stable
-# names for tooling/CSS hooks).
-_LEGACY_KIND_TO_CLASS_PREFIX: dict[str, str] = {
-    "literary": "scene",
-    "physics": "phys",
-    "math": "math",
-    "history": "hist",
-    "celestial": "cel",
-    "default": "default",
-}
-
-
-_FALLBACK_HINT = (
-    "Đây là khung canvas khởi đầu — kéo thanh trượt để thấy hệ thống "
-    "phản hồi theo tham số. Cho Wiii biết hiện tượng/dữ liệu/tương tác "
-    "cụ thể bạn muốn dựng và mình sẽ thay phần lõi bằng nội dung "
-    "đúng chủ đề."
-)
-
-
-def _build_shell(
-    *,
-    prefix: str,
-    spec: dict,
-    canvas_html: str,
-    controls_html: str,
-    script_html: str,
-) -> str:
-    """Compose stage + canvas + controls + hint + script into final HTML.
-
-    Emits two stage classes: ``wiii-{primitive}-stage`` (for primitive-
-    specific styling) AND ``wiii-{kind}-stage`` (for legacy kind-keyed
-    tooling/tests). Both reference the same shared CSS rules.
-    """
-    palette = _PALETTES.get(spec.get("palette", "lab_bright"), _PALETTES["lab_bright"])
-    aria = html.escape(_aria_label(spec, _short_title(spec.get("title", ""))))
-    legacy_kind = _legacy_kind_for(spec)
-    kind_class_prefix = _LEGACY_KIND_TO_CLASS_PREFIX.get(legacy_kind, "default")
-    hint_text = spec.get("hint") or _FALLBACK_HINT
-    hint_html_escaped = html.escape(hint_text)
-    common_css = _common_styles(prefix, palette, kind=legacy_kind)
-    # Append a kind-aliased CSS rule so `.wiii-{kind}-stage` selector
-    # resolves to the same shared styles. Tests look for the substring
-    # `wiii-{kind}-stage` and tooling can hook on either class.
-    kind_alias_css = (
-        f".wiii-{kind_class_prefix}-stage{{display:contents;}}"
-    )
-    return f"""
-<style>
-{common_css}
-{kind_alias_css}
-</style>
-<div class="{prefix}-stage wiii-{kind_class_prefix}-stage" data-scaffold-kind="{legacy_kind}" data-scaffold-primitive="{spec.get('primitive')}" role="region" aria-label="{aria}">
-  {canvas_html}
-  <div class="{prefix}-controls">
-    {controls_html}
-  </div>
-</div>
-<div class="{prefix}-hint">{hint_html_escaped}</div>
-{script_html}
-""".strip()
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Moves shared Code Studio scaffold shell helpers into `code_studio_scaffold_shell.py`.
- Keeps `code_studio_template_scaffold.py` focused on spec inference, renderer wrappers, registry, and public API.
- Preserves renderer wrapper names and deterministic fallback HTML shape.
- Updates cleanup audit and codebase map.

Closes #493

## Scope
In scope: backend refactor of deterministic Code Studio scaffold shell/palette/style/script helper boundaries.

Out of scope: visual intent routing, primitive renderer body logic, frontend artifact rendering, Code Studio tool dispatch, deployment.

## Verification
- `uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_code_studio_template_scaffold.py -q --tb=short` -> 57 passed
- `uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_code_studio_template_scaffold.py tests/unit/test_graph_routing.py -q --tb=short` -> 131 passed
- `uv run --with ruff ruff check app/engine/multi_agent/code_studio_template_scaffold.py app/engine/multi_agent/code_studio_scaffold_shell.py tests/unit/test_code_studio_template_scaffold.py` -> passed
- `uv run --with ruff ruff check app/ --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk and rollback
Risk is fallback HTML parity drift for Code Studio visual scaffolds. Rollback is reverting this PR; no migrations, persistent data writes, LMS mutations, secrets, or deployment changes are included.

## Reviewer focus
- Confirm public API and private renderer wrappers remain import-compatible.
- Confirm shell/palette extraction does not change stage CSS, ARIA labels, script wrapper, or responsive behavior.
- Confirm Code Studio tool routing and frontend artifact rendering are untouched.