### PR TITLE
refactor(backend): isolate direct evidence prompts

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -193,6 +193,9 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   thinking-example loading into `direct_prompt_visible_thinking.py`, keeping
   source-backed/codebase thinking instructions separate from the direct prompt
   assembly shell.
+- Follow-up #537 moved live-evidence planner prompt text and hint-list
+  formatting into `direct_prompt_evidence.py`, keeping current-source lookup
+  guidance separate from the direct prompt assembly shell.
 
 ## Preserved Intentionally
 
@@ -234,8 +237,9 @@ backups, data PDFs, or local skill folders.
 - `direct_prompts.py` remains the main direct prompt assembly surface. Force-bound
   skill directives, Pointy inventory prompt injection, the direct turn contract,
   provider-aware tool binding, tool-context prompt builders, selfhood/origin
-  prompt contracts, and visible-thinking prompt guidance now live in focused
-  helper modules, and consumers import those helper contracts directly.
+  prompt contracts, visible-thinking prompt guidance, and live-evidence prompt
+  contracts now live in focused helper modules, and consumers import those
+  helper contracts directly.
 - `direct_tool_rounds_runtime.py` is now a smaller orchestration shell. Pointy,
   explicit web-search policy, deterministic document host-action execution,
   uploaded-document preview/course payload shell, uploaded-document course

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompt_evidence.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompt_evidence.py
@@ -1,0 +1,63 @@
+"""Live-evidence prompt contracts for the direct response lane."""
+
+from __future__ import annotations
+
+from app.engine.multi_agent.direct_evidence_planner import build_direct_evidence_plan
+from app.engine.multi_agent.state import AgentState
+
+
+def _build_live_evidence_planner_contract(query: str, state: AgentState) -> str:
+    plan = build_direct_evidence_plan(query, state, [])
+    if plan.family in {"none", "product_search_handoff"}:
+        return ""
+
+    lines = [
+        "## LIVE EVIDENCE PLANNER:",
+        f"- Query family: {plan.family}",
+        f"- Topic cluster: {plan.topic_cluster or 'general'}",
+        f"- Locality policy: {plan.locality}",
+        f"- Answer mode: {plan.answer_mode}",
+    ]
+    if plan.needs_time_anchor:
+        lines.append("- Bat buoc chot moc thoi gian hien tai truoc khi tong hop.")
+    if plan.requires_current_sources:
+        lines.append("- Bat buoc dua tren nguon hien tai/nguon co moc thoi gian ro.")
+    if plan.axes:
+        lines.append(f"- Evidence axes: {_join_direct_hint_list(list(plan.axes), limit=4)}.")
+    if plan.source_plan:
+        lines.append(f"- Source plan: {_join_direct_hint_list(list(plan.source_plan), limit=3)}.")
+    if plan.source_policy:
+        lines.append(f"- Source policy: {_join_direct_hint_list(list(plan.source_policy), limit=3)}.")
+    if plan.family == "live_weather":
+        lines.extend(
+            [
+                "- Mo answer bang dia diem + tinh hinh thoi tiet hien tai truoc, roi moi den du bao/canh bao neu can.",
+                "- Neu dia diem user noi mo ho, noi ro dia diem dang duoc gia dinh thay vi gia vo user da chi ro.",
+            ]
+        )
+    elif plan.family in {"live_news_lookup", "live_current_lookup"}:
+        lines.extend(
+            [
+                "- Uu tien fact snapshot co moc ngay gio ro, roi moi them boi canh ngan.",
+                "- Neu nguon chua du chac de chot cung, noi muc do chac va diem con mo.",
+            ]
+        )
+    elif plan.family in {"live_market_price", "market_analysis"}:
+        lines.extend(
+            [
+                "- Neu gia/quote cac nguon lech nhau, tra khoang hoac noi ro nguon dang phan ky.",
+                "- Khong bien answer thanh market essay chung chung neu user dang hoi moc gia hien tai.",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _join_direct_hint_list(items: list[str], *, limit: int = 3) -> str:
+    chosen = [str(item or "").strip() for item in items if str(item or "").strip()][:limit]
+    if not chosen:
+        return ""
+    if len(chosen) == 1:
+        return chosen[0]
+    if len(chosen) == 2:
+        return f"{chosen[0]} va {chosen[1]}"
+    return ", ".join(chosen[:-1]) + f", va {chosen[-1]}"

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
@@ -19,6 +19,10 @@ from app.engine.multi_agent.direct_prompt_turn_contracts import (
 from app.engine.multi_agent.direct_prompt_tool_context import (
     _build_direct_tools_context as _build_direct_tools_context_impl,
 )
+from app.engine.multi_agent.direct_prompt_evidence import (
+    _build_live_evidence_planner_contract,
+    _join_direct_hint_list,
+)
 from app.engine.multi_agent.direct_prompt_selfhood import (
     _build_direct_selfhood_system_prompt,
     _identity_answer_contract_lines,
@@ -31,7 +35,6 @@ from app.engine.multi_agent.direct_intent import (
     _looks_identity_selfhood_turn,
     _normalize_for_intent,
 )
-from app.engine.multi_agent.direct_evidence_planner import build_direct_evidence_plan
 from app.engine.multi_agent.direct_reasoning import (
     _build_direct_analytical_axes,
     _build_direct_evidence_plan,
@@ -42,55 +45,6 @@ from app.engine.multi_agent.direct_reasoning import (
 from app.prompts.prompt_context_utils import build_response_language_instruction
 
 logger = logging.getLogger(__name__)
-
-
-def _build_live_evidence_planner_contract(query: str, state: AgentState) -> str:
-    plan = build_direct_evidence_plan(query, state, [])
-    if plan.family in {"none", "product_search_handoff"}:
-        return ""
-
-    lines = [
-        "## LIVE EVIDENCE PLANNER:",
-        f"- Query family: {plan.family}",
-        f"- Topic cluster: {plan.topic_cluster or 'general'}",
-        f"- Locality policy: {plan.locality}",
-        f"- Answer mode: {plan.answer_mode}",
-    ]
-    if plan.needs_time_anchor:
-        lines.append("- Bat buoc chot moc thoi gian hien tai truoc khi tong hop.")
-    if plan.requires_current_sources:
-        lines.append("- Bat buoc dua tren nguon hien tai/nguon co moc thoi gian ro.")
-    if plan.axes:
-        lines.append(f"- Evidence axes: {_join_direct_hint_list(list(plan.axes), limit=4)}.")
-    if plan.source_plan:
-        lines.append(f"- Source plan: {_join_direct_hint_list(list(plan.source_plan), limit=3)}.")
-    if plan.source_policy:
-        lines.append(f"- Source policy: {_join_direct_hint_list(list(plan.source_policy), limit=3)}.")
-    if plan.family == "live_weather":
-        lines.extend(
-            [
-                "- Mo answer bang dia diem + tinh hinh thoi tiet hien tai truoc, roi moi den du bao/canh bao neu can.",
-                "- Neu dia diem user noi mo ho, noi ro dia diem dang duoc gia dinh thay vi gia vo user da chi ro.",
-            ]
-        )
-    elif plan.family in {"live_news_lookup", "live_current_lookup"}:
-        lines.extend(
-            [
-                "- Uu tien fact snapshot co moc ngay gio ro, roi moi them boi canh ngan.",
-                "- Neu nguon chua du chac de chot cung, noi muc do chac va diem con mo.",
-            ]
-        )
-    elif plan.family in {"live_market_price", "market_analysis"}:
-        lines.extend(
-            [
-                "- Neu gia/quote cac nguon lech nhau, tra khoang hoac noi ro nguon dang phan ky.",
-                "- Khong bien answer thanh market essay chung chung neu user dang hoi moc gia hien tai.",
-            ]
-        )
-    return "\n".join(lines)
-
-
-
 
 
 def _build_direct_chatter_system_prompt(state: AgentState, role_name: str) -> str:
@@ -362,15 +316,6 @@ def _build_code_studio_delivery_contract(query: str) -> str:
     return "\n".join(lines)
 
 
-def _join_direct_hint_list(items: list[str], *, limit: int = 3) -> str:
-    chosen = [str(item or "").strip() for item in items if str(item or "").strip()][:limit]
-    if not chosen:
-        return ""
-    if len(chosen) == 1:
-        return chosen[0]
-    if len(chosen) == 2:
-        return f"{chosen[0]} va {chosen[1]}"
-    return ", ".join(chosen[:-1]) + f", va {chosen[-1]}"
 
 
 def _build_direct_analytical_answer_contract(query: str, state: AgentState) -> str:


### PR DESCRIPTION
## Summary
- Fixes #537.
- Moves live-evidence planner prompt text and hint-list formatting into `direct_prompt_evidence.py`.
- Keeps `direct_prompts.py` as the direct system-message assembly shell while preserving source-backed/live lookup guidance.
- Updates the runtime cleanup audit with the new boundary.

## Scope
In scope:
- Live-evidence prompt contract extraction.
- Runtime cleanup audit update.

Out of scope:
- Prompt text rewrites.
- Provider routing, web-search execution, tool execution, memory, LMS, frontend, deployment, or Code Studio behavior.

## Verification
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_direct_prompts_analytical_contract.py tests/unit/test_direct_prompts_identity_contract.py tests/unit/test_direct_prompts_turn_contract.py tests/unit/test_direct_codebase_thinking_quality.py -q --tb=short` -> `21 passed`
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_graph_routing.py -q --tb=short` -> `74 passed`
- `uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/direct_prompts.py app/engine/multi_agent/direct_prompt_evidence.py --select=E9,F63,F7,F401` -> `All checks passed!`
- `git diff --check` -> passed

## Risk / rollback
- Risk is low-to-moderate because live evidence guidance affects current/source-backed turns, but this is a mechanical extraction and keeps `_build_direct_system_messages` behavior intact.
- Rollback: revert this commit to restore the previous single-file prompt layout.

## Reviewer focus
- Confirm live-evidence prompt text was moved, not rewritten.
- Confirm analytical prompt code still imports the shared hint-list formatter.