### PR TITLE
Refactor backend: shrink direct tool-round compat exports

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -171,6 +171,11 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   `direct_node_visible_thinking_finalization.py`, keeping aligned thinking,
   unsafe thought clearing, language checks, emotional-rescue thinking, and
   snapshot side effects outside the main direct node.
+- Follow-up #521 closed the obsolete private-helper compatibility export
+  surface in `direct_tool_rounds_runtime.py`; tests now import synthesis,
+  web-search policy, uploaded-document payload, document text, and Pointy
+  selector helpers from their owning modules while the shell only exposes
+  `execute_direct_tool_rounds_impl`.
 
 ## Preserved Intentionally
 
@@ -222,9 +227,9 @@ backups, data PDFs, or local skill folders.
   builders, generic tool dispatch, final synthesis helper construction, final
   synthesis execution, post-tool convergence policy, follow-up LLM
   selection/invocation, response finalization, post-tool search-template
-  returns, and forced web-search shortcuts have moved out. The next durable
-  step is shrinking the compatibility export surface once external imports can
-  close.
+  returns, and forced web-search shortcuts have moved out. Its obsolete
+  private-helper compatibility export surface is now closed; internal tests and
+  consumers import only the orchestration entry point from this shell.
 - `direct_execution.py` is now closer to a provider invocation/fallback shell:
   visible answer/thinking text shaping moved to `direct_stream_text_runtime.py`.
   It still carries graph-era compatibility re-exports for wait-surface and
@@ -423,3 +428,7 @@ focused direct-node regression set still passed with 68 tests after moving
 private direct-node helper imports from `direct_node_runtime.py` to their owning
 modules and removing obsolete compatibility export tuples/imports from the
 runtime.
+In follow-up #521, the direct tool-round regression set passed with 81 tests
+after moving private helper imports from `direct_tool_rounds_runtime.py` to
+their owning modules and removing obsolete compatibility aliases/export tuples
+from the tool-round orchestration shell.

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -47,9 +47,6 @@ from app.engine.multi_agent.direct_reasoning import (
     _build_direct_tool_reflection,
     _infer_direct_reasoning_cue,
 )
-from app.engine.multi_agent.direct_final_synthesis_runtime import (
-    build_direct_final_synthesis_instruction,
-)
 from app.engine.multi_agent.direct_search_template_runtime import (
     build_direct_post_tool_search_template_response,
 )
