### PR TITLE
Refactor visual runtime contracts

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539, #549, #551, #553, #555, #557, #559 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539, #549, #551, #553, #555, #557, #559, #561 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -235,6 +235,12 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   collapsed tables, horizontal rules, and inline lists; made Code Studio
   previews render through the `app`/`immersive` iframe lane; and let tall app
   frames scroll internally instead of clipping simulations.
+- Follow-up #561 moved visual-intent runtime metadata and Code Studio
+  visual-code lane resolution behind typed contracts. Tool runtime metadata is
+  now built through `VisualToolRuntimeIntent`, and `tool_create_visual_code`
+  resolves presentation intent, studio lane, artifact kind, renderer kind,
+  patch strategy, quality profile, and runtime manifest through
+  `VisualCodeRuntimeContract` before validation/payload build.
 
 ## Preserved Intentionally
 
@@ -303,8 +309,11 @@ backups, data PDFs, or local skill folders.
   quality, captions, registry, shell, and renderer modules. The remaining debt
   is product quality rather than module size: high-severity slop is now gated
   before preview, and the first markdown/iframe UX cleanup landed in #559. The
-  scaffold should keep moving toward richer typed visual intents and away from
-  broad template fallback when the primary visual tool path is healthy.
+  scaffold should keep moving away from broad template fallback when the
+  primary visual tool path is healthy. Follow-up #561 introduced typed runtime
+  contracts for visual intent metadata and Code Studio visual-code lanes; the
+  next quality frontier is using those contracts to reduce deterministic
+  scaffold fallback in product flows, not adding more ad-hoc templates.
 - Some tests still import compatibility `graph.py` modules. Move tests toward
   `runtime.py` imports when the external import window can close.
 

--- a/maritime-ai-service/app/engine/multi_agent/tool_collection.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_collection.py
@@ -155,6 +155,13 @@ def merge_quality_profile(base_profile, override_profile):
     )(base_profile, override_profile)
 
 
