### PR TITLE
Improve Code Studio markdown and iframe UX

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539, #549, #551, #553, #555, #557 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539, #549, #551, #553, #555, #557, #559 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -231,6 +231,10 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   `direct_node_llm_fallback.py`, keeping source-backed codebase fallback,
   phase fallback, and explicit-provider fail-closed behavior behind a typed
   helper before the larger LLM execution shell is split.
+- Follow-up #559 added a guarded assistant-markdown normalization pass for
+  collapsed tables, horizontal rules, and inline lists; made Code Studio
+  previews render through the `app`/`immersive` iframe lane; and let tall app
+  frames scroll internally instead of clipping simulations.
 
 ## Preserved Intentionally
 
@@ -298,9 +302,9 @@ backups, data PDFs, or local skill folders.
 - Code Studio deterministic fallback is now split across contract, spec,
   quality, captions, registry, shell, and renderer modules. The remaining debt
   is product quality rather than module size: high-severity slop is now gated
-  before preview, and the scaffold should keep moving toward richer typed
-  visual intents and away from broad template fallback when the primary visual
-  tool path is healthy.
+  before preview, and the first markdown/iframe UX cleanup landed in #559. The
+  scaffold should keep moving toward richer typed visual intents and away from
+  broad template fallback when the primary visual tool path is healthy.
 - Some tests still import compatibility `graph.py` modules. Move tests toward
   `runtime.py` imports when the external import window can close.
 
@@ -504,3 +508,7 @@ modules.
 In follow-up #527, the runtime metrics regression tests passed after switching
 `time_block()` from the coarse Windows monotonic clock to high-resolution
 `perf_counter_ns()`.
+In follow-up #559, the desktop targeted markdown/Code Studio/iframe regression
+set passed with 59 tests, full desktop Vitest passed with 2481 tests, TypeScript
+typecheck passed, `build:embed` passed, and local browser smoke loaded the Wiii
+chat shell on `http://127.0.0.1:1420/`.

--- a/wiii-desktop/src/__tests__/assistant-markdown.test.ts
+++ b/wiii-desktop/src/__tests__/assistant-markdown.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAssistantMarkdown } from "@/lib/assistant-markdown";
+
+describe("normalizeAssistantMarkdown", () => {
+  it("repairs collapsed tables and section separators before rendering", () => {
+    const input =
+      "So sánh nhanh: | Tiêu chí | Annex I | Annex VI | |------|------|------| | Ô nhiễm | Dầu ra biển | Khí thải | --- Mẹo nhớ: đọc theo từng cột.";
+
+    const normalized = normalizeAssistantMarkdown(input);
+
+    expect(normalized).toContain("So sánh nhanh:\n\n| Tiêu chí | Annex I | Annex VI |");
+    expect(normalized).toContain("\n|------|------|------|");
+    expect(normalized).toContain("\n| Ô nhiễm | Dầu ra biển | Khí thải |");
+    expect(normalized).toContain("\n\n---\n\nMẹo nhớ:");
+  });
+
+  it("keeps fenced code blocks byte-stable", () => {
+    const input = [
+      "Trước code --- có separator",
+      "```md",
+      "| Không | sửa |",
+      "|---|---|",
+      "A --- B",
+      "```",
+      "Sau code --- có separator",
+    ].join("\n");
+
+    const normalized = normalizeAssistantMarkdown(input);
+
+    expect(normalized).toContain("```md\n| Không | sửa |\n|---|---|\nA --- B\n```");
+    expect(normalized).toContain("Trước code\n\n---\n\ncó separator");
+    expect(normalized).toContain("Sau code\n\n---\n\ncó separator");
+  });
+
+  it("only promotes inline bullets after punctuation boundaries", () => {
+    const input = "Các bước: - Mở lớp - Chọn bài - Áp dụng nhưng câu A - B vẫn là văn xuôi.";
+
+    const normalized = normalizeAssistantMarkdown(input);
+
+    expect(normalized).toContain("Các bước:\n- Mở lớp\n- Chọn bài\n- Áp dụng");
+    expect(normalized).toContain("câu A - B vẫn là văn xuôi");
+  });
+});

--- a/wiii-desktop/src/__tests__/code-studio-panel.test.tsx
+++ b/wiii-desktop/src/__tests__/code-studio-panel.test.tsx
@@ -5,6 +5,8 @@ import { CodeStudioPanel } from "@/components/layout/CodeStudioPanel";
 import { useCodeStudioStore } from "@/stores/code-studio-store";
 import { useUIStore } from "@/stores/ui-store";
 
