### PR TITLE
test(backend): reset shared database cooldown

### DIFF
--- a/maritime-ai-service/tests/unit/conftest.py
+++ b/maritime-ai-service/tests/unit/conftest.py
@@ -26,6 +26,16 @@ def _disable_rate_limiting():
 
 
 @pytest.fixture(autouse=True)
+def _reset_shared_db_unavailable_state():
+    """Keep shared DB cooldown state from leaking between unit tests."""
+    from app.core.database import clear_shared_database_unavailable
+
+    clear_shared_database_unavailable()
+    yield
+    clear_shared_database_unavailable()
+
+
+@pytest.fixture(autouse=True)
 def _prevent_db_connection_hangs():
     """Prevent unit tests from hanging on DB connection attempts.
 


### PR DESCRIPTION
## Summary

- clear shared database unavailable cooldown state before and after each backend unit test
- keep production cooldown behavior unchanged while preventing cross-test leakage from DB-failure tests into mocked repository tests

Closes #529.

## Verification

- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_sprint160b_hardening.py::TestCharacterOrgFilter::test_get_all_blocks_includes_org_filter -q --tb=short` -> 1 passed
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_sprint160b_hardening.py -q --tb=short` -> 30 passed
- `uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check tests/unit/conftest.py --select=E9,F63,F7,F401` -> pass
- `git diff --check` -> pass

Additional local signal: full backend `pytest tests/unit/ -x -p no:capture --tb=short -q` now passes the previous CharacterRepository stop and reaches 8950 passed before a separate semantic-memory embedding-space local failure in `test_sprint30_semantic_memory_repo.py::TestSaveMemory::test_successful_save`; that is outside this cooldown-isolation PR.

## Risk / rollback

Risk is low and limited to unit tests. Tests that assert cooldown behavior inside one test keep working because the fixture only clears state at test boundaries. Roll back by reverting this PR if a test intentionally depends on cross-test DB cooldown leakage.