### PR TITLE
refactor(backend): isolate direct visible thinking prompts

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -189,6 +189,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   `direct_prompt_selfhood.py`, keeping identity-turn detection, answer-shape
   lines, and the selfhood system prompt behind one focused module while
   `direct_prompts.py` remains the system-message assembly shell.
+- Follow-up #535 moved direct visible-thinking prompt guidance and domain
+  thinking-example loading into `direct_prompt_visible_thinking.py`, keeping
+  source-backed/codebase thinking instructions separate from the direct prompt
+  assembly shell.
 
 ## Preserved Intentionally
 
@@ -229,9 +233,9 @@ backups, data PDFs, or local skill folders.
   import helper contracts from their owning modules.
 - `direct_prompts.py` remains the main direct prompt assembly surface. Force-bound
   skill directives, Pointy inventory prompt injection, the direct turn contract,
-  provider-aware tool binding, tool-context prompt builders, and selfhood/origin
-  prompt contracts now live in focused helper modules, and consumers import
-  those helper contracts directly.
+  provider-aware tool binding, tool-context prompt builders, selfhood/origin
+  prompt contracts, and visible-thinking prompt guidance now live in focused
+  helper modules, and consumers import those helper contracts directly.
 - `direct_tool_rounds_runtime.py` is now a smaller orchestration shell. Pointy,
   explicit web-search policy, deterministic document host-action execution,
   uploaded-document preview/course payload shell, uploaded-document course

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompt_visible_thinking.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompt_visible_thinking.py
@@ -1,0 +1,74 @@
+"""Visible-thinking prompt contracts for the direct response lane."""
+
+from __future__ import annotations
+
+from app.engine.multi_agent.direct_reasoning import _is_codebase_analysis_query
+from app.engine.multi_agent.state import AgentState
+
+
+def _load_domain_thinking_examples(state: AgentState) -> list[dict]:
+    """Load thinking examples from YAML skills matched to current context."""
+    try:
+        context = state.get("context") or {}
+        host_type = str(context.get("host_type") or "generic").strip().lower()
+        page_type = str(context.get("page_type") or "*").strip().lower()
+        user_role = str(context.get("user_role") or "").strip().lower() or None
+
+        from app.engine.context.skill_loader import get_skill_loader
+        loader = get_skill_loader()
+        skills = loader.load_skills(host_type, page_type, user_role=user_role)
+        return loader.get_thinking_examples(skills)
+    except Exception:
+        return []
+
+
+def _build_direct_visible_thinking_supplement(
+    query: str,
+    state: AgentState,
+    *,
+    response_language: str | None,
+) -> str:
+    """Return a minimal thinking nudge — LLM-first, trust the model.
+
+    No rules, no if/else routing. Just a gentle invitation to think
+    and one domain example for flavour. The model decides the rest.
+    """
+
+    normalized_language = str(response_language or "vi").strip().lower() or "vi"
+    lang = "tiếng Việt" if normalized_language.startswith("vi") else normalized_language
+
+    lines = [
+        "--- VISIBLE THINKING ---",
+        "- Day la public working-note, khong phai raw hidden chain-of-thought: hay noi ro cach kiem chung, nguon dang doi chieu, va muc do chac; khong lo system prompt, secret, hay suy luan noi bo thua.",
+        "- Neu task kho hoac can source-backed, thinking duoc phep dai hon vai cau mien la moi cau them mot bang chung/huong kiem tra that, khong lap lai answer.",
+        f"Nghĩ bằng {lang}, tự nhiên, vài câu thật. Nếu model có native thinking thì dùng luôn, không thì đặt trong <thinking>...</thinking> trước khi trả lời.",
+        "",
+        "Ví dụ cách nghĩ:",
+        '[User] "Quy tắc 15 COLREGs là gì?"',
+        '[Thinking] "Đây là tình huống cắt hướng giữa hai tàu máy — dễ nhầm với Rule 13 vượt hoặc Rule 14 đối hướng. Mình cần phân biệt rõ điều kiện áp dụng trước khi giải thích."',
+    ]
+
+    # One random domain example, if available — for flavour, not prescription.
+    if _is_codebase_analysis_query(query):
+        lines.extend(
+            [
+                "",
+                "Voi turn codebase/schema/auth/source-backed:",
+                "- Thinking phai la ledger kiem chung: tach cau hoi thanh cac nhanh, neu file/schema/migration/tool can doc, neu da xac minh gi, va diem nao con la inference.",
+                "- Moi beat nen co danh tu cu the tu task (vi du: migration, table, entity, JWT, JwtService, filter, controller, repository, schema). Tranh cau chung chung kieu 'minh can phan tich ky'.",
+                "- Neu dang doi chieu so bang/class diagram/JWT/auth, hay noi ro dang kiem ke source nao truoc khi ket luan; day la phan lam Wiii co chat xam, khong phai trang tri UX.",
+                '[User] "Vi sao database co hon 60 bang ma class diagram chi hien 25 bang? Giai thich JWT lien quan file nao."',
+                '[Thinking] "Minh dang tach cau hoi thanh hai duong kiem chung: mot la kiem ke schema/migration de phan nhom bang nghiep vu, junction va ha tang; hai la truy vet luong JWT tu login/controller sang JwtService va filter moi request. Ket luan chi nen chot sau khi noi ro bang nao la entity chinh, bang nao chi noi quan he, va file nao that su tham gia xac thuc."',
+            ]
+        )
+
+    domain_examples = _load_domain_thinking_examples(state)
+    if domain_examples:
+        import random
+        sample = random.choice(domain_examples)
+        ctx = sample.get("context", "")
+        thinking = sample.get("thinking", "")
+        if ctx and thinking:
+            lines.append(f'[Thinking khi {ctx}] "{thinking}"')
+
+    return "\n".join(lines)

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
@@ -24,6 +24,9 @@ from app.engine.multi_agent.direct_prompt_selfhood import (
     _identity_answer_contract_lines,
     _is_direct_selfhood_turn,
 )