+const inlineVisualFrameSpy = vi.fn();
+
 vi.mock("motion/react", () => ({
   AnimatePresence: ({ children }: any) => createElement("div", null, children),
   motion: {
@@ -16,8 +18,10 @@ vi.mock("motion/react", () => ({
 }));
 
 vi.mock("@/components/common/InlineVisualFrame", () => ({
-  InlineVisualFrame: ({ title }: { title: string }) =>
-    createElement("div", { "data-testid": "inline-visual-frame" }, `Preview: ${title}`),
+  InlineVisualFrame: (props: Record<string, unknown>) => {
+    inlineVisualFrameSpy(props);
+    return createElement("div", { "data-testid": "inline-visual-frame" }, `Preview: ${props.title}`);
+  },
 }));
 
 if (typeof globalThis.requestAnimationFrame === "undefined") {
@@ -31,6 +35,7 @@ if (typeof globalThis.cancelAnimationFrame === "undefined") {
 }
 
 function resetStores() {
+  inlineVisualFrameSpy.mockReset();
   useUIStore.setState({
     codeStudioPanelOpen: false,
     artifactPanelOpen: false,
@@ -115,5 +120,24 @@ describe("CodeStudioPanel", () => {
     });
 
     expect(useCodeStudioStore.getState().sessions["vs_1"].metadata.requestedView).toBe("preview");
+  });
+
+  it("renders Code Studio previews as app frames", async () => {
+    seedCompleteSession("preview");
+
+    render(<CodeStudioPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("inline-visual-frame")).toBeTruthy();
+    });
+
+    expect(inlineVisualFrameSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        frameKind: "app",
+        shellVariant: "immersive",
+        hostShellMode: "force",
+        className: "w-full h-full",
+      }),
+    );
   });
 });

--- a/wiii-desktop/src/__tests__/inline-visual-frame.test.ts
+++ b/wiii-desktop/src/__tests__/inline-visual-frame.test.ts
@@ -46,4 +46,19 @@ describe("InlineVisualFrame host shell", () => {
     expect(wrapped).toContain("Compute cost");
     expect(wrapped).toContain("Figure nay chung minh chi phi tang nhanh theo context.");
   });
+
+  it("allows app frames to scroll inside the iframe instead of clipping tall simulations", () => {
+    const wrapped = buildVisualFrameDocument("<main style=\"height:1400px\">Tall app</main>", {
+      title: "Tall simulation",
+      summary: "",
+      sessionId: "vs-tall",
+      shellVariant: "immersive",
+      frameKind: "app",
+      showFrameIntro: false,
+      hostShellMode: "force",
+    });
+
+    expect(wrapped).toContain("overflow: auto;");
+    expect(wrapped).toContain("overscroll-behavior: contain;");
+  });
 });