@@ -64,68 +61,12 @@ from app.engine.multi_agent.direct_document_host_action_runtime import (
     execute_requested_document_host_action_shortcut,
 )
 from app.engine.multi_agent.direct_document_preview_payloads import (
-    _DOC_PREVIEW_LOW_VALUE_LABELS,
-    _looks_uploaded_doc_course_request,
-    _normalize_doc_preview_text,
-    _is_doc_preview_scaffold_line,
-    _is_doc_preview_low_value_line,
     _find_doc_preview_host_action_tool,
     _find_doc_course_host_action_tool,
     _should_request_uploaded_doc_course_preview,
     _should_request_uploaded_doc_preview,
-    _first_nonempty_line,
-    _select_doc_preview_title_line,
-    _score_doc_preview_title_candidate,
-    _is_doc_preview_cover_metadata_line,
-    _clean_doc_preview_line,
-    _extract_marker,
-    _strip_doc_preview_goal_label,
-    _is_doc_preview_ordered_action_line,
-    _strip_doc_preview_ordered_action_prefix,
-    _is_doc_preview_admonition_line,
-    _repair_doc_preview_common_truncations,
-    _clip_doc_preview_line,
-    _shape_doc_preview_learning_goal,
-    _supplement_doc_preview_learning_goals,
-    _extract_relevant_lines,
-    _extract_doc_preview_title_from_query,
-    _polish_doc_preview_vietnamese_title,
-    _is_low_value_doc_preview_title,
-    _focus_doc_preview_markdown,
-    _extract_source_pages,
-    _resolve_doc_preview_lesson_id,
-    _resolve_doc_preview_course_id,
-    _extend_doc_context_id_candidates,
-    _extract_doc_course_title_from_query,
-    _doc_source_reference,
-    _extract_doc_section_references,
-    _match_doc_refs,
-    _looks_holilihu_lms_manual_document,
-    _looks_maritime_vessel_management_document,
-    _looks_maritime_training_lms_document,
-    _dedupe_doc_refs,
-    _top_course_source_references,
-    _lms_manual_lesson,
-    _build_lms_manual_course_plan,
-    _build_maritime_vessel_management_course_plan,
-    _build_maritime_training_lms_course_plan,
-    _extract_doc_headings,
-    _section_candidate_markers,
-    _copy_doc_refs_with_indices,
-    _document_course_section_candidates,
-    _cluster_document_course_sections,
-    _select_lesson_section_candidates,
-    _cluster_title,
-    _lesson_refs_for_candidate,
-    _classify_uploaded_document_course_domain,
-    _build_document_course_quality_report,
-    _build_generic_document_course_plan,
     _build_uploaded_doc_course_params,
     _build_uploaded_doc_preview_params,
-)
-from app.engine.multi_agent.direct_pointy_runtime import (
-    _format_pointy_inventory,  # noqa: F401 - compatibility alias
-    _validate_pointy_selector,  # noqa: F401 - compatibility alias
 )
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.tool_call_text_parser import (
@@ -133,11 +74,8 @@ from app.engine.multi_agent.tool_call_text_parser import (
     tool_names_from_tools,
 )
 from app.engine.multi_agent.direct_web_search_policy import (
-    _has_search_tool_result,  # noqa: F401 - compatibility alias
     _is_search_tool_name,
     _prefer_official_query_for_known_docs,
-    _should_return_search_template_after_tool_round,  # noqa: F401 - compatibility alias
-    _should_use_search_template_for_empty_response,  # noqa: F401 - compatibility alias
 )
 from app.engine.multi_agent.visual_events import (
     _collect_active_visual_session_ids,
@@ -148,70 +86,6 @@ from app.engine.multi_agent.visual_events import (
 )
 
 logger = logging.getLogger(__name__)
-
-# Compatibility alias for older tests and graph imports while synthesis helpers move out.
-_build_direct_final_synthesis_instruction = build_direct_final_synthesis_instruction
-
-_DIRECT_DOCUMENT_PREVIEW_PAYLOAD_COMPAT_EXPORTS = (
-    _DOC_PREVIEW_LOW_VALUE_LABELS,
-    _looks_uploaded_doc_course_request,
-    _normalize_doc_preview_text,
-    _is_doc_preview_scaffold_line,
-    _is_doc_preview_low_value_line,
-    _find_doc_preview_host_action_tool,
-    _find_doc_course_host_action_tool,
-    _should_request_uploaded_doc_course_preview,
-    _should_request_uploaded_doc_preview,
-    _first_nonempty_line,
-    _select_doc_preview_title_line,
-    _score_doc_preview_title_candidate,
-    _is_doc_preview_cover_metadata_line,
-    _clean_doc_preview_line,
-    _extract_marker,
-    _strip_doc_preview_goal_label,
-    _is_doc_preview_ordered_action_line,
-    _strip_doc_preview_ordered_action_prefix,
-    _is_doc_preview_admonition_line,
-    _repair_doc_preview_common_truncations,
-    _clip_doc_preview_line,
-    _shape_doc_preview_learning_goal,
-    _supplement_doc_preview_learning_goals,
-    _extract_relevant_lines,
-    _extract_doc_preview_title_from_query,
-    _polish_doc_preview_vietnamese_title,
-    _is_low_value_doc_preview_title,
-    _focus_doc_preview_markdown,
-    _extract_source_pages,
-    _resolve_doc_preview_lesson_id,
-    _resolve_doc_preview_course_id,
-    _extend_doc_context_id_candidates,
-    _extract_doc_course_title_from_query,
-    _doc_source_reference,
-    _extract_doc_section_references,
-    _match_doc_refs,
-    _looks_holilihu_lms_manual_document,
-    _looks_maritime_vessel_management_document,
-    _looks_maritime_training_lms_document,
-    _dedupe_doc_refs,
-    _top_course_source_references,
-    _lms_manual_lesson,
-    _build_lms_manual_course_plan,
-    _build_maritime_vessel_management_course_plan,
-    _build_maritime_training_lms_course_plan,
-    _extract_doc_headings,
-    _section_candidate_markers,
-    _copy_doc_refs_with_indices,
-    _document_course_section_candidates,
-    _cluster_document_course_sections,
-    _select_lesson_section_candidates,
-    _cluster_title,
-    _lesson_refs_for_candidate,
-    _classify_uploaded_document_course_domain,
-    _build_document_course_quality_report,
-    _build_generic_document_course_plan,
-    _build_uploaded_doc_course_params,
-    _build_uploaded_doc_preview_params,
-)
 
 _DOC_COURSE_HOST_ACTION_SHORTCUT = DocumentHostActionShortcut(
     tool_name=_DOC_COURSE_HOST_ACTION_TOOL,

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -13,8 +13,8 @@ from app.engine.multi_agent.direct_document_host_action_runtime import (
 
 
 def test_build_direct_final_synthesis_instruction_is_mode_aware_for_market_turn():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
-        _build_direct_final_synthesis_instruction,
+    from app.engine.multi_agent.direct_final_synthesis_runtime import (
+        build_direct_final_synthesis_instruction as _build_direct_final_synthesis_instruction,
     )
 
     instruction = _build_direct_final_synthesis_instruction(
@@ -31,7 +31,7 @@ def test_build_direct_final_synthesis_instruction_is_mode_aware_for_market_turn(
 
 
 def test_explicit_web_search_returns_template_after_fetch_evidence():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_web_search_policy import (
         _prefer_official_query_for_known_docs,
         _should_return_search_template_after_tool_round,
         _should_use_search_template_for_empty_response,
@@ -316,8 +316,8 @@ def test_direct_public_thinking_dedupe_allows_changed_blocks():
 
 
 def test_build_direct_final_synthesis_instruction_is_mode_aware_for_math_turn():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
-        _build_direct_final_synthesis_instruction,
+    from app.engine.multi_agent.direct_final_synthesis_runtime import (
+        build_direct_final_synthesis_instruction as _build_direct_final_synthesis_instruction,
     )
 
     instruction = _build_direct_final_synthesis_instruction(
@@ -1379,7 +1379,7 @@ async def test_uploaded_document_course_plan_runs_host_action_without_planner_ll
 
 
 def test_uploaded_doc_course_plan_builder_creates_full_lms_architecture():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_course_params,
     )
 
@@ -1431,7 +1431,7 @@ def test_uploaded_doc_course_plan_builder_creates_full_lms_architecture():
 
 
 def test_uploaded_doc_course_plan_builder_keeps_maritime_research_out_of_lms_manual():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_course_params,
         _normalize_doc_preview_text,
     )
@@ -1501,7 +1501,7 @@ def test_uploaded_doc_course_plan_builder_keeps_maritime_research_out_of_lms_man
 
 
 def test_uploaded_doc_course_plan_builder_keeps_maritime_lms_research_out_of_holilihu_manual():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_course_params,
         _normalize_doc_preview_text,
     )
@@ -1556,7 +1556,7 @@ def test_uploaded_doc_course_plan_builder_keeps_maritime_lms_research_out_of_hol
 
 
 def test_uploaded_doc_course_plan_research_title_overrides_manual_markers_in_body():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_course_params,
         _normalize_doc_preview_text,
     )
@@ -1608,7 +1608,7 @@ def test_uploaded_doc_course_plan_research_title_overrides_manual_markers_in_bod
 
 
 def test_uploaded_doc_course_plan_maritime_lms_does_not_use_vessel_template():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_course_params,
         _normalize_doc_preview_text,
     )
@@ -1663,7 +1663,7 @@ def test_uploaded_doc_course_plan_maritime_lms_does_not_use_vessel_template():
 
 
 def test_uploaded_doc_course_title_skips_cover_metadata_for_long_thesis_doc():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_course_params,
         _normalize_doc_preview_text,
     )
@@ -1718,7 +1718,7 @@ def test_uploaded_doc_course_title_skips_cover_metadata_for_long_thesis_doc():
 
 
 def test_generic_uploaded_doc_course_clusters_full_long_document_map():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_course_params,
         _normalize_doc_preview_text,
     )
@@ -1775,7 +1775,7 @@ def test_generic_uploaded_doc_course_clusters_full_long_document_map():
 
 
 def test_uploaded_doc_course_parses_unicode_vietnamese_source_lines():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_course_params,
     )
 
