### PR TITLE
test(backend): isolate semantic memory save embedding

### DIFF
--- a/maritime-ai-service/tests/unit/test_sprint30_semantic_memory_repo.py
+++ b/maritime-ai-service/tests/unit/test_sprint30_semantic_memory_repo.py
@@ -15,9 +15,9 @@ Covers:
 - delete_memory: single memory delete
 """
 
-import pytest
 import json
-from unittest.mock import patch, MagicMock, PropertyMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 from uuid import uuid4
 from datetime import datetime, timezone
 
@@ -98,7 +98,9 @@ class TestFormatEmbedding:
 class TestSaveMemory:
     """Test memory saving."""
 
-    def test_successful_save(self):
+    def test_successful_save(self, monkeypatch):
+        from app.repositories import semantic_memory_repository_runtime as runtime_mod
+
         repo = _make_repo()
 
         mock_row = MagicMock()
@@ -113,6 +115,34 @@ class TestSaveMemory:
         mock_row.updated_at = None
 
         mock_session = _mock_session(repo, fetchone=mock_row)
+        inline_space = SimpleNamespace(
+            storage_kind="inline",
+            provider="google",
+            model="models/gemini-embedding-001",
+            dimensions=768,
+            space_fingerprint="google:models/gemini-embedding-001:768",
+        )
+        source_contract = SimpleNamespace(
+            provider="google",
+            model="models/gemini-embedding-001",
+            dimensions=768,
+            fingerprint="google:models/gemini-embedding-001:768",
+        )
+        monkeypatch.setattr(
+            runtime_mod,
+            "get_embedding_write_spaces",
+            lambda *_args, **_kwargs: (inline_space,),
+        )
+        monkeypatch.setattr(
+            runtime_mod,
+            "get_active_embedding_space_contract",
+            lambda: source_contract,
+        )
+        monkeypatch.setattr(
+            runtime_mod,
+            "build_shadow_embedding_sync",
+            lambda **kwargs: list(kwargs["source_embedding"]),
+        )
 
         from app.models.semantic_memory import SemanticMemoryCreate
         memory = SemanticMemoryCreate(


### PR DESCRIPTION
## Summary
- Fixes #531.
- Makes `TestSaveMemory.test_successful_save` deterministic by mocking semantic memory embedding write spaces and shadow embedding construction.
- Keeps the metadata-stamping contract under test without depending on live Google embedding credentials or local provider availability.
- Removes unused imports from the touched test module.

## Scope
In scope:
- `maritime-ai-service/tests/unit/test_sprint30_semantic_memory_repo.py`
- Unit-test isolation for semantic memory save behavior.

Out of scope:
- Production semantic memory behavior changes.
- Embedding provider configuration, migrations, runtime registry changes, or frontend behavior.

## Verification
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_sprint30_semantic_memory_repo.py::TestSaveMemory::test_successful_save -q --tb=short` -> `1 passed`
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_sprint30_semantic_memory_repo.py -q --tb=short` -> `34 passed`
- `uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check tests/unit/test_sprint30_semantic_memory_repo.py --select=E9,F63,F7,F401` -> `All checks passed!`
- `git diff --check` -> passed
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/ -x -p no:capture --tb=short -q` -> `13007 passed, 38 skipped, 74 warnings`

## Risk / rollback
- Risk is low and test-only. It reduces environment-dependent behavior in unit tests.
- Rollback: revert this commit to restore the prior test behavior.

## Reviewer focus
- Confirm the test still validates semantic memory metadata stamping while avoiding live provider availability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixtures and mocking for semantic memory validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->