### PR TITLE
Refactor direct node LLM fallback lifecycle

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539, #549, #551, #553, #555 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539, #549, #551, #553, #555, #557 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -227,6 +227,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
 - Follow-up #555 connected high-severity AI-slop detection to Code Studio
   visual-code validation, so structural emoji and obvious hero-gradient slop
   force a repair turn before preview instead of opening weak app chrome.
+- Follow-up #557 moved direct-node no-LLM fallback selection into
+  `direct_node_llm_fallback.py`, keeping source-backed codebase fallback,
+  phase fallback, and explicit-provider fail-closed behavior behind a typed
+  helper before the larger LLM execution shell is split.
 
 ## Preserved Intentionally
 
@@ -260,7 +264,8 @@ backups, data PDFs, or local skill folders.
   thought helpers, thinking snapshot side effects, document-preview
   host-action rebinding/execution/preflight, image-input preflight,
   direct-node event sink lifecycle, direct-node turn-start lifecycle,
-  direct-node turn-policy lifecycle, direct-node tool selection, LLM preflight, execution preparation, response cleanup,
+  direct-node turn-policy lifecycle, direct-node tool selection, LLM preflight,
+  LLM-unavailable fallback selection, execution preparation, response cleanup,
   visible-thinking finalization,
   exception/source fallback lifecycle, final state/domain notice handling, and
   host UI timeout handling have moved out. The long-term cleanup direction is

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_llm_fallback.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_llm_fallback.py
@@ -1,0 +1,70 @@
+"""Fallback lifecycle for direct-node turns when no LLM is available."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from app.core.exceptions import ProviderUnavailableError
+from app.engine.multi_agent.direct_reasoning import _is_codebase_analysis_query
+from app.engine.multi_agent.state import AgentState
+
+
+RecordDirectThinkingSnapshot = Callable[..., Any]
+RecordThinkingSnapshot = Callable[..., Any]
+
+
+@dataclass(frozen=True)
+class DirectNodeLlmUnavailableFallback:
+    """Resolved response for the no-LLM direct-node branch."""
+
+    response: str
+    response_type: str
+
+
+def resolve_direct_node_llm_unavailable_fallback(
+    *,
+    query: str,
+    state: AgentState,
+    explicit_user_provider: str | None,
+    explicit_web_search_turn: bool,
+    enable_natural_conversation: bool,
+    get_phase_fallback: Callable[[AgentState], str],
+    build_codebase_analysis_fallback_answer: Callable[[str], str],
+    build_codebase_analysis_fallback_thinking: Callable[[str], str],
+    record_direct_node_thinking_snapshot: RecordDirectThinkingSnapshot,
+    record_thinking_snapshot_fn: RecordThinkingSnapshot,
+) -> DirectNodeLlmUnavailableFallback:
+    """Fail closed or build a deterministic fallback when LLM resolution is empty."""
+
+    if explicit_user_provider:
+        raise ProviderUnavailableError(
+            provider=str(explicit_user_provider).strip().lower(),
+            reason_code="busy",
+            message="Provider được chọn hiện không sẵn sàng để xử lý yêu cầu này.",
+        )
+
+    if _is_codebase_analysis_query(query) and not explicit_web_search_turn:
+        response = build_codebase_analysis_fallback_answer(query)
+        codebase_thinking = build_codebase_analysis_fallback_thinking(query)
+        record_direct_node_thinking_snapshot(
+            state=state,
+            thinking=codebase_thinking,
+            provenance="deterministic_codebase_fallback",
+            record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+        )
+        return DirectNodeLlmUnavailableFallback(
+            response=response,
+            response_type="codebase_source_backed_fallback",
+        )
+
+    response = (
+        get_phase_fallback(state)
+        if enable_natural_conversation
+        else "Xin chao! Toi co the giup gi cho ban?"
+    )
+    return DirectNodeLlmUnavailableFallback(
+        response=response,
+        response_type="fallback",
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -6,7 +6,6 @@ import logging
 from typing import Any
 
 from app.core.config import settings
-from app.core.exceptions import ProviderUnavailableError
 from app.engine.multi_agent.document_preview_contract import (
     has_uploaded_document_context as _has_uploaded_document_context,
 )
@@ -37,6 +36,9 @@ from app.engine.multi_agent.direct_node_llm_preflight import (
     apply_direct_node_natural_conversation_penalties,
     maybe_build_uploaded_visual_guard,
     select_direct_node_llm,
+)
+from app.engine.multi_agent.direct_node_llm_fallback import (
+    resolve_direct_node_llm_unavailable_fallback,
 )
 from app.engine.multi_agent.direct_node_response_cleanup import (
     apply_source_backed_empty_response_fallback,
@@ -591,37 +593,31 @@ async def direct_response_node_impl(
                     },
                 )
             elif not response:
-                if explicit_user_provider:
-                    raise ProviderUnavailableError(
-                        provider=str(explicit_user_provider).strip().lower(),
-                        reason_code="busy",
-                        message="Provider được chọn hiện không sẵn sàng để xử lý yêu cầu này.",
-                    )
-                if _is_codebase_analysis_query(query) and not explicit_web_search_turn:
-                    response = _build_codebase_analysis_fallback_answer(query)
-                    codebase_thinking = _build_codebase_analysis_fallback_thinking(query)
-                    record_direct_node_thinking_snapshot(
-                        state=state,
-                        thinking=codebase_thinking,
-                        provenance="deterministic_codebase_fallback",
-                        record_thinking_snapshot_fn=record_thinking_snapshot,
-                    )
-                else:
-                    response = (
-                        get_phase_fallback(state)
-                        if getattr(settings, "enable_natural_conversation", False) is True
-                        else "Xin chao! Toi co the giup gi cho ban?"
-                    )
+                llm_fallback = resolve_direct_node_llm_unavailable_fallback(
+                    query=query,
+                    state=state,
+                    explicit_user_provider=explicit_user_provider,
+                    explicit_web_search_turn=explicit_web_search_turn,
+                    enable_natural_conversation=(
+                        getattr(settings, "enable_natural_conversation", False) is True
+                    ),
+                    get_phase_fallback=get_phase_fallback,
+                    build_codebase_analysis_fallback_answer=(
+                        _build_codebase_analysis_fallback_answer
+                    ),
+                    build_codebase_analysis_fallback_thinking=(
+                        _build_codebase_analysis_fallback_thinking
+                    ),
+                    record_direct_node_thinking_snapshot=(
+                        record_direct_node_thinking_snapshot
+                    ),
+                    record_thinking_snapshot_fn=record_thinking_snapshot,
+                )
+                response = llm_fallback.response
                 tracer.end_step(
                     result="Fallback (LLM unavailable)",
                     confidence=0.5,
-                    details={
-                        "response_type": (
-                            "codebase_source_backed_fallback"
-                            if _is_codebase_analysis_query(query) and not explicit_web_search_turn
-                            else "fallback"
-                        )
-                    },
+                    details={"response_type": llm_fallback.response_type},
                 )
         except Exception as exc:
             fallback_result = await handle_direct_node_generation_exception(

--- a/maritime-ai-service/tests/unit/test_direct_node_llm_fallback.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_llm_fallback.py
@@ -1,0 +1,88 @@
+import pytest
+
+from app.core.exceptions import ProviderUnavailableError
+from app.engine.multi_agent.direct_node_llm_fallback import (
+    resolve_direct_node_llm_unavailable_fallback,
+)
+
+
+def test_llm_unavailable_fallback_fails_closed_for_explicit_provider():
+    with pytest.raises(ProviderUnavailableError) as exc_info:
+        resolve_direct_node_llm_unavailable_fallback(
+            query="xin chao",
+            state={},
+            explicit_user_provider="Google",
+            explicit_web_search_turn=False,
+            enable_natural_conversation=True,
+            get_phase_fallback=lambda _state: "phase fallback",
+            build_codebase_analysis_fallback_answer=lambda _query: "codebase",
+            build_codebase_analysis_fallback_thinking=lambda _query: "thinking",
+            record_direct_node_thinking_snapshot=lambda **_kwargs: None,
+            record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
+        )
+
+    assert exc_info.value.provider == "google"
+    assert exc_info.value.reason_code == "busy"
+
+
+def test_llm_unavailable_fallback_uses_codebase_source_backed_answer():
+    state: dict = {}
+    calls: list[dict] = []
+
+    result = resolve_direct_node_llm_unavailable_fallback(
+        query="Bao cao source notes ve jwt auth trong codebase",
+        state=state,
+        explicit_user_provider=None,
+        explicit_web_search_turn=False,
+        enable_natural_conversation=True,
+        get_phase_fallback=lambda _state: "phase fallback",
+        build_codebase_analysis_fallback_answer=lambda _query: "codebase answer",
+        build_codebase_analysis_fallback_thinking=lambda _query: "codebase thinking",
+        record_direct_node_thinking_snapshot=lambda **kwargs: calls.append(kwargs),
+        record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
+    )
+
+    assert result.response == "codebase answer"
+    assert result.response_type == "codebase_source_backed_fallback"
+    assert calls[0]["state"] is state
+    assert calls[0]["thinking"] == "codebase thinking"
+    assert calls[0]["provenance"] == "deterministic_codebase_fallback"
+
+
+def test_llm_unavailable_fallback_respects_explicit_web_search():
+    calls: list[dict] = []
+
+    result = resolve_direct_node_llm_unavailable_fallback(
+        query="@web-search Bao cao source notes ve jwt auth trong codebase",
+        state={},
+        explicit_user_provider=None,
+        explicit_web_search_turn=True,
+        enable_natural_conversation=True,
+        get_phase_fallback=lambda _state: "phase fallback",
+        build_codebase_analysis_fallback_answer=lambda _query: "codebase answer",
+        build_codebase_analysis_fallback_thinking=lambda _query: "codebase thinking",
+        record_direct_node_thinking_snapshot=lambda **kwargs: calls.append(kwargs),
+        record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
+    )
+
+    assert result.response == "phase fallback"
+    assert result.response_type == "fallback"
+    assert calls == []
+
+
+def test_llm_unavailable_fallback_uses_legacy_copy_when_natural_conversation_off():
+    result = resolve_direct_node_llm_unavailable_fallback(
+        query="xin chao",
+        state={},
+        explicit_user_provider=None,
+        explicit_web_search_turn=False,
+        enable_natural_conversation=False,
+        get_phase_fallback=lambda _state: "phase fallback",
+        build_codebase_analysis_fallback_answer=lambda _query: "codebase answer",
+        build_codebase_analysis_fallback_thinking=lambda _query: "codebase thinking",
+        record_direct_node_thinking_snapshot=lambda **_kwargs: None,
+        record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
+    )
+
+    assert result.response == "Xin chao! Toi co the giup gi cho ban?"
+    assert result.response_type == "fallback"


### PR DESCRIPTION
## Summary
- Extract direct-node no-LLM fallback selection into `direct_node_llm_fallback.py`.
- Preserve source-backed codebase fallback, phase fallback, and explicit-provider fail-closed behavior behind one typed helper.
- Add focused unit coverage and update the runtime cleanup audit.

## Verification
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_direct_node_llm_fallback.py tests/unit/test_direct_node_provider_errors.py -q --tb=short` -> `39 passed`
- `uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/direct_node_runtime.py app/engine/multi_agent/direct_node_llm_fallback.py tests/unit/test_direct_node_llm_fallback.py --select=E9,F` -> passed
- `git diff --check` -> passed

## Risk / Rollback
Risk is moderate because this fallback determines whether Wiii fails closed, answers source-backed codebase prompts, or returns generic fallback copy when LLM resolution is empty. Rollback by reverting this squash commit to restore inline fallback selection in `direct_node_runtime.py`.

Closes #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced fallback handling when LLM is unavailable, including source-backed responses for codebase analysis queries and improved phase-aware defaults.

* **Bug Fixes**
  * Enforces strict fail-closed behavior when explicit provider constraints are specified and the LLM becomes unavailable.

* **Tests**
  * Added comprehensive test coverage for LLM unavailability scenarios, including provider constraints, codebase fallbacks, and conversation modes.

* **Documentation**
  * Updated operational documentation with follow-up issue tracking for recent refactoring efforts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->