### PR TITLE
Refactor direct node LLM execution finalization

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -6,7 +6,7 @@ Owner: Project leadership
 
 Issue: #411
 
-Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539, #549, #551, #553, #555, #557, #559, #561 (owner: Architecture Maintainers)
+Follow-up issues: #413, #415, #417, #419, #421, #423, #425, #427, #429, #431, #433, #435, #437, #439, #441, #477, #479, #481, #483, #485, #487, #489, #491, #493, #495, #497, #499, #501, #503, #505, #507, #509, #511, #513, #515, #517, #519, #521, #523, #525, #527, #533, #535, #537, #539, #549, #551, #553, #555, #557, #559, #561, #563 (owner: Architecture Maintainers)
 
 ## Purpose
 
@@ -241,6 +241,12 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   resolves presentation intent, studio lane, artifact kind, renderer kind,
   patch strategy, quality profile, and runtime manifest through
   `VisualCodeRuntimeContract` before validation/payload build.
+- Follow-up #563 moved direct-node LLM/tool execution result finalization into
+  `direct_node_llm_execution_finalization.py`, keeping response extraction,
+  cleanup, source-backed empty-response fallback, visible-thinking finalization,
+  and `tool_call_events` / `tools_used` state side effects behind one tested
+  helper while preserving host-timeout execution and exception salvage in the
+  main shell.
 
 ## Preserved Intentionally
 
@@ -275,8 +281,8 @@ backups, data PDFs, or local skill folders.
   host-action rebinding/execution/preflight, image-input preflight,
   direct-node event sink lifecycle, direct-node turn-start lifecycle,
   direct-node turn-policy lifecycle, direct-node tool selection, LLM preflight,