@@ -1811,8 +1811,8 @@ def test_uploaded_doc_course_parses_unicode_vietnamese_source_lines():
 
 
 def test_uploaded_doc_course_request_matches_real_teacher_curriculum_wording():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
-        _looks_uploaded_doc_course_request,
+    from app.engine.multi_agent.document_preview_contract import (
+        looks_uploaded_document_course_request as _looks_uploaded_doc_course_request,
     )
 
     assert _looks_uploaded_doc_course_request("Tạo bài giảng đi.")
@@ -1828,7 +1828,7 @@ def test_uploaded_doc_course_request_matches_real_teacher_curriculum_wording():
 
 
 def test_uploaded_doc_preview_skips_logo_data_uri_and_focuses_teacher_manual():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_preview_params,
     )
 
@@ -1879,7 +1879,7 @@ def test_uploaded_doc_preview_skips_logo_data_uri_and_focuses_teacher_manual():
 
 
 def test_uploaded_doc_preview_preserves_general_wiii_marker_from_query():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_preview_params,
     )
 
@@ -1913,7 +1913,7 @@ def test_uploaded_doc_preview_preserves_general_wiii_marker_from_query():
 
 
 def test_uploaded_doc_preview_preserves_labelled_non_wiii_marker_from_query():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_preview_params,
     )
 
