### PR TITLE
Refactor direct node turn policy lifecycle

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539, #549, #551 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539, #549, #551, #553 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -220,6 +220,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   `direct_node_turn_start.py`, keeping deterministic greetings, explicit
   web-search detection, and source-backed codebase fast answers behind a small
   tested lifecycle contract.
+- Follow-up #553 moved direct-node turn policy setup into
+  `direct_node_turn_policy.py`, keeping routing metadata, identity/social
+  chatter policy, visual effort upgrade, provider override selection, and
+  codebase/uploaded-document guards behind a typed lifecycle contract.
 
 ## Preserved Intentionally
 
@@ -253,7 +257,7 @@ backups, data PDFs, or local skill folders.
   thought helpers, thinking snapshot side effects, document-preview
   host-action rebinding/execution/preflight, image-input preflight,
   direct-node event sink lifecycle, direct-node turn-start lifecycle,
-  direct-node tool selection, LLM preflight, execution preparation, response cleanup,
+  direct-node turn-policy lifecycle, direct-node tool selection, LLM preflight, execution preparation, response cleanup,
   visible-thinking finalization,
   exception/source fallback lifecycle, final state/domain notice handling, and
   host UI timeout handling have moved out. The long-term cleanup direction is

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -45,9 +45,6 @@ from app.engine.multi_agent.direct_node_response_cleanup import (
 from app.engine.multi_agent.direct_node_visible_thinking_finalization import (
     finalize_direct_node_visible_thinking,
 )
-from app.engine.multi_agent.direct_intent import (
-    _looks_emotional_support_turn,
-)
 from app.engine.multi_agent.direct_reasoning import (
     _is_codebase_analysis_query,
 )
@@ -62,17 +59,14 @@ from app.engine.multi_agent.direct_node_final_state import finalize_direct_node_
 from app.engine.multi_agent.direct_node_operational_fast_paths import (
     _build_codebase_analysis_fallback_answer,
     _build_codebase_analysis_fallback_thinking,
-    _is_explicit_web_search_turn_for_direct,
     _looks_generic_direct_fallback_response,
     _strip_dsml_residue,
-)
-from app.engine.multi_agent.direct_node_thinking_effort import (
-    _resolve_direct_thinking_effort,
 )
 from app.engine.multi_agent.direct_node_thinking_snapshot import (
     record_direct_node_thinking_snapshot,
 )
 from app.engine.multi_agent.direct_node_tool_selection import select_direct_node_tools
+from app.engine.multi_agent.direct_node_turn_policy import resolve_direct_node_turn_policy
 from app.engine.multi_agent.direct_node_turn_start import start_direct_node_turn
 from app.engine.multi_agent.direct_node_uploaded_context import (
     _build_uploaded_document_context_fallback_answer,
@@ -261,98 +255,42 @@ async def direct_response_node_impl(
         try:
             from app.engine.multi_agent.agent_config import AgentConfigRegistry
 
-            ctx = state.get("context", {})
-            response_language = str(ctx.get("response_language") or "vi").strip() or "vi"
-            thinking_effort = state.get("thinking_effort")
-            routing_meta = state.get("routing_metadata") or {}
-            routing_hint = state.get("_routing_hint") if isinstance(state.get("_routing_hint"), dict) else {}
-            routing_method = str(routing_meta.get("method") or "").strip().lower()
-            routing_intent = str(routing_meta.get("intent") or "").strip().lower()
-            hint_kind = str(routing_hint.get("kind") or "").strip().lower()
-            hint_shape = str(routing_hint.get("shape") or "").strip().lower()
-            normalized_query = normalize_for_intent(query)
-            short_token_count = len([token for token in normalized_query.split() if token])
-            is_identity_turn = (
-                hint_kind == "identity_probe"
-                or hint_kind == "selfhood_followup"
-                or routing_intent in {"identity", "selfhood"}
-                or looks_identity_selfhood_turn(query)
-            )
-            is_emotional_support_turn = _looks_emotional_support_turn(query)
-            is_chatter_fast_path = (
-                routing_method == "always_on_chatter_fast_path"
-                or (hint_kind == "fast_chatter" and hint_shape in {"reaction", "vague_banter"})
-            )
-            is_social_fast_path = (
-                routing_method == "always_on_social_fast_path"
-                or (hint_kind == "fast_chatter" and hint_shape == "social")
-            )
-            visual_decision = resolve_visual_intent(query)
-            is_short_house_chatter = (
-                not is_identity_turn
-                and (
-                    is_chatter_fast_path
-                    or is_social_fast_path
-                    or (
-                        routing_intent == "social"
-                        and short_token_count <= 6
-                        and not needs_web_search(query)
-                        and not needs_datetime(query)
-                        and not visual_decision.force_tool
-                    )
-                )
-            )
-            history_limit = 0 if is_short_house_chatter else 10
-            tools_context_override = "" if is_short_house_chatter else None
-            role_name = (
-                "direct_chatter_agent"
-                if (is_short_house_chatter or is_identity_turn)
-                else "direct_agent"
-            )
-            if is_short_house_chatter:
-                history_limit = 0
-                tools_context_override = ""
-            if is_identity_turn:
-                history_limit = max(history_limit, 6)
-            thinking_effort = _resolve_direct_thinking_effort(
+            turn_policy = resolve_direct_node_turn_policy(
                 query=query,
                 state=state,
-                current_effort=thinking_effort,
-                is_identity_turn=is_identity_turn,
-                is_short_house_chatter=is_short_house_chatter,
+                has_uploaded_document_context=has_uploaded_document_context,
+                normalize_for_intent=normalize_for_intent,
+                looks_identity_selfhood_turn=looks_identity_selfhood_turn,
+                needs_web_search=needs_web_search,
+                needs_datetime=needs_datetime,
+                resolve_visual_intent=resolve_visual_intent,
+                recommended_visual_thinking_effort=recommended_visual_thinking_effort,
+                get_active_code_studio_session=get_active_code_studio_session,
+                merge_thinking_effort=merge_thinking_effort,
+                get_effective_provider=get_effective_provider,
+                get_explicit_user_provider=get_explicit_user_provider,
+                looks_uploaded_document_preview_request=(
+                    _looks_uploaded_document_preview_request
+                ),
+                logger_obj=logger,
             )
-
-            visual_effort = recommended_visual_thinking_effort(
-                query,
-                active_code_session=get_active_code_studio_session(state),
-            )
-            if visual_effort:
-                previous_effort = thinking_effort
-                thinking_effort = merge_thinking_effort(
-                    thinking_effort,
-                    visual_effort,
-                )
-                if thinking_effort != previous_effort:
-                    logger.info(
-                        "[DIRECT] Visual intent detected -> upgrade thinking effort %s -> %s",
-                        previous_effort or "default",
-                        thinking_effort,
-                    )
-
-            preferred_provider = get_effective_provider(state)
-            explicit_user_provider = get_explicit_user_provider(state)
-            use_house_voice_direct = (
-                routing_intent in {"social", "personal", "off_topic"}
-                and not needs_web_search(query)
-                and not needs_datetime(query)
-                and not visual_decision.force_tool
-            )
-            direct_provider_override = explicit_user_provider or preferred_provider
-            is_codebase_source_turn = _is_codebase_analysis_query(query) and not (
-                has_uploaded_document_context
-                and _looks_uploaded_document_preview_request(query)
-            )
-            explicit_web_search_turn = _is_explicit_web_search_turn_for_direct(query, state)
+            ctx = turn_policy.ctx
+            response_language = turn_policy.response_language
+            thinking_effort = turn_policy.thinking_effort
+            routing_intent = turn_policy.routing_intent
+            is_identity_turn = turn_policy.is_identity_turn
+            is_emotional_support_turn = turn_policy.is_emotional_support_turn
+            is_short_house_chatter = turn_policy.is_short_house_chatter
+            visual_decision = turn_policy.visual_decision
+            history_limit = turn_policy.history_limit
+            tools_context_override = turn_policy.tools_context_override
+            role_name = turn_policy.role_name
+            preferred_provider = turn_policy.preferred_provider
+            explicit_user_provider = turn_policy.explicit_user_provider
+            use_house_voice_direct = turn_policy.use_house_voice_direct
+            direct_provider_override = turn_policy.direct_provider_override
+            is_codebase_source_turn = turn_policy.is_codebase_source_turn
+            explicit_web_search_turn = turn_policy.explicit_web_search_turn
 
             tool_selection = select_direct_node_tools(
                 query=query,

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_turn_policy.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_turn_policy.py
@@ -1,0 +1,179 @@
+"""Per-turn planning policy for the direct node."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from app.engine.multi_agent.direct_intent import _looks_emotional_support_turn
+from app.engine.multi_agent.direct_node_operational_fast_paths import (
+    _is_explicit_web_search_turn_for_direct,
+)
+from app.engine.multi_agent.direct_node_thinking_effort import (
+    _resolve_direct_thinking_effort,
+)
+from app.engine.multi_agent.direct_reasoning import _is_codebase_analysis_query
+from app.engine.multi_agent.state import AgentState
+
+
+TextPredicate = Callable[[str], bool]
+StateGetter = Callable[[AgentState], Any]
+VisualIntentResolver = Callable[[str], Any]
+RecommendedVisualEffort = Callable[..., Any]
+MergeThinkingEffort = Callable[[Any, Any], Any]
+
+
+@dataclass(frozen=True)
+class DirectNodeTurnPolicy:
+    """Resolved direct-node planning state used before tool and LLM execution."""
+
+    ctx: dict[str, Any]
+    response_language: str
+    thinking_effort: Any
+    routing_intent: str
+    is_identity_turn: bool
+    is_emotional_support_turn: bool
+    is_short_house_chatter: bool
+    visual_decision: Any
+    history_limit: int
+    tools_context_override: str | None
+    role_name: str
+    preferred_provider: Any
+    explicit_user_provider: Any
+    use_house_voice_direct: bool
+    direct_provider_override: Any
+    is_codebase_source_turn: bool
+    explicit_web_search_turn: bool
+
+
+def resolve_direct_node_turn_policy(
+    *,
+    query: str,
+    state: AgentState,
+    has_uploaded_document_context: bool,
+    normalize_for_intent: Callable[[str], str],
+    looks_identity_selfhood_turn: TextPredicate,
+    needs_web_search: TextPredicate,
+    needs_datetime: TextPredicate,
+    resolve_visual_intent: VisualIntentResolver,
+    recommended_visual_thinking_effort: RecommendedVisualEffort,
+    get_active_code_studio_session: StateGetter,
+    merge_thinking_effort: MergeThinkingEffort,
+    get_effective_provider: StateGetter,
+    get_explicit_user_provider: StateGetter,
+    looks_uploaded_document_preview_request: TextPredicate,
+    logger_obj: logging.Logger | None = None,
+) -> DirectNodeTurnPolicy:
+    """Resolve the per-turn policy that feeds tools, prompts, and provider choice."""
+
+    ctx = state.get("context", {})
+    response_language = str(ctx.get("response_language") or "vi").strip() or "vi"
+    thinking_effort = state.get("thinking_effort")
+    routing_meta = state.get("routing_metadata") or {}
+    routing_hint = state.get("_routing_hint") if isinstance(state.get("_routing_hint"), dict) else {}
+    routing_method = str(routing_meta.get("method") or "").strip().lower()
+    routing_intent = str(routing_meta.get("intent") or "").strip().lower()
+    hint_kind = str(routing_hint.get("kind") or "").strip().lower()
+    hint_shape = str(routing_hint.get("shape") or "").strip().lower()
+    normalized_query = normalize_for_intent(query)
+    short_token_count = len([token for token in normalized_query.split() if token])
+    is_identity_turn = (
+        hint_kind == "identity_probe"
+        or hint_kind == "selfhood_followup"
+        or routing_intent in {"identity", "selfhood"}
+        or looks_identity_selfhood_turn(query)
+    )
+    is_emotional_support_turn = _looks_emotional_support_turn(query)
+    is_chatter_fast_path = (
+        routing_method == "always_on_chatter_fast_path"
+        or (hint_kind == "fast_chatter" and hint_shape in {"reaction", "vague_banter"})
+    )
+    is_social_fast_path = (
+        routing_method == "always_on_social_fast_path"
+        or (hint_kind == "fast_chatter" and hint_shape == "social")
+    )
+    visual_decision = resolve_visual_intent(query)
+    is_short_house_chatter = (
+        not is_identity_turn
+        and (
+            is_chatter_fast_path
+            or is_social_fast_path
+            or (
+                routing_intent == "social"
+                and short_token_count <= 6
+                and not needs_web_search(query)
+                and not needs_datetime(query)
+                and not visual_decision.force_tool
+            )
+        )
+    )
+    history_limit = 0 if is_short_house_chatter else 10
+    tools_context_override = "" if is_short_house_chatter else None
+    role_name = (
+        "direct_chatter_agent"
+        if (is_short_house_chatter or is_identity_turn)
+        else "direct_agent"
+    )
+    if is_identity_turn:
+        history_limit = max(history_limit, 6)
+    thinking_effort = _resolve_direct_thinking_effort(
+        query=query,
+        state=state,
+        current_effort=thinking_effort,
+        is_identity_turn=is_identity_turn,
+        is_short_house_chatter=is_short_house_chatter,
+    )
+
+    visual_effort = recommended_visual_thinking_effort(
+        query,
+        active_code_session=get_active_code_studio_session(state),
+    )
+    if visual_effort:
+        previous_effort = thinking_effort
+        thinking_effort = merge_thinking_effort(
+            thinking_effort,
+            visual_effort,
+        )
+        if thinking_effort != previous_effort and logger_obj is not None:
+            logger_obj.info(
+                "[DIRECT] Visual intent detected -> upgrade thinking effort %s -> %s",
+                previous_effort or "default",
+                thinking_effort,
+            )
+
+    preferred_provider = get_effective_provider(state)
+    explicit_user_provider = get_explicit_user_provider(state)
+    use_house_voice_direct = (
+        routing_intent in {"social", "personal", "off_topic"}
+        and not needs_web_search(query)
+        and not needs_datetime(query)
+        and not visual_decision.force_tool
+    )
+    direct_provider_override = explicit_user_provider or preferred_provider
+    is_codebase_source_turn = _is_codebase_analysis_query(query) and not (
+        has_uploaded_document_context
+        and looks_uploaded_document_preview_request(query)
+    )
+    explicit_web_search_turn = _is_explicit_web_search_turn_for_direct(query, state)
+
+    return DirectNodeTurnPolicy(
+        ctx=ctx,
+        response_language=response_language,
+        thinking_effort=thinking_effort,
+        routing_intent=routing_intent,
+        is_identity_turn=is_identity_turn,
+        is_emotional_support_turn=is_emotional_support_turn,
+        is_short_house_chatter=is_short_house_chatter,
+        visual_decision=visual_decision,
+        history_limit=history_limit,
+        tools_context_override=tools_context_override,
+        role_name=role_name,
+        preferred_provider=preferred_provider,
+        explicit_user_provider=explicit_user_provider,
+        use_house_voice_direct=use_house_voice_direct,
+        direct_provider_override=direct_provider_override,
+        is_codebase_source_turn=is_codebase_source_turn,
+        explicit_web_search_turn=explicit_web_search_turn,
+    )

--- a/maritime-ai-service/tests/unit/test_direct_node_turn_policy.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_turn_policy.py
@@ -1,0 +1,107 @@
+from types import SimpleNamespace
+
+from app.engine.multi_agent.direct_node_turn_policy import (
+    resolve_direct_node_turn_policy,
+)
+
+
+def _base_policy_kwargs(**overrides):
+    kwargs = {
+        "query": "xin chao",
+        "state": {
+            "context": {"response_language": "vi"},
+            "routing_metadata": {},
+        },
+        "has_uploaded_document_context": False,
+        "normalize_for_intent": lambda text: text.lower(),
+        "looks_identity_selfhood_turn": lambda _query: False,
+        "needs_web_search": lambda _query: False,
+        "needs_datetime": lambda _query: False,
+        "resolve_visual_intent": lambda _query: SimpleNamespace(force_tool=False),
+        "recommended_visual_thinking_effort": lambda *_args, **_kwargs: None,
+        "get_active_code_studio_session": lambda _state: None,
+        "merge_thinking_effort": lambda current, visual: visual or current,
+        "get_effective_provider": lambda _state: "qwen",
+        "get_explicit_user_provider": lambda _state: None,
+        "looks_uploaded_document_preview_request": lambda _query: False,
+        "logger_obj": None,
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_resolve_direct_node_turn_policy_short_social_chatter():
+    state = {
+        "context": {"response_language": "vi"},
+        "routing_metadata": {"intent": "social"},
+    }
+
+    result = resolve_direct_node_turn_policy(
+        **_base_policy_kwargs(query="he nhe", state=state)
+    )
+
+    assert result.ctx is state["context"]
+    assert result.response_language == "vi"
+    assert result.routing_intent == "social"
+    assert result.is_short_house_chatter is True
+    assert result.history_limit == 0
+    assert result.tools_context_override == ""
+    assert result.role_name == "direct_chatter_agent"
+    assert result.thinking_effort == "low"
+    assert result.use_house_voice_direct is True
+    assert result.direct_provider_override == "qwen"
+
+
+def test_resolve_direct_node_turn_policy_identity_keeps_context_history():
+    state = {
+        "context": {"response_language": "vi"},
+        "routing_metadata": {"intent": "social"},
+        "_routing_hint": {"kind": "identity_probe"},
+    }
+
+    result = resolve_direct_node_turn_policy(
+        **_base_policy_kwargs(query="ban la ai", state=state)
+    )
+
+    assert result.is_identity_turn is True
+    assert result.is_short_house_chatter is False
+    assert result.history_limit == 10
+    assert result.tools_context_override is None
+    assert result.role_name == "direct_chatter_agent"
+    assert result.thinking_effort == "high"
+
+
+def test_resolve_direct_node_turn_policy_visual_effort_and_explicit_provider():
+    state = {
+        "context": {"response_language": "en"},
+        "routing_metadata": {"intent": "general"},
+        "thinking_effort": "low",
+    }
+
+    result = resolve_direct_node_turn_policy(
+        **_base_policy_kwargs(
+            query="tao mo phong canvas",
+            state=state,
+            recommended_visual_thinking_effort=lambda *_args, **_kwargs: "high",
+            get_explicit_user_provider=lambda _state: "openai",
+            merge_thinking_effort=lambda current, visual: f"{current}+{visual}",
+        )
+    )
+
+    assert result.response_language == "en"
+    assert result.thinking_effort == "low+high"
+    assert result.explicit_user_provider == "openai"
+    assert result.direct_provider_override == "openai"
+
+
+def test_resolve_direct_node_turn_policy_codebase_excludes_uploaded_preview():
+    result = resolve_direct_node_turn_policy(
+        **_base_policy_kwargs(
+            query="Bao cao source notes ve jwt auth trong codebase",
+            has_uploaded_document_context=True,
+            looks_uploaded_document_preview_request=lambda _query: True,
+        )
+    )
+
+    assert result.is_codebase_source_turn is False
+    assert result.explicit_web_search_turn is False


### PR DESCRIPTION
## Summary
- Extract direct-node LLM/tool turn policy setup into `direct_node_turn_policy.py`.
- Keep routing metadata, identity/social chatter policy, visual effort upgrade, provider override selection, and codebase/uploaded-document guards behind a typed lifecycle contract.
- Add focused unit coverage and update the runtime cleanup audit.

## Verification
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_direct_node_turn_policy.py tests/unit/test_direct_node_turn_start.py tests/unit/test_direct_node_provider_errors.py -q --tb=short` -> `43 passed`
- `uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/direct_node_runtime.py app/engine/multi_agent/direct_node_turn_policy.py --select=E9,F63,F7,F401` -> passed
- `git diff --check` -> passed

## Risk / Rollback
Risk is moderate because this policy feeds tool selection, prompt assembly, provider routing, and visible thinking. Rollback by reverting this squash commit to restore inline turn-policy logic in `direct_node_runtime.py`.

Closes #553