### PR TITLE
Refactor backend: close direct prompt compat exports

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -179,6 +179,9 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
 - Follow-up #523 moved graph runtime wait-surface and Code Studio regex
   bindings to their canonical modules, closing obsolete graph-era re-exports
   from `direct_execution.py`.
+- Follow-up #525 moved direct prompt consumers to canonical turn-contract,
+  tool-binding, and tool-context modules, closing obsolete compatibility export
+  tuples and implicit private-helper re-exports from `direct_prompts.py`.
 
 ## Preserved Intentionally
 
@@ -217,10 +220,10 @@ backups, data PDFs, or local skill folders.
   lifecycle modules and SSE V3 parity modules with narrow contract tests. Its
   obsolete private helper compatibility export tuples are now closed; tests
   import helper contracts from their owning modules.
-- `direct_prompts.py` remains the main direct prompt assembly surface, but
-  force-bound skill directives, Pointy inventory prompt injection, the direct
-  turn contract, provider-aware tool binding, and tool-context prompt builders
-  now live in focused helper modules.
+- `direct_prompts.py` remains the main direct prompt assembly surface. Force-bound
+  skill directives, Pointy inventory prompt injection, the direct turn contract,
+  provider-aware tool binding, and tool-context prompt builders now live in
+  focused helper modules, and consumers import those helper contracts directly.
 - `direct_tool_rounds_runtime.py` is now a smaller orchestration shell. Pointy,
   explicit web-search policy, deterministic document host-action execution,
   uploaded-document preview/course payload shell, uploaded-document course
@@ -438,3 +441,7 @@ from the tool-round orchestration shell.
 In follow-up #523, direct execution streaming tests and graph routing tests
 passed after moving graph runtime wait-surface and Code Studio regex bindings
 away from `direct_execution.py` and into their canonical helper modules.
+In follow-up #525, direct prompt contract tests, direct tool-round force-skill
+tests, and graph prompt compatibility tests passed after moving prompt helper
+consumers to the canonical turn-contract, tool-binding, and tool-context
+modules.