--- a/wiii-desktop/src/components/chat/CodeStudioCard.tsx
+++ b/wiii-desktop/src/components/chat/CodeStudioCard.tsx
@@ -61,7 +61,10 @@ export const CodeStudioCard = memo(function CodeStudioCard({
   // Single return — avoids early returns that can cause React reconciler issues
   // with "Rendered fewer hooks than expected" when phase transitions change the tree.
   return (
-    <article className="code-studio-card rounded-xl border border-border/60 overflow-hidden">
+    <article
+      className="code-studio-card rounded-xl border border-border/60 overflow-hidden"
+      data-status={session?.status ?? "missing"}
+    >
       {!session ? null : isStreaming && !hasCode ? (
         /* Phase 1: Planning (streaming, no code yet) */
         <>
@@ -105,8 +108,8 @@ export const CodeStudioCard = memo(function CodeStudioCard({
               ))}
             </div>
           )}
-          <div className="max-h-[280px] overflow-y-auto bg-[#0f172a] text-[#e2e8f0] border-t border-border/30">
-            <pre className="p-3 text-[11px] leading-relaxed font-mono whitespace-pre-wrap break-all m-0">
+          <div className="max-h-[320px] overflow-auto bg-[#0f172a] text-[#e2e8f0] border-t border-border/30">
+            <pre className="p-3 text-[11px] leading-relaxed font-mono whitespace-pre-wrap break-words m-0">
               <code>{session.code}</code>
               <span className="inline-block w-[2px] h-[14px] bg-[var(--accent)] animate-pulse ml-0.5 align-middle" />
               <div ref={codeEndRef} />

--- a/wiii-desktop/src/components/common/InlineVisualFrame.tsx
+++ b/wiii-desktop/src/components/common/InlineVisualFrame.tsx
@@ -437,7 +437,8 @@ export function buildVisualFrameDocument(
     rect.c-green,g.c-green>rect { fill: light-dark(#ecfdf5,#0d3320); stroke: light-dark(#6ee7b7,#34d399); }
     body {
       padding: ${bodyPadding};
-      overflow: hidden;
+      overflow: ${frameKind === "app" ? "auto" : "hidden"};
+      overscroll-behavior: contain;
       background: transparent;
     }
     body.wiii-host-shell-active {
@@ -633,7 +634,7 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const blobUrlRef = useRef<string | null>(null);
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
-  const [height, setHeight] = useState(frameKind === "app" ? 420 : 320);
+  const [height, setHeight] = useState(frameKind === "app" ? 520 : 320);
   const [error, setError] = useState<string | null>(null);
   const [tweaksAvailable, setTweaksAvailable] = useState(false);
   const [tweaksActive, setTweaksActive] = useState(false);
@@ -716,11 +717,10 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
         const nextHeight = (data.payload as { height?: number } | undefined)
           ?.height;
         if (typeof nextHeight === "number" && nextHeight > 0) {
+          const minHeight = frameKind === "app" ? 360 : 120;
+          const maxHeight = frameKind === "app" ? 1120 : 880;
           setHeight(
-            Math.min(
-              Math.max(nextHeight + 10, frameKind === "app" ? 260 : 120),
-              frameKind === "app" ? 980 : 880,
-            ),
+            Math.min(Math.max(nextHeight + 10, minHeight), maxHeight),
           );
         }
         return;
@@ -809,6 +809,11 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
       : shellVariant === "editorial"
         ? "overflow-visible bg-transparent"
         : "overflow-clip rounded-2xl bg-transparent";
+  const iframeMinHeight = frameKind === "app" ? 360 : 120;
+  const iframeHeight =
+    frameKind === "app" && /\bh-full\b/.test(className)
+      ? `max(${height}px, 100%)`
+      : `${height}px`;
 
   return (
     <div
@@ -826,7 +831,8 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
         allowtransparency="true"
         style={{
           width: "100%",
-          height: `${height}px`,
+          height: iframeHeight,
+          minHeight: `${iframeMinHeight}px`,
           border: "none",
           display: "block",
           background: "transparent",

--- a/wiii-desktop/src/components/common/MarkdownRenderer.tsx
+++ b/wiii-desktop/src/components/common/MarkdownRenderer.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useDeferredValue, useMemo } from "react";
 import { stripWiiiInternalMarkup } from "@/lib/internal-markup";
+import { normalizeAssistantMarkdown } from "@/lib/assistant-markdown";
 import { splitWidgetBlocks } from "./widget-segments";
 
 const InlineHtmlWidget = lazy(() => import("./InlineHtmlWidget"));
@@ -121,7 +122,7 @@ export function MarkdownRenderer({
   // Reference: https://react.dev/reference/react/useDeferredValue
   const deferredContent = useDeferredValue(content);
   const safeContent = useMemo(
-    () => stripWiiiInternalMarkup(deferredContent),
+    () => normalizeAssistantMarkdown(stripWiiiInternalMarkup(deferredContent)),
     [deferredContent],
   );
   const segments = useMemo(() => splitWidgetBlocks(safeContent), [safeContent]);

--- a/wiii-desktop/src/components/layout/CodeStudioPanel.tsx
+++ b/wiii-desktop/src/components/layout/CodeStudioPanel.tsx
@@ -377,6 +377,9 @@ function PreviewTab({ session }: { session: CodeStudioSession }) {
         title={session.title}
         sessionId={session.sessionId}
         className="w-full h-full"
+        frameKind="app"
+        shellVariant="immersive"
+        hostShellMode="force"
         showTweaksToggle
       />
     </div>

--- a/wiii-desktop/src/lib/assistant-markdown.ts
+++ b/wiii-desktop/src/lib/assistant-markdown.ts
@@ -1,0 +1,88 @@
+const FENCED_BLOCK_RE = /(```[\s\S]*?```|~~~[\s\S]*?~~~)/g;
+const TABLE_SEPARATOR_ROW_RE =
+  /\|\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?/;
+
+function splitCodeSafe(content: string): string[] {
+  return content.split(FENCED_BLOCK_RE);
+}
+
+function isFencedBlock(segment: string): boolean {
+  return /^(```|~~~)/.test(segment.trimStart());
+}
+
+function normalizeInlineSeparators(segment: string): string {
+  const promoted = segment
+    .replace(/([^|\n])\s+(---|\*\*\*|___)\s+(?=\S)/g, "$1\n\n$2\n\n")
+    .replace(/[ \t]+([0-9]{1,2}[.)])[ \t]+(?=\S)/g, "\n$1 ")
+    .replace(/[ \t]+([-*+])[ \t]+(?=\S)/g, (match, marker, offset, source) => {
+      const before = source.slice(Math.max(0, offset - 24), offset);
+      if (!/[:.;!?)]\s*$|\n\s*$/.test(before)) return match;
+      return `\n${marker} `;
+    });
+
+  let next = promoted;
+  for (let pass = 0; pass < 4; pass += 1) {
+    const previous = next;
+    next = next.replace(
+      /(\n[ \t]*[-*+][ \t]+[^\n]*?)[ \t]+([-*+])[ \t]+(?=\S)/g,
+      (match, prefix: string, marker: string, offset: number, source: string) => {
+        const after = source.slice(offset + match.length, offset + match.length + 16);
+        if (/^[A-Z]\b/.test(after)) return match;
+        return `${prefix}\n${marker} `;
+      },
+    );
+    if (next === previous) break;
+  }
+  return next;
+}
+
+function normalizeCollapsedPipeTableLine(line: string): string {
+  if (!TABLE_SEPARATOR_ROW_RE.test(line)) return line;
+
+  const firstPipe = line.indexOf("|");
+  if (firstPipe < 0) return line;
+
+  const prefix = line.slice(0, firstPipe).trimEnd();
+  const table = line
+    .slice(firstPipe)
+    .trim()
+    .replace(/\|\s+\|(?=\s*\S)/g, "|\n|")
+    .replace(/\|\s+(---|\*\*\*|___)\s+(?=\S)/g, "|\n\n$1\n\n")
+    .split("\n")
+    .map((row) => row.trim())
+    .filter(Boolean)
+    .join("\n");
+
+  if (!prefix) return table;
+  return `${prefix}\n\n${table}`;
+}
+
+function normalizeCollapsedPipeTables(segment: string): string {
+  return segment
+    .split("\n")
+    .map(normalizeCollapsedPipeTableLine)
+    .join("\n");
+}
+
+function normalizeParagraphSpacing(segment: string): string {
+  return segment
+    .replace(/\n(---|\*\*\*|___)\n/g, "\n\n$1\n\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/[ \t]+\n/g, "\n");
+}
+
+function normalizeMarkdownSegment(segment: string): string {
+  const withTables = normalizeCollapsedPipeTables(segment);
+  const withSeparators = normalizeInlineSeparators(withTables);
+  return normalizeParagraphSpacing(withSeparators);
+}
+
+export function normalizeAssistantMarkdown(content: string): string {
+  if (!content) return content;
+
+  return splitCodeSafe(content)
+    .map((segment) =>
+      isFencedBlock(segment) ? segment : normalizeMarkdownSegment(segment),
+    )
+    .join("");
+}


### PR DESCRIPTION
## Summary
- Add a guarded assistant-markdown normalization pass so collapsed tables, inline horizontal rules, and punctuation-led inline lists render as structured markdown while fenced code and comparison symbols stay intact.
- Render Code Studio previews through the `app`/`immersive` iframe lane and allow tall app frames to scroll internally instead of clipping simulations.
- Improve inline Code Studio streaming cards with stable status metadata and more readable code wrapping.
- Update the runtime cleanup audit for #559.

## Verification
- `npx vitest run src/__tests__/assistant-markdown.test.ts src/__tests__/code-studio-panel.test.tsx src/__tests__/inline-visual-frame.test.ts` -> `10 passed`
- `npx vitest run src/__tests__/code-studio-store.test.ts src/__tests__/inline-html-widget.test.tsx src/__tests__/message-bubble-fast-path.test.tsx src/__tests__/interleaved-block-sequence.test.tsx` -> `49 passed`
- `npx vitest run src/__tests__/assistant-markdown.test.ts src/__tests__/code-block-highlighting.test.tsx` -> `33 passed`
- `npx vitest run` -> `128 passed / 2481 tests` (jsdom navigation warning from existing Pointy bridge test; exit code 0)
- `npx tsc --noEmit` -> passed
- `npm run build:embed` -> passed (existing chunk-size/dynamic-import warnings only)
- `git diff --check` -> passed
- Local browser smoke loaded Wiii at `http://127.0.0.1:1420/`, entered dev mode, and reached the chat shell.

## Risk / Rollback
Risk is moderate because this touches shared chat markdown rendering and Code Studio preview framing. Rollback by reverting this PR to restore the previous raw markdown rendering and default iframe lane/height behavior.

Closes #559