### PR TITLE
Gate high-severity Code Studio slop before preview

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539, #549, #551, #553 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539, #549, #551, #553, #555 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -224,6 +224,9 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   `direct_node_turn_policy.py`, keeping routing metadata, identity/social
   chatter policy, visual effort upgrade, provider override selection, and
   codebase/uploaded-document guards behind a typed lifecycle contract.
+- Follow-up #555 connected high-severity AI-slop detection to Code Studio
+  visual-code validation, so structural emoji and obvious hero-gradient slop
+  force a repair turn before preview instead of opening weak app chrome.
 
 ## Preserved Intentionally
 
@@ -289,9 +292,10 @@ backups, data PDFs, or local skill folders.
   from their canonical modules instead of through direct execution.
 - Code Studio deterministic fallback is now split across contract, spec,
   quality, captions, registry, shell, and renderer modules. The remaining debt
-  is product quality rather than module size: the scaffold should keep moving
-  toward richer typed visual intents and away from broad template fallback when
-  the primary visual tool path is healthy.
+  is product quality rather than module size: high-severity slop is now gated
+  before preview, and the scaffold should keep moving toward richer typed
+  visual intents and away from broad template fallback when the primary visual
+  tool path is healthy.
 - Some tests still import compatibility `graph.py` modules. Move tests toward
   `runtime.py` imports when the external import window can close.
 

--- a/maritime-ai-service/app/engine/tools/visual_code_quality.py
+++ b/maritime-ai-service/app/engine/tools/visual_code_quality.py
@@ -2,14 +2,8 @@ import logging
 import re
 
 from app.engine.tools.visual_html_builders import _wrap_html
-from app.engine.tools.visual_pendulum_scaffold import (
-    _build_pendulum_simulation_scaffold,
-    _looks_like_pendulum_simulation,
-)
+from app.engine.tools.visual_ai_slop import check_ai_slop_patterns
 from app.engine.tools.visual_scaffolds import (
-    _looks_like_dashboard,
-    _looks_like_quiz,
-    _looks_like_simulation,
     build_scaffold,
     detect_scaffold,
 )
@@ -64,6 +58,24 @@ def validate_code_studio_output_impl(
     quality_profile: str,
 ) -> str | None:
     lowered = raw_html.lower()
+    high_severity_slop = [
+        violation
+        for violation in check_ai_slop_patterns(raw_html)
+        if violation.severity == "high"
+    ]
+    if high_severity_slop:
+        details = "\n".join(
+            f"- {violation.rule}: {violation.message}"
+            for violation in high_severity_slop[:3]
+        )
+        return (
+            "Error: Code Studio output chua dat bar UI/UX truoc preview. "
+            "Hay sua cac dau hieu AI slop high-severity sau:\n"
+            f"{details}\n\n"
+            "Dung icon/SVG thay emoji trong UI chrome, tranh hero gradient tim-xanh, "
+            "va giu visual tap trung vao state/controls/readout that."
+        )
+
     chart_like = requested_visual_type == "chart" or artifact_kind == "chart_widget"
     uses_chart_runtime = any(
         token in lowered

--- a/maritime-ai-service/tests/unit/test_visual_tools.py
+++ b/maritime-ai-service/tests/unit/test_visual_tools.py
@@ -1548,6 +1548,30 @@ class TestCreateVisualCodeTool:
 
         assert "tool_generate_visual" in result
 
+    def test_rejects_high_severity_ai_slop_before_preview(self, monkeypatch):
+        class FakeSettings:
+            enable_llm_code_gen_visuals = True
+        monkeypatch.setattr("app.core.config.get_settings", lambda: FakeSettings())
+        from app.engine.tools.visual_tools import tool_create_visual_code
+
+        result = tool_create_visual_code.invoke({
+            "code_html": (
+                "<style>"
+                ".hero{padding:24px;background:#0f172a;color:white}"
+                ".action{border:1px solid #475569;padding:12px}"
+                "</style>"
+                "<div class='hero'>"
+                "<h2>" + "\U0001F680" + " Launch Panel</h2>"
+                "<button class='action'>" + "\U0001F680" + " Start</button>"
+                "<p>Interactive shell with enough visible content for validation.</p>"
+                "</div>"
+            ),
+            "title": "Slop Gate",
+        })
+
+        assert "AI slop" in result
+        assert "emoji_in_code_elements" in result
+
     def test_full_html_passthrough(self, monkeypatch):
         class FakeSettings:
             enable_llm_code_gen_visuals = True


### PR DESCRIPTION
## Summary
- Connect high-severity AI-slop detection to Code Studio visual-code validation.
- Reject structural emoji and obvious hero-gradient slop before preview, with an actionable repair message.
- Remove stale unused imports in `visual_code_quality.py` and update the runtime cleanup audit.

## Verification
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_visual_tools.py::TestCreateVisualCodeTool tests/unit/test_visual_ai_slop.py -q --tb=short` -> `41 passed`
- `uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/tools/visual_code_quality.py --select=E9,F63,F7,F401` -> passed
- `git diff --check` -> passed

## Risk / Rollback
Risk is moderate because stricter quality gates can force a model repair turn instead of previewing weak code. The gate is conservative and only blocks high-severity slop. Rollback by reverting this squash commit to restore previous Code Studio validation behavior.

Closes #555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Visual code validation now detects high-severity code quality issues and prevents them from appearing in preview, providing specific feedback for correction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->