--- a/maritime-ai-service/app/engine/multi_agent/agents/tutor_node.py
+++ b/maritime-ai-service/app/engine/multi_agent/agents/tutor_node.py
@@ -56,7 +56,7 @@ from app.engine.multi_agent.agents.tutor_tool_dispatch_runtime import (
 from app.engine.multi_agent.graph_surface_runtime import (
     get_effective_provider_impl as _get_effective_provider,
 )
-from app.engine.multi_agent.direct_prompts import (
+from app.engine.multi_agent.direct_prompt_tool_binding import (
     _resolve_tool_choice,
 )
 from app.engine.reasoning import (
@@ -68,15 +68,11 @@ from app.engine.reasoning import (
 )
 from app.prompts.prompt_context_utils import build_response_language_instruction
 from app.engine.multi_agent.agents.tutor_surface import (
-    LLM_CODE_GEN_VISUAL_INSTRUCTION,
-    STRUCTURED_VISUAL_TOOL_INSTRUCTION,
-    THINKING_CHAIN_INSTRUCTION,
-    TOOL_INSTRUCTION,
-    TOOL_INSTRUCTION_DEFAULT,
+    THINKING_CHAIN_INSTRUCTION,  # noqa: F401 - legacy tutor_node import surface
+    TOOL_INSTRUCTION,  # noqa: F401 - legacy tutor_node import surface
+    TOOL_INSTRUCTION_DEFAULT,  # noqa: F401 - legacy tutor_node import surface
     _MAX_PHASE_TRANSITIONS,
-    _infer_tutor_loop_phase,
     _iteration_beat,
-    _iteration_label,
     _tool_acknowledgment,
     build_tutor_identity_grounding_prompt,
     build_tutor_living_stream_cues,

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_context.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_context.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.code_studio_surface import _extract_code_studio_artifact_names
 from app.engine.multi_agent.direct_intent import _normalize_for_intent
-from app.engine.multi_agent.direct_prompts import _tool_name
+from app.engine.multi_agent.direct_prompt_tool_binding import _tool_name
 from app.engine.multi_agent.visual_intent_resolver import resolve_visual_intent
 
 

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_surface.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_surface.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 from typing import Any
 
 from app.core.config import settings
-from app.engine.multi_agent.direct_prompts import (
+from app.engine.multi_agent.direct_prompt_tool_context import (
     _build_code_studio_tools_context,
+)
+from app.engine.multi_agent.direct_prompts import (
     _build_direct_system_messages,
 )
 from app.engine.multi_agent.state import AgentState

--- a/maritime-ai-service/app/engine/multi_agent/direct_document_preview_payloads.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_document_preview_payloads.py
@@ -12,7 +12,7 @@ from app.engine.multi_agent.document_preview_contract import (
     normalize_document_contract_text as _normalize_doc_preview_text,
     uploaded_document_attachments_from_state as _uploaded_document_attachments_from_state,
 )
-from app.engine.multi_agent.direct_prompts import _tool_name
+from app.engine.multi_agent.direct_prompt_tool_binding import _tool_name
 from app.engine.multi_agent.direct_document_preview_text import (
     _DOC_PREVIEW_LOW_VALUE_LABELS,
     _clean_doc_preview_line,

--- a/maritime-ai-service/app/engine/multi_agent/direct_execution.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_execution.py
@@ -30,7 +30,7 @@ from app.engine.multi_agent.direct_response_runtime import (
 )
 from app.engine.multi_agent.state import AgentState
 
-from app.engine.multi_agent.direct_prompts import _resolve_tool_choice
+from app.engine.multi_agent.direct_prompt_tool_binding import _resolve_tool_choice
 from app.engine.multi_agent.direct_runtime_bindings import (
     _extract_runtime_target,
     _is_native_runtime_handle,

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
@@ -13,19 +13,11 @@ from app.core.config import settings
 from app.engine.multi_agent.state import AgentState
 
 from app.engine.multi_agent.direct_prompt_turn_contracts import (
-    _build_direct_turn_contract,
-    _build_force_skill_directive,
-    _extract_pointy_inventory,
-    _force_skills_for_turn,
-)
-from app.engine.multi_agent.direct_prompt_tool_binding import (
-    _bind_direct_tools,
-    _resolve_tool_choice,
-    _tool_name,
+    _build_direct_turn_contract as _build_direct_turn_contract_impl,
+    _build_force_skill_directive as _build_force_skill_directive_impl,
 )
 from app.engine.multi_agent.direct_prompt_tool_context import (
-    _build_code_studio_tools_context,
-    _build_direct_tools_context,
+    _build_direct_tools_context as _build_direct_tools_context_impl,
 )
 from app.engine.multi_agent.direct_intent import (
     _looks_identity_selfhood_turn,
@@ -44,20 +36,6 @@ from app.engine.multi_agent.direct_reasoning import (
 from app.prompts.prompt_context_utils import build_response_language_instruction
 
 logger = logging.getLogger(__name__)
-
-_DIRECT_PROMPT_TURN_CONTRACT_COMPAT_EXPORTS = (
-    _build_direct_turn_contract,
-    _build_force_skill_directive,
-    _extract_pointy_inventory,
-    _force_skills_for_turn,
-)
-
-_DIRECT_PROMPT_TOOL_COMPAT_EXPORTS = (
-    _bind_direct_tools,
-    _resolve_tool_choice,
-    _tool_name,
-    _build_code_studio_tools_context,
-)
 
 _DIRECT_SELFHOOD_ORIGIN_QUERY_MARKERS = (
     "ra doi",
@@ -737,7 +715,7 @@ def _build_direct_system_messages(
     tools_ctx = (
         tools_context_override
         if tools_context_override is not None
-        else _build_direct_tools_context(
+        else _build_direct_tools_context_impl(
             settings,
             domain_name_vi,
             ctx.get("user_role", "student"),
@@ -804,7 +782,7 @@ def _build_direct_system_messages(
                 + "- Nếu người dùng hỏi 'bạn là ai', 'tên gì', 'cuộc sống thế nào', hãy trả lời trực diện, tự nhiên, có hồn."
             )
 
-    turn_contract = _build_direct_turn_contract(state)
+    turn_contract = _build_direct_turn_contract_impl(state)
     if turn_contract:
         system_prompt = system_prompt + "\n\n" + turn_contract
 
@@ -905,7 +883,7 @@ def _build_direct_system_messages(
     # for `tool_choice="required"` flows: positive imperative phrasing
     # ("YOU MUST call X NOW with the right id from inventory") rather
     # than prohibitions ("don't generate prose").
-    force_directive = _build_force_skill_directive(state)
+    force_directive = _build_force_skill_directive_impl(state)
     if force_directive and not is_chatter_role:
         system_prompt = force_directive + "\n\n" + system_prompt
 

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_followup_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_followup_runtime.py
@@ -7,7 +7,10 @@ from dataclasses import dataclass
 import logging
 from typing import Any, Awaitable, Callable
 
-from app.engine.multi_agent.direct_prompts import _resolve_tool_choice, _tool_name
+from app.engine.multi_agent.direct_prompt_tool_binding import (
+    _resolve_tool_choice,
+    _tool_name,
+)
 from app.engine.multi_agent.visual_intent_resolver import (
     required_visual_tool_names,
 )

--- a/maritime-ai-service/app/engine/multi_agent/graph_runtime_bindings.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph_runtime_bindings.py
@@ -513,13 +513,13 @@ _build_visual_tool_runtime_metadata = _load_attr(
     "_build_visual_tool_runtime_metadata",
 )
 
-_tool_name = _load_attr("app.engine.multi_agent.direct_prompts", "_tool_name")
+_tool_name = _load_attr("app.engine.multi_agent.direct_prompt_tool_binding", "_tool_name")
 _resolve_tool_choice = _load_attr(
-    "app.engine.multi_agent.direct_prompts",
+    "app.engine.multi_agent.direct_prompt_tool_binding",
     "_resolve_tool_choice",
 )
 _bind_direct_tools_impl = _load_attr(
-    "app.engine.multi_agent.direct_prompts",
+    "app.engine.multi_agent.direct_prompt_tool_binding",
     "_bind_direct_tools",
 )
 _build_code_studio_delivery_contract = _load_attr(
@@ -527,11 +527,11 @@ _build_code_studio_delivery_contract = _load_attr(
     "_build_code_studio_delivery_contract",
 )
 _build_direct_tools_context = _load_attr(
-    "app.engine.multi_agent.direct_prompts",
+    "app.engine.multi_agent.direct_prompt_tool_context",
     "_build_direct_tools_context",
 )
 _build_code_studio_tools_context = _load_attr(
-    "app.engine.multi_agent.direct_prompts",
+    "app.engine.multi_agent.direct_prompt_tool_context",
     "_build_code_studio_tools_context",
 )
 _build_direct_chatter_system_prompt = _load_attr(

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -2690,7 +2690,7 @@ def test_build_force_skill_directive_pointy_inlines_inventory():
     """v3.0 F5: when @-mention force-binds wiii-pointy, system prompt
     directive must inline the available_targets so LLM picks right id
     without round-tripping tool_pointy_inventory."""
-    from app.engine.multi_agent.direct_prompts import _build_force_skill_directive
+    from app.engine.multi_agent.direct_prompt_turn_contracts import _build_force_skill_directive
 
     state = {
         'context': {
@@ -2722,14 +2722,14 @@ def test_build_force_skill_directive_pointy_inlines_inventory():
 
 
 def test_build_force_skill_directive_empty_when_no_force_skills():
-    from app.engine.multi_agent.direct_prompts import _build_force_skill_directive
+    from app.engine.multi_agent.direct_prompt_turn_contracts import _build_force_skill_directive
 
     assert _build_force_skill_directive({'context': {}}) == ''
     assert _build_force_skill_directive({}) == ''
 
 
 def test_build_force_skill_directive_web_search_branch():
-    from app.engine.multi_agent.direct_prompts import _build_force_skill_directive
+    from app.engine.multi_agent.direct_prompt_turn_contracts import _build_force_skill_directive
 
     state = {'context': {'force_skills': ['web-search']}}
     result = _build_force_skill_directive(state)


### PR DESCRIPTION
Closes #525.\n\n## Summary\n- Moves direct prompt helper consumers to canonical turn-contract, tool-binding, and tool-context modules.\n- Removes obsolete compatibility export tuples and implicit private-helper re-exports from direct_prompts.py.\n- Keeps documented tutor legacy instruction aliases intact while removing unrelated unused tutor imports caught by focused lint.\n- Updates the runtime cleanup audit with the completed #525 slice.\n\n## Verification\n- uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_direct_prompts_turn_contract.py tests/unit/test_direct_prompts_identity_contract.py tests/unit/test_direct_prompts_analytical_contract.py tests/unit/test_direct_codebase_thinking_quality.py tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_graph_routing.py -q --tb=short -> 176 passed\n- uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_tutor_agent.py tests/unit/test_tutor_agent_node.py -q --tb=short -> 62 passed\n- uv run --with pytest --with hypothesis --with pytest-asyncio pytest tests/unit/test_sprint80_off_topic.py -q --tb=short -> 58 passed\n- uv run --with ruff ruff check app/engine/multi_agent/direct_prompts.py app/engine/multi_agent/direct_execution.py app/engine/multi_agent/direct_document_preview_payloads.py app/engine/multi_agent/code_studio_context.py app/engine/multi_agent/code_studio_surface.py app/engine/multi_agent/direct_tool_followup_runtime.py app/engine/multi_agent/agents/tutor_node.py app/engine/multi_agent/graph_runtime_bindings.py tests/unit/test_direct_tool_rounds_runtime.py --select=E9,F63,F7,F401 -> passed\n- uv run --with ruff ruff check app/ --select=E9,F63,F7 -> passed\n- git diff --check -> passed\n\n## Risk / rollback\nRisk is low import-source cleanup; prompt content and tool behavior remain unchanged. Roll back by reverting this PR to restore the prior compatibility export surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated runtime cleanup audit documentation with latest migration guidance and verification notes.

* **Refactor**
  * Reorganized internal module structure to consolidate related functionality and improve code organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->