-  LLM-unavailable fallback selection, execution preparation, response cleanup,
-  visible-thinking finalization,
+  LLM-unavailable fallback selection, execution preparation, LLM/tool execution
+  result finalization,
   exception/source fallback lifecycle, final state/domain notice handling, and
   host UI timeout handling have moved out. The long-term cleanup direction is
   lifecycle modules and SSE V3 parity modules with narrow contract tests. Its

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_llm_execution_finalization.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_llm_execution_finalization.py
@@ -1,0 +1,135 @@
+"""Finalize direct-node LLM/tool execution results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from app.engine.multi_agent.direct_node_operational_fast_paths import (
+    _build_codebase_analysis_fallback_answer,
+    _build_codebase_analysis_fallback_thinking,
+    _looks_generic_direct_fallback_response,
+    _strip_dsml_residue,
+)
+from app.engine.multi_agent.direct_node_response_cleanup import (
+    apply_source_backed_empty_response_fallback,
+    clean_direct_node_llm_response,
+)
+from app.engine.multi_agent.direct_node_thinking_snapshot import (
+    record_direct_node_thinking_snapshot,
+)
+from app.engine.multi_agent.direct_node_visible_thinking_finalization import (
+    finalize_direct_node_visible_thinking,
+)
+from app.engine.multi_agent.direct_node_visible_thought import (
+    _compact_basic_identity_answer,
+    _strip_direct_inline_private_asides,
+)
+from app.engine.multi_agent.direct_reasoning import _is_codebase_analysis_query
+from app.engine.multi_agent.direct_search_synthesis_fallback import (
+    build_search_template_fallback,
+    looks_like_search_placeholder_answer,
+)
+from app.engine.reasoning import record_thinking_snapshot
+from app.engine.runtime.runtime_metrics import inc_counter
+
+
+@dataclass(slots=True)
+class DirectNodeLlmExecutionFinalizationResult:
+    response: str
+    thinking_content: str
+    tools_used: list[Any]
+    tool_call_events: list[dict[str, Any]]
+
+
+async def finalize_direct_node_llm_execution(
+    *,
+    query: str,
+    state: dict[str, Any],
+    llm_response: Any,
+    messages: list[Any],
+    tool_call_events: list[dict[str, Any]],
+    llm: Any,
+    routing_intent: str,
+    response_language: str,
+    is_identity_turn: bool,
+    explicit_web_search_turn: bool,
+    extract_direct_response: Callable[[Any, list[Any]], tuple[str, str, list[Any]]],
+    sanitize_structured_visual_answer_text: Callable[[str], str],
+    sanitize_wiii_house_text: Callable[[str], str],
+    build_direct_reasoning_summary: Callable[..., str],
+    logger_obj: Any,
+    clean_direct_node_llm_response_fn: Callable[..., Any] = clean_direct_node_llm_response,
+    apply_source_backed_empty_response_fallback_fn: Callable[..., Any] = (
+        apply_source_backed_empty_response_fallback
+    ),
+    finalize_direct_node_visible_thinking_fn: Callable[..., Any] = (
+        finalize_direct_node_visible_thinking
+    ),
+) -> DirectNodeLlmExecutionFinalizationResult:
+    """Finalize a completed LLM/tool round and apply direct-node state effects."""
+
+    if tool_call_events:
+        state["tool_call_events"] = tool_call_events
+
+    response, thinking_content, tools_used = extract_direct_response(llm_response, messages)
+    cleaned_response = clean_direct_node_llm_response_fn(
+        query=query,
+        state=state,
+        response=response,
+        thinking_content=thinking_content,
+        tools_used=tools_used,
+        tool_call_events=tool_call_events,
+        is_identity_turn=is_identity_turn,
+        is_codebase_analysis_turn=_is_codebase_analysis_query(query),
+        explicit_web_search_turn=explicit_web_search_turn,
+        sanitize_structured_visual_answer_text=sanitize_structured_visual_answer_text,
+        sanitize_wiii_house_text=sanitize_wiii_house_text,
+        strip_direct_inline_private_asides=_strip_direct_inline_private_asides,
+        strip_dsml_residue=_strip_dsml_residue,
+        compact_basic_identity_answer=_compact_basic_identity_answer,
+        looks_generic_direct_fallback_response=_looks_generic_direct_fallback_response,
+        build_codebase_analysis_fallback_answer=_build_codebase_analysis_fallback_answer,
+        build_codebase_analysis_fallback_thinking=_build_codebase_analysis_fallback_thinking,
+        record_direct_node_thinking_snapshot=record_direct_node_thinking_snapshot,
+        record_thinking_snapshot_fn=record_thinking_snapshot,
+    )
+    response = cleaned_response.response
+    thinking_content = cleaned_response.thinking_content
+    tools_used = list(cleaned_response.tools_used or [])
+
+    source_fallback = apply_source_backed_empty_response_fallback_fn(
+        query=query,
+        response=response,
+        tools_used=tools_used,
+        tool_call_events=tool_call_events,
+        looks_like_search_placeholder_answer=looks_like_search_placeholder_answer,
+        build_search_template_fallback=build_search_template_fallback,
+        inc_counter=inc_counter,
+        logger_obj=logger_obj,
+    )
+    response = source_fallback.response
+    tools_used = list(source_fallback.tools_used or [])
+
+    await finalize_direct_node_visible_thinking_fn(
+        query=query,
+        state=state,
+        response=response,
+        thinking_content=thinking_content,
+        routing_intent=routing_intent,
+        response_language=response_language,
+        llm=llm,
+        tools_used=list(tools_used or []),
+        build_direct_reasoning_summary=build_direct_reasoning_summary,
+        record_direct_node_thinking_snapshot=record_direct_node_thinking_snapshot,
+        record_thinking_snapshot_fn=record_thinking_snapshot,
+    )
+    if tools_used:
+        state["tools_used"] = tools_used
+
+    return DirectNodeLlmExecutionFinalizationResult(
+        response=response,
+        thinking_content=thinking_content,
+        tools_used=tools_used,
+        tool_call_events=tool_call_events,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -40,19 +40,11 @@ from app.engine.multi_agent.direct_node_llm_preflight import (
 from app.engine.multi_agent.direct_node_llm_fallback import (
     resolve_direct_node_llm_unavailable_fallback,
 )
-from app.engine.multi_agent.direct_node_response_cleanup import (
-    apply_source_backed_empty_response_fallback,
-    clean_direct_node_llm_response,
-)
-from app.engine.multi_agent.direct_node_visible_thinking_finalization import (
-    finalize_direct_node_visible_thinking,
-)
-from app.engine.multi_agent.direct_reasoning import (
-    _is_codebase_analysis_query,
+from app.engine.multi_agent.direct_node_llm_execution_finalization import (
+    finalize_direct_node_llm_execution,
 )
 from app.engine.multi_agent.direct_search_synthesis_fallback import (
     build_search_template_fallback,
-    looks_like_search_placeholder_answer,
 )
 from app.engine.multi_agent.direct_node_exception_fallbacks import (
     handle_direct_node_generation_exception,
@@ -61,7 +53,6 @@ from app.engine.multi_agent.direct_node_final_state import finalize_direct_node_
 from app.engine.multi_agent.direct_node_operational_fast_paths import (
     _build_codebase_analysis_fallback_answer,
     _build_codebase_analysis_fallback_thinking,
-    _looks_generic_direct_fallback_response,
     _strip_dsml_residue,
 )
 from app.engine.multi_agent.direct_node_thinking_snapshot import (
@@ -78,7 +69,6 @@ from app.engine.multi_agent.direct_node_uploaded_context import (
     _provider_likely_supports_image_blocks,
 )
 from app.engine.multi_agent.direct_node_visible_thought import (
-    _compact_basic_identity_answer,
     _strip_direct_inline_private_asides,
 )
 from app.engine.runtime.runtime_metrics import inc_counter
@@ -337,8 +327,6 @@ async def direct_response_node_impl(
                 )
                 if preview_result is not None:
                     response = preview_result.response
-                    thinking_content = preview_result.thinking_content
-                    tools_used = preview_result.tools_used
                     messages = preview_result.messages
                     tool_call_events = preview_result.tool_call_events
                     tracer.end_step(
@@ -515,73 +503,24 @@ async def direct_response_node_impl(
                     logger_obj=logger,
                 )
 
-                if tool_call_events:
-                    state["tool_call_events"] = tool_call_events
-
-                response, thinking_content, tools_used = extract_direct_response(llm_response, messages)
-                cleaned_response = clean_direct_node_llm_response(
+                llm_finalization = await finalize_direct_node_llm_execution(
                     query=query,
                     state=state,
-                    response=response,
-                    thinking_content=thinking_content,
-                    tools_used=tools_used,
+                    llm_response=llm_response,
+                    messages=messages,
                     tool_call_events=tool_call_events,
-                    is_identity_turn=is_identity_turn,
-                    is_codebase_analysis_turn=_is_codebase_analysis_query(query),
-                    explicit_web_search_turn=explicit_web_search_turn,
-                    sanitize_structured_visual_answer_text=sanitize_structured_visual_answer_text,
-                    sanitize_wiii_house_text=sanitize_wiii_house_text,
-                    strip_direct_inline_private_asides=_strip_direct_inline_private_asides,
-                    strip_dsml_residue=_strip_dsml_residue,
-                    compact_basic_identity_answer=_compact_basic_identity_answer,
-                    looks_generic_direct_fallback_response=(
-                        _looks_generic_direct_fallback_response
-                    ),
-                    build_codebase_analysis_fallback_answer=(
-                        _build_codebase_analysis_fallback_answer
-                    ),
-                    build_codebase_analysis_fallback_thinking=(
-                        _build_codebase_analysis_fallback_thinking
-                    ),
-                    record_direct_node_thinking_snapshot=record_direct_node_thinking_snapshot,
-                    record_thinking_snapshot_fn=record_thinking_snapshot,
-                )
-                response = cleaned_response.response
-                thinking_content = cleaned_response.thinking_content
-                tools_used = cleaned_response.tools_used
-                # Source-backed graceful synthesis: when the LLM returned an
-                # empty body but tools captured real search results (Perplexity
-                # 2026 / Anthropic Computer Use 2026 evidence-pool pattern),
-                # build a citation-bearing answer directly from tool_call_events
-                # instead of letting the user see nothing.
-                source_fallback = apply_source_backed_empty_response_fallback(
-                    query=query,
-                    response=response,
-                    tools_used=tools_used,
-                    tool_call_events=tool_call_events,
-                    looks_like_search_placeholder_answer=looks_like_search_placeholder_answer,
-                    build_search_template_fallback=build_search_template_fallback,
-                    inc_counter=inc_counter,
-                    logger_obj=logger,
-                )
-                response = source_fallback.response
-                tools_used = source_fallback.tools_used
-
-                await finalize_direct_node_visible_thinking(
-                    query=query,
-                    state=state,
-                    response=response,
-                    thinking_content=thinking_content,
+                    llm=llm,
                     routing_intent=routing_intent,
                     response_language=response_language,
-                    llm=llm,
-                    tools_used=list(tools_used or []),
+                    is_identity_turn=is_identity_turn,
+                    explicit_web_search_turn=explicit_web_search_turn,
+                    extract_direct_response=extract_direct_response,
+                    sanitize_structured_visual_answer_text=sanitize_structured_visual_answer_text,
+                    sanitize_wiii_house_text=sanitize_wiii_house_text,
                     build_direct_reasoning_summary=build_direct_reasoning_summary,
-                    record_direct_node_thinking_snapshot=record_direct_node_thinking_snapshot,
-                    record_thinking_snapshot_fn=record_thinking_snapshot,
+                    logger_obj=logger,
                 )
-                if tools_used:
-                    state["tools_used"] = tools_used
+                response = llm_finalization.response
 
                 tracer.end_step(
                     result=f"Phan hoi LLM: {len(response)} chars",

--- a/maritime-ai-service/tests/unit/test_direct_node_llm_execution_finalization.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_llm_execution_finalization.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.engine.multi_agent.direct_node_llm_execution_finalization import (
+    finalize_direct_node_llm_execution,
+)
+
+
+@pytest.mark.asyncio
+async def test_finalize_direct_node_llm_execution_applies_cleanup_fallback_and_state() -> None:
+    state: dict[str, Any] = {}
+    finalizer_calls: list[dict[str, Any]] = []
+    tool_events = [{"type": "result", "name": "tool_web_search", "content": "source"}]
+
+    def extract_direct_response(_llm_response: Any, _messages: list[Any]):
+        return "raw answer", "thinking", ["tool_web_search"]
+
+    def clean_response(**kwargs: Any):
+        assert kwargs["response"] == "raw answer"
+        assert kwargs["tool_call_events"] == tool_events
+        return SimpleNamespace(
+            response="clean answer",
+            thinking_content="clean thinking",
+            tools_used=["tool_web_search"],
+        )
+
+    def source_fallback(**kwargs: Any):
+        assert kwargs["response"] == "clean answer"
+        return SimpleNamespace(
+            response="source-backed answer",
+            tools_used=[*kwargs["tools_used"], {"name": "tool_knowledge_search"}],
+        )
+
+    async def finalize_visible_thinking(**kwargs: Any):
+        finalizer_calls.append(kwargs)
+
+    result = await finalize_direct_node_llm_execution(
+        query="gia dau hom nay",
+        state=state,
+        llm_response=SimpleNamespace(content="raw"),
+        messages=["message"],
+        tool_call_events=tool_events,
+        llm=SimpleNamespace(name="llm"),
+        routing_intent="lookup",
+        response_language="vi",
+        is_identity_turn=False,
+        explicit_web_search_turn=True,
+        extract_direct_response=extract_direct_response,
+        sanitize_structured_visual_answer_text=lambda text, **_kwargs: text,
+        sanitize_wiii_house_text=lambda text, **_kwargs: text,
+        build_direct_reasoning_summary=lambda **_kwargs: "summary",
+        logger_obj=logging.getLogger(__name__),
+        clean_direct_node_llm_response_fn=clean_response,
+        apply_source_backed_empty_response_fallback_fn=source_fallback,
+        finalize_direct_node_visible_thinking_fn=finalize_visible_thinking,
+    )
+
+    assert result.response == "source-backed answer"
+    assert result.thinking_content == "clean thinking"
+    assert result.tools_used == [
+        "tool_web_search",
+        {"name": "tool_knowledge_search"},
+    ]
+    assert state["tool_call_events"] == tool_events
+    assert state["tools_used"] == result.tools_used
+    assert finalizer_calls[0]["response"] == "source-backed answer"
+    assert finalizer_calls[0]["thinking_content"] == "clean thinking"
+    assert finalizer_calls[0]["tools_used"] == result.tools_used
+
+
+@pytest.mark.asyncio
+async def test_finalize_direct_node_llm_execution_leaves_empty_tool_state_when_no_tools() -> None:
+    state: dict[str, Any] = {}
+
+    def extract_direct_response(_llm_response: Any, _messages: list[Any]):
+        return "answer", "", []
+
+    def clean_response(**_kwargs: Any):
+        return SimpleNamespace(response="answer", thinking_content="", tools_used=[])
+
+    def source_fallback(**kwargs: Any):
+        return SimpleNamespace(response=kwargs["response"], tools_used=kwargs["tools_used"])
+
+    async def finalize_visible_thinking(**_kwargs: Any):
+        return None
+
+    result = await finalize_direct_node_llm_execution(
+        query="xin chao",
+        state=state,
+        llm_response=SimpleNamespace(content="answer"),
+        messages=[],
+        tool_call_events=[],
+        llm=None,
+        routing_intent="chat",
+        response_language="vi",
+        is_identity_turn=False,
+        explicit_web_search_turn=False,
+        extract_direct_response=extract_direct_response,
+        sanitize_structured_visual_answer_text=lambda text, **_kwargs: text,
+        sanitize_wiii_house_text=lambda text, **_kwargs: text,
+        build_direct_reasoning_summary=lambda **_kwargs: "",
+        logger_obj=logging.getLogger(__name__),
+        clean_direct_node_llm_response_fn=clean_response,
+        apply_source_backed_empty_response_fallback_fn=source_fallback,
+        finalize_direct_node_visible_thinking_fn=finalize_visible_thinking,
+    )
+
+    assert result.response == "answer"
+    assert result.tools_used == []
+    assert "tool_call_events" not in state
+    assert "tools_used" not in state


### PR DESCRIPTION
﻿## Summary
- Move direct-node LLM/tool execution result finalization into direct_node_llm_execution_finalization.py.
- Keep response extraction, cleanup, source-backed empty-response fallback, visible-thinking finalization, and state side effects behind one tested helper.
- Preserve host-timeout execution and exception salvage in direct_node_runtime.py.

Closes #563

## Verification
- cd maritime-ai-service && uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_direct_node_llm_execution_finalization.py tests/unit/test_direct_node_response_cleanup.py tests/unit/test_direct_node_execution_prep.py tests/unit/test_direct_node_provider_errors.py -q --tb=short
- cd maritime-ai-service && uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/direct_node_runtime.py app/engine/multi_agent/direct_node_llm_execution_finalization.py tests/unit/test_direct_node_llm_execution_finalization.py --select=E9,F
- git diff --check

## Risk and rollback
- Risk: direct answer execution finalization is a sensitive orchestration path. Mitigation: the extraction starts only after the host-timeout/tool-loop returns, so existing outer exception fallback still receives llm_response/messages/tool_call_events for salvage. Existing provider/direct-node regression tests pass.
- Rollback: revert this PR; it is code-only, with no migrations, auth changes, persistent data writes, or deployment changes.
