### PR TITLE
refactor(backend): isolate document host-action shortcuts

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -204,6 +204,9 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   `direct_node_image_input_preflight.py`, keeping uploaded-document image-error
   cleanup, vision-unavailable fallback, and base64 image analysis ahead of the
   planner LLM.
+- Follow-up #543 moved uploaded-document LMS host-action shortcut contracts
+  into `direct_document_host_action_shortcuts.py`, keeping preview/course
+  approval-token safety text out of the direct tool-loop shell.
 
 ## Preserved Intentionally
 
@@ -254,7 +257,7 @@ backups, data PDFs, or local skill folders.
   uploaded-document preview/course payload shell, uploaded-document course
   analysis/generic planning, uploaded-document text shaping, document source
   refs, domain-specific course plan builder modules, visual-turn policy,
-  graph/runtime binding resolution, per-turn provider policy, message
+  document host-action shortcut contracts, graph/runtime binding resolution, per-turn provider policy, message
   builders, generic tool dispatch, final synthesis helper construction, final
   synthesis execution, post-tool convergence policy, follow-up LLM
   selection/invocation, response finalization, post-tool search-template

--- a/maritime-ai-service/app/engine/multi_agent/direct_document_host_action_shortcuts.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_document_host_action_shortcuts.py
@@ -1,0 +1,50 @@
+"""Uploaded-document LMS host-action shortcut contracts."""
+
+from __future__ import annotations
+
+from app.engine.multi_agent.document_preview_contract import (
+    DOC_COURSE_HOST_ACTION_TOOL,
+    DOC_PREVIEW_HOST_ACTION_TOOL,
+)
+from app.engine.multi_agent.direct_document_host_action_runtime import (
+    DocumentHostActionShortcut,
+)
+
+
+DOC_COURSE_HOST_ACTION_SHORTCUT = DocumentHostActionShortcut(
+    tool_name=DOC_COURSE_HOST_ACTION_TOOL,
+    tool_call_id="forced_doc_course_preview_0",
+    thinking=(
+        "Mình nhận đây là flow tạo cấu trúc khóa học từ tài liệu upload. "
+        "Vì thao tác này có thể sinh nhiều chương/bài trong LMS, mình dựng "
+        "course_plan có nguồn trích dẫn trước và chỉ gửi host action preview; LMS sẽ "
+        "yêu cầu giáo viên bấm Áp dụng để cấp approval_token trước khi ghi dữ liệu."
+    ),
+    thinking_summary="Tạo cây khóa học từ tài liệu",
+    thinking_provenance="deterministic_document_course_host_action",
+    response=(
+        "Mình đã gửi bản thiết kế khóa học từ tài liệu sang LMS. "
+        "Bạn xem cây chương/bài và nguồn trích dẫn trong hộp xem trước, rồi chỉ bấm Áp dụng "
+        "nếu muốn LMS tạo các chương/bài draft tương ứng."
+    ),
+    failure_log_message="[DIRECT] Deterministic document course host action failed: %s",
+)
+
+DOC_PREVIEW_HOST_ACTION_SHORTCUT = DocumentHostActionShortcut(
+    tool_name=DOC_PREVIEW_HOST_ACTION_TOOL,
+    tool_call_id="forced_doc_preview_0",
+    thinking=(
+        "Mình nhận đây là flow upload tài liệu -> tạo preview bài học. "
+        "Vì đây là đường ghi LMS có ràng buộc an toàn, mình không chờ model tự gọi tool; "
+        "mình dựng payload preview từ document_context và gửi host action preview-only "
+        "để LMS mở phần so sánh thay đổi và nguồn trích dẫn trước."
+    ),
+    thinking_summary="Tạo preview bài học từ tài liệu",
+    thinking_provenance="deterministic_document_preview_host_action",
+    response=(
+        "Mình đã gửi bản preview từ tài liệu sang LMS. "
+        "Bạn kiểm tra phần so sánh thay đổi và nguồn trích dẫn trong hộp xem trước, "
+        "rồi chỉ bấm Áp dụng nếu nội dung đúng."
+    ),
+    failure_log_message="[DIRECT] Deterministic document preview host action failed: %s",
+)

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py
@@ -8,8 +8,6 @@ from typing import Optional
 
 from app.core.config import settings
 from app.engine.multi_agent.document_preview_contract import (
-    DOC_COURSE_HOST_ACTION_TOOL as _DOC_COURSE_HOST_ACTION_TOOL,
-    DOC_PREVIEW_HOST_ACTION_TOOL as _DOC_PREVIEW_HOST_ACTION_TOOL,
     uploaded_document_attachments_from_state as _uploaded_document_attachments_from_state,
 )
 from app.engine.multi_agent.direct_opening_runtime import (
@@ -57,8 +55,11 @@ from app.engine.multi_agent.direct_visual_tool_policy_runtime import (
     build_direct_visual_tool_policy,
 )
 from app.engine.multi_agent.direct_document_host_action_runtime import (
-    DocumentHostActionShortcut,
     execute_requested_document_host_action_shortcut,
+)
+from app.engine.multi_agent.direct_document_host_action_shortcuts import (
+    DOC_COURSE_HOST_ACTION_SHORTCUT,
+    DOC_PREVIEW_HOST_ACTION_SHORTCUT,
 )
 from app.engine.multi_agent.direct_document_preview_payloads import (
     _find_doc_preview_host_action_tool,
@@ -86,42 +87,6 @@ from app.engine.multi_agent.visual_events import (
 )
 
 logger = logging.getLogger(__name__)
-
-_DOC_COURSE_HOST_ACTION_SHORTCUT = DocumentHostActionShortcut(
-    tool_name=_DOC_COURSE_HOST_ACTION_TOOL,
-    tool_call_id="forced_doc_course_preview_0",
-    thinking=(
-        "Mình nhận đây là flow tạo cấu trúc khóa học từ tài liệu upload. "
-        "Vì thao tác này có thể sinh nhiều chương/bài trong LMS, mình dựng "
-        "course_plan có nguồn trích dẫn trước và chỉ gửi host action preview; LMS sẽ "
-        "yêu cầu giáo viên bấm Áp dụng để cấp approval_token trước khi ghi dữ liệu."
-    ),
-    thinking_summary="Tạo cây khóa học từ tài liệu",
-    thinking_provenance="deterministic_document_course_host_action",
-    response=(
-        "Mình đã gửi bản thiết kế khóa học từ tài liệu sang LMS. "
-        "Bạn xem cây chương/bài và nguồn trích dẫn trong hộp xem trước, rồi chỉ bấm Áp dụng "
-        "nếu muốn LMS tạo các chương/bài draft tương ứng."
-    ),
-    failure_log_message="[DIRECT] Deterministic document course host action failed: %s",
-)
-
-_DOC_PREVIEW_HOST_ACTION_SHORTCUT = DocumentHostActionShortcut(
-    tool_name=_DOC_PREVIEW_HOST_ACTION_TOOL,
-    tool_call_id="forced_doc_preview_0",
-    thinking=(
-        "Mình nhận đây là flow upload tài liệu -> tạo preview bài học. "
-        "Vì đây là đường ghi LMS có ràng buộc an toàn, mình không chờ model tự gọi tool; "
-        "mình dựng payload preview từ document_context và gửi host action preview-only để LMS mở phần so sánh thay đổi và nguồn trích dẫn trước."
-    ),
-    thinking_summary="Tao preview bai hoc tu tai lieu",
-    thinking_provenance="deterministic_document_preview_host_action",
-    response=(
-        "Mình đã gửi bản preview từ tài liệu sang LMS. "
-        "Bạn kiểm tra phần so sánh thay đổi và nguồn trích dẫn trong hộp xem trước, rồi chỉ bấm Áp dụng nếu nội dung đúng."
-    ),
-    failure_log_message="[DIRECT] Deterministic document preview host action failed: %s",
-)
 
 async def execute_direct_tool_rounds_impl(
     llm_with_tools,
@@ -240,11 +205,11 @@ async def execute_direct_tool_rounds_impl(
             should_request_course_preview=_should_request_uploaded_doc_course_preview,
             find_course_host_action_tool=_find_doc_course_host_action_tool,
             build_course_params=_build_uploaded_doc_course_params,
-            course_shortcut=_DOC_COURSE_HOST_ACTION_SHORTCUT,
+            course_shortcut=DOC_COURSE_HOST_ACTION_SHORTCUT,
             should_request_lesson_preview=_should_request_uploaded_doc_preview,
             find_lesson_host_action_tool=_find_doc_preview_host_action_tool,
             build_lesson_params=_build_uploaded_doc_preview_params,
-            lesson_shortcut=_DOC_PREVIEW_HOST_ACTION_SHORTCUT,
+            lesson_shortcut=DOC_PREVIEW_HOST_ACTION_SHORTCUT,
             build_assistant_message=_build_assistant_message,
             uploaded_document_attachments_from_state=_uploaded_document_attachments_from_state,
             logger_obj=logger,


### PR DESCRIPTION
## Summary
- Extract uploaded-document LMS preview/course shortcut contracts into direct_document_host_action_shortcuts.py.
- Keep direct tool-loop dispatch and document host-action execution behavior unchanged.
- Update the runtime cleanup audit for the next cleanup slice.

Closes #543.

## Verification
- uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short -> 81 passed
- uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/direct_tool_rounds_runtime.py app/engine/multi_agent/direct_document_host_action_shortcuts.py --select=E9,F63,F7,F401 -> All checks passed!
- git diff --check -> passed

## Risk
Low-to-moderate. This is intended as pure relocation, but the moved constants are LMS-sensitive preview-only / approval-token contract text.

## Rollback
Revert this squash commit to restore the shortcut constants inside direct_tool_rounds_runtime.py.