### PR TITLE
fix(backend): stabilize runtime metrics clock

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -182,6 +182,9 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
 - Follow-up #525 moved direct prompt consumers to canonical turn-contract,
   tool-binding, and tool-context modules, closing obsolete compatibility export
   tuples and implicit private-helper re-exports from `direct_prompts.py`.
+- Follow-up #527 made runtime metrics timing use a high-resolution monotonic
+  clock, so local Windows verification and CI Linux record `time_block()`
+  durations through the same stable contract.
 
 ## Preserved Intentionally
 
@@ -445,3 +448,6 @@ In follow-up #525, direct prompt contract tests, direct tool-round force-skill
 tests, and graph prompt compatibility tests passed after moving prompt helper
 consumers to the canonical turn-contract, tool-binding, and tool-context
 modules.
+In follow-up #527, the runtime metrics regression tests passed after switching
+`time_block()` from the coarse Windows monotonic clock to high-resolution
+`perf_counter_ns()`.

--- a/maritime-ai-service/app/engine/runtime/runtime_metrics.py
+++ b/maritime-ai-service/app/engine/runtime/runtime_metrics.py
@@ -222,11 +222,11 @@ def time_block(
     name: str, *, labels: Optional[LabelDict] = None
 ) -> Generator[None, None, None]:
     """Context manager that records the duration of the block in ms."""
-    started = time.monotonic()
+    started_ns = time.perf_counter_ns()
     try:
         yield
     finally:
-        elapsed = (time.monotonic() - started) * 1000.0
+        elapsed = (time.perf_counter_ns() - started_ns) / 1_000_000.0
         record_latency_ms(name, elapsed, labels=labels)
 
 


### PR DESCRIPTION
## Summary

- switch `runtime_metrics.time_block()` from coarse `time.monotonic()` float timing to high-resolution `time.perf_counter_ns()` duration timing
- update the runtime cleanup audit with follow-up #527 and verification notes

Closes #527.

## Verification

- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/engine/runtime/test_runtime_metrics.py::test_time_block_records_duration -q --tb=short` -> 1 passed
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/engine/runtime/test_runtime_metrics.py -q --tb=short` -> 13 passed
- `uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/runtime/runtime_metrics.py --select=E9,F63,F7,F401` -> pass
- `git diff --check` -> pass

Additional local signal: full backend `pytest tests/unit/ -x -p no:capture --tb=short -q` now passes the previous runtime metrics stop and reaches 4814 passed before an isolated-order local Windows failure in `test_sprint160b_hardening.py::TestCharacterOrgFilter::test_get_all_blocks_includes_org_filter`; that test passes when run directly and is not part of this clock change.

## Risk / rollback

Risk is low: `perf_counter_ns()` is monotonic and intended for short duration measurement. Roll back by reverting this PR if a platform reports unexpected duration behavior.