### PR TITLE
Refactor backend: close direct execution legacy re-exports

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -176,6 +176,9 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   web-search policy, uploaded-document payload, document text, and Pointy
   selector helpers from their owning modules while the shell only exposes
   `execute_direct_tool_rounds_impl`.
+- Follow-up #523 moved graph runtime wait-surface and Code Studio regex
+  bindings to their canonical modules, closing obsolete graph-era re-exports
+  from `direct_execution.py`.
 
 ## Preserved Intentionally
 
@@ -231,9 +234,9 @@ backups, data PDFs, or local skill folders.
   private-helper compatibility export surface is now closed; internal tests and
   consumers import only the orchestration entry point from this shell.
 - `direct_execution.py` is now closer to a provider invocation/fallback shell:
-  visible answer/thinking text shaping moved to `direct_stream_text_runtime.py`.
-  It still carries graph-era compatibility re-exports for wait-surface and
-  Code Studio regex helpers until legacy `graph.py` imports can close.
+  visible answer/thinking text shaping moved to `direct_stream_text_runtime.py`,
+  and graph runtime bindings now load wait-surface and Code Studio regex helpers
+  from their canonical modules instead of through direct execution.
 - Code Studio deterministic fallback is now split across contract, spec,
   quality, captions, registry, shell, and renderer modules. The remaining debt
   is product quality rather than module size: the scaffold should keep moving
@@ -432,3 +435,6 @@ In follow-up #521, the direct tool-round regression set passed with 81 tests
 after moving private helper imports from `direct_tool_rounds_runtime.py` to
 their owning modules and removing obsolete compatibility aliases/export tuples
 from the tool-round orchestration shell.
+In follow-up #523, direct execution streaming tests and graph routing tests
+passed after moving graph runtime wait-surface and Code Studio regex bindings
+away from `direct_execution.py` and into their canonical helper modules.