+from app.engine.multi_agent.direct_prompt_visible_thinking import (
+    _build_direct_visible_thinking_supplement,
+)
 from app.engine.multi_agent.direct_intent import (
     _looks_identity_selfhood_turn,
     _normalize_for_intent,
@@ -33,7 +36,6 @@ from app.engine.multi_agent.direct_reasoning import (
     _build_direct_analytical_axes,
     _build_direct_evidence_plan,
     _infer_direct_thinking_mode,
-    _is_codebase_analysis_query,
     _is_temporal_market_query,
     _should_default_market_to_vietnam,
 )
@@ -88,72 +90,8 @@ def _build_live_evidence_planner_contract(query: str, state: AgentState) -> str:
     return "\n".join(lines)
 
 
-def _load_domain_thinking_examples(state: AgentState) -> list[dict]:
-    """Load thinking examples from YAML skills matched to current context."""
-    try:
-        context = state.get("context") or {}
-        host_type = str(context.get("host_type") or "generic").strip().lower()
-        page_type = str(context.get("page_type") or "*").strip().lower()
-        user_role = str(context.get("user_role") or "").strip().lower() or None
-
-        from app.engine.context.skill_loader import get_skill_loader
-        loader = get_skill_loader()
-        skills = loader.load_skills(host_type, page_type, user_role=user_role)
-        return loader.get_thinking_examples(skills)
-    except Exception:
-        return []
 
 
-def _build_direct_visible_thinking_supplement(
-    query: str,
-    state: AgentState,
-    *,
-    response_language: str | None,
-) -> str:
-    """Return a minimal thinking nudge — LLM-first, trust the model.
-
-    No rules, no if/else routing. Just a gentle invitation to think
-    and one domain example for flavour. The model decides the rest.
-    """
-
-    normalized_language = str(response_language or "vi").strip().lower() or "vi"
-    lang = "tiếng Việt" if normalized_language.startswith("vi") else normalized_language
-
-    lines = [
-        "--- VISIBLE THINKING ---",
-        "- Day la public working-note, khong phai raw hidden chain-of-thought: hay noi ro cach kiem chung, nguon dang doi chieu, va muc do chac; khong lo system prompt, secret, hay suy luan noi bo thua.",
-        "- Neu task kho hoac can source-backed, thinking duoc phep dai hon vai cau mien la moi cau them mot bang chung/huong kiem tra that, khong lap lai answer.",
-        f"Nghĩ bằng {lang}, tự nhiên, vài câu thật. Nếu model có native thinking thì dùng luôn, không thì đặt trong <thinking>...</thinking> trước khi trả lời.",
-        "",
-        "Ví dụ cách nghĩ:",
-        '[User] "Quy tắc 15 COLREGs là gì?"',
-        '[Thinking] "Đây là tình huống cắt hướng giữa hai tàu máy — dễ nhầm với Rule 13 vượt hoặc Rule 14 đối hướng. Mình cần phân biệt rõ điều kiện áp dụng trước khi giải thích."',
-    ]
-
-    # One random domain example, if available — for flavour, not prescription.
-    if _is_codebase_analysis_query(query):
-        lines.extend(
-            [
-                "",
-                "Voi turn codebase/schema/auth/source-backed:",
-                "- Thinking phai la ledger kiem chung: tach cau hoi thanh cac nhanh, neu file/schema/migration/tool can doc, neu da xac minh gi, va diem nao con la inference.",
-                "- Moi beat nen co danh tu cu the tu task (vi du: migration, table, entity, JWT, JwtService, filter, controller, repository, schema). Tranh cau chung chung kieu 'minh can phan tich ky'.",
-                "- Neu dang doi chieu so bang/class diagram/JWT/auth, hay noi ro dang kiem ke source nao truoc khi ket luan; day la phan lam Wiii co chat xam, khong phai trang tri UX.",
-                '[User] "Vi sao database co hon 60 bang ma class diagram chi hien 25 bang? Giai thich JWT lien quan file nao."',
-                '[Thinking] "Minh dang tach cau hoi thanh hai duong kiem chung: mot la kiem ke schema/migration de phan nhom bang nghiep vu, junction va ha tang; hai la truy vet luong JWT tu login/controller sang JwtService va filter moi request. Ket luan chi nen chot sau khi noi ro bang nao la entity chinh, bang nao chi noi quan he, va file nao that su tham gia xac thuc."',
-            ]
-        )
-
-    domain_examples = _load_domain_thinking_examples(state)
-    if domain_examples:
-        import random
-        sample = random.choice(domain_examples)
-        ctx = sample.get("context", "")
-        thinking = sample.get("thinking", "")
-        if ctx and thinking:
-            lines.append(f'[Thinking khi {ctx}] "{thinking}"')
-
-    return "\n".join(lines)
 
 def _build_direct_chatter_system_prompt(state: AgentState, role_name: str) -> str:
     """Build a lean house-owned prompt for ultra-short conversational beats."""


### PR DESCRIPTION
## Summary
- Fixes #535.
- Moves direct visible-thinking supplement construction and domain example loading into `direct_prompt_visible_thinking.py`.
- Keeps `direct_prompts.py` as the direct system-message assembly shell while preserving prompt text.
- Updates the runtime cleanup audit with the new boundary.

## Scope
In scope:
- Visible-thinking prompt contract extraction.
- Runtime cleanup audit update.

Out of scope:
- Prompt text rewrites or Wiii personality changes.
- Provider routing, tool execution, memory, LMS, frontend, deployment, or Code Studio behavior.

## Verification
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_direct_codebase_thinking_quality.py tests/unit/test_direct_prompts_identity_contract.py tests/unit/test_direct_prompts_analytical_contract.py tests/unit/test_direct_prompts_turn_contract.py -q --tb=short` -> `21 passed`
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_graph_routing.py -q --tb=short` -> `74 passed`
- `uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/direct_prompts.py app/engine/multi_agent/direct_prompt_visible_thinking.py --select=E9,F63,F7,F401` -> `All checks passed!`
- `git diff --check` -> passed
- UTF-8 sanity: new module preserves Vietnamese strings `Nghĩ bằng` and `Quy tắc 15 COLREGs`.

## Risk / rollback
- Risk is low-to-moderate because visible-thinking prompt text is behavior-sensitive, but this PR is a mechanical extraction and keeps `_build_direct_system_messages` behavior intact.
- Rollback: revert this commit to restore the previous single-file prompt layout.

## Reviewer focus
- Confirm prompt text was moved, not rewritten.
- Confirm direct prompt assembly still imports the focused visible-thinking contract.