### PR TITLE
refactor(backend): gate Code Studio scaffold fallback

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -247,6 +247,13 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   and `tool_call_events` / `tools_used` state side effects behind one tested
   helper while preserving host-timeout execution and exception salvage in the
   main shell.
+- Follow-up #565 moved deterministic Code Studio scaffold fallback decisions
+  behind `code_studio_scaffold_fallback_policy.py`. Tool-round timeouts,
+  no-tool-call responses, and outer Code Studio node exceptions now resolve a
+  typed `VisualCodeRuntimeContract` before engaging a template fallback.
+  Generic app/simulation failures are suppressed with an auditable safe-stop
+  response; artifact fallback remains allowed when the contract says it is the
+  right lane.
 
 ## Preserved Intentionally
 
@@ -317,9 +324,10 @@ backups, data PDFs, or local skill folders.
   before preview, and the first markdown/iframe UX cleanup landed in #559. The
   scaffold should keep moving away from broad template fallback when the
   primary visual tool path is healthy. Follow-up #561 introduced typed runtime
-  contracts for visual intent metadata and Code Studio visual-code lanes; the
-  next quality frontier is using those contracts to reduce deterministic
-  scaffold fallback in product flows, not adding more ad-hoc templates.
+  contracts for visual intent metadata and Code Studio visual-code lanes, and
+  follow-up #565 now uses those contracts to suppress broad app/simulation
+  scaffold fallback in product flows. The next quality frontier is deeper typed
+  visual intents for app categories, not adding more ad-hoc templates.
 - Some tests still import compatibility `graph.py` modules. Move tests toward
   `runtime.py` imports when the external import window can close.
 

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 
-from app.engine.multi_agent.code_studio_template_scaffold import (
-    build_scaffold_visible_caption,
-    detect_scaffold_kind,
+from app.engine.multi_agent.code_studio_scaffold_fallback_policy import (
+    resolve_code_studio_scaffold_fallback,
 )
 from app.engine.multi_agent.state import AgentState
 from app.engine.reasoning import (
@@ -328,18 +327,23 @@ async def code_studio_node_impl(
             )
     except Exception as e:
         logger.error("[CODE_STUDIO] Generation failed: %s", e, exc_info=True)
-        # Even when the upstream tool-rounds path could not engage its own
-        # scaffold (e.g. tool collection or message building threw early),
-        # speak to the user in the same source-backed-fallback voice — never
-        # ship a generic "có trục trặc" message that hides actual progress.
-        response = build_scaffold_visible_caption(query)
+        # Even when the upstream tool-rounds path fails before it can make
+        # its own decision, do not blindly ship the deterministic template:
+        # the visual/runtime contract decides whether fallback is allowed.
+        fallback_decision = resolve_code_studio_scaffold_fallback(
+            query=query,
+            state=state,
+            reason=f"node_outer_{type(e).__name__}",
+        )
+        response = fallback_decision.response
         try:
             inc_counter(
-                "wiii.code_studio.scaffold.engaged",
-                labels={
-                    "kind": detect_scaffold_kind(query),
-                    "reason": f"node_outer_{type(e).__name__}",
-                },
+                (
+                    "wiii.code_studio.scaffold.engaged"
+                    if fallback_decision.engage_scaffold
+                    else "wiii.code_studio.scaffold.suppressed"
+                ),
+                labels=fallback_decision.metric_labels(),
             )
         except Exception:  # noqa: BLE001 — never let metrics break a request
             pass
@@ -347,7 +351,8 @@ async def code_studio_node_impl(
             result=f"Fallback (code studio error: {type(e).__name__})",
             confidence=0.5,
             details={
-                "response_type": "code_studio_template_fallback",
+                "response_type": fallback_decision.response_type,
+                "fallback_policy_reason": fallback_decision.policy_reason,
                 "error": str(e)[:200],
             },
         )

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_fallback_policy.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_fallback_policy.py
@@ -1,0 +1,240 @@
+"""Contract-gated policy for deterministic Code Studio scaffold fallbacks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from app.engine.multi_agent.code_studio_template_scaffold import (
+    build_scaffold_visible_caption,
+    detect_scaffold_kind,
+)
+from app.engine.multi_agent.visual_intent_resolver import resolve_visual_intent
+from app.engine.tools.visual_code_runtime_contract import (
+    resolve_visual_code_runtime_contract,
+)
+
+
+_SAFE_SCAFFOLD_PRESENTATION_INTENTS = frozenset({"artifact"})
+
+
+@dataclass(frozen=True, slots=True)
+class CodeStudioScaffoldFallbackDecision:
+    """Auditable decision for whether Code Studio may use a template fallback."""
+
+    engage_scaffold: bool
+    response: str
+    metric_kind: str
+    callsite_reason: str
+    policy_reason: str
+    response_type: str
+    presentation_intent: str
+    preferred_tool: str
+    studio_lane: str
+    artifact_kind: str
+    visual_type: str
+    quality_profile: str
+
+    def metric_labels(self) -> dict[str, str]:
+        """Return stable metric labels for engaged and suppressed fallbacks."""
+        return {
+            "kind": self.metric_kind,
+            "reason": self.callsite_reason,
+            "policy_reason": self.policy_reason,
+            "presentation_intent": self.presentation_intent,
+            "visual_type": self.visual_type,
+            "studio_lane": self.studio_lane,
+        }
+
+
+VisualIntentResolver = Callable[[str], Any]
+RuntimeContractResolver = Callable[..., Any]
+CaptionBuilder = Callable[[str], str]
+KindDetector = Callable[[str], str]
+
+
+def _safe_kind(query: str, detect_kind: KindDetector) -> str:
+    try:
+        return str(detect_kind(query) or "default")
+    except Exception:
+        return "default"
+
+
+def _safe_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _safe_failure_response(
+    *,
+    visual_type: str,
+    presentation_intent: str,
+) -> str:
+    if presentation_intent == "code_studio_app" and visual_type == "simulation":
+        return (
+            "Mình đã mở đúng lane mô phỏng trong Code Studio, nhưng lượt này chưa tạo được "
+            "preview thật. Mình dừng ở trạng thái an toàn thay vì mở một template chung chung, "
+            "để không đưa ra mô phỏng sai."
+        )
+    if presentation_intent == "code_studio_app":
+        return (
+            "Mình đã giữ đúng lane Code Studio, nhưng lượt này chưa tạo được preview app thật. "
+            "Mình dừng ở trạng thái an toàn thay vì mở một template chung chung."
+        )
+    return (
+        "Yêu cầu này không thuộc lane Code Studio đáng tin cậy ở lượt hiện tại, nên mình không "
+        "mở template HTML dự phòng."
+    )
+
+
+def _resolution_failure_decision(
+    *,
+    query: str,
+    reason: str,
+    detect_kind: KindDetector,
+) -> CodeStudioScaffoldFallbackDecision:
+    return CodeStudioScaffoldFallbackDecision(
+        engage_scaffold=False,
+        response=(
+            "Mình chưa xác định được contract runtime đủ chắc cho Code Studio ở lượt này, "
+            "nên mình không mở template dự phòng."
+        ),
+        metric_kind=_safe_kind(query, detect_kind),
+        callsite_reason=reason,
+        policy_reason="visual_contract_resolution_failed",
+        response_type="code_studio_scaffold_suppressed",
+        presentation_intent="unknown",
+        preferred_tool="unknown",
+        studio_lane="unknown",
+        artifact_kind="unknown",
+        visual_type="unknown",
+        quality_profile="unknown",
+    )
+
+
+def resolve_code_studio_scaffold_fallback(
+    *,
+    query: str,
+    state: Any | None = None,
+    reason: str = "unknown",
+    resolve_visual_intent_fn: VisualIntentResolver = resolve_visual_intent,
+    resolve_contract_fn: RuntimeContractResolver = resolve_visual_code_runtime_contract,
+    build_caption_fn: CaptionBuilder = build_scaffold_visible_caption,
+    detect_kind_fn: KindDetector = detect_scaffold_kind,
+) -> CodeStudioScaffoldFallbackDecision:
+    """Resolve whether a deterministic scaffold is allowed for this failure path.
+
+    Generic app/simulation fallbacks are intentionally suppressed: if the
+    tool path cannot produce a real app preview, Wiii should fail visibly and
+    safely instead of shipping a broad topic template.
+    """
+    del state  # Reserved for future session-aware policy without changing call sites.
+
+    try:
+        visual_decision = resolve_visual_intent_fn(query)
+    except Exception:
+        return _resolution_failure_decision(
+            query=query,
+            reason=reason,
+            detect_kind=detect_kind_fn,
+        )
+
+    presentation_intent = _safe_text(getattr(visual_decision, "presentation_intent", ""))
+    preferred_tool = _safe_text(getattr(visual_decision, "preferred_tool", ""))
+    studio_lane = _safe_text(getattr(visual_decision, "studio_lane", ""))
+    artifact_kind = _safe_text(getattr(visual_decision, "artifact_kind", ""))
+    visual_type = _safe_text(getattr(visual_decision, "visual_type", ""))
+    quality_profile = _safe_text(getattr(visual_decision, "quality_profile", ""))
+    metric_kind = _safe_kind(query, detect_kind_fn)
+
+    if not getattr(visual_decision, "force_tool", False) or preferred_tool != "tool_create_visual_code":
+        return CodeStudioScaffoldFallbackDecision(
+            engage_scaffold=False,
+            response=_safe_failure_response(
+                visual_type=visual_type,
+                presentation_intent=presentation_intent,
+            ),
+            metric_kind=metric_kind,
+            callsite_reason=reason,
+            policy_reason="not_code_studio_tool_contract",
+            response_type="code_studio_scaffold_suppressed",
+            presentation_intent=presentation_intent,
+            preferred_tool=preferred_tool or "none",
+            studio_lane=studio_lane or "none",
+            artifact_kind=artifact_kind or "none",
+            visual_type=visual_type or "none",
+            quality_profile=quality_profile or "standard",
+        )
+
+    try:
+        contract = resolve_contract_fn(
+            presentation_intent=presentation_intent,
+            studio_lane=studio_lane,
+            artifact_kind=artifact_kind,
+            requested_visual_type=visual_type,
+            quality_profile=quality_profile,
+        )
+    except Exception:
+        return _resolution_failure_decision(
+            query=query,
+            reason=reason,
+            detect_kind=detect_kind_fn,
+        )
+
+    presentation_intent = _safe_text(getattr(contract, "presentation_intent", presentation_intent))
+    studio_lane = _safe_text(getattr(contract, "studio_lane", studio_lane))
+    artifact_kind = _safe_text(getattr(contract, "artifact_kind", artifact_kind))
+    visual_type = _safe_text(getattr(contract, "resolved_visual_type", visual_type))
+    quality_profile = _safe_text(getattr(contract, "quality_profile", quality_profile))
+
+    if getattr(contract, "is_blocked_for_code_studio", False):
+        return CodeStudioScaffoldFallbackDecision(
+            engage_scaffold=False,
+            response=_safe_failure_response(
+                visual_type=visual_type,
+                presentation_intent=presentation_intent,
+            ),
+            metric_kind=metric_kind,
+            callsite_reason=reason,
+            policy_reason="blocked_code_studio_presentation_intent",
+            response_type="code_studio_scaffold_suppressed",
+            presentation_intent=presentation_intent,
+            preferred_tool=preferred_tool,
+            studio_lane=studio_lane,
+            artifact_kind=artifact_kind,
+            visual_type=visual_type,
+            quality_profile=quality_profile,
+        )
+
+    if presentation_intent not in _SAFE_SCAFFOLD_PRESENTATION_INTENTS:
+        return CodeStudioScaffoldFallbackDecision(
+            engage_scaffold=False,
+            response=_safe_failure_response(
+                visual_type=visual_type,
+                presentation_intent=presentation_intent,
+            ),
+            metric_kind=metric_kind,
+            callsite_reason=reason,
+            policy_reason="app_requires_tool_generated_preview",
+            response_type="code_studio_scaffold_suppressed",
+            presentation_intent=presentation_intent,
+            preferred_tool=preferred_tool,
+            studio_lane=studio_lane,
+            artifact_kind=artifact_kind,
+            visual_type=visual_type,
+            quality_profile=quality_profile,
+        )
+
+    return CodeStudioScaffoldFallbackDecision(
+        engage_scaffold=True,
+        response=build_caption_fn(query),
+        metric_kind=metric_kind,
+        callsite_reason=reason,
+        policy_reason="artifact_contract_allows_scaffold",
+        response_type="code_studio_contract_scaffold_fallback",
+        presentation_intent=presentation_intent,
+        preferred_tool=preferred_tool,
+        studio_lane=studio_lane,
+        artifact_kind=artifact_kind,
+        visual_type=visual_type,
+        quality_profile=quality_profile,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_tool_rounds.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_tool_rounds.py
@@ -9,11 +9,13 @@ import time
 import uuid
 from typing import Optional
 
+from app.engine.multi_agent.code_studio_scaffold_fallback_policy import (
+    CodeStudioScaffoldFallbackDecision,
+    resolve_code_studio_scaffold_fallback,
+)
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.code_studio_template_scaffold import (
     build_code_studio_scaffold,
-    build_scaffold_visible_caption,
-    detect_scaffold_kind,
 )
 from app.engine.runtime.runtime_metrics import inc_counter
 
@@ -43,24 +45,40 @@ def _build_scaffold_manual_tool_call(
     query: str,
     *,
     reason: str = "unknown",
-) -> tuple[dict, str]:
-    """Build a synthetic tool_call payload that injects an HTML scaffold.
+    state: Optional[AgentState] = None,
+) -> tuple[dict | None, str, CodeStudioScaffoldFallbackDecision]:
+    """Build a synthetic scaffold tool call only when the contract allows it.
 
-    Returned ``manual_tc`` matches the shape expected by the rest of the
-    code_studio loop (``name``/``args``/``id``); ``visible_caption`` is the
-    short Vietnamese explainer the chat thread shows above the canvas.
+    Returned ``manual_tc`` is ``None`` when the policy suppresses broad
+    template rescue. Otherwise it matches the shape expected by the rest of the
+    Code Studio loop (``name``/``args``/``id``). ``visible_caption`` is either
+    the scaffold caption or a short safe-stop response.
 
     The ``reason`` label is forwarded to the
-    ``wiii.code_studio.scaffold.engaged`` counter so operators can see in
-    Grafana whether stream timeouts, ainvoke timeouts, or LLM-prose-only
-    rounds are driving the fallback rate.
+    scaffold metrics so operators can see whether stream timeouts, ainvoke
+    timeouts, or LLM-prose-only rounds are driving engaged or suppressed
+    fallback rate.
 
     Pattern reference: Anthropic Computer Use 2026 evidence-pool retention
     + Wiii VISUAL_CODE_GEN.md "host-governed runtime" lane.
     """
+    fallback_decision = resolve_code_studio_scaffold_fallback(
+        query=query,
+        state=state,
+        reason=reason,
+    )
+    if not fallback_decision.engage_scaffold:
+        try:
+            inc_counter(
+                "wiii.code_studio.scaffold.suppressed",
+                labels=fallback_decision.metric_labels(),
+            )
+        except Exception:  # noqa: BLE001 — never let metrics break a request
+            pass
+        return None, fallback_decision.response, fallback_decision
+
     scaffold_html = build_code_studio_scaffold(query)
-    visible_caption = build_scaffold_visible_caption(query)
-    kind = detect_scaffold_kind(query)
+    visible_caption = fallback_decision.response
     short_title = (query or "Khung dựng cảnh").strip()[:60]
     manual_tc = {
         "name": "tool_create_visual_code",
@@ -74,11 +92,11 @@ def _build_scaffold_manual_tool_call(
     try:
         inc_counter(
             "wiii.code_studio.scaffold.engaged",
-            labels={"kind": kind, "reason": reason},
+            labels=fallback_decision.metric_labels(),
         )
     except Exception:  # noqa: BLE001 — never let metrics break a request
         pass
-    return manual_tc, visible_caption
+    return manual_tc, visible_caption, fallback_decision
 
 
 async def execute_code_studio_tool_rounds_impl(
@@ -140,6 +158,16 @@ async def execute_code_studio_tool_rounds_impl(
             return Message(role="assistant", content=content, tool_calls=native_tcs)
         return Message(role="assistant", content=content)
 
+    def _scaffold_or_safe_response(reason: str) -> Message:
+        manual_tc, visible_caption, _decision = _build_scaffold_manual_tool_call(
+            query,
+            reason=reason,
+            state=state,
+        )
+        if manual_tc:
+            return _AM(content=visible_caption, tool_calls=[manual_tc])
+        return _AM(content=visible_caption)
+
     def _TM(content: str = "", *, tool_call_id: str = "") -> Message:
         """Native tool-result message."""
         return Message(role="tool", content=str(content), tool_call_id=str(tool_call_id))
@@ -185,7 +213,7 @@ async def execute_code_studio_tool_rounds_impl(
         # and the per-chunk asyncio.wait_for cannot reliably cancel the
         # underlying httpx connection. We therefore wrap the entire stream
         # loop with asyncio.timeout() (Python 3.11+) so the runtime cancels
-        # the whole task tree and the graceful scaffold fallback engages.
+        # the whole task tree and then resolves the contract-gated fallback.
         stream_overall_timeout = float(getattr(settings_obj, "code_studio_stream_overall_timeout_seconds", 90.0))
         code_html_done_at: float | None = None
         astream_timed_out = False
@@ -279,7 +307,7 @@ async def execute_code_studio_tool_rounds_impl(
             except (asyncio.TimeoutError, TimeoutError):
                 astream_timed_out = True
                 logger.warning(
-                    "[CODE_STUDIO] astream overall timeout after %ds — engaging graceful scaffold",
+                    "[CODE_STUDIO] astream overall timeout after %ds — resolving contract-gated fallback",
                     stream_overall_timeout,
                 )
             # Existing code below uses the astream loop's outputs.
@@ -297,10 +325,7 @@ async def execute_code_studio_tool_rounds_impl(
             # (provider-level hang or connection reset that the per-chunk
             # timeout could not interrupt).
             try:
-                manual_tc, visible_caption = _build_scaffold_manual_tool_call(
-                    query, reason="stream_overall_timeout"
-                )
-                llm_response = _AM(content=visible_caption, tool_calls=[manual_tc])
+                llm_response = _scaffold_or_safe_response("stream_overall_timeout")
             except Exception as scaffold_err:
                 logger.warning(
                     "[CODE_STUDIO] Scaffold construction after stream timeout failed: %s",
@@ -330,27 +355,21 @@ async def execute_code_studio_tool_rounds_impl(
             )
         elif not has_tool_calls and not code_streamer.full_code_html:
             # Stream finished/timed-out without producing either a tool call
-            # or any usable code_html. Fall through to the topic-aware scaffold
-            # so the user still gets a canvas instead of an empty turn.
+            # or any usable code_html. Fall through to the contract-gated
+            # fallback policy; app/simulation turns may stop safely here.
             logger.warning(
                 "[CODE_STUDIO] Stream produced no tool_calls and no code_html — "
-                "engaging graceful HTML scaffold"
+                "resolving contract-gated fallback"
             )
-            manual_tc, visible_caption = _build_scaffold_manual_tool_call(
-                query, reason="stream_empty"
-            )
-            llm_response = _AM(
-                content=visible_caption,
-                tool_calls=[manual_tc],
-            )
+            llm_response = _scaffold_or_safe_response("stream_empty")
     else:
         progress_messages = build_code_studio_progress_messages(query, state)
         # Non-streaming planning call — operator-tunable so the graceful
         # scaffold can engage well before the user's HTTP timeout. The
         # streaming path covers the same query type within
         # ``code_studio_stream_overall_timeout_seconds`` when the provider
-        # is healthy; an unhealthy provider fails over to the topic-aware
-        # scaffold rather than burning a multi-minute wait.
+        # is healthy; an unhealthy provider resolves a contract-gated fallback
+        # rather than burning a multi-minute wait.
         llm_hard_timeout = float(getattr(settings_obj, "code_studio_llm_hard_timeout_seconds", 90.0))
         poll_interval = 8.0
 
@@ -445,17 +464,11 @@ async def execute_code_studio_tool_rounds_impl(
                     )
                 except Exception as fb_err:
                     logger.warning(
-                        "[CODE_STUDIO] Fallback ainvoke also failed (%s) — engaging "
-                        "graceful HTML scaffold so user still gets a canvas",
+                        "[CODE_STUDIO] Fallback ainvoke also failed (%s) — resolving "
+                        "contract-gated fallback",
                         fb_err,
                     )
-                    manual_tc, visible_caption = _build_scaffold_manual_tool_call(
-                        query, reason="ainvoke_fallback_fail"
-                    )
-                    llm_response = _AM(
-                        content=visible_caption,
-                        tool_calls=[manual_tc],
-                    )
+                    llm_response = _scaffold_or_safe_response("ainvoke_fallback_fail")
                 break
             try:
                 await asyncio.wait_for(asyncio.shield(llm_task), timeout=poll_interval)
@@ -478,30 +491,18 @@ async def execute_code_studio_tool_rounds_impl(
         if llm_response is None:
             if llm_task.cancelled():
                 logger.warning(
-                    "[CODE_STUDIO] LLM call cancelled — engaging graceful HTML scaffold"
+                    "[CODE_STUDIO] LLM call cancelled — resolving contract-gated fallback"
                 )
-                manual_tc, visible_caption = _build_scaffold_manual_tool_call(
-                    query, reason="ainvoke_cancelled"
-                )
-                llm_response = _AM(
-                    content=visible_caption,
-                    tool_calls=[manual_tc],
-                )
+                llm_response = _scaffold_or_safe_response("ainvoke_cancelled")
             else:
                 llm_exc = llm_task.exception()
                 if llm_exc is not None:
                     logger.warning(
                         "[CODE_STUDIO] Initial tool-planning call failed before any tool call (%s) "
-                        "— engaging graceful HTML scaffold",
+                        "— resolving contract-gated fallback",
                         llm_exc,
                     )
-                    manual_tc, visible_caption = _build_scaffold_manual_tool_call(
-                        query, reason="ainvoke_exception"
-                    )
-                    llm_response = _AM(
-                        content=visible_caption,
-                        tool_calls=[manual_tc],
-                    )
+                    llm_response = _scaffold_or_safe_response("ainvoke_exception")
                 else:
                     llm_response = llm_task.result()
 
@@ -509,20 +510,14 @@ async def execute_code_studio_tool_rounds_impl(
     if not has_initial_tool_calls and requires_code_studio_visual_delivery(query, tools):
         logger.warning(
             "[CODE_STUDIO] LLM returned prose without tool call but visual "
-            "delivery is required — engaging graceful HTML scaffold"
+            "delivery is required — resolving contract-gated fallback"
         )
-        manual_tc, visible_caption = _build_scaffold_manual_tool_call(
-            query, reason="llm_prose_no_tool_call"
-        )
-        llm_response = _AM(
-            content=visible_caption,
-            tool_calls=[manual_tc],
-        )
+        llm_response = _scaffold_or_safe_response("llm_prose_no_tool_call")
 
     total_tool_calls = 0
     max_total_tool_calls = 6
     # Sprint 35e follow-up: cap the post-tool synthesizer round so the
-    # graceful scaffold path doesn't burn 15+ minutes when NVIDIA NIM
+    # fallback path doesn't burn 15+ minutes when NVIDIA NIM
     # stalls after our scaffold tool result lands. Without this cap,
     # ``TIMEOUT_PROFILE_BACKGROUND`` lets the wait stretch indefinitely.
     post_tool_synthesis_timeout = float(getattr(

--- a/maritime-ai-service/tests/unit/test_code_studio_scaffold_fallback_policy.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_scaffold_fallback_policy.py
@@ -1,0 +1,148 @@
+from types import SimpleNamespace
+
+from app.engine.multi_agent.code_studio_scaffold_fallback_policy import (
+    resolve_code_studio_scaffold_fallback,
+)
+from app.engine.multi_agent import code_studio_tool_rounds
+
+
+def _visual_decision(**overrides):
+    data = {
+        "mode": "app",
+        "force_tool": True,
+        "presentation_intent": "code_studio_app",
+        "preferred_tool": "tool_create_visual_code",
+        "studio_lane": "app",
+        "artifact_kind": "html_app",
+        "visual_type": "simulation",
+        "quality_profile": "premium",
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def test_suppresses_generic_simulation_scaffold_fallback() -> None:
+    decision = resolve_code_studio_scaffold_fallback(
+        query="Tạo mô phỏng hảo hán đối ẩm",
+        reason="llm_prose_no_tool_call",
+        resolve_visual_intent_fn=lambda _query: _visual_decision(),
+        build_caption_fn=lambda _query: "caption should not be used",
+    )
+
+    assert decision.engage_scaffold is False
+    assert decision.policy_reason == "app_requires_tool_generated_preview"
+    assert decision.response_type == "code_studio_scaffold_suppressed"
+    assert "template chung chung" in decision.response
+    assert decision.metric_labels()["reason"] == "llm_prose_no_tool_call"
+
+
+def test_suppresses_non_code_studio_visual_lane() -> None:
+    decision = resolve_code_studio_scaffold_fallback(
+        query="Vẽ biểu đồ giá dầu hôm nay",
+        reason="stream_empty",
+        resolve_visual_intent_fn=lambda _query: _visual_decision(
+            mode="inline_html",
+            force_tool=True,
+            presentation_intent="chart_runtime",
+            preferred_tool="tool_generate_visual",
+            studio_lane=None,
+            visual_type="chart",
+        ),
+        build_caption_fn=lambda _query: "caption should not be used",
+    )
+
+    assert decision.engage_scaffold is False
+    assert decision.policy_reason == "not_code_studio_tool_contract"
+    assert decision.presentation_intent == "chart_runtime"
+    assert decision.preferred_tool == "tool_generate_visual"
+
+
+def test_suppresses_plain_text_misroute_without_sanitizing_to_app() -> None:
+    decision = resolve_code_studio_scaffold_fallback(
+        query="Chào Wiii",
+        reason="node_outer_RuntimeError",
+        resolve_visual_intent_fn=lambda _query: _visual_decision(
+            mode="text",
+            force_tool=False,
+            presentation_intent="text",
+            preferred_tool=None,
+            studio_lane=None,
+            visual_type=None,
+        ),
+    )
+
+    assert decision.engage_scaffold is False
+    assert decision.policy_reason == "not_code_studio_tool_contract"
+    assert decision.presentation_intent == "text"
+    assert decision.preferred_tool == "none"
+
+
+def test_allows_artifact_scaffold_fallback_with_contract_metadata() -> None:
+    decision = resolve_code_studio_scaffold_fallback(
+        query="Tạo một mini app HTML để nhúng LMS",
+        reason="ainvoke_exception",
+        resolve_visual_intent_fn=lambda _query: _visual_decision(
+            presentation_intent="artifact",
+            studio_lane="artifact",
+            visual_type=None,
+            quality_profile="premium",
+        ),
+        build_caption_fn=lambda _query: "artifact caption",
+        detect_kind_fn=lambda _query: "default",
+    )
+
+    assert decision.engage_scaffold is True
+    assert decision.response == "artifact caption"
+    assert decision.policy_reason == "artifact_contract_allows_scaffold"
+    assert decision.response_type == "code_studio_contract_scaffold_fallback"
+    assert decision.presentation_intent == "artifact"
+    assert decision.studio_lane == "artifact"
+    assert decision.metric_labels()["kind"] == "default"
+
+
+def test_resolution_failure_suppresses_scaffold() -> None:
+    def broken_resolver(_query: str):
+        raise RuntimeError("resolver unavailable")
+
+    decision = resolve_code_studio_scaffold_fallback(
+        query="Tạo mô phỏng bất kỳ",
+        reason="node_outer_RuntimeError",
+        resolve_visual_intent_fn=broken_resolver,
+    )
+
+    assert decision.engage_scaffold is False
+    assert decision.policy_reason == "visual_contract_resolution_failed"
+    assert decision.presentation_intent == "unknown"
+
+
+def test_manual_scaffold_helper_does_not_inject_tool_call_for_simulation() -> None:
+    manual_tc, visible_caption, decision = code_studio_tool_rounds._build_scaffold_manual_tool_call(
+        "Hay mo phong vat ly con lac co the keo tha",
+        reason="stream_empty",
+        state={},
+    )
+
+    assert manual_tc is None
+    assert decision.engage_scaffold is False
+    assert decision.policy_reason == "app_requires_tool_generated_preview"
+    assert "template chung chung" in visible_caption
+
+
+def test_manual_scaffold_helper_keeps_artifact_fallback(monkeypatch) -> None:
+    monkeypatch.setattr(
+        code_studio_tool_rounds,
+        "build_code_studio_scaffold",
+        lambda _query: "<html><body>artifact scaffold</body></html>",
+    )
+
+    manual_tc, visible_caption, decision = code_studio_tool_rounds._build_scaffold_manual_tool_call(
+        "Tao mot mini app HTML de nhung vao LMS",
+        reason="ainvoke_exception",
+        state={},
+    )
+
+    assert decision.engage_scaffold is True
+    assert manual_tc is not None
+    assert manual_tc["name"] == "tool_create_visual_code"
+    assert manual_tc["args"]["code_html"] == "<html><body>artifact scaffold</body></html>"
+    assert visible_caption


### PR DESCRIPTION
## Summary
- Adds a typed Code Studio scaffold fallback policy that resolves visual intent plus `VisualCodeRuntimeContract` before deterministic templates can engage.
- Suppresses broad app/simulation template rescue across tool-round timeouts, prose-without-tool responses, and outer Code Studio node failures.
- Keeps artifact scaffold fallback allowed when the contract says the lane is artifact-safe, with engaged/suppressed metric labels for audit.
- Updates the runtime cleanup audit with the new contract-gated fallback state.

## Linked Issue
Closes #565

## Scope
In scope: backend Code Studio fallback policy, tool-round fallback call sites, outer Code Studio node error fallback, targeted tests, audit doc.
Out of scope: frontend Code Studio UX, new templates, LMS preview/apply behavior, provider routing.

## Verification
- `uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_code_studio_scaffold_fallback_policy.py tests/unit/test_visual_code_runtime_contract.py tests/unit/test_visual_intent_resolver.py tests/unit/test_code_studio_template_scaffold.py tests/unit/test_graph_routing.py::TestCodeStudioProgressHeartbeat::test_preserves_timeout_fallback_response_without_overwrite tests/unit/test_graph_routing.py::TestCodeStudioProgressHeartbeat::test_returns_missing_tool_response_when_initial_code_studio_call_times_out -q --tb=short` -> 102 passed
- `uv run --python 3.12 --with-requirements requirements.txt --with ruff ruff check app/engine/multi_agent/code_studio_scaffold_fallback_policy.py app/engine/multi_agent/code_studio_node_runtime.py app/engine/multi_agent/code_studio_tool_rounds.py tests/unit/test_code_studio_scaffold_fallback_policy.py --select=E9,F63,F7,F82` -> All checks passed
- `git diff --cached --check` -> passed

## Risk
Moderate product behavior risk for Code Studio failure paths: generic app/simulation requests that previously received deterministic fallback previews now get a safe-stop response when the real tool path fails. This is intentional to avoid slop previews.

## Rollback
Revert commit `2a687827` to restore the previous broad deterministic scaffold fallback behavior.

## Reviewer Focus
- Whether artifact fallback is the right remaining allowed deterministic scaffold lane.
- Whether the suppressed metric labels are sufficient for observing provider/tool drift.
- Whether the safe-stop response is acceptable when simulation tool generation fails.