### PR TITLE
refactor(backend): isolate code studio delivery prompt

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -207,6 +207,9 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
 - Follow-up #543 moved uploaded-document LMS host-action shortcut contracts
   into `direct_document_host_action_shortcuts.py`, keeping preview/course
   approval-token safety text out of the direct tool-loop shell.
+- Follow-up #545 moved the Code Studio delivery-first answer contract into
+  `direct_prompt_code_studio.py`, keeping artifact/code delivery UX rules out
+  of the general direct prompt assembly shell.
 
 ## Preserved Intentionally
 
@@ -250,8 +253,8 @@ backups, data PDFs, or local skill folders.
   skill directives, Pointy inventory prompt injection, the direct turn contract,
   provider-aware tool binding, tool-context prompt builders, selfhood/origin
   prompt contracts, visible-thinking prompt guidance, and live-evidence prompt
-  contracts now live in focused helper modules, and consumers import those
-  helper contracts directly.
+  contracts, and Code Studio delivery prompt rules now live in focused helper
+  modules, and consumers import those helper contracts directly.
 - `direct_tool_rounds_runtime.py` is now a smaller orchestration shell. Pointy,
   explicit web-search policy, deterministic document host-action execution,
   uploaded-document preview/course payload shell, uploaded-document course

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompt_code_studio.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompt_code_studio.py
@@ -1,0 +1,37 @@
+"""Prompt contracts for Code Studio delivery turns."""
+
+from __future__ import annotations
+
+from app.engine.multi_agent.direct_intent import _normalize_for_intent
+
+
+def _build_code_studio_delivery_contract(query: str) -> str:
+    """Role-local answer contract for delivery-first technical responses."""
+
+    normalized = _normalize_for_intent(query)
+    is_chart_request = any(
+        token in normalized
+        for token in ("bieu do", "chart", "plot", "matplotlib", "seaborn", "png", "svg")
+    )
+    is_html_request = any(
+        token in normalized
+        for token in ("html", "landing page", "website", "web app", "microsite", "trang web")
+    )
+
+    lines = [
+        "## CODE STUDIO DELIVERY CONTRACT:",
+        "- Voi tac vu ky thuat, mo dau answer bang ket qua da tao hoac da xac nhan. Khong mo dau bang loi chao, tu gioi thieu, hay small talk.",
+        "- Khi vua tao artifact, neu ro ten file, loai san pham, va dieu nguoi dung co the mo ra ngay luc nay.",
+        "- Neu yeu cau chua du du lieu cu the, tao mot demo trung tinh phu hop voi task va noi ro do la demo. Khong bien no thanh lore ca nhan cua Wiii.",
+        "- Khong dua nhan vat phu, thu cung ao, catchphrase, hay chi tiet de thuong khong lien quan vao output ky thuat neu user khong yeu cau.",
+        "- Uu tien 3 phan theo thu tu: da tao gi, no dung de lam gi, nguoi dung co the lam gi tiep theo.",
+    ]
+    if is_chart_request:
+        lines.append(
+            "- Voi yeu cau bieu do/chart mo ho, uu tien tao mot chart demo trung tinh va giao lai file PNG that (neu co sandbox), hoac Mermaid SVG khi khong co sandbox."
+        )
+    if is_html_request:
+        lines.append(
+            "- Voi yeu cau landing page/HTML, tao file HTML that va mo ta ro nhung gi nguoi dung co the xem/mo ngay."
+        )
+    return "\n".join(lines)

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
@@ -23,6 +23,9 @@ from app.engine.multi_agent.direct_prompt_evidence import (
     _build_live_evidence_planner_contract,
     _join_direct_hint_list,
 )
+from app.engine.multi_agent.direct_prompt_code_studio import (
+    _build_code_studio_delivery_contract,
+)
 from app.engine.multi_agent.direct_prompt_selfhood import (
     _build_direct_selfhood_system_prompt,
     _identity_answer_contract_lines,
@@ -33,7 +36,6 @@ from app.engine.multi_agent.direct_prompt_visible_thinking import (
 )
 from app.engine.multi_agent.direct_intent import (
     _looks_identity_selfhood_turn,
-    _normalize_for_intent,
 )
 from app.engine.multi_agent.direct_reasoning import (
     _build_direct_analytical_axes,
@@ -283,39 +285,6 @@ def _build_direct_analytical_system_prompt(
         sections.append(tools_context.strip())
 
     return "\n\n".join(section for section in sections if section.strip())
-
-
-def _build_code_studio_delivery_contract(query: str) -> str:
-    """Role-local answer contract for delivery-first technical responses."""
-    normalized = _normalize_for_intent(query)
-    is_chart_request = any(
-        token in normalized
-        for token in ("bieu do", "chart", "plot", "matplotlib", "seaborn", "png", "svg")
-    )
-    is_html_request = any(
-        token in normalized
-        for token in ("html", "landing page", "website", "web app", "microsite", "trang web")
-    )
-
-    lines = [
-        "## CODE STUDIO DELIVERY CONTRACT:",
-        "- Voi tac vu ky thuat, mo dau answer bang ket qua da tao hoac da xac nhan. Khong mo dau bang loi chao, tu gioi thieu, hay small talk.",
-        "- Khi vua tao artifact, neu ro ten file, loai san pham, va dieu nguoi dung co the mo ra ngay luc nay.",
-        "- Neu yeu cau chua du du lieu cu the, tao mot demo trung tinh phu hop voi task va noi ro do la demo. Khong bien no thanh lore ca nhan cua Wiii.",
-        "- Khong dua nhan vat phu, thu cung ao, catchphrase, hay chi tiet de thuong khong lien quan vao output ky thuat neu user khong yeu cau.",
-        "- Uu tien 3 phan theo thu tu: da tao gi, no dung de lam gi, nguoi dung co the lam gi tiep theo.",
-    ]
-    if is_chart_request:
-        lines.append(
-            "- Voi yeu cau bieu do/chart mo ho, uu tien tao mot chart demo trung tinh va giao lai file PNG that (neu co sandbox), hoac Mermaid SVG khi khong co sandbox."
-        )
-    if is_html_request:
-        lines.append(
-            "- Voi yeu cau landing page/HTML, tao file HTML that va mo ta ro nhung gi nguoi dung co the xem/mo ngay."
-        )
-    return "\n".join(lines)
-
-
 
 
 def _build_direct_analytical_answer_contract(query: str, state: AgentState) -> str:


### PR DESCRIPTION
## Summary
- Move the Code Studio delivery-first answer contract into direct_prompt_code_studio.py.
- Preserve the direct_prompts compatibility import surface used by graph/runtime bindings.
- Update the runtime cleanup audit.

Closes #545.

## Verification
- uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_sprint154_tech_debt.py tests/unit/test_sprint174_cross_platform.py tests/unit/test_direct_prompts_turn_contract.py tests/unit/test_direct_prompts_identity_contract.py tests/unit/test_direct_prompts_analytical_contract.py -q --tb=short -> 140 passed
- uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/direct_prompts.py app/engine/multi_agent/direct_prompt_code_studio.py --select=E9,F63,F7,F401 -> All checks passed!
- git diff --check -> passed

## Risk
Low. This is intended as pure relocation, but the prompt affects Code Studio delivery wording and artifact/code UX.

## Rollback
Revert this squash commit to restore _build_code_studio_delivery_contract inside direct_prompts.py.