### PR TITLE
refactor(backend): shrink direct node compat exports

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -206,7 +206,9 @@ backups, data PDFs, or local skill folders.
   execution preparation, response cleanup, visible-thinking finalization,
   exception/source fallback lifecycle, final state/domain notice handling, and
   host UI timeout handling have moved out. The long-term cleanup direction is
-  lifecycle modules and SSE V3 parity modules with narrow contract tests.
+  lifecycle modules and SSE V3 parity modules with narrow contract tests. Its
+  obsolete private helper compatibility export tuples are now closed; tests
+  import helper contracts from their owning modules.
 - `direct_prompts.py` remains the main direct prompt assembly surface, but
   force-bound skill directives, Pointy inventory prompt injection, the direct
   turn contract, provider-aware tool binding, and tool-context prompt builders
@@ -416,3 +418,8 @@ direct-node regression set passed with 68 tests after moving final thinking
 snapshot resolution, `final_response`/`agent_outputs` assignment, current-agent
 marking, and general-intent domain notice handling into
 `direct_node_final_state.py`.
+In follow-up #519, affected import-surface tests passed with 142 tests and the
+focused direct-node regression set still passed with 68 tests after moving
+private direct-node helper imports from `direct_node_runtime.py` to their owning
+modules and removing obsolete compatibility export tuples/imports from the
+runtime.

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -9,7 +9,6 @@ from app.core.config import settings
 from app.core.exceptions import ProviderUnavailableError
 from app.engine.multi_agent.document_preview_contract import (
     has_uploaded_document_context as _has_uploaded_document_context,
-    uploaded_document_attachments_from_context as _uploaded_document_attachments,
 )
 from app.engine.multi_agent.direct_node_document_preview_runtime import (
     execute_direct_node_document_preview_round,
@@ -36,12 +35,10 @@ from app.engine.multi_agent.direct_node_visible_thinking_finalization import (
     finalize_direct_node_visible_thinking,
 )
 from app.engine.multi_agent.direct_node_document_preview_rebind import (
-    _direct_role_candidates,
     _rebind_document_preview_host_action_tool,
 )
 from app.engine.multi_agent.direct_intent import (
     _looks_emotional_support_turn,
-    _normalize_for_intent,
 )
 from app.engine.multi_agent.direct_reasoning import (
     _is_codebase_analysis_query,
@@ -50,60 +47,22 @@ from app.engine.multi_agent.direct_search_synthesis_fallback import (
     build_search_template_fallback,
     looks_like_search_placeholder_answer,
 )
-from app.engine.multi_agent.direct_session_memory_runtime import (
-    _build_session_memory_write_answer,
-    _build_session_memory_write_thinking,
-    _extract_session_memory_items_from_text,
-    _extract_session_memory_recall_answer,
-    _with_requested_response_marker,
-)
-from app.engine.multi_agent.direct_text_utils import _fold_direct_text
-from app.engine.multi_agent.direct_node_chatter_runtime import (
-    _build_hunger_chatter_answer,
-    _build_hunger_chatter_thinking,
-    _looks_hunger_chatter_turn,
-)
-from app.engine.multi_agent.direct_node_meta_fast_paths import (
-    _build_reasoning_safety_meta_answer,
-    _build_reasoning_safety_meta_thinking,
-    _build_self_feeling_probe_answer,
-    _build_self_feeling_probe_thinking,
-    _build_wiii_capability_inventory_answer,
-    _build_wiii_capability_inventory_thinking,
-    _looks_self_feeling_probe_turn,
-)
 from app.engine.multi_agent.direct_node_exception_fallbacks import (
     handle_direct_node_generation_exception,
 )
 from app.engine.multi_agent.direct_node_final_state import finalize_direct_node_state
 from app.engine.multi_agent.direct_node_operational_fast_paths import (
-    _DSML_BLOCK_RE,
-    _DSML_STRAY_ASCII_RE,
-    _DSML_STRAY_FULLWIDTH_RE,
-    _GENERIC_DIRECT_FALLBACK_MARKERS,
     _build_codebase_analysis_fallback_answer,
     _build_codebase_analysis_fallback_thinking,
     _build_image_input_thinking,
     _build_image_input_unavailable_answer,
     _build_image_input_unavailable_thinking,
-    _build_pointy_fast_path_thinking,
-    _build_pointy_missing_inventory_answer,
-    _build_pointy_missing_inventory_thinking,
-    _build_wiii_pipeline_meta_answer,
-    _build_wiii_pipeline_meta_thinking,
-    _clean_emergency_web_search_query,
-    _extract_direct_reply_only_answer,
-    _extract_pointy_fast_path_answer,
     _is_explicit_web_search_turn_for_direct,
     _looks_generic_direct_fallback_response,
-    _pointy_requested_without_inventory,
     _should_use_codebase_source_note_fast_answer,
     _strip_dsml_residue,
 )
 from app.engine.multi_agent.direct_node_thinking_effort import (
-    _DIRECT_ANALYTICAL_THINKING_MODES,
-    _DIRECT_CANONICAL_THINKING_EFFORT_ALIASES,
-    _canonicalize_direct_thinking_effort,
     _resolve_direct_thinking_effort,
 )
 from app.engine.multi_agent.direct_node_thinking_snapshot import (
@@ -114,131 +73,21 @@ from app.engine.multi_agent.direct_node_uploaded_context import (
     _build_image_input_answer,
     _build_uploaded_document_context_fallback_answer,
     _build_uploaded_document_visual_guard_answer,
-    _first_markdown_line,
-    _image_payload_attr,
-    _looks_uploaded_context_fact_query,
     _looks_uploaded_document_preview_request,
-    _looks_uploaded_file_metadata_query,
     _looks_uploaded_file_visual_inspection_query,
-    _plain_markdown_excerpt,
     _provider_likely_supports_image_blocks,
-    _uploaded_context_has_video,
 )
 from app.engine.multi_agent.direct_node_visible_thought import (
-    _DIRECT_ENGLISH_PLANNER_MARKERS,
-    _DIRECT_INTERNAL_THOUGHT_MARKERS,
-    _DIRECT_VISIBLE_THOUGHT_DRAFT_SPLITTERS,
-    _DIRECT_VISIBLE_THOUGHT_TRAILING_SELF_EVAL,
-    _DIRECT_WOVEN_THOUGHT_INTENTS,
-    _IDENTITY_LORE_MARKERS,
-    _IDENTITY_ORIGIN_QUERY_MARKERS,
     _compact_basic_identity_answer,
-    _extract_direct_woven_thought,
-    _looks_like_direct_english_planner_thought,
     _strip_direct_inline_private_asides,
-    _trim_direct_visible_thought_answer_draft,
 )
 from app.engine.runtime.runtime_metrics import inc_counter
 from app.engine.multi_agent.state import AgentState
 from app.engine.reasoning import (
-    align_visible_thinking_language,
     record_thinking_snapshot,
-)
-from app.engine.multi_agent.supervisor_runtime_support import (
-    _looks_reasoning_safety_meta_turn,
-    _looks_session_memory_ack_only_turn,
-    _looks_session_memory_recall_turn,
-    _looks_session_memory_write_turn,
-    _looks_wiii_capability_inventory_turn,
-    _looks_wiii_pipeline_meta_turn,
 )
 
 logger = logging.getLogger(__name__)
-
-_DIRECT_SESSION_MEMORY_COMPAT_EXPORTS = (
-    _build_session_memory_write_answer,
-    _build_session_memory_write_thinking,
-    _extract_session_memory_items_from_text,
-    _extract_session_memory_recall_answer,
-    _with_requested_response_marker,
-)
-
-_DIRECT_FAST_RESPONSE_COMPAT_EXPORTS = (
-    _build_hunger_chatter_answer,
-    _build_hunger_chatter_thinking,
-    _build_pointy_fast_path_thinking,
-    _build_pointy_missing_inventory_answer,
-    _build_pointy_missing_inventory_thinking,
-    _build_reasoning_safety_meta_answer,
-    _build_reasoning_safety_meta_thinking,
-    _build_self_feeling_probe_answer,
-    _build_self_feeling_probe_thinking,
-    _build_wiii_capability_inventory_answer,
-    _build_wiii_capability_inventory_thinking,
-    _build_wiii_pipeline_meta_answer,
-    _build_wiii_pipeline_meta_thinking,
-    _extract_direct_reply_only_answer,
-    _extract_pointy_fast_path_answer,
-    _fold_direct_text,
-    _looks_hunger_chatter_turn,
-    _looks_reasoning_safety_meta_turn,
-    _looks_self_feeling_probe_turn,
-    _looks_session_memory_ack_only_turn,
-    _looks_session_memory_recall_turn,
-    _looks_session_memory_write_turn,
-    _looks_wiii_capability_inventory_turn,
-    _looks_wiii_pipeline_meta_turn,
-    _pointy_requested_without_inventory,
-)
-
-_DIRECT_VISIBLE_THOUGHT_COMPAT_EXPORTS = (
-    align_visible_thinking_language,
-    _DIRECT_ENGLISH_PLANNER_MARKERS,
-    _DIRECT_INTERNAL_THOUGHT_MARKERS,
-    _DIRECT_VISIBLE_THOUGHT_DRAFT_SPLITTERS,
-    _DIRECT_VISIBLE_THOUGHT_TRAILING_SELF_EVAL,
-    _DIRECT_WOVEN_THOUGHT_INTENTS,
-    _IDENTITY_LORE_MARKERS,
-    _extract_direct_woven_thought,
-    _looks_like_direct_english_planner_thought,
-    _trim_direct_visible_thought_answer_draft,
-)
-
-_DIRECT_UPLOADED_CONTEXT_COMPAT_EXPORTS = (
-    _uploaded_document_attachments,
-    _image_payload_attr,
-    _first_markdown_line,
-    _plain_markdown_excerpt,
-    _uploaded_context_has_video,
-    _build_uploaded_document_context_fallback_answer,
-    _looks_uploaded_context_fact_query,
-    _looks_uploaded_file_metadata_query,
-    _looks_uploaded_file_visual_inspection_query,
-    _provider_likely_supports_image_blocks,
-)
-
-_DIRECT_OPERATIONAL_FAST_PATH_COMPAT_EXPORTS = (
-    _normalize_for_intent,
-    _DSML_BLOCK_RE,
-    _DSML_STRAY_ASCII_RE,
-    _DSML_STRAY_FULLWIDTH_RE,
-    _GENERIC_DIRECT_FALLBACK_MARKERS,
-    _build_image_input_thinking,
-    _clean_emergency_web_search_query,
-    _strip_dsml_residue,
-)
-
-_DIRECT_THINKING_EFFORT_COMPAT_EXPORTS = (
-    _DIRECT_ANALYTICAL_THINKING_MODES,
-    _DIRECT_CANONICAL_THINKING_EFFORT_ALIASES,
-    _IDENTITY_ORIGIN_QUERY_MARKERS,
-    _canonicalize_direct_thinking_effort,
-)
-
-_DIRECT_DOCUMENT_PREVIEW_REBIND_COMPAT_EXPORTS = (
-    _direct_role_candidates,
-    _rebind_document_preview_host_action_tool,
-)
 
 _HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS = 45.0  # Phase F3 (2026-05-06): bumped 24→45s. NVIDIA DeepSeek tool-heavy pointy turns (inventory + show + synthesis) regularly hit 25-35s; 24s caused canned fallback even when LLM was actively succeeding.
 

--- a/maritime-ai-service/app/services/chat_orchestrator.py
+++ b/maritime-ai-service/app/services/chat_orchestrator.py
@@ -312,7 +312,7 @@ class ChatOrchestrator:
             return None
 
         if shape == "hunger_chatter":
-            from app.engine.multi_agent.direct_node_runtime import (
+            from app.engine.multi_agent.direct_node_chatter_runtime import (
                 _build_hunger_chatter_answer,
                 _build_hunger_chatter_thinking,
             )

--- a/maritime-ai-service/tests/unit/test_conservative_evolution.py
+++ b/maritime-ai-service/tests/unit/test_conservative_evolution.py
@@ -336,7 +336,7 @@ class TestConservativeFastRouting:
         )
 
     def test_session_memory_extracts_unscoped_explicit_remember_turn(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_session_memory_runtime import (
             _extract_session_memory_items_from_text,
         )
 
@@ -355,7 +355,7 @@ class TestConservativeFastRouting:
         ) == ["màu kiểm thử hôm nay là xanh rêu 548"]
 
     def test_session_memory_write_answer_acknowledges_specific_temporary_item(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_session_memory_runtime import (
             _build_session_memory_write_answer,
             _build_session_memory_write_thinking,
         )
@@ -373,7 +373,7 @@ class TestConservativeFastRouting:
         assert "semantic memory" in thinking
 
     def test_direct_reply_only_answer_extracts_exact_ack(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_node_operational_fast_paths import (
             _extract_direct_reply_only_answer,
         )
 
@@ -385,7 +385,7 @@ class TestConservativeFastRouting:
         )
 
     def test_session_memory_recall_answer_extracts_recent_session_seed(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_session_memory_runtime import (
             _extract_session_memory_recall_answer,
         )
 
@@ -420,7 +420,7 @@ class TestConservativeFastRouting:
         )
 
     def test_session_memory_recall_list_instruction_does_not_filter_by_pointy(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_session_memory_runtime import (
             _extract_session_memory_recall_answer,
         )
 
@@ -455,7 +455,7 @@ class TestConservativeFastRouting:
         )
 
     def test_session_memory_recall_keeps_labeled_priority_bundle_together(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_session_memory_runtime import (
             _extract_session_memory_recall_answer,
         )
 
@@ -490,7 +490,7 @@ class TestConservativeFastRouting:
         )
 
     def test_session_memory_recall_keeps_acceptance_criteria_bundle_together(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_session_memory_runtime import (
             _extract_session_memory_recall_answer,
         )
 
@@ -530,7 +530,7 @@ class TestConservativeFastRouting:
         )
 
     def test_session_memory_recall_answer_extracts_single_named_value(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_session_memory_runtime import (
             _extract_session_memory_recall_answer,
         )
 
@@ -561,7 +561,7 @@ class TestConservativeFastRouting:
         ) == "mỏ neo xanh 507"
 
     def test_session_memory_recall_answer_extracts_natural_just_said_value(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_session_memory_runtime import (
             _extract_session_memory_recall_answer,
         )
 
@@ -592,7 +592,7 @@ class TestConservativeFastRouting:
         ) == "xanh neo"
 
     def test_session_memory_recall_answer_extracts_today_color_value(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_session_memory_runtime import (
             _extract_session_memory_recall_answer,
         )
 
@@ -619,7 +619,7 @@ class TestConservativeFastRouting:
         ) == "xanh rêu 548"
 
     def test_wiii_pipeline_meta_answer_is_bounded_and_actionable(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_node_operational_fast_paths import (
             _build_wiii_pipeline_meta_answer,
         )
 
@@ -690,7 +690,7 @@ class TestConservativeFastRouting:
         ) is False
 
     def test_session_memory_numbered_criteria_are_preserved(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_session_memory_runtime import (
             _extract_session_memory_items_from_text,
             _extract_session_memory_recall_answer,
         )
@@ -719,7 +719,7 @@ class TestConservativeFastRouting:
         assert "multimodal" in answer
 
     def test_session_memory_anchor_bundle_in_current_session_is_preserved(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_session_memory_runtime import (
             _extract_session_memory_items_from_text,
             _extract_session_memory_recall_answer,
         )
@@ -760,11 +760,11 @@ class TestConservativeFastRouting:
         assert len(answer) > 300
 
     def test_hunger_chatter_doi_qua_routes_to_fast_social(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_node_chatter_runtime import (
             _build_hunger_chatter_answer,
-            _fold_direct_text,
             _looks_hunger_chatter_turn,
         )
+        from app.engine.multi_agent.direct_text_utils import _fold_direct_text
         from app.engine.multi_agent.supervisor_hint_runtime import (
             classify_fast_chatter_turn_impl,
         )
@@ -796,7 +796,7 @@ class TestConservativeFastRouting:
         ) is False
 
     def test_reasoning_safety_meta_answer_is_safe_and_bounded(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_node_meta_fast_paths import (
             _build_reasoning_safety_meta_answer,
             _build_reasoning_safety_meta_thinking,
         )
@@ -814,7 +814,7 @@ class TestConservativeFastRouting:
         assert "mềm, rõ" in thinking
 
     def test_reasoning_safety_meta_answer_supports_richer_public_thinking(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_node_meta_fast_paths import (
             _build_reasoning_safety_meta_answer,
             _build_reasoning_safety_meta_thinking,
         )
@@ -831,7 +831,7 @@ class TestConservativeFastRouting:
         assert "không lộ phần nội bộ" in answer
 
     def test_hunger_chatter_has_useful_fast_answer_and_thinking(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_node_chatter_runtime import (
             _build_hunger_chatter_answer,
             _build_hunger_chatter_thinking,
             _looks_hunger_chatter_turn,
@@ -861,7 +861,7 @@ class TestConservativeFastRouting:
         assert _build_hunger_chatter_answer("bụng đói").startswith("Bụng đói")
 
     def test_self_feeling_probe_keeps_living_boundary(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_node_meta_fast_paths import (
             _build_self_feeling_probe_answer,
             _build_self_feeling_probe_thinking,
             _looks_self_feeling_probe_turn,
@@ -895,7 +895,7 @@ class TestConservativeFastRouting:
         assert "một cái máy phủ nhận" in thinking
 
     def test_wiii_capability_inventory_is_truthful_about_current_surface(self):
-        from app.engine.multi_agent.direct_node_runtime import (
+        from app.engine.multi_agent.direct_node_meta_fast_paths import (
             _build_wiii_capability_inventory_answer,
             _build_wiii_capability_inventory_thinking,
         )

--- a/maritime-ai-service/tests/unit/test_direct_codebase_thinking_quality.py
+++ b/maritime-ai-service/tests/unit/test_direct_codebase_thinking_quality.py
@@ -96,7 +96,9 @@ def test_codebase_fallback_thinking_is_public_evidence_ledger_not_answer_copy():
 
 
 def test_image_input_thinking_is_evidence_led_for_ocr_and_color_questions():
-    from app.engine.multi_agent.direct_node_runtime import _build_image_input_thinking
+    from app.engine.multi_agent.direct_node_operational_fast_paths import (
+        _build_image_input_thinking,
+    )
 
     thinking = _build_image_input_thinking("Doc chu va mau nen trong anh nay")
 
@@ -107,7 +109,7 @@ def test_image_input_thinking_is_evidence_led_for_ocr_and_color_questions():
 
 
 def test_codebase_fallback_answer_replaces_generic_phase_greeting():
-    from app.engine.multi_agent.direct_node_runtime import (
+    from app.engine.multi_agent.direct_node_operational_fast_paths import (
         _build_codebase_analysis_fallback_answer,
         _build_codebase_analysis_fallback_thinking,
         _looks_generic_direct_fallback_response,
@@ -131,7 +133,7 @@ def test_codebase_fallback_answer_replaces_generic_phase_greeting():
 
 
 def test_codebase_source_notes_use_deterministic_fast_answer():
-    from app.engine.multi_agent.direct_node_runtime import (
+    from app.engine.multi_agent.direct_node_operational_fast_paths import (
         _build_codebase_analysis_fallback_answer,
         _should_use_codebase_source_note_fast_answer,
     )
@@ -189,7 +191,9 @@ async def test_guardian_fast_passes_safe_image_inspection_without_llm():
 
 def test_hunger_chatter_unicode_fast_path_matches_vietnamese() -> None:
     from app.engine.multi_agent.direct_intent import _normalize_for_intent
-    from app.engine.multi_agent.direct_node_runtime import _looks_hunger_chatter_turn
+    from app.engine.multi_agent.direct_node_chatter_runtime import (
+        _looks_hunger_chatter_turn,
+    )
 
     query = "\u0111\u00f3i ph\u1ebft"
 
@@ -197,7 +201,7 @@ def test_hunger_chatter_unicode_fast_path_matches_vietnamese() -> None:
 
 
 def test_pointy_missing_inventory_fails_soft_without_llm() -> None:
-    from app.engine.multi_agent.direct_node_runtime import (
+    from app.engine.multi_agent.direct_node_operational_fast_paths import (
         _build_pointy_missing_inventory_answer,
         _pointy_requested_without_inventory,
     )

--- a/maritime-ai-service/tests/unit/test_direct_identity_answer_policy.py
+++ b/maritime-ai-service/tests/unit/test_direct_identity_answer_policy.py
@@ -1,15 +1,13 @@
 import pytest
 
-from app.engine.multi_agent.direct_node_runtime import (
-    _compact_basic_identity_answer,
-    _extract_direct_woven_thought,
-    _strip_direct_inline_private_asides,
-    _trim_direct_visible_thought_answer_draft,
-)
 from app.engine.multi_agent.direct_node_visible_thought import (
     _align_direct_visible_thought,
+    _compact_basic_identity_answer,
     _contains_direct_internal_thought_leak,
+    _extract_direct_woven_thought,
     _should_surface_direct_visible_thought,
+    _strip_direct_inline_private_asides,
+    _trim_direct_visible_thought_answer_draft,
 )
 
 

--- a/maritime-ai-service/tests/unit/test_direct_reasoning_effort.py
+++ b/maritime-ai-service/tests/unit/test_direct_reasoning_effort.py
@@ -1,4 +1,4 @@
-from app.engine.multi_agent.direct_node_runtime import (
+from app.engine.multi_agent.direct_node_thinking_effort import (
     _canonicalize_direct_thinking_effort,
     _resolve_direct_thinking_effort,
 )

--- a/maritime-ai-service/tests/unit/test_document_context_api.py
+++ b/maritime-ai-service/tests/unit/test_document_context_api.py
@@ -307,7 +307,9 @@ def test_document_context_injection_builds_shared_prompt_surface():
 
 
 def test_uploaded_document_context_allows_image_error_to_fall_through():
-    from app.engine.multi_agent.direct_node_runtime import _has_uploaded_document_context
+    from app.engine.multi_agent.document_preview_contract import (
+        has_uploaded_document_context as _has_uploaded_document_context,
+    )
 
     assert _has_uploaded_document_context(
         {
@@ -352,7 +354,7 @@ def test_supervisor_routes_uploaded_file_context_to_direct(monkeypatch):
 
 
 def test_uploaded_video_context_fallback_mentions_parse_facts():
-    from app.engine.multi_agent.direct_node_runtime import (
+    from app.engine.multi_agent.direct_node_uploaded_context import (
         _build_uploaded_document_context_fallback_answer,
     )
 
@@ -390,7 +392,7 @@ def test_uploaded_video_context_fallback_mentions_parse_facts():
 
 
 def test_uploaded_video_metadata_query_stays_deterministic():
-    from app.engine.multi_agent.direct_node_runtime import (
+    from app.engine.multi_agent.direct_node_uploaded_context import (
         _build_uploaded_document_context_fallback_answer,
         _looks_uploaded_file_metadata_query,
         _looks_uploaded_file_visual_inspection_query,
@@ -433,7 +435,7 @@ def test_uploaded_video_metadata_query_stays_deterministic():
 
 
 def test_uploaded_document_marker_query_stays_deterministic():
-    from app.engine.multi_agent.direct_node_runtime import (
+    from app.engine.multi_agent.direct_node_uploaded_context import (
         _build_uploaded_document_context_fallback_answer,
         _looks_uploaded_context_fact_query,
         _looks_uploaded_file_visual_inspection_query,
@@ -475,7 +477,7 @@ def test_uploaded_document_marker_query_stays_deterministic():
 
 
 def test_uploaded_document_preview_request_bypasses_fact_fast_path():
-    from app.engine.multi_agent.direct_node_runtime import (
+    from app.engine.multi_agent.direct_node_uploaded_context import (
         _looks_uploaded_context_fact_query,
         _looks_uploaded_document_preview_request,
     )
@@ -506,7 +508,7 @@ def test_uploaded_document_preview_request_bypasses_fact_fast_path():
 
 
 def test_uploaded_document_visual_guard_does_not_describe_frames_without_vision():
-    from app.engine.multi_agent.direct_node_runtime import (
+    from app.engine.multi_agent.direct_node_uploaded_context import (
         _build_uploaded_document_visual_guard_answer,
         _looks_uploaded_file_visual_inspection_query,
         _provider_likely_supports_image_blocks,


### PR DESCRIPTION
## Summary

- Move direct-node private helper imports in tests to the modules that now own those helpers.
- Remove obsolete compatibility export tuples/import-only dependencies from `direct_node_runtime.py`.
- Keep actual `direct_response_node_impl` imports unchanged for runtime callers.
- Update cleanup audit notes for issue #519.

Closes #519.

## Verification

- `uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_conservative_evolution.py tests/unit/test_direct_codebase_thinking_quality.py tests/unit/test_direct_identity_answer_policy.py tests/unit/test_direct_reasoning_effort.py tests/unit/test_document_context_api.py tests/unit/test_direct_node_provider_errors.py -q --tb=short` -> 142 passed
- `uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_node_final_state.py tests/unit/test_direct_node_exception_fallbacks.py tests/unit/test_direct_node_provider_errors.py tests/unit/test_direct_node_visible_thinking_finalization.py tests/unit/test_direct_node_response_cleanup.py tests/unit/test_direct_node_llm_preflight.py tests/unit/test_direct_node_execution_prep.py tests/unit/test_direct_node_tool_selection.py tests/unit/test_direct_node_host_timeout.py tests/unit/test_direct_node_document_preview_runtime.py tests/unit/test_direct_node_fast_response_runtime.py -q --tb=short` -> 68 passed
- `uv run --with ruff ruff check app/engine/multi_agent/direct_node_runtime.py tests/unit/test_conservative_evolution.py tests/unit/test_direct_codebase_thinking_quality.py tests/unit/test_direct_identity_answer_policy.py tests/unit/test_direct_reasoning_effort.py tests/unit/test_document_context_api.py` -> passed
- `uv run --with ruff ruff check app/ --select=E9,F63,F7` -> passed
- `git diff --check` -> passed (only Git line-ending warning for existing runtime file on Windows)

## Risk / rollback

Low behavior risk; this is import-surface cleanup. No runtime routing/provider/LMS/prompt behavior changes intended. Rollback via PR revert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module structure to better distribute helper functions across specialized modules.
  * Updated import paths throughout the codebase to reflect new module organization.

* **Documentation**
  * Updated documentation to reflect module reorganization and import changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->