### PR TITLE
refactor(backend): isolate document preview preflight

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -196,6 +196,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
 - Follow-up #537 moved live-evidence planner prompt text and hint-list
   formatting into `direct_prompt_evidence.py`, keeping current-source lookup
   guidance separate from the direct prompt assembly shell.
+- Follow-up #539 moved uploaded-document context plan recording, preview
+  response sanitization, and the early LMS document-preview preflight into
+  `direct_node_document_preflight.py`, keeping preview-before-planner safety
+  visible as a focused lifecycle helper.
 
 ## Preserved Intentionally
 
@@ -227,7 +231,7 @@ backups, data PDFs, or local skill folders.
   thinking-effort policy, emergency fallback/salvage helpers, uploaded-context
   guards, operational/meta/chatter fast-response selection, visible
   thought helpers, thinking snapshot side effects, document-preview
-  host-action rebinding/execution, direct-node tool selection, LLM preflight,
+  host-action rebinding/execution/preflight, direct-node tool selection, LLM preflight,
   execution preparation, response cleanup, visible-thinking finalization,
   exception/source fallback lifecycle, final state/domain notice handling, and
   host UI timeout handling have moved out. The long-term cleanup direction is

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_document_preflight.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_document_preflight.py
@@ -1,0 +1,134 @@
+"""Uploaded-document preflight helpers for the direct node."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from app.engine.multi_agent.direct_node_document_preview_rebind import (
+    _rebind_document_preview_host_action_tool,
+)
+from app.engine.multi_agent.direct_node_document_preview_runtime import (
+    execute_direct_node_document_preview_round,
+)
+from app.engine.multi_agent.direct_node_thinking_snapshot import (
+    record_direct_node_thinking_snapshot,
+)
+from app.engine.multi_agent.state import AgentState
+
+
+@dataclass(frozen=True)
+class DirectDocumentPreviewPreflightResult:
+    response: str
+    response_type: str = "document_preview_host_action"
+
+
+def build_document_preview_response_sanitizer(
+    *,
+    query: str,
+    sanitize_structured_visual_answer_text: Callable[..., str],
+    sanitize_wiii_house_text: Callable[..., str],
+    strip_direct_inline_private_asides: Callable[[str], str],
+    strip_dsml_residue: Callable[[str], str],
+) -> Callable[[str, list[dict[str, Any]]], str]:
+    def sanitize_document_preview_response(
+        preview_response: str,
+        preview_tool_call_events: list[dict[str, Any]],
+    ) -> str:
+        preview_response = sanitize_structured_visual_answer_text(
+            preview_response,
+            tool_call_events=preview_tool_call_events,
+        )
+        preview_response = sanitize_wiii_house_text(preview_response, query=query)
+        preview_response = strip_direct_inline_private_asides(preview_response)
+        return strip_dsml_residue(preview_response).strip()
+
+    return sanitize_document_preview_response
+
+
+def record_uploaded_document_context_plan(
+    *,
+    state: AgentState,
+    response_present: bool,
+    has_uploaded_document_context: bool,
+    document_thinking: str,
+    record_thinking_snapshot_fn,
+) -> None:
+    if (
+        response_present
+        or not has_uploaded_document_context
+        or str(state.get("thinking_content") or "").strip()
+    ):
+        return
+    record_direct_node_thinking_snapshot(
+        state=state,
+        thinking=document_thinking,
+        provenance="document_context_plan",
+        record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+    )
+
+
+async def execute_direct_node_document_preview_preflight(
+    *,
+    query: str,
+    state: AgentState,
+    ctx: dict[str, Any],
+    bus_id: str | None,
+    response_present: bool,
+    has_uploaded_document_context: bool,
+    looks_uploaded_document_preview_request: Callable[[str], bool],
+    push_event,
+    build_visual_tool_runtime_metadata,
+    execute_direct_tool_rounds,
+    extract_direct_response,
+    sanitize_preview_response,
+    fallback_response: str,
+    logger_obj,
+) -> DirectDocumentPreviewPreflightResult | None:
+    if (
+        response_present
+        or not has_uploaded_document_context
+        or not looks_uploaded_document_preview_request(query)
+    ):
+        return None
+
+    routing_meta = state.get("routing_metadata")
+    if not isinstance(routing_meta, dict):
+        routing_meta = {}
+        state["routing_metadata"] = routing_meta
+    preview_tools, preview_force_tools, doc_preview_debug = (
+        _rebind_document_preview_host_action_tool(
+            tools=[],
+            force_tools=False,
+            query=query,
+            state=state,
+            ctx=ctx,
+        )
+    )
+    routing_meta["doc_preview_preflight"] = doc_preview_debug
+    preview_result = await execute_direct_node_document_preview_round(
+        query=query,
+        state=state,
+        ctx=ctx,
+        bus_id=bus_id,
+        tools=preview_tools,
+        force_tools=preview_force_tools,
+        messages=[],
+        push_event=push_event,
+        build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
+        execute_direct_tool_rounds=execute_direct_tool_rounds,
+        extract_direct_response=extract_direct_response,
+        sanitize_preview_response=sanitize_preview_response,
+        fallback_response=fallback_response,
+        debug=doc_preview_debug,
+        routing_metadata_key="doc_preview_preflight",
+        success_status="executed",
+        failure_status="execution_failed",
+        failure_log_message="[DIRECT] Early document preview host action failed: %s",
+        logger_obj=logger_obj,
+    )
+    if preview_result is None:
+        return None
+
+    logger_obj.info("[DIRECT] Executed LMS document preview host action before planner LLM")
+    return DirectDocumentPreviewPreflightResult(response=preview_result.response)

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -13,6 +13,11 @@ from app.engine.multi_agent.document_preview_contract import (
 from app.engine.multi_agent.direct_node_document_preview_runtime import (
     execute_direct_node_document_preview_round,
 )
+from app.engine.multi_agent.direct_node_document_preflight import (
+    build_document_preview_response_sanitizer,
+    execute_direct_node_document_preview_preflight,
+    record_uploaded_document_context_plan,
+)
 from app.engine.multi_agent.direct_node_fast_response_runtime import (
     resolve_direct_node_fast_response,
 )
@@ -33,9 +38,6 @@ from app.engine.multi_agent.direct_node_response_cleanup import (
 )
 from app.engine.multi_agent.direct_node_visible_thinking_finalization import (
     finalize_direct_node_visible_thinking,
-)
-from app.engine.multi_agent.direct_node_document_preview_rebind import (
-    _rebind_document_preview_host_action_tool,
 )
 from app.engine.multi_agent.direct_intent import (
     _looks_emotional_support_turn,
@@ -170,83 +172,48 @@ async def direct_response_node_impl(
     ctx_for_preflight = state.get("context", {}) if isinstance(state.get("context"), dict) else {}
     has_uploaded_document_context = _has_uploaded_document_context(ctx_for_preflight)
 
-    def sanitize_document_preview_response(
-        preview_response: str,
-        preview_tool_call_events: list[dict[str, Any]],
-    ) -> str:
-        preview_response = sanitize_structured_visual_answer_text(
-            preview_response,
-            tool_call_events=preview_tool_call_events,
-        )
-        preview_response = sanitize_wiii_house_text(preview_response, query=query)
-        preview_response = _strip_direct_inline_private_asides(preview_response)
-        return _strip_dsml_residue(preview_response).strip()
+    sanitize_document_preview_response = build_document_preview_response_sanitizer(
+        query=query,
+        sanitize_structured_visual_answer_text=sanitize_structured_visual_answer_text,
+        sanitize_wiii_house_text=sanitize_wiii_house_text,
+        strip_direct_inline_private_asides=_strip_direct_inline_private_asides,
+        strip_dsml_residue=_strip_dsml_residue,
+    )
 
-    if (
-        not response
-        and has_uploaded_document_context
-        and not str(state.get("thinking_content") or "").strip()
-    ):
-        document_thinking = (
-            "Mình nhận đây là lượt hỏi có tài liệu upload đã được parse thành Markdown, "
-            "nên ưu tiên đối chiếu marker, bảng và các dòng trong document_context trước khi suy luận thêm. "
-            "Nếu phần nào không có trong file, Wiii phải nói rõ thay vì bịa."
-        )
-        record_direct_node_thinking_snapshot(
-            state=state,
-            thinking=document_thinking,
-            provenance="document_context_plan",
-            record_thinking_snapshot_fn=record_thinking_snapshot,
-        )
-    if (
-        not response
-        and has_uploaded_document_context
-        and _looks_uploaded_document_preview_request(query)
-    ):
-        routing_meta = state.get("routing_metadata")
-        if not isinstance(routing_meta, dict):
-            routing_meta = {}
-            state["routing_metadata"] = routing_meta
-        preview_tools, preview_force_tools, doc_preview_debug = (
-            _rebind_document_preview_host_action_tool(
-                tools=[],
-                force_tools=False,
-                query=query,
-                state=state,
-                ctx=ctx_for_preflight,
-            )
-        )
-        routing_meta["doc_preview_preflight"] = doc_preview_debug
-        preview_result = await execute_direct_node_document_preview_round(
-            query=query,
-            state=state,
-            ctx=ctx_for_preflight,
-            bus_id=bus_id,
-            tools=preview_tools,
-            force_tools=preview_force_tools,
-            messages=[],
-            push_event=push_event,
-            build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
-            execute_direct_tool_rounds=execute_direct_tool_rounds,
-            extract_direct_response=extract_direct_response,
-            sanitize_preview_response=sanitize_document_preview_response,
-            fallback_response=(
-                "Mình đã gửi bản preview bài học sang LMS. "
-                "Giáo viên cần xem phần so sánh thay đổi và nguồn trích dẫn rồi bấm Áp dụng để cấp approval_token."
-            ),
-            debug=doc_preview_debug,
-            routing_metadata_key="doc_preview_preflight",
-            success_status="executed",
-            failure_status="execution_failed",
-            failure_log_message="[DIRECT] Early document preview host action failed: %s",
-            logger_obj=logger,
-        )
-        if preview_result is not None:
-            response = preview_result.response
-            response_type = "document_preview_host_action"
-            logger.info(
-                "[DIRECT] Executed LMS document preview host action before planner LLM"
-            )
+    document_thinking = (
+        "Mình nhận đây là lượt hỏi có tài liệu upload đã được parse thành Markdown, "
+        "nên ưu tiên đối chiếu marker, bảng và các dòng trong document_context trước khi suy luận thêm. "
+        "Nếu phần nào không có trong file, Wiii phải nói rõ thay vì bịa."
+    )
+    record_uploaded_document_context_plan(
+        state=state,
+        response_present=bool(response),
+        has_uploaded_document_context=has_uploaded_document_context,
+        document_thinking=document_thinking,
+        record_thinking_snapshot_fn=record_thinking_snapshot,
+    )
+    document_preflight_result = await execute_direct_node_document_preview_preflight(
+        query=query,
+        state=state,
+        ctx=ctx_for_preflight,
+        bus_id=bus_id,
+        response_present=bool(response),
+        has_uploaded_document_context=has_uploaded_document_context,
+        looks_uploaded_document_preview_request=_looks_uploaded_document_preview_request,
+        push_event=push_event,
+        build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
+        execute_direct_tool_rounds=execute_direct_tool_rounds,
+        extract_direct_response=extract_direct_response,
+        sanitize_preview_response=sanitize_document_preview_response,
+        fallback_response=(
+            "Mình đã gửi bản preview bài học sang LMS. "
+            "Giáo viên cần xem phần so sánh thay đổi và nguồn trích dẫn rồi bấm Áp dụng để cấp approval_token."
+        ),
+        logger_obj=logger,
+    )
+    if document_preflight_result is not None:
+        response = document_preflight_result.response
+        response_type = document_preflight_result.response_type
     if ctx_for_preflight.get("image_input_error") and has_uploaded_document_context:
         ctx_for_preflight["images"] = []
     if (


### PR DESCRIPTION
## Summary
- Fixes #539.
- Moves uploaded-document context plan recording, preview-response sanitization, and the early LMS document-preview preflight into `direct_node_document_preflight.py`.
- Keeps preview-before-planner behavior intact so uploaded-document LMS draft flows still emit preview-only host actions before any planner LLM/tool collection path.
- Updates the runtime cleanup audit with the new boundary.

## Scope
In scope:
- Direct node uploaded-document preview preflight lifecycle extraction.
- Runtime cleanup audit update.

Out of scope:
- LMS mutation/apply behavior.
- Provider routing, general tool-loop execution, frontend, deployment, or Code Studio behavior.

## Verification
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_direct_node_document_preview_runtime.py tests/unit/test_direct_node_provider_errors.py -q --tb=short` -> `38 passed`
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_graph_routing.py tests/unit/test_runner_node_surface.py tests/unit/test_direct_identity_house_prompt_runtime.py -q --tb=short` -> `77 passed`
- `uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/direct_node_runtime.py app/engine/multi_agent/direct_node_document_preflight.py --select=E9,F63,F7,F401` -> `All checks passed!`
- `git diff --check` -> passed

## Risk / rollback
- Risk is moderate because the uploaded-document LMS preview preflight is a high-value safety surface. Mitigation: behavior is preserved, user-facing text stays in `direct_node_runtime.py`, and existing tests verify preflight before tool collection/planner LLM plus host-action metadata.
- Rollback: revert this commit to restore the previous single-file direct node preflight block.

## Reviewer focus
- Confirm the preflight still runs before tool collection/planner LLM for uploaded-document preview requests.
- Confirm this keeps preview-only host action behavior and does not introduce an apply/mutation path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Reorganized document preview preprocessing functionality into a dedicated module with improved response handling and sanitization workflows.

* **Documentation**
  * Updated operations audit documentation with additional follow-up items and refactored component descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->