### PR TITLE
refactor(backend): isolate direct image input preflight

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -200,6 +200,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   response sanitization, and the early LMS document-preview preflight into
   `direct_node_document_preflight.py`, keeping preview-before-planner safety
   visible as a focused lifecycle helper.
+- Follow-up #541 moved direct-node image-input preflight into
+  `direct_node_image_input_preflight.py`, keeping uploaded-document image-error
+  cleanup, vision-unavailable fallback, and base64 image analysis ahead of the
+  planner LLM.
 
 ## Preserved Intentionally
 
@@ -231,8 +235,9 @@ backups, data PDFs, or local skill folders.
   thinking-effort policy, emergency fallback/salvage helpers, uploaded-context
   guards, operational/meta/chatter fast-response selection, visible
   thought helpers, thinking snapshot side effects, document-preview
-  host-action rebinding/execution/preflight, direct-node tool selection, LLM preflight,
-  execution preparation, response cleanup, visible-thinking finalization,
+  host-action rebinding/execution/preflight, image-input preflight,
+  direct-node tool selection, LLM preflight, execution preparation, response cleanup,
+  visible-thinking finalization,
   exception/source fallback lifecycle, final state/domain notice handling, and
   host UI timeout handling have moved out. The long-term cleanup direction is
   lifecycle modules and SSE V3 parity modules with narrow contract tests. Its

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_image_input_preflight.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_image_input_preflight.py
@@ -1,0 +1,71 @@
+"""Direct-node deterministic image-input preflight."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from app.engine.multi_agent.direct_node_operational_fast_paths import (
+    _build_image_input_thinking,
+    _build_image_input_unavailable_answer,
+    _build_image_input_unavailable_thinking,
+)
+from app.engine.multi_agent.direct_node_thinking_snapshot import (
+    record_direct_node_thinking_snapshot,
+)
+from app.engine.multi_agent.direct_node_uploaded_context import _build_image_input_answer
+from app.engine.multi_agent.state import AgentState
+
+
+@dataclass(frozen=True)
+class DirectImageInputPreflightResult:
+    response: str
+    response_type: str
+
+
+async def execute_direct_node_image_input_preflight(
+    *,
+    query: str,
+    state: AgentState,
+    ctx: dict[str, Any],
+    response_present: bool,
+    has_uploaded_document_context: bool,
+    record_thinking_snapshot_fn: Callable[..., Any],
+) -> DirectImageInputPreflightResult | None:
+    """Resolve image-input turns before the direct node falls through to an LLM."""
+
+    if ctx.get("image_input_error") and has_uploaded_document_context:
+        ctx["images"] = []
+    if response_present:
+        return None
+
+    if ctx.get("image_input_error") and not has_uploaded_document_context:
+        fast_thinking = _build_image_input_unavailable_thinking()
+        record_direct_node_thinking_snapshot(
+            state=state,
+            thinking=fast_thinking,
+            provenance="deterministic_image_input_unavailable",
+            record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+        )
+        return DirectImageInputPreflightResult(
+            response=_build_image_input_unavailable_answer(query),
+            response_type="image_input_unavailable",
+        )
+
+    if ctx.get("images") and not has_uploaded_document_context:
+        fast_thinking = _build_image_input_thinking(query)
+        record_direct_node_thinking_snapshot(
+            state=state,
+            thinking=fast_thinking,
+            provenance="deterministic_image_input",
+            record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+        )
+        return DirectImageInputPreflightResult(
+            response=await _build_image_input_answer(
+                query,
+                list(ctx.get("images") or []),
+            ),
+            response_type="image_input",
+        )
+
+    return None

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -24,6 +24,9 @@ from app.engine.multi_agent.direct_node_fast_response_runtime import (
 from app.engine.multi_agent.direct_node_host_timeout import (
     run_direct_node_execution_with_host_timeout,
 )
+from app.engine.multi_agent.direct_node_image_input_preflight import (
+    execute_direct_node_image_input_preflight,
+)
 from app.engine.multi_agent.direct_node_execution_prep import (
     prepare_direct_node_tool_execution,
 )
@@ -56,9 +59,6 @@ from app.engine.multi_agent.direct_node_final_state import finalize_direct_node_
 from app.engine.multi_agent.direct_node_operational_fast_paths import (
     _build_codebase_analysis_fallback_answer,
     _build_codebase_analysis_fallback_thinking,
-    _build_image_input_thinking,
-    _build_image_input_unavailable_answer,
-    _build_image_input_unavailable_thinking,
     _is_explicit_web_search_turn_for_direct,
     _looks_generic_direct_fallback_response,
     _should_use_codebase_source_note_fast_answer,
@@ -72,7 +72,6 @@ from app.engine.multi_agent.direct_node_thinking_snapshot import (
 )
 from app.engine.multi_agent.direct_node_tool_selection import select_direct_node_tools
 from app.engine.multi_agent.direct_node_uploaded_context import (
-    _build_image_input_answer,
     _build_uploaded_document_context_fallback_answer,
     _build_uploaded_document_visual_guard_answer,
     _looks_uploaded_document_preview_request,
@@ -214,35 +213,18 @@ async def direct_response_node_impl(
     if document_preflight_result is not None:
         response = document_preflight_result.response
         response_type = document_preflight_result.response_type
-    if ctx_for_preflight.get("image_input_error") and has_uploaded_document_context:
-        ctx_for_preflight["images"] = []
-    if (
-        not response
-        and ctx_for_preflight.get("image_input_error")
-        and not has_uploaded_document_context
-    ):
-        response = _build_image_input_unavailable_answer(query)
-        response_type = "image_input_unavailable"
-        fast_thinking = _build_image_input_unavailable_thinking()
-        record_direct_node_thinking_snapshot(
-            state=state,
-            thinking=fast_thinking,
-            provenance="deterministic_image_input_unavailable",
-            record_thinking_snapshot_fn=record_thinking_snapshot,
-        )
-    elif not response and ctx_for_preflight.get("images") and not has_uploaded_document_context:
-        response = await _build_image_input_answer(
-            query,
-            list(ctx_for_preflight.get("images") or []),
-        )
-        response_type = "image_input"
-        fast_thinking = _build_image_input_thinking(query)
-        record_direct_node_thinking_snapshot(
-            state=state,
-            thinking=fast_thinking,
-            provenance="deterministic_image_input",
-            record_thinking_snapshot_fn=record_thinking_snapshot,
-        )
+
+    image_preflight_result = await execute_direct_node_image_input_preflight(
+        query=query,
+        state=state,
+        ctx=ctx_for_preflight,
+        response_present=bool(response),
+        has_uploaded_document_context=has_uploaded_document_context,
+        record_thinking_snapshot_fn=record_thinking_snapshot,
+    )
+    if image_preflight_result is not None:
+        response = image_preflight_result.response
+        response_type = image_preflight_result.response_type
 
     if not response:
         fast_response = resolve_direct_node_fast_response(

--- a/maritime-ai-service/tests/unit/test_direct_node_image_input_preflight.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_image_input_preflight.py
@@ -1,0 +1,79 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_image_preflight_clears_images_when_document_context_owns_turn():
+    from app.engine.multi_agent.direct_node_image_input_preflight import (
+        execute_direct_node_image_input_preflight,
+    )
+
+    ctx = {
+        "image_input_error": "vision_disabled",
+        "images": [{"data": "ignored"}],
+    }
+
+    result = await execute_direct_node_image_input_preflight(
+        query="tao bai giang tu file vua upload",
+        state={},
+        ctx=ctx,
+        response_present=False,
+        has_uploaded_document_context=True,
+        record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
+    )
+
+    assert result is None
+    assert ctx["images"] == []
+
+
+@pytest.mark.asyncio
+async def test_image_preflight_returns_vision_unavailable_without_llm():
+    from app.engine.multi_agent.direct_node_image_input_preflight import (
+        execute_direct_node_image_input_preflight,
+    )
+
+    snapshots = []
+    state = {}
+
+    result = await execute_direct_node_image_input_preflight(
+        query="Nhin anh nay va mo ta giup minh",
+        state=state,
+        ctx={"image_input_error": "vision_disabled"},
+        response_present=False,
+        has_uploaded_document_context=False,
+        record_thinking_snapshot_fn=lambda *args, **kwargs: snapshots.append(
+            (args, kwargs)
+        ),
+    )
+
+    assert result is not None
+    assert result.response_type == "image_input_unavailable"
+    assert "vision" in result.response.lower()
+    assert state["thinking_content"]
+    assert snapshots[0][1]["provenance"] == "deterministic_image_input_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_image_preflight_analyzes_base64_images_before_llm(monkeypatch):
+    from app.engine.multi_agent import direct_node_image_input_preflight as module
+
+    async def fake_build_image_input_answer(query, images):
+        assert query == "Nhin anh nay"
+        assert images == [{"type": "base64", "data": "abc"}]
+        return "Anh co mot vung chu thich mau xanh."
+
+    monkeypatch.setattr(module, "_build_image_input_answer", fake_build_image_input_answer)
+
+    state = {}
+    result = await module.execute_direct_node_image_input_preflight(
+        query="Nhin anh nay",
+        state=state,
+        ctx={"images": [{"type": "base64", "data": "abc"}]},
+        response_present=False,
+        has_uploaded_document_context=False,
+        record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
+    )
+
+    assert result is not None
+    assert result.response == "Anh co mot vung chu thich mau xanh."
+    assert result.response_type == "image_input"
+    assert state["thinking_content"]


### PR DESCRIPTION
## Summary
- Extract deterministic direct-node image-input preflight into direct_node_image_input_preflight.py.
- Preserve uploaded-document image-error cleanup, vision-unavailable response, and base64 image analysis before planner LLM/tool collection.
- Add focused preflight tests and update the runtime cleanup audit.

Closes #541.

## Verification
- uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_direct_node_image_input_preflight.py tests/unit/test_direct_node_provider_errors.py tests/unit/test_conservative_evolution.py -q --tb=short -> 98 passed
- uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/direct_node_runtime.py app/engine/multi_agent/direct_node_image_input_preflight.py --select=E9,F63,F7,F401 -> All checks passed!
- git diff --check -> passed

## Risk
Moderate. Image-upload turns are safety-sensitive because a vision-disabled request must not fall through to RAG or generic chat, and uploaded-document context must continue to own its preview/document lane.

## Rollback
Revert this squash commit to restore the previous inline image-input block in direct_node_runtime.py.