@@ -1945,7 +1945,7 @@ def test_uploaded_doc_preview_preserves_labelled_non_wiii_marker_from_query():
 
 
 def test_uploaded_doc_preview_prefers_explicit_query_title_over_parser_metadata():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_preview_params,
     )
 
@@ -1980,7 +1980,7 @@ def test_uploaded_doc_preview_prefers_explicit_query_title_over_parser_metadata(
 
 
 def test_uploaded_doc_preview_prefers_real_teacher_heading_over_smart_excerpt_outline():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_preview_params,
     )
 
@@ -2033,7 +2033,7 @@ def test_uploaded_doc_preview_prefers_real_teacher_heading_over_smart_excerpt_ou
 
 
 def test_doc_preview_clean_line_drops_checkbox_table_markers():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import _clean_doc_preview_line
+    from app.engine.multi_agent.direct_document_preview_text import _clean_doc_preview_line
 
     assert _clean_doc_preview_line(
         "| **□** | Thong tin khoa hoan chinh. | Co tieu de va muc tieu hoc tap. |"
@@ -2041,7 +2041,7 @@ def test_doc_preview_clean_line_drops_checkbox_table_markers():
 
 
 def test_uploaded_doc_preview_filters_bare_table_labels_from_goals():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_preview_params,
     )
 
@@ -2078,7 +2078,7 @@ def test_uploaded_doc_preview_filters_bare_table_labels_from_goals():
 
 
 def test_uploaded_doc_preview_keeps_ordered_actions_out_of_learning_goals():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_preview_params,
     )
 
@@ -2115,7 +2115,7 @@ def test_uploaded_doc_preview_keeps_ordered_actions_out_of_learning_goals():
 
 
 def test_uploaded_doc_preview_excludes_admonitions_from_learning_goals():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_preview_params,
     )
 
@@ -2148,7 +2148,7 @@ def test_uploaded_doc_preview_excludes_admonitions_from_learning_goals():
 
 
 def test_uploaded_doc_preview_shapes_descriptive_excerpt_into_learning_goal():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_preview_params,
     )
 
@@ -2181,7 +2181,7 @@ def test_uploaded_doc_preview_shapes_descriptive_excerpt_into_learning_goal():
 
 
 def test_uploaded_doc_preview_repairs_truncated_publish_word_in_learning_goal():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_preview_params,
     )
 
@@ -2212,7 +2212,7 @@ def test_uploaded_doc_preview_repairs_truncated_publish_word_in_learning_goal():
 
 
 def test_uploaded_doc_preview_supplements_sparse_lms_learning_goals():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_document_preview_payloads import (
         _build_uploaded_doc_preview_params,
     )
 
@@ -2462,7 +2462,7 @@ def _state_with_targets(*ids: str) -> SimpleNamespace:
 
 
 def test_pointy_validator_accepts_bare_id_in_inventory():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_pointy_runtime import (
         _validate_pointy_selector,
     )
 
@@ -2551,7 +2551,7 @@ async def test_direct_pointy_post_dispatch_rewrites_inventory_result() -> None:
 
 
 def test_pointy_validator_accepts_auto_id_in_inventory():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_pointy_runtime import (
         _validate_pointy_selector,
     )
 