+def build_visual_tool_runtime_intent(*, query: str, visual_decision):
+    return _load_attr(
+        "app.engine.multi_agent.visual_runtime_metadata_contract",
+        "build_visual_tool_runtime_intent",
+    )(query=query, visual_decision=visual_decision)
+
+
 def _log_visual_telemetry(event_name: str, **kwargs) -> None:
     return _load_attr(
         "app.engine.multi_agent.visual_events",
@@ -1056,35 +1063,11 @@ def _code_studio_required_tool_names(query: str, user_role: str = "student") -> 
 def _build_visual_tool_runtime_metadata(state: dict, query: str) -> dict[str, Any] | None:
     """Provide visual intent metadata and patch defaults to the tool runtime layer."""
     visual_decision = resolve_visual_intent(query)
-    metadata: dict[str, Any] = {}
-
-    if visual_decision.force_tool and visual_decision.mode in {"template", "inline_html", "app", "mermaid"}:
-        metadata.update({
-            "visual_user_query": query,
-            "visual_intent_mode": visual_decision.mode,
-            "visual_intent_reason": visual_decision.reason,
-            "visual_force_tool": True,
-            "presentation_intent": visual_decision.presentation_intent,
-            "figure_budget": visual_decision.figure_budget,
-            "quality_profile": visual_decision.quality_profile,
-            "preferred_render_surface": visual_decision.preferred_render_surface,
-            "planning_profile": visual_decision.planning_profile,
-            "thinking_floor": visual_decision.thinking_floor,
-            "critic_policy": visual_decision.critic_policy,
-            "living_expression_mode": visual_decision.living_expression_mode,
-        })
-        if visual_decision.visual_type:
-            metadata["visual_requested_type"] = visual_decision.visual_type
-        if visual_decision.preferred_tool:
-            metadata["preferred_visual_tool"] = visual_decision.preferred_tool
-        if visual_decision.studio_lane:
-            metadata["studio_lane"] = visual_decision.studio_lane
-        if visual_decision.artifact_kind:
-            metadata["artifact_kind"] = visual_decision.artifact_kind
-        if visual_decision.renderer_contract:
-            metadata["renderer_contract"] = visual_decision.renderer_contract
-        if visual_decision.renderer_kind_hint:
-            metadata["renderer_kind_hint"] = visual_decision.renderer_kind_hint
+    runtime_intent = build_visual_tool_runtime_intent(
+        query=query,
+        visual_decision=visual_decision,
+    )
+    metadata: dict[str, Any] = runtime_intent.to_metadata() if runtime_intent else {}
 
     if not detect_visual_patch_request(query):
         return metadata or None

--- a/maritime-ai-service/app/engine/multi_agent/visual_runtime_metadata_contract.py
+++ b/maritime-ai-service/app/engine/multi_agent/visual_runtime_metadata_contract.py
@@ -1,0 +1,117 @@
+"""Typed metadata bridge from visual intent decisions into tool runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+VISUAL_RUNTIME_MODES = frozenset({"template", "inline_html", "app", "mermaid"})
+PRESENTATION_INTENTS = frozenset(
+    {"text", "article_figure", "chart_runtime", "code_studio_app", "artifact"}
+)
+QUALITY_PROFILES = frozenset({"draft", "standard", "premium"})
+
+
+def _text(value: Any, default: str = "") -> str:
+    cleaned = str(value if value is not None else default).strip()
+    return cleaned or default
+
+
+def _bounded_figure_budget(value: Any) -> int:
+    try:
+        return max(1, min(3, int(value or 1)))
+    except Exception:
+        return 1
+
+
+@dataclass(frozen=True, slots=True)
+class VisualToolRuntimeIntent:
+    """Tool-runtime view of a resolved visual turn."""
+
+    query: str
+    mode: str
+    reason: str
+    presentation_intent: str
+    figure_budget: int
+    quality_profile: str
+    preferred_render_surface: str
+    planning_profile: str
+    thinking_floor: str
+    critic_policy: str
+    living_expression_mode: str
+    visual_type: str = ""
+    preferred_tool: str = ""
+    studio_lane: str = ""
+    artifact_kind: str = ""
+    renderer_contract: str = ""
+    renderer_kind_hint: str = ""
+
+    def to_metadata(self) -> dict[str, Any]:
+        metadata: dict[str, Any] = {
+            "visual_user_query": self.query,
+            "visual_intent_mode": self.mode,
+            "visual_intent_reason": self.reason,
+            "visual_force_tool": True,
+            "presentation_intent": self.presentation_intent,
+            "figure_budget": self.figure_budget,
+            "quality_profile": self.quality_profile,
+            "preferred_render_surface": self.preferred_render_surface,
+            "planning_profile": self.planning_profile,
+            "thinking_floor": self.thinking_floor,
+            "critic_policy": self.critic_policy,
+            "living_expression_mode": self.living_expression_mode,
+        }
+        optional_fields = {
+            "visual_requested_type": self.visual_type,
+            "preferred_visual_tool": self.preferred_tool,
+            "studio_lane": self.studio_lane,
+            "artifact_kind": self.artifact_kind,
+            "renderer_contract": self.renderer_contract,
+            "renderer_kind_hint": self.renderer_kind_hint,
+        }
+        metadata.update({key: value for key, value in optional_fields.items() if value})
+        return metadata
+
+
+def build_visual_tool_runtime_intent(
+    *,
+    query: str,
+    visual_decision: Any,
+) -> VisualToolRuntimeIntent | None:
+    """Build auditable tool-runtime metadata from one visual intent decision."""
+
+    if not bool(getattr(visual_decision, "force_tool", False)):
+        return None
+
+    mode = _text(getattr(visual_decision, "mode", ""))
+    if mode not in VISUAL_RUNTIME_MODES:
+        return None
+
+    presentation_intent = _text(getattr(visual_decision, "presentation_intent", ""), "text")
+    if presentation_intent not in PRESENTATION_INTENTS:
+        presentation_intent = "text"
+
+    quality_profile = _text(getattr(visual_decision, "quality_profile", ""), "standard")
+    if quality_profile not in QUALITY_PROFILES:
+        quality_profile = "standard"
+
+    return VisualToolRuntimeIntent(
+        query=query,
+        mode=mode,
+        reason=_text(getattr(visual_decision, "reason", "")),
+        presentation_intent=presentation_intent,
+        figure_budget=_bounded_figure_budget(getattr(visual_decision, "figure_budget", 1)),
+        quality_profile=quality_profile,
+        preferred_render_surface=_text(getattr(visual_decision, "preferred_render_surface", "")),
+        planning_profile=_text(getattr(visual_decision, "planning_profile", "")),
+        thinking_floor=_text(getattr(visual_decision, "thinking_floor", "")),
+        critic_policy=_text(getattr(visual_decision, "critic_policy", "")),
+        living_expression_mode=_text(getattr(visual_decision, "living_expression_mode", "")),
+        visual_type=_text(getattr(visual_decision, "visual_type", "")),
+        preferred_tool=_text(getattr(visual_decision, "preferred_tool", "")),
+        studio_lane=_text(getattr(visual_decision, "studio_lane", "")),
+        artifact_kind=_text(getattr(visual_decision, "artifact_kind", "")),
+        renderer_contract=_text(getattr(visual_decision, "renderer_contract", "")),
+        renderer_kind_hint=_text(getattr(visual_decision, "renderer_kind_hint", "")),
+    )

--- a/maritime-ai-service/app/engine/tools/visual_code_runtime_contract.py
+++ b/maritime-ai-service/app/engine/tools/visual_code_runtime_contract.py
@@ -1,0 +1,136 @@
+"""Typed runtime contract for Code Studio visual-code payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+BLOCKED_CODE_STUDIO_PRESENTATION_INTENTS = frozenset({"article_figure", "chart_runtime"})
+CODE_STUDIO_PRESENTATION_INTENTS = frozenset({"code_studio_app", "artifact"})
+CODE_STUDIO_VISUAL_TYPES = frozenset(
+    {
+        "comparison",
+        "process",
+        "matrix",
+        "architecture",
+        "concept",
+        "infographic",
+        "chart",
+        "timeline",
+        "map_lite",
+        "simulation",
+        "quiz",
+        "interactive_table",
+        "react_app",
+    }
+)
+CODE_STUDIO_LANES = frozenset({"app", "artifact", "widget"})
+CODE_STUDIO_ARTIFACT_KINDS = frozenset(
+    {"html_app", "code_widget", "search_widget", "document", "chart_widget"}
+)
+CODE_STUDIO_QUALITY_PROFILES = frozenset({"draft", "standard", "premium"})
+
+
+def _text(value: Any, default: str = "") -> str:
+    cleaned = str(value if value is not None else default).strip()
+    return cleaned or default
+
+
+def _choice(value: Any, allowed: frozenset[str], default: str) -> str:
+    candidate = _text(value, default)
+    return candidate if candidate in allowed else default
+
+
+def _code_studio_version(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except Exception:
+        return 0
+
+
+@dataclass(frozen=True, slots=True)
+class VisualCodeRuntimeContract:
+    """Host-shell contract resolved before a Code Studio visual payload is built."""
+
+    presentation_intent: str
+    studio_lane: str
+    artifact_kind: str
+    requested_visual_type: str
+    resolved_visual_type: str
+    renderer_kind: str
+    shell_variant: str
+    patch_strategy: str
+    quality_profile: str
+    code_studio_version: int = 0
+    renderer_contract: str = "host_shell"
+
+    @property
+    def is_blocked_for_code_studio(self) -> bool:
+        return self.presentation_intent in BLOCKED_CODE_STUDIO_PRESENTATION_INTENTS
+
+    @property
+    def runtime_manifest(self) -> dict[str, Any] | None:
+        if self.renderer_kind != "app":
+            return None
+        return {
+            "ui_runtime": "html",
+            "storage": False,
+            "mcp_access": False,
+            "file_export": self.studio_lane == "artifact",
+            "shareability": "session" if self.studio_lane == "app" else "artifact",
+        }
+
+    def payload_metadata(self) -> dict[str, Any]:
+        metadata: dict[str, Any] = {
+            "source_tool": "tool_create_visual_code",
+            "presentation_intent": (
+                self.presentation_intent
+                if self.presentation_intent in CODE_STUDIO_PRESENTATION_INTENTS
+                else "code_studio_app"
+            ),
+            "studio_lane": self.studio_lane,
+            "artifact_kind": self.artifact_kind,
+            "quality_profile": self.quality_profile,
+            "renderer_contract": self.renderer_contract,
+        }
+        if self.code_studio_version > 0:
+            metadata["code_studio_version"] = self.code_studio_version
+        return metadata
+
+
+def resolve_visual_code_runtime_contract(
+    *,
+    presentation_intent: str = "",
+    studio_lane: str = "",
+    artifact_kind: str = "",
+    requested_visual_type: str = "",
+    quality_profile: str = "",
+    code_studio_version: Any = 0,
+) -> VisualCodeRuntimeContract:
+    """Resolve Code Studio lane metadata once, before validation and payload build."""
+
+    raw_intent = _text(presentation_intent, "code_studio_app")
+    if raw_intent in BLOCKED_CODE_STUDIO_PRESENTATION_INTENTS:
+        resolved_intent = raw_intent
+    else:
+        resolved_intent = raw_intent if raw_intent in CODE_STUDIO_PRESENTATION_INTENTS else "code_studio_app"
+
+    resolved_lane = _choice(studio_lane, CODE_STUDIO_LANES, "app")
+    resolved_artifact_kind = _choice(artifact_kind, CODE_STUDIO_ARTIFACT_KINDS, "html_app")
+    requested_type = _text(requested_visual_type, "concept")
+    resolved_visual_type = requested_type if requested_type in CODE_STUDIO_VISUAL_TYPES else "concept"
+    renderer_kind = "app" if resolved_lane in {"app", "widget"} else "inline_html"
+
+    return VisualCodeRuntimeContract(
+        presentation_intent=resolved_intent,
+        studio_lane=resolved_lane,
+        artifact_kind=resolved_artifact_kind,
+        requested_visual_type=requested_type,
+        resolved_visual_type=resolved_visual_type,
+        renderer_kind=renderer_kind,
+        shell_variant="immersive" if renderer_kind == "app" else "editorial",
+        patch_strategy="app_state" if renderer_kind == "app" else "replace_html",
+        quality_profile=_choice(quality_profile, CODE_STUDIO_QUALITY_PROFILES, "standard"),
+        code_studio_version=_code_studio_version(code_studio_version),
+    )

--- a/maritime-ai-service/app/engine/tools/visual_tool_runtime.py
+++ b/maritime-ai-service/app/engine/tools/visual_tool_runtime.py
@@ -2,6 +2,10 @@ import json
 import re
 from typing import Any, Callable
 
+from app.engine.tools.visual_code_runtime_contract import (
+    resolve_visual_code_runtime_contract,
+)
+
 
 def tool_generate_visual_impl(
     *,
@@ -246,64 +250,51 @@ def tool_create_visual_code_impl(
     if not getattr(get_settings(), "enable_llm_code_gen_visuals", False):
         return "Error: Visual code generation chưa được bật (enable_llm_code_gen_visuals=False)."
 
-    presentation_intent = runtime_presentation_intent()
-    if presentation_intent in {"article_figure", "chart_runtime"}:
+    runtime_contract = resolve_visual_code_runtime_contract(
+        presentation_intent=runtime_presentation_intent(),
+        studio_lane=runtime_studio_lane(),
+        artifact_kind=runtime_artifact_kind(),
+        requested_visual_type=runtime_metadata_text("visual_requested_type", "concept"),
+        quality_profile=runtime_quality_profile(),
+        code_studio_version=runtime_code_studio_version(),
+    )
+    if runtime_contract.is_blocked_for_code_studio:
         return (
             "Error: tool_create_visual_code khong phai lane dung cho article figure/chart runtime. "
             "Hay dung tool_generate_visual de tao figure giai thich hoac chart runtime chuan."
         )
 
-    studio_lane = runtime_studio_lane() or "app"
-    artifact_kind = runtime_artifact_kind() or "html_app"
-    requested_visual_type = runtime_metadata_text("visual_requested_type", "concept")
-    resolved_visual_type = requested_visual_type if requested_visual_type in {
-        "comparison",
-        "process",
-        "matrix",
-        "architecture",
-        "concept",
-        "infographic",
-        "chart",
-        "timeline",
-        "map_lite",
-        "simulation",
-        "quiz",
-        "interactive_table",
-        "react_app",
-    } else "concept"
-    resolved_renderer_kind = "app" if studio_lane in {"app", "widget"} else "inline_html"
-    resolved_shell_variant = "immersive" if resolved_renderer_kind == "app" else "editorial"
-    resolved_patch_strategy = "app_state" if resolved_renderer_kind == "app" else "replace_html"
-    quality_profile = runtime_quality_profile()
-
     raw = maybe_upgrade_code_studio_output(
         raw,
         title=title,
         subtitle=subtitle,
-        requested_visual_type=resolved_visual_type,
-        studio_lane=studio_lane,
-        artifact_kind=artifact_kind,
-        quality_profile=quality_profile,
+        requested_visual_type=runtime_contract.resolved_visual_type,
+        studio_lane=runtime_contract.studio_lane,
+        artifact_kind=runtime_contract.artifact_kind,
+        quality_profile=runtime_contract.quality_profile,
     )
 
     quality_error = validate_code_studio_output(
         raw,
-        requested_visual_type=resolved_visual_type,
-        studio_lane=studio_lane,
-        artifact_kind=artifact_kind,
-        quality_profile=quality_profile,
+        requested_visual_type=runtime_contract.resolved_visual_type,
+        studio_lane=runtime_contract.studio_lane,
+        artifact_kind=runtime_contract.artifact_kind,
+        quality_profile=runtime_contract.quality_profile,
     )
     if quality_error:
         return quality_error
 
     raw_len = len(raw)
     if raw_len > 500:
-        quality_score, quality_deficiencies = quality_score_visual_output(raw, resolved_visual_type)
+        quality_score, quality_deficiencies = quality_score_visual_output(
+            raw,
+            runtime_contract.resolved_visual_type,
+        )
         logger.info(
             "[QUALITY_GATE] raw=%d chars, score=%d/10, type=%s, deficiencies=%d",
             raw_len,
             quality_score,
-            resolved_visual_type,
+            runtime_contract.resolved_visual_type,
             len(quality_deficiencies),
         )
         if quality_score < 6 and quality_deficiencies:
@@ -342,34 +333,20 @@ def tool_create_visual_code_impl(
     )
 
     payload = normalize_visual_payload(
-        visual_type=resolved_visual_type,
+        visual_type=runtime_contract.resolved_visual_type,
         spec={},
         title=safe_title,
         summary=safe_summary,
         subtitle=subtitle,
         visual_session_id=resolved_visual_session_id,
         operation=resolved_operation,
-        renderer_kind=resolved_renderer_kind,
-        shell_variant=resolved_shell_variant,
-        patch_strategy=resolved_patch_strategy,
+        renderer_kind=runtime_contract.renderer_kind,
+        shell_variant=runtime_contract.shell_variant,
+        patch_strategy=runtime_contract.patch_strategy,
         narrative_anchor="after-lead",
         fallback_html=final_html,
-        runtime_manifest={
-            "ui_runtime": "html",
-            "storage": False,
-            "mcp_access": False,
-            "file_export": studio_lane == "artifact",
-            "shareability": "session" if studio_lane == "app" else "artifact",
-        } if resolved_renderer_kind == "app" else None,
-        metadata={
-            "source_tool": "tool_create_visual_code",
-            "presentation_intent": presentation_intent or "code_studio_app",
-            "studio_lane": studio_lane,
-            "artifact_kind": artifact_kind,
-            "quality_profile": quality_profile,
-            "renderer_contract": "host_shell",
-            **({"code_studio_version": runtime_code_studio_version()} if runtime_code_studio_version() > 0 else {}),
-        },
+        runtime_manifest=runtime_contract.runtime_manifest,
+        metadata=runtime_contract.payload_metadata(),
     )
     log_visual_telemetry(
         "tool_create_visual_code",

--- a/maritime-ai-service/tests/unit/test_visual_code_runtime_contract.py
+++ b/maritime-ai-service/tests/unit/test_visual_code_runtime_contract.py
@@ -1,0 +1,89 @@
+from app.engine.tools.visual_code_runtime_contract import (
+    resolve_visual_code_runtime_contract,
+)
+
+
+def test_visual_code_contract_resolves_simulation_app_lane() -> None:
+    contract = resolve_visual_code_runtime_contract(
+        presentation_intent="code_studio_app",
+        studio_lane="app",
+        artifact_kind="html_app",
+        requested_visual_type="simulation",
+        quality_profile="premium",
+        code_studio_version="3",
+    )
+
+    assert contract.presentation_intent == "code_studio_app"
+    assert contract.studio_lane == "app"
+    assert contract.artifact_kind == "html_app"
+    assert contract.requested_visual_type == "simulation"
+    assert contract.resolved_visual_type == "simulation"
+    assert contract.renderer_kind == "app"
+    assert contract.shell_variant == "immersive"
+    assert contract.patch_strategy == "app_state"
+    assert contract.quality_profile == "premium"
+    assert contract.code_studio_version == 3
+    assert contract.runtime_manifest == {
+        "ui_runtime": "html",
+        "storage": False,
+        "mcp_access": False,
+        "file_export": False,
+        "shareability": "session",
+    }
+    assert contract.payload_metadata()["code_studio_version"] == 3
+
+
+def test_visual_code_contract_resolves_artifact_lane_as_inline_html() -> None:
+    contract = resolve_visual_code_runtime_contract(
+        presentation_intent="artifact",
+        studio_lane="artifact",
+        artifact_kind="document",
+        requested_visual_type="interactive_table",
+        quality_profile="standard",
+    )
+
+    assert contract.presentation_intent == "artifact"
+    assert contract.studio_lane == "artifact"
+    assert contract.artifact_kind == "document"
+    assert contract.resolved_visual_type == "interactive_table"
+    assert contract.renderer_kind == "inline_html"
+    assert contract.shell_variant == "editorial"
+    assert contract.patch_strategy == "replace_html"
+    assert contract.runtime_manifest is None
+    assert contract.payload_metadata()["presentation_intent"] == "artifact"
+
+
+def test_visual_code_contract_marks_article_and_chart_lanes_blocked() -> None:
+    article = resolve_visual_code_runtime_contract(
+        presentation_intent="article_figure",
+        requested_visual_type="comparison",
+    )
+    chart = resolve_visual_code_runtime_contract(
+        presentation_intent="chart_runtime",
+        requested_visual_type="chart",
+    )
+
+    assert article.is_blocked_for_code_studio is True
+    assert chart.is_blocked_for_code_studio is True
+
+
+def test_visual_code_contract_sanitizes_unknown_runtime_values() -> None:
+    contract = resolve_visual_code_runtime_contract(
+        presentation_intent="text",
+        studio_lane="detached",
+        artifact_kind="unknown",
+        requested_visual_type="freeform_untyped",
+        quality_profile="heroic",
+        code_studio_version="bad",
+    )
+
+    assert contract.presentation_intent == "code_studio_app"
+    assert contract.studio_lane == "app"
+    assert contract.artifact_kind == "html_app"
+    assert contract.requested_visual_type == "freeform_untyped"
+    assert contract.resolved_visual_type == "concept"
+    assert contract.renderer_kind == "app"
+    assert contract.quality_profile == "standard"
+    assert contract.code_studio_version == 0
+    assert contract.payload_metadata()["presentation_intent"] == "code_studio_app"
+    assert "code_studio_version" not in contract.payload_metadata()

--- a/maritime-ai-service/tests/unit/test_visual_runtime_metadata_contract.py
+++ b/maritime-ai-service/tests/unit/test_visual_runtime_metadata_contract.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+
+from app.engine.multi_agent.visual_runtime_metadata_contract import (
+    build_visual_tool_runtime_intent,
+)
+
+
+def test_build_visual_tool_runtime_intent_preserves_typed_lane_metadata() -> None:
+    decision = SimpleNamespace(
+        force_tool=True,
+        mode="app",
+        reason="simulation cue",
+        presentation_intent="code_studio_app",
+        figure_budget=5,
+        quality_profile="premium",
+        preferred_render_surface="canvas",
+        planning_profile="simulation_canvas",
+        thinking_floor="max",
+        critic_policy="premium",
+        living_expression_mode="expressive",
+        visual_type="simulation",
+        preferred_tool="tool_create_visual_code",
+        studio_lane="app",
+        artifact_kind="html_app",
+        renderer_contract="host_shell",
+        renderer_kind_hint="app",
+    )
+
+    runtime_intent = build_visual_tool_runtime_intent(
+        query="tao mo phong con lac",
+        visual_decision=decision,
+    )
+
+    assert runtime_intent is not None
+    metadata = runtime_intent.to_metadata()
+    assert metadata["visual_user_query"] == "tao mo phong con lac"
+    assert metadata["visual_intent_mode"] == "app"
+    assert metadata["presentation_intent"] == "code_studio_app"
+    assert metadata["figure_budget"] == 3
+    assert metadata["quality_profile"] == "premium"
+    assert metadata["preferred_render_surface"] == "canvas"
+    assert metadata["visual_requested_type"] == "simulation"
+    assert metadata["preferred_visual_tool"] == "tool_create_visual_code"
+    assert metadata["studio_lane"] == "app"
+    assert metadata["artifact_kind"] == "html_app"
+    assert metadata["renderer_contract"] == "host_shell"
+    assert metadata["renderer_kind_hint"] == "app"
+
+
+def test_build_visual_tool_runtime_intent_skips_non_visual_turns() -> None:
+    decision = SimpleNamespace(force_tool=False, mode="app")
+
+    runtime_intent = build_visual_tool_runtime_intent(
+        query="xin chao",
+        visual_decision=decision,
+    )
+
+    assert runtime_intent is None
+
+
+def test_build_visual_tool_runtime_intent_normalizes_unknown_quality() -> None:
+    decision = SimpleNamespace(
+        force_tool=True,
+        mode="inline_html",
+        reason="chart cue",
+        presentation_intent="chart_runtime",
+        figure_budget="bad",
+        quality_profile="heroic",
+        preferred_render_surface="svg",
+        planning_profile="chart_svg",
+        thinking_floor="medium",
+        critic_policy="standard",
+        living_expression_mode="subtle",
+    )
+
+    runtime_intent = build_visual_tool_runtime_intent(
+        query="ve bieu do",
+        visual_decision=decision,
+    )
+
+    assert runtime_intent is not None
+    metadata = runtime_intent.to_metadata()
+    assert metadata["figure_budget"] == 1
+    assert metadata["quality_profile"] == "standard"
+    assert "visual_requested_type" not in metadata
+
+
+def test_build_visual_tool_runtime_intent_rejects_unknown_runtime_mode() -> None:
+    decision = SimpleNamespace(force_tool=True, mode="raw_html")
+
+    runtime_intent = build_visual_tool_runtime_intent(
+        query="tao visual",
+        visual_decision=decision,
+    )
+
+    assert runtime_intent is None


### PR DESCRIPTION
﻿## Summary
- Move visual intent -> tool runtime metadata shaping into a typed VisualToolRuntimeIntent contract.
- Move Code Studio visual-code lane/renderer/patch/quality/runtime-manifest resolution into VisualCodeRuntimeContract.
- Update runtime cleanup audit for follow-up #561.

Closes #561

## Verification
- cd maritime-ai-service && uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_visual_runtime_metadata_contract.py tests/unit/test_visual_code_runtime_contract.py tests/unit/test_graph_routing.py::TestVisualRuntimeMetadata -q --tb=short
- cd maritime-ai-service && uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_visual_tools.py -q --tb=short
- cd maritime-ai-service && uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_sprint154_tech_debt.py -k "visual_runtime_metadata_reuses or visual_runtime_metadata_preserves" -q --tb=short
- cd maritime-ai-service && uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_visual_intent_resolver.py tests/unit/test_direct_visual_tool_policy_runtime.py tests/unit/test_direct_node_execution_prep.py -q --tb=short
- cd maritime-ai-service && uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/visual_runtime_metadata_contract.py app/engine/multi_agent/tool_collection.py app/engine/tools/visual_code_runtime_contract.py app/engine/tools/visual_tool_runtime.py tests/unit/test_visual_runtime_metadata_contract.py tests/unit/test_visual_code_runtime_contract.py --select=E9,F
- git diff --check --cached

## Risk and rollback
- Risk: visual app/chart routing metadata could drift if the typed contract normalizes values differently from legacy inline logic. Mitigation: regression coverage exercises chart metadata, Code Studio visual payloads, active-session patch metadata, visual intent policy, and direct execution prep.
- Rollback: revert this PR; it only changes runtime metadata/lane shaping and adds tests/docs, with no migrations or persistent data writes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling for visual code generation requests.
  * Added blocking checks to prevent unsupported code generation scenarios.

* **Refactor**
  * Restructured visual runtime metadata handling for better type safety and consistency.

* **Tests**
  * Added comprehensive unit tests for visual runtime configuration resolution and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->