### PR TITLE
refactor(backend): isolate direct node event sink

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -213,6 +213,9 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
 - Follow-up #547 moved the late analytical answer contract into
   `direct_prompt_analytical_answer.py`, keeping market/math/codebase answer
   style rules separate from direct system prompt assembly.
+- Follow-up #549 moved direct-node event sink creation and event dispatch into
+  `direct_node_event_sink.py`, keeping capture + SSE bus forwarding out of the
+  direct-node runtime shell.
 
 ## Preserved Intentionally
 
@@ -245,7 +248,7 @@ backups, data PDFs, or local skill folders.
   guards, operational/meta/chatter fast-response selection, visible
   thought helpers, thinking snapshot side effects, document-preview
   host-action rebinding/execution/preflight, image-input preflight,
-  direct-node tool selection, LLM preflight, execution preparation, response cleanup,
+  direct-node event sink lifecycle, direct-node tool selection, LLM preflight, execution preparation, response cleanup,
   visible-thinking finalization,
   exception/source fallback lifecycle, final state/domain notice handling, and
   host UI timeout handling have moved out. The long-term cleanup direction is

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_event_sink.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_event_sink.py
@@ -1,0 +1,47 @@
+"""Direct-node event sink lifecycle helpers."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from app.engine.multi_agent.state import AgentState
+
+
+@dataclass
+class DirectNodeEventSink:
+    state: AgentState
+    capture_public_thinking_event: Callable[[AgentState, dict[str, Any]], Any]
+    event_queue: Any | None
+    logger_obj: logging.Logger
+
+    async def push_event(self, event: dict[str, Any]) -> None:
+        self.capture_public_thinking_event(self.state, event)
+        if self.event_queue:
+            try:
+                self.event_queue.put_nowait(event)
+            except Exception as queue_error:  # noqa: BLE001
+                self.logger_obj.debug("[DIRECT] Event queue push failed: %s", queue_error)
+
+
+def build_direct_node_event_sink(
+    *,
+    state: AgentState,
+    bus_id: str | None,
+    capture_public_thinking_event: Callable[[AgentState, dict[str, Any]], Any],
+    logger_obj: logging.Logger,
+) -> DirectNodeEventSink:
+    """Create the direct-node event sink without binding the runtime shell to SSE."""
+
+    event_queue = None
+    if bus_id:
+        from app.engine.multi_agent.graph_event_bus import _get_event_queue
+
+        event_queue = _get_event_queue(bus_id)
+    return DirectNodeEventSink(
+        state=state,
+        capture_public_thinking_event=capture_public_thinking_event,
+        event_queue=event_queue,
+        logger_obj=logger_obj,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -21,6 +21,9 @@ from app.engine.multi_agent.direct_node_document_preflight import (
 from app.engine.multi_agent.direct_node_fast_response_runtime import (
     resolve_direct_node_fast_response,
 )
+from app.engine.multi_agent.direct_node_event_sink import (
+    build_direct_node_event_sink,
+)
 from app.engine.multi_agent.direct_node_host_timeout import (
     run_direct_node_execution_with_host_timeout,
 )
@@ -128,20 +131,14 @@ async def direct_response_node_impl(
     """Direct response node - conversational responses without RAG."""
     query = state.get("query", "")
 
-    event_queue = None
     bus_id = state.get("_event_bus_id")
-    if bus_id:
-        from app.engine.multi_agent.graph_event_bus import _get_event_queue
-
-        event_queue = _get_event_queue(bus_id)
-
-    async def push_event(event: dict):
-        capture_public_thinking_event(state, event)
-        if event_queue:
-            try:
-                event_queue.put_nowait(event)
-            except Exception as queue_error:
-                logger.debug("[DIRECT] Event queue push failed: %s", queue_error)
+    event_sink = build_direct_node_event_sink(
+        state=state,
+        bus_id=bus_id,
+        capture_public_thinking_event=capture_public_thinking_event,
+        logger_obj=logger,
+    )
+    push_event = event_sink.push_event
 
     tracer = get_or_create_tracer(state)
     tracer.start_step(direct_response_step_name, "Tao phan hoi truc tiep")

--- a/maritime-ai-service/tests/unit/test_direct_node_event_sink.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_event_sink.py
@@ -1,0 +1,76 @@
+import asyncio
+import logging
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_direct_node_event_sink_captures_and_pushes_to_queue():
+    from app.engine.multi_agent.direct_node_event_sink import DirectNodeEventSink
+
+    state = {"query": "hello"}
+    captured = []
+    queue: asyncio.Queue = asyncio.Queue()
+    sink = DirectNodeEventSink(
+        state=state,
+        capture_public_thinking_event=lambda current_state, event: captured.append(
+            (current_state, event)
+        ),
+        event_queue=queue,
+        logger_obj=logging.getLogger("test"),
+    )
+    event = {"type": "answer_delta", "content": "Xin chao", "node": "direct"}
+
+    await sink.push_event(event)
+
+    assert captured == [(state, event)]
+    assert queue.get_nowait() == event
+
+
+@pytest.mark.asyncio
+async def test_direct_node_event_sink_capture_survives_queue_failure(caplog):
+    from app.engine.multi_agent.direct_node_event_sink import DirectNodeEventSink
+
+    class BrokenQueue:
+        def put_nowait(self, _event):
+            raise RuntimeError("queue closed")
+
+    logger = logging.getLogger("test.direct_node_event_sink")
+    captured = []
+    sink = DirectNodeEventSink(
+        state={},
+        capture_public_thinking_event=lambda current_state, event: captured.append(
+            (current_state, event)
+        ),
+        event_queue=BrokenQueue(),
+        logger_obj=logger,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        await sink.push_event({"type": "status", "content": "thinking"})
+
+    assert captured
+    assert "Event queue push failed" in caplog.text
+
+
+def test_build_direct_node_event_sink_uses_registered_bus_queue():
+    from app.engine.multi_agent.direct_node_event_sink import build_direct_node_event_sink
+    from app.engine.multi_agent.graph_event_bus import (
+        _discard_event_queue,
+        _register_event_queue,
+    )
+
+    bus_id = "direct-node-event-sink-test"
+    queue: asyncio.Queue = asyncio.Queue()
+    _register_event_queue(bus_id, queue)
+    try:
+        sink = build_direct_node_event_sink(
+            state={},
+            bus_id=bus_id,
+            capture_public_thinking_event=lambda *_args, **_kwargs: None,
+            logger_obj=logging.getLogger("test"),
+        )
+    finally:
+        _discard_event_queue(bus_id)
+
+    assert sink.event_queue is queue


### PR DESCRIPTION
## Summary
- Extract direct-node event capture and event-bus forwarding into direct_node_event_sink.py.
- Preserve the async push_event callable used by document preview, tool execution, exception fallback, and host UI timeout paths.
- Add focused event-sink tests and update the runtime cleanup audit.

Closes #549.

## Verification
- uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_direct_node_event_sink.py tests/unit/test_direct_node_provider_errors.py -q --tb=short -> 38 passed
- uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/direct_node_runtime.py app/engine/multi_agent/direct_node_event_sink.py --select=E9,F63,F7,F401 -> All checks passed!
- git diff --check -> passed

## Risk
Low-to-moderate. Streaming events must continue to reach both public-thinking capture and the SSE event bus; the new helper preserves the same put_nowait behavior and fail-soft logging.

## Rollback
Revert this squash commit to restore the inline event queue lookup and push_event closure in direct_node_runtime.py.