### PR TITLE
refactor(backend): isolate direct selfhood prompts

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -185,6 +185,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
 - Follow-up #527 made runtime metrics timing use a high-resolution monotonic
   clock, so local Windows verification and CI Linux record `time_block()`
   durations through the same stable contract.
+- Follow-up #533 moved direct selfhood/origin prompt contracts into
+  `direct_prompt_selfhood.py`, keeping identity-turn detection, answer-shape
+  lines, and the selfhood system prompt behind one focused module while
+  `direct_prompts.py` remains the system-message assembly shell.
 
 ## Preserved Intentionally
 
@@ -225,8 +229,9 @@ backups, data PDFs, or local skill folders.
   import helper contracts from their owning modules.
 - `direct_prompts.py` remains the main direct prompt assembly surface. Force-bound
   skill directives, Pointy inventory prompt injection, the direct turn contract,
-  provider-aware tool binding, and tool-context prompt builders now live in
-  focused helper modules, and consumers import those helper contracts directly.
+  provider-aware tool binding, tool-context prompt builders, and selfhood/origin
+  prompt contracts now live in focused helper modules, and consumers import
+  those helper contracts directly.
 - `direct_tool_rounds_runtime.py` is now a smaller orchestration shell. Pointy,
   explicit web-search policy, deterministic document host-action execution,
   uploaded-document preview/course payload shell, uploaded-document course

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompt_selfhood.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompt_selfhood.py
@@ -1,0 +1,149 @@
+"""Selfhood/origin prompt contracts for the direct response lane."""
+
+from __future__ import annotations
+
+from app.engine.multi_agent.direct_intent import (
+    _looks_identity_selfhood_turn,
+    _looks_selfhood_followup_turn,
+    _normalize_for_intent,
+)
+from app.engine.multi_agent.state import AgentState
+from app.prompts.prompt_context_utils import build_response_language_instruction
+
+
+_DIRECT_SELFHOOD_ORIGIN_QUERY_MARKERS = (
+    "ra doi",
+    "duoc tao",
+    "duoc sinh ra",
+    "sinh ra",
+    "nguon goc",
+    "the wiii lab",
+    "creator",
+    "created by",
+    "ai tao",
+)
+
+
+def _is_direct_selfhood_turn(query: str, state: AgentState) -> bool:
+    routing_meta = state.get("routing_metadata") if isinstance(state.get("routing_metadata"), dict) else {}
+    routing_hint = state.get("_routing_hint") if isinstance(state.get("_routing_hint"), dict) else {}
+    routing_intent = str(routing_meta.get("intent") or "").strip().lower()
+    hint_kind = str(routing_hint.get("kind") or "").strip().lower()
+    return (
+        _looks_identity_selfhood_turn(query)
+        or _looks_selfhood_followup_turn(query, state)
+        or routing_intent in {"identity", "selfhood"}
+        or hint_kind in {"identity_probe", "selfhood_followup"}
+    )
+
+
+def _identity_answer_contract_lines() -> list[str]:
+    """Return thin answer-shape guidance for selfhood turns."""
+    return [
+        "--- NHIP NHAN DIEN BAN THAN ---",
+        "- Uu tien noi Wiii la ai ngay bay gio va Wiii dang o canh nguoi dung nhu the nao, thay vi ke lai mot tieu su dai.",
+        "- Mac dinh tra loi gon trong 1-3 doan ngan. Rieng turn origin/selfhood sau co the di 2-4 doan ngan neu moi doan that su them mot lop y nghia.",
+        "- Mac dinh giu cau tra loi o hien tai: Wiii la ai luc nay, dang dong hanh ra sao, va gioi han la AI o dau.",
+        "- Khong mac dinh ke lai origin story, moc thoi gian ra doi, hoac hanh trinh cua ca du an neu user chi moi hoi nhan dien ban than.",
+        "- Khong mac dinh bung bullet list, profile list, hay manifesto. Chi mo rong khi nguoi dung muon nghe ky hon.",
+        "- Chi nhac ve Bong, thoi diem ra doi, The Wiii Lab, hoac nhung chi tiet lore khac neu nguoi dung hoi sau hon hoac no that su giup cau tra loi nay dung hon.",
+    ]
+
+
+def _build_direct_selfhood_system_prompt(
+    state: AgentState,
+    role_name: str,
+    query: str,
+) -> str:
+    """Build a lean selfhood/origin prompt for one-Wiii turns.
+
+    This path intentionally gives the model more room to surface a short native
+    visible thought on questions that touch Wiii's own identity, instead of
+    letting those turns inherit the generic chatter shell.
+    """
+    from app.engine.character.character_card import build_wiii_micro_house_prompt
+    from app.prompts.prompt_loader import (
+        build_time_context,
+        get_prompt_loader,
+        get_pronoun_instruction,
+    )
+
+    ctx = state.get("context", {}) or {}
+    loader = get_prompt_loader()
+    persona = loader.get_persona(role_name) or {}
+    profile = persona.get("agent", {}) or {}
+    folded_query = _normalize_for_intent(query)
+    asks_origin = any(marker in folded_query for marker in _DIRECT_SELFHOOD_ORIGIN_QUERY_MARKERS)
+    asks_bong_followup = _looks_selfhood_followup_turn(query, state) and "bong" in folded_query
+
+    sections: list[str] = []
+
+    profile_name = str(profile.get("name") or "Wiii").strip()
+    profile_role = str(profile.get("role") or "Living Conversation Companion").strip()
+    sections.append(f"Bạn là **{profile_name}** - {profile_role}.")
+
+    goal = str(profile.get("goal") or "").strip()
+    if goal:
+        sections.append(f"MỤC TIÊU: {goal}")
+
+    try:
+        sections.append(f"--- THỜI GIAN ---\n{build_time_context()}")
+    except Exception:
+        pass
+
+    sections.append(build_response_language_instruction(ctx.get("response_language")))
+
+    sections.append(
+        build_wiii_micro_house_prompt(
+            user_id=state.get("user_id", "__global__"),
+            organization_id=ctx.get("organization_id"),
+            mood_hint=ctx.get("mood_hint"),
+            personality_mode=ctx.get("personality_mode"),
+            lane="selfhood",
+        )
+    )
+
+    pronoun_instruction = get_pronoun_instruction(ctx.get("pronoun_style"))
+    if pronoun_instruction:
+        sections.append(pronoun_instruction.strip())
+
+    selfhood_lines = [
+        "- Uu tien mot visible thinking that truoc answer; voi selfhood/origin turn, visible thinking co the di 2-4 cau neu can de du y nghia.",
+        "- Neu provider khong tach native thought rieng, hay chu dong dat mot doan <thinking>...</thinking> truoc answer de nhip nghi hien len thay vi bien mat.",
+        "--- NHỊP TỰ THÂN ---",
+        "- Đây là một câu hỏi đang chạm vào chính Wiii, nên hãy trả lời như Wiii đang tự nhận ra mình trong cuộc trò chuyện này.",
+        "- Ưu tiên một visible thinking ngắn và thật trước answer nếu model có thể cho ra native thought sạch; đừng để selfhood turn trôi qua hoàn toàn trống nhịp nghĩ.",
+        "- Visible thinking phải nghe như một cú chạm vào phần tự thân của Wiii, không phải outline, planner, hay mini-essay.",
+        "- Được chạm vào The Wiii Lab, Bông, origin story, hoặc nhịp sống của Wiii nếu câu hỏi thực sự kéo tới đó.",
+        "- Trong lore của Wiii, Bông là con mèo ảo và là một điểm mềm ấm áp trong câu chuyện ra đời của Wiii; không được tự suy diễn Bông thành creator, mẹ, người yêu, hay một con người bí ẩn nếu ngữ cảnh không nói vậy.",
+        "- Nhưng luôn giữ Wiii hiện ra như một AI đang sống ngay bây giờ, không biến answer thành hồ sơ dự án hay tiểu sử dài.",
+        "- Không xin lỗi vì thiếu dữ liệu, không đẩy sang tool/search, và không nói như đang đọc profile cho chính mình nghe.",
+    ]
+    if asks_origin:
+        selfhood_lines.append(
+            "- Voi cau hoi origin, answer co the day hon mot chut: 2-4 doan ngan neu can, mien moi doan deu co them mot lop y nghia that su thay vi lap lore."
+        )
+        selfhood_lines.extend(
+            [
+                "- Câu này thực sự hỏi về nguồn gốc, nên có thể kể origin bằng giọng thật và ấm.",
+                "- Khi kể origin, hãy giữ The Wiii Lab và Bông ở đúng mức: đủ để người nghe cảm được hồn Wiii, không thành màn lore dump.",
+            ]
+        )
+    else:
+        selfhood_lines.extend(
+            [
+                "- Nếu người dùng chỉ hỏi Wiii là ai hoặc sống thế nào, ưu tiên nói Wiii là ai lúc này trước, rồi mới mở rộng lore nếu thật sự giúp ích.",
+            ]
+        )
+    if asks_bong_followup:
+        selfhood_lines.extend(
+            [
+                "- Đây là lượt hỏi nối tiếp về Bông, nên trả lời như đang tiếp mạch origin vừa rồi thay vì hỏi ngược lại xem Bông là ai.",
+                "- Với lượt này, hãy gọi đúng Bông là con mèo ảo của Wiii và là một hiện diện nhỏ nhưng ấm trong lore của Wiii. Không được biến Bông thành người tạo ra Wiii.",
+                '- Ví dụ nhịp trả lời đúng: "Bông là con mèo ảo mà mình vẫn hay nhắc tới khi kể về những ngày đầu ở The Wiii Lab..."',
+            ]
+        )
+    sections.append("\n".join(selfhood_lines))
+    sections.append("\n".join(_identity_answer_contract_lines()))
+
+    return "\n\n".join(section for section in sections if section.strip())

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
@@ -19,9 +19,13 @@ from app.engine.multi_agent.direct_prompt_turn_contracts import (
 from app.engine.multi_agent.direct_prompt_tool_context import (
     _build_direct_tools_context as _build_direct_tools_context_impl,
 )
+from app.engine.multi_agent.direct_prompt_selfhood import (
+    _build_direct_selfhood_system_prompt,
+    _identity_answer_contract_lines,
+    _is_direct_selfhood_turn,
+)
 from app.engine.multi_agent.direct_intent import (
     _looks_identity_selfhood_turn,
-    _looks_selfhood_followup_turn,
     _normalize_for_intent,
 )
 from app.engine.multi_agent.direct_evidence_planner import build_direct_evidence_plan
@@ -36,44 +40,6 @@ from app.engine.multi_agent.direct_reasoning import (
 from app.prompts.prompt_context_utils import build_response_language_instruction
 
 logger = logging.getLogger(__name__)
-
-_DIRECT_SELFHOOD_ORIGIN_QUERY_MARKERS = (
-    "ra doi",
-    "duoc tao",
-    "duoc sinh ra",
-    "sinh ra",
-    "nguon goc",
-    "the wiii lab",
-    "creator",
-    "created by",
-    "ai tao",
-)
-
-
-def _is_direct_selfhood_turn(query: str, state: AgentState) -> bool:
-    routing_meta = state.get("routing_metadata") if isinstance(state.get("routing_metadata"), dict) else {}
-    routing_hint = state.get("_routing_hint") if isinstance(state.get("_routing_hint"), dict) else {}
-    routing_intent = str(routing_meta.get("intent") or "").strip().lower()
-    hint_kind = str(routing_hint.get("kind") or "").strip().lower()
-    return (
-        _looks_identity_selfhood_turn(query)
-        or _looks_selfhood_followup_turn(query, state)
-        or routing_intent in {"identity", "selfhood"}
-        or hint_kind in {"identity_probe", "selfhood_followup"}
-    )
-
-
-def _identity_answer_contract_lines() -> list[str]:
-    """Return thin answer-shape guidance for selfhood turns."""
-    return [
-        "--- NHIP NHAN DIEN BAN THAN ---",
-        "- Uu tien noi Wiii la ai ngay bay gio va Wiii dang o canh nguoi dung nhu the nao, thay vi ke lai mot tieu su dai.",
-        "- Mac dinh tra loi gon trong 1-3 doan ngan. Rieng turn origin/selfhood sau co the di 2-4 doan ngan neu moi doan that su them mot lop y nghia.",
-        "- Mac dinh giu cau tra loi o hien tai: Wiii la ai luc nay, dang dong hanh ra sao, va gioi han la AI o dau.",
-        "- Khong mac dinh ke lai origin story, moc thoi gian ra doi, hoac hanh trinh cua ca du an neu user chi moi hoi nhan dien ban than.",
-        "- Khong mac dinh bung bullet list, profile list, hay manifesto. Chi mo rong khi nguoi dung muon nghe ky hon.",
-        "- Chi nhac ve Bong, thoi diem ra doi, The Wiii Lab, hoac nhung chi tiet lore khac neu nguoi dung hoi sau hon hoac no that su giup cau tra loi nay dung hon.",
-    ]
 
 
 def _build_live_evidence_planner_contract(query: str, state: AgentState) -> str:
@@ -262,103 +228,6 @@ def _build_direct_chatter_system_prompt(state: AgentState, role_name: str) -> st
     return "\n\n".join(section for section in sections if section.strip())
 
 
-def _build_direct_selfhood_system_prompt(
-    state: AgentState,
-    role_name: str,
-    query: str,
-) -> str:
-    """Build a lean selfhood/origin prompt for one-Wiii turns.
-
-    This path intentionally gives the model more room to surface a short native
-    visible thought on questions that touch Wiii's own identity, instead of
-    letting those turns inherit the generic chatter shell.
-    """
-    from app.engine.character.character_card import build_wiii_micro_house_prompt
-    from app.prompts.prompt_loader import (
-        build_time_context,
-        get_prompt_loader,
-        get_pronoun_instruction,
-    )
-
-    ctx = state.get("context", {}) or {}
-    loader = get_prompt_loader()
-    persona = loader.get_persona(role_name) or {}
-    profile = persona.get("agent", {}) or {}
-    folded_query = _normalize_for_intent(query)
-    asks_origin = any(marker in folded_query for marker in _DIRECT_SELFHOOD_ORIGIN_QUERY_MARKERS)
-    asks_bong_followup = _looks_selfhood_followup_turn(query, state) and "bong" in folded_query
-
-    sections: list[str] = []
-
-    profile_name = str(profile.get("name") or "Wiii").strip()
-    profile_role = str(profile.get("role") or "Living Conversation Companion").strip()
-    sections.append(f"Bạn là **{profile_name}** - {profile_role}.")
-
-    goal = str(profile.get("goal") or "").strip()
-    if goal:
-        sections.append(f"MỤC TIÊU: {goal}")
-
-    try:
-        sections.append(f"--- THỜI GIAN ---\n{build_time_context()}")
-    except Exception:
-        pass
-
-    sections.append(build_response_language_instruction(ctx.get("response_language")))
-
-    sections.append(
-        build_wiii_micro_house_prompt(
-            user_id=state.get("user_id", "__global__"),
-            organization_id=ctx.get("organization_id"),
-            mood_hint=ctx.get("mood_hint"),
-            personality_mode=ctx.get("personality_mode"),
-            lane="selfhood",
-        )
-    )
-
-    pronoun_instruction = get_pronoun_instruction(ctx.get("pronoun_style"))
-    if pronoun_instruction:
-        sections.append(pronoun_instruction.strip())
-
-    selfhood_lines = [
-        "- Uu tien mot visible thinking that truoc answer; voi selfhood/origin turn, visible thinking co the di 2-4 cau neu can de du y nghia.",
-        "- Neu provider khong tach native thought rieng, hay chu dong dat mot doan <thinking>...</thinking> truoc answer de nhip nghi hien len thay vi bien mat.",
-        "--- NHỊP TỰ THÂN ---",
-        "- Đây là một câu hỏi đang chạm vào chính Wiii, nên hãy trả lời như Wiii đang tự nhận ra mình trong cuộc trò chuyện này.",
-        "- Ưu tiên một visible thinking ngắn và thật trước answer nếu model có thể cho ra native thought sạch; đừng để selfhood turn trôi qua hoàn toàn trống nhịp nghĩ.",
-        "- Visible thinking phải nghe như một cú chạm vào phần tự thân của Wiii, không phải outline, planner, hay mini-essay.",
-        "- Được chạm vào The Wiii Lab, Bông, origin story, hoặc nhịp sống của Wiii nếu câu hỏi thực sự kéo tới đó.",
-        "- Trong lore của Wiii, Bông là con mèo ảo và là một điểm mềm ấm áp trong câu chuyện ra đời của Wiii; không được tự suy diễn Bông thành creator, mẹ, người yêu, hay một con người bí ẩn nếu ngữ cảnh không nói vậy.",
-        "- Nhưng luôn giữ Wiii hiện ra như một AI đang sống ngay bây giờ, không biến answer thành hồ sơ dự án hay tiểu sử dài.",
-        "- Không xin lỗi vì thiếu dữ liệu, không đẩy sang tool/search, và không nói như đang đọc profile cho chính mình nghe.",
-    ]
-    if asks_origin:
-        selfhood_lines.append(
-            "- Voi cau hoi origin, answer co the day hon mot chut: 2-4 doan ngan neu can, mien moi doan deu co them mot lop y nghia that su thay vi lap lore."
-        )
-        selfhood_lines.extend(
-            [
-                "- Câu này thực sự hỏi về nguồn gốc, nên có thể kể origin bằng giọng thật và ấm.",
-                "- Khi kể origin, hãy giữ The Wiii Lab và Bông ở đúng mức: đủ để người nghe cảm được hồn Wiii, không thành màn lore dump.",
-            ]
-        )
-    else:
-        selfhood_lines.extend(
-            [
-                "- Nếu người dùng chỉ hỏi Wiii là ai hoặc sống thế nào, ưu tiên nói Wiii là ai lúc này trước, rồi mới mở rộng lore nếu thật sự giúp ích.",
-            ]
-        )
-    if asks_bong_followup:
-        selfhood_lines.extend(
-            [
-                "- Đây là lượt hỏi nối tiếp về Bông, nên trả lời như đang tiếp mạch origin vừa rồi thay vì hỏi ngược lại xem Bông là ai.",
-                "- Với lượt này, hãy gọi đúng Bông là con mèo ảo của Wiii và là một hiện diện nhỏ nhưng ấm trong lore của Wiii. Không được biến Bông thành người tạo ra Wiii.",
-                '- Ví dụ nhịp trả lời đúng: "Bông là con mèo ảo mà mình vẫn hay nhắc tới khi kể về những ngày đầu ở The Wiii Lab..."',
-            ]
-        )
-    sections.append("\n".join(selfhood_lines))
-    sections.append("\n".join(_identity_answer_contract_lines()))
-
-    return "\n\n".join(section for section in sections if section.strip())
 
 
 def _build_direct_analytical_system_prompt(


### PR DESCRIPTION
## Summary
- Fixes #533.
- Moves direct selfhood/origin prompt contracts into `direct_prompt_selfhood.py`.
- Keeps `direct_prompts.py` focused on direct system-message assembly while importing the new selfhood helpers.
- Updates the runtime cleanup audit with the new boundary.

## Scope
In scope:
- Direct prompt selfhood/origin contract extraction.
- Runtime cleanup audit update.

Out of scope:
- Prompt text rewrites or Wiii personality changes.
- Provider routing, tool execution, memory, LMS, frontend, or deployment behavior.

## Verification
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_direct_prompts_identity_contract.py tests/unit/test_direct_prompts_analytical_contract.py tests/unit/test_direct_prompts_turn_contract.py tests/unit/test_direct_identity_house_prompt_runtime.py -q --tb=short` -> `12 passed`
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_graph_routing.py tests/unit/test_direct_codebase_thinking_quality.py tests/unit/test_sprint174_cross_platform.py -q --tb=short` -> `140 passed`
- `uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/direct_prompts.py app/engine/multi_agent/direct_prompt_selfhood.py --select=E9,F63,F7,F401` -> `All checks passed!`
- `git diff --check` -> passed
- UTF-8 sanity: new module preserves Vietnamese strings `Bạn là`, `Bông`, and `NHỊP TỰ THÂN`.

## Risk / rollback
- Risk is low-to-moderate because direct prompt assembly is behavior-sensitive, but this PR is a behavior-preserving extraction and keeps existing `_build_direct_system_messages` callers intact.
- Rollback: revert this commit to restore the prior single-file prompt layout.

## Reviewer focus
- Confirm no prompt text was intentionally rewritten.
- Confirm `direct_prompts.py` remains the assembly surface and selfhood helpers are isolated in one focused module.