@@ -2560,7 +2560,7 @@ def test_pointy_validator_accepts_auto_id_in_inventory():
 
 
 def test_pointy_validator_accepts_data_wiii_id_verbose_form():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_pointy_runtime import (
         _validate_pointy_selector,
     )
 
@@ -2572,7 +2572,7 @@ def test_pointy_validator_accepts_data_wiii_id_verbose_form():
 
 
 def test_pointy_validator_rejects_compound_css_selector():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_pointy_runtime import (
         _validate_pointy_selector,
     )
 
@@ -2588,7 +2588,7 @@ def test_pointy_validator_rejects_compound_css_selector():
 
 
 def test_pointy_validator_rejects_class_selector():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_pointy_runtime import (
         _validate_pointy_selector,
     )
 
@@ -2599,7 +2599,7 @@ def test_pointy_validator_rejects_class_selector():
 
 
 def test_pointy_validator_rejects_aria_label_selector():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_pointy_runtime import (
         _validate_pointy_selector,
     )
 
@@ -2610,7 +2610,7 @@ def test_pointy_validator_rejects_aria_label_selector():
 
 
 def test_pointy_validator_rejects_pseudo_class_selector():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_pointy_runtime import (
         _validate_pointy_selector,
     )
 
@@ -2621,7 +2621,7 @@ def test_pointy_validator_rejects_pseudo_class_selector():
 
 def test_pointy_validator_rejects_id_with_hash_prefix():
     """The `#chat-send-button` form is a CSS id selector, not a bare id."""
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_pointy_runtime import (
         _validate_pointy_selector,
     )
 
@@ -2631,7 +2631,7 @@ def test_pointy_validator_rejects_id_with_hash_prefix():
 
 
 def test_pointy_validator_rejects_empty_selector():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_pointy_runtime import (
         _validate_pointy_selector,
     )
 
@@ -2642,7 +2642,7 @@ def test_pointy_validator_rejects_empty_selector():
 
 
 def test_pointy_validator_rejects_unknown_bare_id_with_inventory_hint():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_pointy_runtime import (
         _validate_pointy_selector,
     )
 
@@ -2654,7 +2654,7 @@ def test_pointy_validator_rejects_unknown_bare_id_with_inventory_hint():
 
 
 def test_pointy_validator_rejects_unknown_auto_id_with_inventory_hint():
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_pointy_runtime import (
         _validate_pointy_selector,
     )
 
@@ -2667,7 +2667,7 @@ def test_pointy_validator_rejects_unknown_auto_id_with_inventory_hint():
 
 def test_pointy_validator_passes_bare_id_when_inventory_empty():
     """Without inventory we can't verify — fall through to permissive."""
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_pointy_runtime import (
         _validate_pointy_selector,
     )
 
@@ -2677,7 +2677,7 @@ def test_pointy_validator_passes_bare_id_when_inventory_empty():
 
 def test_pointy_validator_passes_auto_id_when_inventory_empty():
     """Without inventory, allow Wiii synthetic id syntax and let frontend resolve."""
-    from app.engine.multi_agent.direct_tool_rounds_runtime import (
+    from app.engine.multi_agent.direct_pointy_runtime import (
         _validate_pointy_selector,
     )
 


### PR DESCRIPTION
Closes #521.\n\n## Summary\n- Removes obsolete private-helper compatibility aliases/export tuple from direct_tool_rounds_runtime.py.\n- Moves direct tool-round tests to import synthesis, web-search policy, document preview payload/text, and Pointy selector helpers from owning modules.\n- Updates the runtime cleanup audit with the completed #521 slice.\n\n## Verification\n- uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short -> 81 passed\n- uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_direct_execution_streaming.py tests/unit/test_direct_execution_answer_replay.py -q --tb=short -> 104 passed\n- uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_document_context_api.py tests/unit/test_direct_node_provider_errors.py -q --tb=short -> 50 passed\n- uv run --with ruff ruff check app/engine/multi_agent/direct_tool_rounds_runtime.py tests/unit/test_direct_tool_rounds_runtime.py --select=E9,F63,F7,F401 -> passed\n- uv run --with ruff ruff check app/ --select=E9,F63,F7 -> passed\n- git diff --check -> passed (Windows CRLF warning only for touched test file)\n\n## Risk / rollback\nRisk is low and limited to import-surface cleanup; runtime behavior continues through execute_direct_tool_rounds_impl. Roll back by reverting this PR to restore the previous compatibility aliases.