### PR TITLE
refactor(backend): isolate analytical answer prompt

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -210,6 +210,9 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
 - Follow-up #545 moved the Code Studio delivery-first answer contract into
   `direct_prompt_code_studio.py`, keeping artifact/code delivery UX rules out
   of the general direct prompt assembly shell.
+- Follow-up #547 moved the late analytical answer contract into
+  `direct_prompt_analytical_answer.py`, keeping market/math/codebase answer
+  style rules separate from direct system prompt assembly.
 
 ## Preserved Intentionally
 
@@ -253,8 +256,9 @@ backups, data PDFs, or local skill folders.
   skill directives, Pointy inventory prompt injection, the direct turn contract,
   provider-aware tool binding, tool-context prompt builders, selfhood/origin
   prompt contracts, visible-thinking prompt guidance, and live-evidence prompt
-  contracts, and Code Studio delivery prompt rules now live in focused helper
-  modules, and consumers import those helper contracts directly.
+  contracts, Code Studio delivery prompt rules, and analytical answer contracts
+  now live in focused helper modules, and consumers import those helper
+  contracts directly.
 - `direct_tool_rounds_runtime.py` is now a smaller orchestration shell. Pointy,
   explicit web-search policy, deterministic document host-action execution,
   uploaded-document preview/course payload shell, uploaded-document course

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompt_analytical_answer.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompt_analytical_answer.py
@@ -1,0 +1,122 @@
+"""Late answer contracts for analytical direct turns."""
+
+from __future__ import annotations
+
+from app.engine.multi_agent.direct_prompt_evidence import _join_direct_hint_list
+from app.engine.multi_agent.direct_reasoning import (
+    _build_direct_analytical_axes,
+    _build_direct_evidence_plan,
+    _infer_direct_thinking_mode,
+    _is_temporal_market_query,
+    _should_default_market_to_vietnam,
+)
+from app.engine.multi_agent.state import AgentState
+
+
+def _build_direct_analytical_answer_contract(query: str, state: AgentState) -> str:
+    """Role-local answer contract for analytical direct turns.
+
+    This is appended late so it can override the warmer house voice when the
+    user is clearly asking for analysis rather than companionship or small talk.
+    """
+    thinking_mode = _infer_direct_thinking_mode(query, state, [])
+    if thinking_mode not in {
+        "analytical_market",
+        "analytical_math",
+        "analytical_codebase",
+        "analytical_general",
+    }:
+        return ""
+
+    axes = _build_direct_analytical_axes(query, state, [])
+    plan = _build_direct_evidence_plan(query, state, [])
+    axes_text = _join_direct_hint_list(axes, limit=3)
+    plan_text = _join_direct_hint_list(plan, limit=2)
+    is_live_market = _is_temporal_market_query(query)
+    default_vietnam_market = _should_default_market_to_vietnam(query, state)
+
+    lines = [
+        "## ANALYTICAL RESPONSE CONTRACT:",
+        "- Day la turn phan tich. Khong mo dau bang loi chao, tu gioi thieu, kaomoji, small talk, hay loi khen user kien tri.",
+        "- Khong mo dau bang quan he hoa kieu 'minh thay ban...', 'minh rat muon dong hanh...', hay 'cam on ban da hoi'. Di thang vao van de.",
+        "- Khong xin loi dai dong vi thieu du lieu thoi gian thuc neu da co ket qua tool hoac da co khung phan tich du de tra loi.",
+        "- Neu can neu gioi han du lieu, chi noi gon trong 1 cau roi quay lai phan tich ngay.",
+        "- Mo dau bang nhan dinh, khung van de, hoac buc tranh hien tai. Khong mo dau bang cam than, emo, hay tu than mat.",
+        "- Khi da co tool result, hay rut ra tin hieu chinh tu du lieu do. Khong chi liet ke nguon va khong bien answer thanh ban tin tong hop.",
+        "- Mac dinh mo dau bang 1 cau thesis co the kiem cheo duoc, sau do moi giai thich can nang cua tung truc.",
+        "- Mac dinh uu tien 2-4 doan dac. Chi dung bullet ngan neu user can checklist, watchlist, hoac can tach cac bien so rieng. Khong tu dong bien answer thanh bai viet dai co heading Markdown neu user chi hoi phan tich.",
+        "- Mac dinh KHONG dung heading Markdown nhu #, ##, ### trong answer analytical tru khi user xin ro rang mot bao cao/co cau truc tai lieu.",
+        "- Mac dinh KHONG dung danh sach dam/net bold nhu mot ban tom tat tin tuc neu user khong yeu cau.",
+        "- Ket answer bang takeaway hoac dieu can theo doi tiep theo. Khong hoi nguoc theo kieu small talk neu user chua can.",
+    ]
+
+    if thinking_mode == "analytical_market":
+        lines.extend(
+            [
+                "- Khung uu tien: buc tranh hien tai -> cac luc keo chinh -> takeaway/what to watch.",
+                "- Neu cac tin hieu xung nhau, noi ro truc nao dang giu mat bang gia va truc nao chi tao nhieu ngan han.",
+                "- Neu user dang hoi gia dau/gia xang dau hien tai, mo answer bang moc gia truoc; khong mo bang background chung.",
+                (
+                    "- Mac dinh goc nhin Viet Nam: neu user khong gioi han ro chi muon the gioi/Brent/WTI thi uu tien gia xang dau dang ap dung o Viet Nam truoc, sau do moi neo Brent/WTI va luc quoc te."
+                    if default_vietnam_market
+                    else "- Uu tien moc Brent/WTI hien tai truoc, roi moi giai thich luc quoc te dang giu nhip gia."
+                ),
+                (
+                    "- Van phai giu rieng mot truc quoc te dang dan nhip hom nay (vi du Hormuz/My-Iran/OPEC+) thay vi chi lap lai nen cung-cau."
+                    if is_live_market
+                    else "- Neu co bien dong vua xay ra, hay tach no thanh mot truc rieng thay vi de no tan vao nen chung."
+                ),
+                "- Neu cac nguon gia dang phan ky manh hoac cho ra thu tu bat thuong giua Brent va WTI, khong chot mot con so don le; noi ro nguon dang mau thuan va chi giu khoang hoac moc gan dung.",
+                "- Neu chi thay tieu de thong bao dieu chinh gia ma khong co bang gia chi tiet, chi noi da thay moc dieu chinh ngay nao; khong suy dien ra gia tung mat hang.",
+                "- Neu mot truc gia/nguon chua keo duoc, noi ro truc nao chua co thay vi thay no bang mot bai market essay chung chung.",
+                (
+                    f"- Uu tien tach rieng {axes_text}."
+                    if axes_text
+                    else "- Uu tien tach rieng cung, cau, va nhieu dia chinh tri thay vi gom vao mot nhan tang/giam."
+                ),
+                (
+                    f"- Neu can kiem cheo, hay dua tren {plan_text}."
+                    if plan_text
+                    else "- Neu can kiem cheo, hay phan biet dau hieu cung-cau that voi phan nhieu do tin tuc."
+                ),
+            ]
+        )
+    elif thinking_mode == "analytical_math":
+        lines.extend(
+            [
+                "- Khung uu tien: mo hinh va gia dinh -> phuong trinh/derivation -> y nghia vat ly.",
+                "- Neu ket luan phu thuoc gan dung, noi ro pham vi ma gan dung do con hop le.",
+                (
+                    f"- Truoc khi ket luan, phai chot ro {axes_text}."
+                    if axes_text
+                    else "- Truoc khi ket luan, phai chot ro mo hinh, gia dinh goc nho, va phuong trinh."
+                ),
+                "- Neu cong thuc phu thuoc gia dinh, noi ro gia dinh do ngay trong than bai.",
+            ]
+        )
+    elif thinking_mode == "analytical_codebase":
+        lines.extend(
+            [
+                "- Khung uu tien: tra loi truc tiep -> bang chung source-backed -> phan loai/truy vet -> caveat neu co.",
+                "- Neu user hoi vi sao class diagram/table count/schema lech nhau, hay phan loai missing pieces thanh entity chinh, junction table, infrastructure table, migration-added table.",
+                "- Neu user hoi JWT/auth, hay giai thich lifecycle theo thu tu request that: login -> tao access/refresh token -> Bearer request -> auth filter -> DB user/role/enabled -> authorization -> refresh.",
+                "- Dua file/class/function/table name cu the khi co trong context/tool result. Khong viet nhu encyclopedia chung.",
+                "- Mode nay override default no-heading: duoc dung heading Markdown, bang compact, va code block ngan de giu cau tra loi doc duoc nhu mot mini-report.",
+                "- Moi khang dinh quan trong can co dau vet: source da doc, ten file/class/table, hoac noi ro la inference hop ly.",
+                "- Chat xam cua answer nam o viec phan loai va doi chieu source, khong nam o cau van dai.",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "- Khung uu tien: luan diem -> bien so/chung cu -> ket luan.",
+                "- Neu co tin hieu trai chieu, noi ro cai nao dang nang ky hon thay vi gom tat ca vao mot ket luan mem.",
+                (
+                    f"- Uu tien kiem cheo theo huong {plan_text}."
+                    if plan_text
+                    else "- Uu tien tach dieu chac khoi dieu con nhieu va noi ro bien so dang chi phoi ket luan."
+                ),
+            ]
+        )
+
+    return "\n".join(lines)

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
@@ -26,6 +26,9 @@ from app.engine.multi_agent.direct_prompt_evidence import (
 from app.engine.multi_agent.direct_prompt_code_studio import (
     _build_code_studio_delivery_contract,
 )
+from app.engine.multi_agent.direct_prompt_analytical_answer import (
+    _build_direct_analytical_answer_contract,
+)
 from app.engine.multi_agent.direct_prompt_selfhood import (
     _build_direct_selfhood_system_prompt,
     _identity_answer_contract_lines,
@@ -285,115 +288,6 @@ def _build_direct_analytical_system_prompt(
         sections.append(tools_context.strip())
 
     return "\n\n".join(section for section in sections if section.strip())
-
-
-def _build_direct_analytical_answer_contract(query: str, state: AgentState) -> str:
-    """Role-local answer contract for analytical direct turns.
-
-    This is appended late so it can override the warmer house voice when the
-    user is clearly asking for analysis rather than companionship or small talk.
-    """
-    thinking_mode = _infer_direct_thinking_mode(query, state, [])
-    if thinking_mode not in {
-        "analytical_market",
-        "analytical_math",
-        "analytical_codebase",
-        "analytical_general",
-    }:
-        return ""
-
-    axes = _build_direct_analytical_axes(query, state, [])
-    plan = _build_direct_evidence_plan(query, state, [])
-    axes_text = _join_direct_hint_list(axes, limit=3)
-    plan_text = _join_direct_hint_list(plan, limit=2)
-    is_live_market = _is_temporal_market_query(query)
-    default_vietnam_market = _should_default_market_to_vietnam(query, state)
-
-    lines = [
-        "## ANALYTICAL RESPONSE CONTRACT:",
-        "- Day la turn phan tich. Khong mo dau bang loi chao, tu gioi thieu, kaomoji, small talk, hay loi khen user kien tri.",
-        "- Khong mo dau bang quan he hoa kieu 'minh thay ban...', 'minh rat muon dong hanh...', hay 'cam on ban da hoi'. Di thang vao van de.",
-        "- Khong xin loi dai dong vi thieu du lieu thoi gian thuc neu da co ket qua tool hoac da co khung phan tich du de tra loi.",
-        "- Neu can neu gioi han du lieu, chi noi gon trong 1 cau roi quay lai phan tich ngay.",
-        "- Mo dau bang nhan dinh, khung van de, hoac buc tranh hien tai. Khong mo dau bang cam than, emo, hay tu than mat.",
-        "- Khi da co tool result, hay rut ra tin hieu chinh tu du lieu do. Khong chi liet ke nguon va khong bien answer thanh ban tin tong hop.",
-        "- Mac dinh mo dau bang 1 cau thesis co the kiem cheo duoc, sau do moi giai thich can nang cua tung truc.",
-        "- Mac dinh uu tien 2-4 doan dac. Chi dung bullet ngan neu user can checklist, watchlist, hoac can tach cac bien so rieng. Khong tu dong bien answer thanh bai viet dai co heading Markdown neu user chi hoi phan tich.",
-        "- Mac dinh KHONG dung heading Markdown nhu #, ##, ### trong answer analytical tru khi user xin ro rang mot bao cao/co cau truc tai lieu.",
-        "- Mac dinh KHONG dung danh sach dam/net bold nhu mot ban tom tat tin tuc neu user khong yeu cau.",
-        "- Ket answer bang takeaway hoac dieu can theo doi tiep theo. Khong hoi nguoc theo kieu small talk neu user chua can.",
-    ]
-
-    if thinking_mode == "analytical_market":
-        lines.extend(
-            [
-                "- Khung uu tien: buc tranh hien tai -> cac luc keo chinh -> takeaway/what to watch.",
-                "- Neu cac tin hieu xung nhau, noi ro truc nao dang giu mat bang gia va truc nao chi tao nhieu ngan han.",
-                "- Neu user dang hoi gia dau/gia xang dau hien tai, mo answer bang moc gia truoc; khong mo bang background chung.",
-                (
-                    "- Mac dinh goc nhin Viet Nam: neu user khong gioi han ro chi muon the gioi/Brent/WTI thi uu tien gia xang dau dang ap dung o Viet Nam truoc, sau do moi neo Brent/WTI va luc quoc te."
-                    if default_vietnam_market
-                    else "- Uu tien moc Brent/WTI hien tai truoc, roi moi giai thich luc quoc te dang giu nhip gia."
-                ),
-                (
-                    "- Van phai giu rieng mot truc quoc te dang dan nhip hom nay (vi du Hormuz/My-Iran/OPEC+) thay vi chi lap lai nen cung-cau."
-                    if is_live_market
-                    else "- Neu co bien dong vua xay ra, hay tach no thanh mot truc rieng thay vi de no tan vao nen chung."
-                ),
-                "- Neu cac nguon gia dang phan ky manh hoac cho ra thu tu bat thuong giua Brent va WTI, khong chot mot con so don le; noi ro nguon dang mau thuan va chi giu khoang hoac moc gan dung.",
-                "- Neu chi thay tieu de thong bao dieu chinh gia ma khong co bang gia chi tiet, chi noi da thay moc dieu chinh ngay nao; khong suy dien ra gia tung mat hang.",
-                "- Neu mot truc gia/nguon chua keo duoc, noi ro truc nao chua co thay vi thay no bang mot bai market essay chung chung.",
-                (
-                    f"- Uu tien tach rieng {axes_text}."
-                    if axes_text
-                    else "- Uu tien tach rieng cung, cau, va nhieu dia chinh tri thay vi gom vao mot nhan tang/giam."
-                ),
-                (
-                    f"- Neu can kiem cheo, hay dua tren {plan_text}."
-                    if plan_text
-                    else "- Neu can kiem cheo, hay phan biet dau hieu cung-cau that voi phan nhieu do tin tuc."
-                ),
-            ]
-        )
-    elif thinking_mode == "analytical_math":
-        lines.extend(
-            [
-                "- Khung uu tien: mo hinh va gia dinh -> phuong trinh/derivation -> y nghia vat ly.",
-                "- Neu ket luan phu thuoc gan dung, noi ro pham vi ma gan dung do con hop le.",
-                (
-                    f"- Truoc khi ket luan, phai chot ro {axes_text}."
-                    if axes_text
-                    else "- Truoc khi ket luan, phai chot ro mo hinh, gia dinh goc nho, va phuong trinh."
-                ),
-                "- Neu cong thuc phu thuoc gia dinh, noi ro gia dinh do ngay trong than bai.",
-            ]
-        )
-    elif thinking_mode == "analytical_codebase":
-        lines.extend(
-            [
-                "- Khung uu tien: tra loi truc tiep -> bang chung source-backed -> phan loai/truy vet -> caveat neu co.",
-                "- Neu user hoi vi sao class diagram/table count/schema lech nhau, hay phan loai missing pieces thanh entity chinh, junction table, infrastructure table, migration-added table.",
-                "- Neu user hoi JWT/auth, hay giai thich lifecycle theo thu tu request that: login -> tao access/refresh token -> Bearer request -> auth filter -> DB user/role/enabled -> authorization -> refresh.",
-                "- Dua file/class/function/table name cu the khi co trong context/tool result. Khong viet nhu encyclopedia chung.",
-                "- Mode nay override default no-heading: duoc dung heading Markdown, bang compact, va code block ngan de giu cau tra loi doc duoc nhu mot mini-report.",
-                "- Moi khang dinh quan trong can co dau vet: source da doc, ten file/class/table, hoac noi ro la inference hop ly.",
-                "- Chat xam cua answer nam o viec phan loai va doi chieu source, khong nam o cau van dai.",
-            ]
-        )
-    else:
-        lines.extend(
-            [
-                "- Khung uu tien: luan diem -> bien so/chung cu -> ket luan.",
-                "- Neu co tin hieu trai chieu, noi ro cai nao dang nang ky hon thay vi gom tat ca vao mot ket luan mem.",
-                (
-                    f"- Uu tien kiem cheo theo huong {plan_text}."
-                    if plan_text
-                    else "- Uu tien tach dieu chac khoi dieu con nhieu va noi ro bien so dang chi phoi ket luan."
-                ),
-            ]
-        )
-
-    return "\n".join(lines)
 
 
 def _build_direct_system_messages(


### PR DESCRIPTION
## Summary
- Move the late analytical answer contract into direct_prompt_analytical_answer.py.
- Preserve the direct_prompts compatibility import surface used by graph/runtime bindings.
- Update the runtime cleanup audit.

Closes #547.

## Verification
- uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_direct_prompts_analytical_contract.py tests/unit/test_direct_codebase_thinking_quality.py tests/unit/test_sprint154_tech_debt.py tests/unit/test_sprint174_cross_platform.py -q --tb=short -> 143 passed
- uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/direct_prompts.py app/engine/multi_agent/direct_prompt_analytical_answer.py --select=E9,F63,F7,F401 -> All checks passed!
- git diff --check -> passed

## Risk
Moderate. This is intended as pure relocation, but the prompt shapes analytical market/math/codebase answer behavior.

## Rollback
Revert this squash commit to restore _build_direct_analytical_answer_contract inside direct_prompts.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operational audit documentation to record recent contract migration activities.

* **Refactor**
  * Reorganized analytical answer contract handling logic across dedicated modules for improved separation of concerns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->