--- a/maritime-ai-service/app/engine/multi_agent/direct_execution.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_execution.py
@@ -18,11 +18,7 @@ from app.engine.multi_agent.direct_intent import (
     _looks_selfhood_followup_turn,
 )
 from app.engine.multi_agent.direct_wait_surface import (
-    _build_code_studio_wait_heartbeat_text,
     _build_direct_wait_heartbeat_text,
-    _compact_visible_query,
-    _contains_wait_marker,
-    _thinking_start_label,
 )
 from app.engine.multi_agent.direct_tool_rounds_runtime import (
     execute_direct_tool_rounds_impl,
@@ -35,12 +31,6 @@ from app.engine.multi_agent.direct_response_runtime import (
 from app.engine.multi_agent.state import AgentState
 
 from app.engine.multi_agent.direct_prompts import _resolve_tool_choice
-from app.engine.multi_agent.code_studio_patterns import (
-    _CODE_STUDIO_ACTION_JSON_RE,
-    _CODE_STUDIO_SANDBOX_IMAGE_RE,
-    _CODE_STUDIO_SANDBOX_LINK_RE,
-    _CODE_STUDIO_SANDBOX_PATH_RE,
-)
 from app.engine.multi_agent.direct_runtime_bindings import (
     _extract_runtime_target,
     _is_native_runtime_handle,
@@ -65,20 +55,6 @@ from app.engine.reasoning import (
 from app.engine.llm_runtime_metadata import record_runtime_failover_event
 
 logger = logging.getLogger(__name__)
-
-
-# Compatibility re-exports for the legacy graph shim. New code should import
-# these helpers from their canonical modules directly.
-__all__ = [
-    "_CODE_STUDIO_ACTION_JSON_RE",
-    "_CODE_STUDIO_SANDBOX_IMAGE_RE",
-    "_CODE_STUDIO_SANDBOX_LINK_RE",
-    "_CODE_STUDIO_SANDBOX_PATH_RE",
-    "_build_code_studio_wait_heartbeat_text",
-    "_compact_visible_query",
-    "_contains_wait_marker",
-    "_thinking_start_label",
-]
 
 
 def _looks_primary_timeout_failure(exc: Exception) -> bool:

--- a/maritime-ai-service/app/engine/multi_agent/graph_runtime_bindings.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph_runtime_bindings.py
@@ -548,15 +548,15 @@ _ainvoke_with_fallback = _load_attr(
     "_ainvoke_with_fallback",
 )
 _compact_visible_query = _load_attr(
-    "app.engine.multi_agent.direct_execution",
+    "app.engine.multi_agent.direct_wait_surface",
     "_compact_visible_query",
 )
 _build_direct_wait_heartbeat_text = _load_attr(
-    "app.engine.multi_agent.direct_execution",
+    "app.engine.multi_agent.direct_wait_surface",
     "_build_direct_wait_heartbeat_text",
 )
 _build_code_studio_wait_heartbeat_text = _load_attr(
-    "app.engine.multi_agent.direct_execution",
+    "app.engine.multi_agent.direct_wait_surface",
     "_build_code_studio_wait_heartbeat_text",
 )
 _push_status_only_progress = _load_attr(
@@ -564,11 +564,11 @@ _push_status_only_progress = _load_attr(
     "_push_status_only_progress",
 )
 _contains_wait_marker = _load_attr(
-    "app.engine.multi_agent.direct_execution",
+    "app.engine.multi_agent.direct_wait_surface",
     "_contains_wait_marker",
 )
 _thinking_start_label = _load_attr(
-    "app.engine.multi_agent.direct_execution",
+    "app.engine.multi_agent.direct_wait_surface",
     "_thinking_start_label",
 )
 _stream_direct_wait_heartbeats = _load_attr(
@@ -600,19 +600,19 @@ _extract_direct_response = _load_attr(
     "_extract_direct_response",
 )
 _CODE_STUDIO_ACTION_JSON_RE = _load_attr(
-    "app.engine.multi_agent.direct_execution",
+    "app.engine.multi_agent.code_studio_patterns",
     "_CODE_STUDIO_ACTION_JSON_RE",
 )
 _CODE_STUDIO_SANDBOX_IMAGE_RE = _load_attr(
-    "app.engine.multi_agent.direct_execution",
+    "app.engine.multi_agent.code_studio_patterns",
     "_CODE_STUDIO_SANDBOX_IMAGE_RE",
 )
 _CODE_STUDIO_SANDBOX_LINK_RE = _load_attr(
-    "app.engine.multi_agent.direct_execution",
+    "app.engine.multi_agent.code_studio_patterns",
     "_CODE_STUDIO_SANDBOX_LINK_RE",
 )
 _CODE_STUDIO_SANDBOX_PATH_RE = _load_attr(
-    "app.engine.multi_agent.direct_execution",
+    "app.engine.multi_agent.code_studio_patterns",
     "_CODE_STUDIO_SANDBOX_PATH_RE",
 )
 


### PR DESCRIPTION
Closes #523.\n\n## Summary\n- Moves graph runtime wait-surface bindings to direct_wait_surface.py.\n- Moves graph runtime Code Studio regex bindings to code_studio_patterns.py.\n- Removes obsolete compatibility re-export imports and __all__ from direct_execution.py.\n- Updates the runtime cleanup audit with the completed #523 slice.\n\n## Verification\n- uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_execution_streaming.py tests/unit/test_direct_execution_answer_replay.py -q --tb=short -> 23 passed\n- uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_graph_routing.py -q --tb=short -> 74 passed\n- uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_sprint154_tech_debt.py tests/unit/test_sprint100_unified_prompt.py tests/unit/test_sprint204_guidance_prompts.py -q --tb=short -> 144 passed\n- uv run --with ruff ruff check app/engine/multi_agent/direct_execution.py app/engine/multi_agent/graph_runtime_bindings.py --select=E9,F63,F7,F401 -> passed\n- uv run --with ruff ruff check app/ --select=E9,F63,F7 -> passed\n- git diff --check -> passed\n\n## Risk / rollback\nRisk is low import-source cleanup; runtime behavior remains in direct execution. Roll back by reverting this PR to restore the prior re-export surface.