### PR TITLE
Refactor direct node turn start lifecycle

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539, #549, #551 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -216,6 +216,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
 - Follow-up #549 moved direct-node event sink creation and event dispatch into
   `direct_node_event_sink.py`, keeping capture + SSE bus forwarding out of the
   direct-node runtime shell.
+- Follow-up #551 moved direct-node turn-start resolution into
+  `direct_node_turn_start.py`, keeping deterministic greetings, explicit
+  web-search detection, and source-backed codebase fast answers behind a small
+  tested lifecycle contract.
 
 ## Preserved Intentionally
 
@@ -248,7 +252,8 @@ backups, data PDFs, or local skill folders.
   guards, operational/meta/chatter fast-response selection, visible
   thought helpers, thinking snapshot side effects, document-preview
   host-action rebinding/execution/preflight, image-input preflight,
-  direct-node event sink lifecycle, direct-node tool selection, LLM preflight, execution preparation, response cleanup,
+  direct-node event sink lifecycle, direct-node turn-start lifecycle,
+  direct-node tool selection, LLM preflight, execution preparation, response cleanup,
   visible-thinking finalization,
   exception/source fallback lifecycle, final state/domain notice handling, and
   host UI timeout handling have moved out. The long-term cleanup direction is

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -64,7 +64,6 @@ from app.engine.multi_agent.direct_node_operational_fast_paths import (
     _build_codebase_analysis_fallback_thinking,
     _is_explicit_web_search_turn_for_direct,
     _looks_generic_direct_fallback_response,
-    _should_use_codebase_source_note_fast_answer,
     _strip_dsml_residue,
 )
 from app.engine.multi_agent.direct_node_thinking_effort import (
@@ -74,6 +73,7 @@ from app.engine.multi_agent.direct_node_thinking_snapshot import (
     record_direct_node_thinking_snapshot,
 )
 from app.engine.multi_agent.direct_node_tool_selection import select_direct_node_tools
+from app.engine.multi_agent.direct_node_turn_start import start_direct_node_turn
 from app.engine.multi_agent.direct_node_uploaded_context import (
     _build_uploaded_document_context_fallback_answer,
     _build_uploaded_document_visual_guard_answer,
@@ -143,27 +143,20 @@ async def direct_response_node_impl(
     tracer = get_or_create_tracer(state)
     tracer.start_step(direct_response_step_name, "Tao phan hoi truc tiep")
 
-    use_natural = getattr(settings, "enable_natural_conversation", False) is True
-    if not use_natural:
-        greetings = get_domain_greetings(state.get("domain_id", settings.default_domain))
-        query_lower = query.lower().strip()
-        response = greetings.get(query_lower)
-    else:
-        query_lower = query.lower().strip()
-        response = None
-    response_type = "greeting" if response else ""
-    explicit_web_search_turn = _is_explicit_web_search_turn_for_direct(query, state)
-    if not response and _is_codebase_analysis_query(query) and not explicit_web_search_turn:
-        codebase_thinking = _build_codebase_analysis_fallback_thinking(query)
-        record_direct_node_thinking_snapshot(
-            state=state,
-            thinking=codebase_thinking,
-            provenance="codebase_source_backed_plan",
-            record_thinking_snapshot_fn=record_thinking_snapshot,
-        )
-        if _should_use_codebase_source_note_fast_answer(query):
-            response = _build_codebase_analysis_fallback_answer(query)
-            response_type = "codebase_source_backed_fast"
+    turn_start = start_direct_node_turn(
+        query=query,
+        state=state,
+        enable_natural_conversation=(
+            getattr(settings, "enable_natural_conversation", False) is True
+        ),
+        default_domain=settings.default_domain,
+        get_domain_greetings=get_domain_greetings,
+        record_thinking_snapshot_fn=record_thinking_snapshot,
+    )
+    query_lower = turn_start.query_lower
+    response = turn_start.response
+    response_type = turn_start.response_type
+    explicit_web_search_turn = turn_start.explicit_web_search_turn
 
     ctx_for_preflight = state.get("context", {}) if isinstance(state.get("context"), dict) else {}
     has_uploaded_document_context = _has_uploaded_document_context(ctx_for_preflight)

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_turn_start.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_turn_start.py
@@ -1,0 +1,72 @@
+"""Turn-start lifecycle helpers for the direct node."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from app.engine.multi_agent.direct_node_operational_fast_paths import (
+    _build_codebase_analysis_fallback_answer,
+    _build_codebase_analysis_fallback_thinking,
+    _is_explicit_web_search_turn_for_direct,
+    _should_use_codebase_source_note_fast_answer,
+)
+from app.engine.multi_agent.direct_node_thinking_snapshot import (
+    record_direct_node_thinking_snapshot,
+)
+from app.engine.multi_agent.direct_reasoning import _is_codebase_analysis_query
+from app.engine.multi_agent.state import AgentState
+
+
+GetDomainGreetings = Callable[[str], dict[str, str]]
+RecordThinkingSnapshot = Callable[..., Any]
+
+
+@dataclass(frozen=True)
+class DirectNodeTurnStart:
+    """Resolved deterministic state at the start of a direct-node turn."""
+
+    query_lower: str
+    response: str | None
+    response_type: str
+    explicit_web_search_turn: bool
+
+
+def start_direct_node_turn(
+    *,
+    query: str,
+    state: AgentState,
+    enable_natural_conversation: bool,
+    default_domain: str,
+    get_domain_greetings: GetDomainGreetings,
+    record_thinking_snapshot_fn: RecordThinkingSnapshot,
+) -> DirectNodeTurnStart:
+    """Resolve greetings and source-backed codebase fast paths before LLM work."""
+
+    query_lower = query.lower().strip()
+    response: str | None = None
+    if not enable_natural_conversation:
+        greetings = get_domain_greetings(str(state.get("domain_id", default_domain)))
+        response = greetings.get(query_lower)
+
+    response_type = "greeting" if response else ""
+    explicit_web_search_turn = _is_explicit_web_search_turn_for_direct(query, state)
+    if not response and _is_codebase_analysis_query(query) and not explicit_web_search_turn:
+        codebase_thinking = _build_codebase_analysis_fallback_thinking(query)
+        record_direct_node_thinking_snapshot(
+            state=state,
+            thinking=codebase_thinking,
+            provenance="codebase_source_backed_plan",
+            record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+        )
+        if _should_use_codebase_source_note_fast_answer(query):
+            response = _build_codebase_analysis_fallback_answer(query)
+            response_type = "codebase_source_backed_fast"
+
+    return DirectNodeTurnStart(
+        query_lower=query_lower,
+        response=response,
+        response_type=response_type,
+        explicit_web_search_turn=explicit_web_search_turn,
+    )

--- a/maritime-ai-service/tests/unit/test_direct_node_turn_start.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_turn_start.py
@@ -1,0 +1,85 @@
+from app.engine.multi_agent.direct_node_turn_start import start_direct_node_turn
+
+
+def test_start_direct_node_turn_resolves_greeting_when_natural_conversation_disabled():
+    state = {"domain_id": "maritime"}
+    result = start_direct_node_turn(
+        query="Xin Chao",
+        state=state,
+        enable_natural_conversation=False,
+        default_domain="default",
+        get_domain_greetings=lambda domain_id: {
+            "xin chao": f"hello from {domain_id}",
+        },
+        record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
+    )
+
+    assert result.query_lower == "xin chao"
+    assert result.response == "hello from maritime"
+    assert result.response_type == "greeting"
+    assert result.explicit_web_search_turn is False
+
+
+def test_start_direct_node_turn_skips_greeting_when_natural_conversation_enabled():
+    state = {"domain_id": "maritime"}
+    result = start_direct_node_turn(
+        query="Xin chao",
+        state=state,
+        enable_natural_conversation=True,
+        default_domain="default",
+        get_domain_greetings=lambda _domain_id: {
+            "xin chao": "should not be used",
+        },
+        record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
+    )
+
+    assert result.response is None
+    assert result.response_type == ""
+
+
+def test_start_direct_node_turn_records_codebase_fast_path_snapshot():
+    state: dict = {}
+    snapshots: list[dict] = []
+
+    def record_snapshot(*args, **kwargs):
+        snapshots.append({"args": args, "kwargs": kwargs})
+
+    result = start_direct_node_turn(
+        query="Bao cao source notes ve jwt auth trong codebase",
+        state=state,
+        enable_natural_conversation=True,
+        default_domain="default",
+        get_domain_greetings=lambda _domain_id: {},
+        record_thinking_snapshot_fn=record_snapshot,
+    )
+
+    assert result.response
+    assert result.response_type == "codebase_source_backed_fast"
+    assert result.explicit_web_search_turn is False
+    assert "thinking_content" in state
+    assert snapshots[0]["args"][0] is state
+    assert snapshots[0]["kwargs"] == {
+        "node": "direct",
+        "provenance": "codebase_source_backed_plan",
+    }
+
+
+def test_start_direct_node_turn_does_not_fast_answer_explicit_web_search():
+    state = {"routing_metadata": {"intent": "web_search"}}
+    snapshots: list[object] = []
+
+    result = start_direct_node_turn(
+        query="@web-search Bao cao source notes ve jwt auth trong codebase",
+        state=state,
+        enable_natural_conversation=True,
+        default_domain="default",
+        get_domain_greetings=lambda _domain_id: {},
+        record_thinking_snapshot_fn=lambda *args, **kwargs: snapshots.append(
+            (args, kwargs)
+        ),
+    )
+
+    assert result.response is None
+    assert result.response_type == ""
+    assert result.explicit_web_search_turn is True
+    assert snapshots == []


### PR DESCRIPTION
## Summary
- Extract direct-node turn-start behavior into `direct_node_turn_start.py`.
- Keep deterministic greetings, explicit web-search guard, and source-backed codebase fast-answer behavior behind a typed result.
- Add focused unit coverage and update the runtime cleanup audit.

## Verification
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_direct_node_turn_start.py tests/unit/test_direct_node_provider_errors.py -q --tb=short` -> `39 passed`
- `uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/direct_node_runtime.py app/engine/multi_agent/direct_node_turn_start.py --select=E9,F63,F7,F401` -> passed
- `git diff --check` -> passed

## Risk / Rollback
Risk is low-to-moderate because this is early direct-node lifecycle behavior. Rollback by reverting this squash commit to restore inline greeting/codebase turn-start logic in `direct_node_runtime.py`.

Closes #551