### PR TITLE
Refactor Code Studio app intents into typed contracts

### DIFF
--- a/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
+++ b/docs/operations/WIII_RUNTIME_CLEANUP_AUDIT_2026-05-19.md
@@ -254,6 +254,13 @@ without broad deletes, secret exposure, or unreviewed product behavior changes.
   Generic app/simulation failures are suppressed with an auditable safe-stop
   response; artifact fallback remains allowed when the contract says it is the
   right lane.
+- Follow-up #567 added a typed Code Studio app-intent contract for simulations,
+  quizzes, dashboards, mini tools, interactive tables, search/code widgets, and
+  artifacts. Visual intent metadata, Code Studio payload metadata, runtime
+  manifests, prompt guidance, and fallback metrics now carry app category,
+  required surface, controls, state/readout expectations, feedback hooks, and
+  reject-if-missing criteria instead of relying on generic `simulation` or
+  `react_app` labels alone.
 
 ## Preserved Intentionally
 
@@ -326,8 +333,9 @@ backups, data PDFs, or local skill folders.
   primary visual tool path is healthy. Follow-up #561 introduced typed runtime
   contracts for visual intent metadata and Code Studio visual-code lanes, and
   follow-up #565 now uses those contracts to suppress broad app/simulation
-  scaffold fallback in product flows. The next quality frontier is deeper typed
-  visual intents for app categories, not adding more ad-hoc templates.
+  scaffold fallback in product flows. Follow-up #567 introduced typed app
+  category contracts so the next quality frontier is local/product E2E evidence
+  and stricter generated-code critique, not adding more ad-hoc templates.
 - Some tests still import compatibility `graph.py` modules. Move tests toward
   `runtime.py` imports when the external import window can close.
 

--- a/maritime-ai-service/app/engine/context/pointy_fast_path.py
+++ b/maritime-ai-service/app/engine/context/pointy_fast_path.py
@@ -61,6 +61,42 @@ _UNSAFE_CLICK_TERMS = (
     "mark complete",
     "hoan thanh",
 )
+_VISUAL_DELIVERY_TERMS = (
+    "mo phong",
+    "simulate",
+    "simulation",
+    "simulator",
+    "canvas",
+    "code studio",
+    "tao visual",
+    "tao hinh",
+    "ve bieu do",
+    "draw chart",
+    "create chart",
+    "mermaid",
+    "html app",
+)
+_EXPLICIT_POINTY_OPERATOR_TERMS = (
+    "pointy",
+    "chi cho",
+    "chi vao",
+    "chi lai",
+    "chi giup",
+    "chi den",
+    "chi toi",
+    "tro toi",
+    "tro vao",
+    "tro den",
+    "highlight",
+    "show me where",
+    "point to",
+    "o dau",
+    "where",
+    "nut",
+    "button",
+    "bam",
+    "click",
+)
 
 _TARGET_ALIASES: tuple[tuple[tuple[str, ...], tuple[str, ...]], ...] = (
     (
@@ -236,6 +272,11 @@ def build_pointy_fast_path_action(
         return None
 
     normalized_prompt = normalize_pointy_text(prompt)
+    if _has_any_term(normalized_prompt, _VISUAL_DELIVERY_TERMS) and not _has_any_term(
+        normalized_prompt,
+        _EXPLICIT_POINTY_OPERATOR_TERMS,
+    ):
+        return None
     wants_locate = _has_any_term(normalized_prompt, _LOCATE_TERMS)
     wants_click = _has_any_term(normalized_prompt, _CLICK_TERMS)
     if not normalized_prompt or (not wants_locate and not wants_click):

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_context.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_context.py
@@ -95,6 +95,22 @@ def _build_code_studio_progress_messages(
             "Mình vẫn đang làm việc và sẽ báo ngay khi preview thật sự sẵn sàng...",
         ]
 
+    if getattr(visual_decision, "app_category", "") == "quiz":
+        return [
+            "Mình đang dựng luồng câu hỏi, lựa chọn trả lời, và trạng thái điểm...",
+            "Mình đang nối submit/reset cùng phản hồi đúng sai...",
+            "Mình đang rà lại để quiz có thể tương tác thật trong Code Studio...",
+            "Mình vẫn đang hoàn thiện preview quiz...",
+        ]
+
+    if getattr(visual_decision, "app_category", "") == "dashboard":
+        return [
+            "Mình đang dựng data model, metric cards, và bộ lọc chính...",
+            "Mình đang nối trạng thái filter/view toggle với phần hiển thị...",
+            "Mình đang rà lại để dashboard không thành biểu đồ giả hoặc card rỗng...",
+            "Mình vẫn đang hoàn thiện preview dashboard...",
+        ]
+
     if visual_decision.presentation_intent == "artifact":
         return [
             "Mình đang lên bộ khung artifact và quy ước nhúng...",

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_fast_paths.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_fast_paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from typing import Any, Awaitable, Callable
@@ -28,48 +29,330 @@ logger = logging.getLogger(__name__)
 _PENDULUM_FAST_PATH_HTML = """
 <div class="pendulum-prototype">
   <style>
-    .pendulum-prototype { font-family: system-ui, sans-serif; background: #f8fafc; border: 1px solid #d8e2f0; border-radius: 16px; padding: 16px; color: #0f172a; }
-    .pendulum-prototype h3 { margin: 0 0 8px; font-size: 18px; }
-    .pendulum-prototype .hint { margin: 0; color: #475569; font-size: 14px; }
-    .pendulum-prototype .scene { margin-top: 16px; height: 180px; position: relative; display: flex; align-items: flex-start; justify-content: center; }
-    .pendulum-prototype .rod { width: 4px; height: 120px; background: linear-gradient(180deg, #64748b, #0f172a); transform-origin: top center; transform: rotate(18deg); border-radius: 999px; position: relative; }
-    .pendulum-prototype .bob { width: 32px; height: 32px; border-radius: 999px; background: radial-gradient(circle at 35% 35%, #fde68a, #f97316); position: absolute; bottom: -16px; left: 50%; transform: translateX(-50%); box-shadow: 0 8px 18px rgba(249, 115, 22, 0.28); }
+    :root { --bg: #0f172a; --fg: #e2e8f0; --accent: #38bdf8; --surface: #1e293b; --border: #475569; --muted: #94a3b8; }
+    @media (prefers-color-scheme: light) {
+      :root { --bg: #f8fafc; --fg: #0f172a; --accent: #0284c7; --surface: #ffffff; --border: #cbd5e1; --muted: #64748b; }
+    }
+    .pendulum-prototype { box-sizing: border-box; display: grid; gap: 14px; width: min(100%, 760px); margin: 0 auto; padding: 16px; border: 1px solid var(--border); border-radius: 14px; background: var(--bg); color: var(--fg); font-family: system-ui, sans-serif; }
+    .pendulum-prototype *, .pendulum-prototype *::before, .pendulum-prototype *::after { box-sizing: inherit; }
+    .pendulum-prototype h3 { margin: 0; font-size: 18px; line-height: 1.25; }
+    .pendulum-prototype .hint { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.5; }
+    .pendulum-prototype canvas { display: block; width: 100%; height: min(48vw, 320px); min-height: 220px; border: 1px solid var(--border); border-radius: 12px; background: color-mix(in srgb, var(--surface) 78%, var(--bg)); }
+    .pendulum-prototype .controls { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+    .pendulum-prototype label { display: grid; gap: 6px; color: var(--muted); font-size: 13px; }
+    .pendulum-prototype input[type="range"] { width: 100%; accent-color: var(--accent); }
+    .pendulum-prototype .readout { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
+    .pendulum-prototype .readout span { min-height: 40px; padding: 9px 10px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); color: var(--fg); font-variant-numeric: tabular-nums; }
+    .pendulum-prototype button { min-height: 38px; border: 1px solid var(--border); border-radius: 9px; background: var(--surface); color: var(--fg); font-weight: 650; cursor: pointer; }
+    @media (max-width: 640px) {
+      .pendulum-prototype .controls, .pendulum-prototype .readout { grid-template-columns: 1fr; }
+    }
   </style>
   <h3>Mô phỏng con lắc đơn</h3>
-  <p class="hint">Bộ khung preview đã sẵn sàng để patch tiếp ngay trong Code Studio.</p>
-  <div class="scene">
-    <div class="rod"><div class="bob"></div></div>
+  <p class="hint">Kéo trực tiếp trên canvas hoặc chỉnh trọng lực và ma sát để thấy chu kỳ thay đổi theo thời gian.</p>
+  <canvas id="pendulumCanvas" width="760" height="320" aria-label="Mô phỏng con lắc đơn có kéo thả"></canvas>
+  <div class="controls">
+    <label>Trọng lực
+      <input id="gravity" type="range" min="4" max="16" step="0.1" value="9.8">
+    </label>
+    <label>Ma sát
+      <input id="damping" type="range" min="0" max="0.12" step="0.005" value="0.035">
+    </label>
   </div>
+  <div class="readout" id="readout" aria-live="polite">
+    <span>Góc: <strong id="angleValue">0°</strong></span>
+    <span>Vận tốc: <strong id="omegaValue">0.00 rad/s</strong></span>
+    <span>Trạng thái: <strong id="stateValue">đang chạy</strong></span>
+  </div>
+  <button id="resetPendulum" type="button">Reset</button>
+  <script>
+    (() => {
+      const canvas = document.getElementById('pendulumCanvas');
+      const ctx = canvas.getContext('2d');
+      const gravityInput = document.getElementById('gravity');
+      const dampingInput = document.getElementById('damping');
+      const angleValue = document.getElementById('angleValue');
+      const omegaValue = document.getElementById('omegaValue');
+      const stateValue = document.getElementById('stateValue');
+      const resetButton = document.getElementById('resetPendulum');
+      const state = { theta: 0.55, omega: 0, length: 130, dragging: false, lastTime: performance.now() };
+      function report(kind, payload, summary, status) {
+        if (window.WiiiVisualBridge && typeof window.WiiiVisualBridge.reportResult === 'function') {
+          window.WiiiVisualBridge.reportResult(kind, payload, summary, status);
+        }
+      }
+      function resize() {
+        const rect = canvas.getBoundingClientRect();
+        const ratio = window.devicePixelRatio || 1;
+        canvas.width = Math.max(320, Math.round(rect.width * ratio));
+        canvas.height = Math.max(220, Math.round(rect.height * ratio));
+        ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+      }
+      function bobPosition() {
+        const w = canvas.clientWidth;
+        const anchor = { x: w / 2, y: 42 };
+        return {
+          anchor,
+          x: anchor.x + Math.sin(state.theta) * state.length,
+          y: anchor.y + Math.cos(state.theta) * state.length,
+        };
+      }
+      function draw() {
+        const w = canvas.clientWidth;
+        const h = canvas.clientHeight;
+        const { anchor, x, y } = bobPosition();
+        ctx.clearRect(0, 0, w, h);
+        ctx.strokeStyle = getComputedStyle(canvas).color || '#e2e8f0';
+        ctx.lineWidth = 3;
+        ctx.beginPath();
+        ctx.moveTo(anchor.x, anchor.y);
+        ctx.lineTo(x, y);
+        ctx.stroke();
+        ctx.fillStyle = '#f59e0b';
+        ctx.beginPath();
+        ctx.arc(x, y, 18, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.fillStyle = '#38bdf8';
+        ctx.beginPath();
+        ctx.arc(anchor.x, anchor.y, 5, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.fillStyle = 'rgba(56, 189, 248, 0.22)';
+        ctx.fillRect(0, h - 34, w, 2);
+      }
+      function updateReadout() {
+        angleValue.textContent = `${Math.round(state.theta * 180 / Math.PI)}°`;
+        omegaValue.textContent = `${state.omega.toFixed(2)} rad/s`;
+        stateValue.textContent = state.dragging ? 'đang kéo' : 'đang chạy';
+      }
+      function tick(now) {
+        const deltaTime = Math.min((now - state.lastTime) / 1000, 0.05);
+        state.lastTime = now;
+        if (!state.dragging) {
+          const gravity = Number(gravityInput.value);
+          const damping = Number(dampingInput.value);
+          const acceleration = -(gravity / state.length) * 92 * Math.sin(state.theta) - damping * state.omega;
+          state.omega += acceleration * deltaTime;
+          state.theta += state.omega * deltaTime;
+        }
+        draw();
+        updateReadout();
+        requestAnimationFrame(tick);
+      }
+      function setFromPointer(event) {
+        const rect = canvas.getBoundingClientRect();
+        const x = event.clientX - rect.left;
+        const y = event.clientY - rect.top;
+        const anchor = bobPosition().anchor;
+        state.theta = Math.atan2(x - anchor.x, y - anchor.y);
+        state.omega = 0;
+        report('pendulum_drag', { theta: state.theta }, 'Người dùng kéo con lắc', 'running');
+      }
+      canvas.addEventListener('pointerdown', (event) => { state.dragging = true; canvas.setPointerCapture(event.pointerId); setFromPointer(event); });
+      canvas.addEventListener('pointermove', (event) => { if (state.dragging) setFromPointer(event); });
+      canvas.addEventListener('pointerup', (event) => { state.dragging = false; canvas.releasePointerCapture(event.pointerId); report('pendulum_release', { theta: state.theta }, 'Con lắc tiếp tục dao động', 'completed'); });
+      resetButton.addEventListener('click', () => { state.theta = 0.55; state.omega = 0; report('pendulum_reset', { theta: state.theta }, 'Reset mô phỏng con lắc', 'completed'); });
+      gravityInput.addEventListener('input', () => report('pendulum_gravity', { gravity: Number(gravityInput.value) }, 'Đổi trọng lực', 'running'));
+      dampingInput.addEventListener('input', () => report('pendulum_damping', { damping: Number(dampingInput.value) }, 'Đổi ma sát', 'running'));
+      new ResizeObserver(resize).observe(canvas);
+      resize();
+      requestAnimationFrame(tick);
+    })();
+  </script>
 </div>
 """.strip()
 
 _COLREG_RULE15_FAST_PATH_HTML = """
-<style>
-  :root { --ship-a: var(--red); --ship-b: var(--green); }
-  .container { display: flex; flex-direction: column; align-items: center; gap: 16px; font-family: sans-serif; }
-  .scene { width: 100%; max-width: 500px; aspect-ratio: 1; background: #f0f5ff; border-radius: 12px; position: relative; overflow: hidden; cursor: crosshair; }
-  .ship { position: absolute; width: 40px; height: 60px; transition: transform 0.1s linear; display: flex; align-items: center; justify-content: center; font-size: 24px; }
-  .ship-a { color: var(--ship-a); }
-  .ship-b { color: var(--ship-b); }
-  .label { position: absolute; font-size: 12px; background: rgba(255,255,255,0.9); padding: 2px 6px; border-radius: 999px; }
-  .controls { display: flex; flex-wrap: wrap; justify-content: center; gap: 12px; }
-  .readout { display: grid; gap: 8px; width: 100%; max-width: 500px; }
-</style>
-<div class="container">
-  <div class="scene">
-    <div class="ship ship-a" style="left:28%;top:60%;transform:rotate(-22deg)">⛴</div>
-    <div class="ship ship-b" style="left:62%;top:28%;transform:rotate(130deg)">🚢</div>
-    <div class="label" style="left:18%;top:75%">Give-way</div>
-    <div class="label" style="left:64%;top:14%">Stand-on</div>
-  </div>
+<div class="colreg-rule15-sim">
+  <style>
+    :root { --bg: #07111f; --fg: #e2e8f0; --accent: #38bdf8; --surface: #122033; --border: #38516f; --give: #f97316; --stand: #22c55e; --muted: #9fb3c8; }
+    @media (prefers-color-scheme: light) {
+      :root { --bg: #f8fafc; --fg: #0f172a; --accent: #0369a1; --surface: #ffffff; --border: #cbd5e1; --give: #c2410c; --stand: #15803d; --muted: #475569; }
+    }
+    .colreg-rule15-sim { box-sizing: border-box; width: min(100%, 820px); margin: 0 auto; padding: 16px; border: 1px solid var(--border); border-radius: 14px; background: var(--bg); color: var(--fg); font-family: system-ui, sans-serif; }
+    .colreg-rule15-sim *, .colreg-rule15-sim *::before, .colreg-rule15-sim *::after { box-sizing: inherit; }
+    .colreg-rule15-sim h3 { margin: 0 0 6px; font-size: 18px; line-height: 1.25; }
+    .colreg-rule15-sim p { margin: 0; color: var(--muted); line-height: 1.5; }
+    .colreg-rule15-sim canvas { display: block; width: 100%; height: min(54vw, 380px); min-height: 260px; margin-top: 14px; border: 1px solid var(--border); border-radius: 12px; background: radial-gradient(circle at 50% 45%, rgba(56,189,248,.16), transparent 36%), color-mix(in srgb, var(--surface) 74%, var(--bg)); }
+    .colreg-rule15-sim .controls { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; margin-top: 12px; }
+    .colreg-rule15-sim label { display: grid; gap: 6px; color: var(--muted); font-size: 13px; }
+    .colreg-rule15-sim input[type="range"] { width: 100%; accent-color: var(--accent); }
+    .colreg-rule15-sim .readout { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin-top: 12px; }
+    .colreg-rule15-sim .readout span { min-height: 48px; padding: 9px 10px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); color: var(--fg); font-variant-numeric: tabular-nums; }
+    .colreg-rule15-sim button { min-height: 38px; border: 1px solid var(--border); border-radius: 9px; background: var(--surface); color: var(--fg); font-weight: 650; cursor: pointer; }
+    @media (max-width: 720px) {
+      .colreg-rule15-sim .controls, .colreg-rule15-sim .readout { grid-template-columns: 1fr; }
+    }
+  </style>
+  <h3>COLREG Rule 15: tình huống cắt hướng</h3>
+  <p>Tàu màu cam thấy tàu xanh ở mạn phải nên là give-way vessel; kéo tốc độ hoặc mức tránh va để xem CPA đổi ra sao.</p>
+  <canvas id="colregCanvas" width="820" height="380" aria-label="Mô phỏng COLREG Rule 15 bằng canvas"></canvas>
   <div class="controls">
-    <button type="button">Chạy mô phỏng</button>
-    <button type="button">Đổi mức CPA</button>
+    <label>Tốc độ tàu give-way
+      <input id="giveSpeed" type="range" min="0.45" max="1.45" step="0.05" value="0.9">
+    </label>
+    <label>Tốc độ tàu stand-on
+      <input id="standSpeed" type="range" min="0.45" max="1.45" step="0.05" value="0.85">
+    </label>
+    <label>Mức đổi hướng tránh va
+      <input id="avoidLevel" type="range" min="0" max="34" step="1" value="18">
+    </label>
   </div>
-  <div class="readout">
-    <strong>Rule 15 - Crossing Situation</strong>
-    <span>Tàu nhìn thấy tàu kia ở mạn phải phải chủ động nhường đường.</span>
+  <div class="readout" id="readout" aria-live="polite">
+    <span>CPA: <strong id="cpaValue">0.00 NM</strong></span>
+    <span>TCPA: <strong id="tcpaValue">0.0 phút</strong></span>
+    <span>Hành động: <strong id="actionValue">nhường đường</strong></span>
   </div>
+  <button id="resetColreg" type="button">Reset tình huống</button>
+  <script>
+    (() => {
+      const canvas = document.getElementById('colregCanvas');
+      const ctx = canvas.getContext('2d');
+      const giveSpeed = document.getElementById('giveSpeed');
+      const standSpeed = document.getElementById('standSpeed');
+      const avoidLevel = document.getElementById('avoidLevel');
+      const cpaValue = document.getElementById('cpaValue');
+      const tcpaValue = document.getElementById('tcpaValue');
+      const actionValue = document.getElementById('actionValue');
+      const resetButton = document.getElementById('resetColreg');
+      const state = { t: 0, lastTime: performance.now(), scale: 1 };
+      function report(kind, payload, summary, status) {
+        if (window.WiiiVisualBridge && typeof window.WiiiVisualBridge.reportResult === 'function') {
+          window.WiiiVisualBridge.reportResult(kind, payload, summary, status);
+        }
+      }
+      function resize() {
+        const rect = canvas.getBoundingClientRect();
+        const ratio = window.devicePixelRatio || 1;
+        canvas.width = Math.max(360, Math.round(rect.width * ratio));
+        canvas.height = Math.max(260, Math.round(rect.height * ratio));
+        ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+      }
+      function vectorFrom(angleDeg, speed) {
+        const angle = angleDeg * Math.PI / 180;
+        return { x: Math.cos(angle) * speed, y: Math.sin(angle) * speed };
+      }
+      function scenario() {
+        const w = canvas.clientWidth;
+        const h = canvas.clientHeight;
+        const give = { x: w * 0.25, y: h * 0.78 };
+        const stand = { x: w * 0.74, y: h * 0.27 };
+        const turn = Number(avoidLevel.value);
+        const vg = vectorFrom(-34 - turn, Number(giveSpeed.value) * 72);
+        const vs = vectorFrom(132, Number(standSpeed.value) * 72);
+        return { w, h, give, stand, vg, vs };
+      }
+      function closestPoint() {
+        const { give, stand, vg, vs } = scenario();
+        const rx = stand.x - give.x;
+        const ry = stand.y - give.y;
+        const vx = vs.x - vg.x;
+        const vy = vs.y - vg.y;
+        const vv = Math.max(1, vx * vx + vy * vy);
+        const tcpa = Math.max(0, -((rx * vx + ry * vy) / vv));
+        const dx = rx + vx * tcpa;
+        const dy = ry + vy * tcpa;
+        const cpaPx = Math.sqrt(dx * dx + dy * dy);
+        return { tcpa, cpaNm: cpaPx / 95 };
+      }
+      function drawShip(x, y, heading, color, label) {
+        ctx.save();
+        ctx.translate(x, y);
+        ctx.rotate(heading);
+        ctx.fillStyle = color;
+        ctx.beginPath();
+        ctx.moveTo(20, 0);
+        ctx.lineTo(-16, -11);
+        ctx.lineTo(-10, 0);
+        ctx.lineTo(-16, 11);
+        ctx.closePath();
+        ctx.fill();
+        ctx.fillStyle = 'rgba(255,255,255,.92)';
+        ctx.font = '12px system-ui';
+        ctx.fillText(label, -30, -18);
+        ctx.restore();
+      }
+      function drawTrack(start, velocity, color) {
+        ctx.strokeStyle = color;
+        ctx.setLineDash([8, 7]);
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(start.x, start.y);
+        ctx.lineTo(start.x + velocity.x * 2.8, start.y + velocity.y * 2.8);
+        ctx.stroke();
+        ctx.setLineDash([]);
+      }
+      function render() {
+        const { w, h, give, stand, vg, vs } = scenario();
+        const motion = (Math.sin(state.t * 0.7) + 1) * 0.5;
+        const gx = give.x + vg.x * motion;
+        const gy = give.y + vg.y * motion;
+        const sx = stand.x + vs.x * motion;
+        const sy = stand.y + vs.y * motion;
+        ctx.clearRect(0, 0, w, h);
+        ctx.strokeStyle = 'rgba(56,189,248,.22)';
+        ctx.lineWidth = 1;
+        for (let x = 40; x < w; x += 40) {
+          ctx.beginPath();
+          ctx.moveTo(x, 0);
+          ctx.lineTo(x, h);
+          ctx.stroke();
+        }
+        for (let y = 40; y < h; y += 40) {
+          ctx.beginPath();
+          ctx.moveTo(0, y);
+          ctx.lineTo(w, y);
+          ctx.stroke();
+        }
+        drawTrack(give, vg, 'rgba(249,115,22,.55)');
+        drawTrack(stand, vs, 'rgba(34,197,94,.55)');
+        drawShip(gx, gy, Math.atan2(vg.y, vg.x), '#f97316', 'Give-way');
+        drawShip(sx, sy, Math.atan2(vs.y, vs.x), '#22c55e', 'Stand-on');
+        ctx.strokeStyle = 'rgba(226,232,240,.55)';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(gx, gy);
+        ctx.lineTo(sx, sy);
+        ctx.stroke();
+      }
+      function updateReadout() {
+        const closest = closestPoint();
+        cpaValue.textContent = `${closest.cpaNm.toFixed(2)} NM`;
+        tcpaValue.textContent = `${(closest.tcpa * 2.4).toFixed(1)} phút`;
+        actionValue.textContent = closest.cpaNm < 1 ? 'đổi hướng sớm hơn' : 'nhường đường rõ';
+      }
+      function tick(now) {
+        const deltaTime = Math.min((now - state.lastTime) / 1000, 0.05);
+        state.lastTime = now;
+        state.t += deltaTime;
+        render();
+        updateReadout();
+        requestAnimationFrame(tick);
+      }
+      function onControlChange() {
+        const closest = closestPoint();
+        report('colreg_rule15_adjust', {
+          giveSpeed: Number(giveSpeed.value),
+          standSpeed: Number(standSpeed.value),
+          avoidLevel: Number(avoidLevel.value),
+          cpaNm: Number(closest.cpaNm.toFixed(2)),
+        }, 'Điều chỉnh tình huống Rule 15', 'running');
+      }
+      giveSpeed.addEventListener('input', onControlChange);
+      standSpeed.addEventListener('input', onControlChange);
+      avoidLevel.addEventListener('input', onControlChange);
+      resetButton.addEventListener('click', () => {
+        state.t = 0;
+        giveSpeed.value = '0.9';
+        standSpeed.value = '0.85';
+        avoidLevel.value = '18';
+        report('colreg_rule15_reset', { reset: true }, 'Reset mô phỏng Rule 15', 'completed');
+      });
+      new ResizeObserver(resize).observe(canvas);
+      resize();
+      requestAnimationFrame(tick);
+      report('colreg_rule15_ready', { rule: 15 }, 'Mô phỏng Rule 15 đã sẵn sàng', 'ready');
+    })();
+  </script>
 </div>
 """.strip()
 
@@ -85,6 +368,19 @@ _ARTIFACT_FAST_PATH_HTML = """
 const state=document.getElementById('state');document.getElementById('cta')?.addEventListener('click',()=>{state.textContent='Clicked once - artifact scaffold is alive';window.WiiiVisualBridge?.reportResult?.('artifact',{clicked:true},'Mini HTML app ready','completed')});
 </script>
 """.strip()
+
+
+def _contains_visual_payload_result(result: Any) -> bool:
+    if not isinstance(result, str):
+        return False
+    stripped = result.strip()
+    if not stripped.startswith("{"):
+        return False
+    try:
+        payload = json.loads(stripped)
+    except Exception:
+        return False
+    return isinstance(payload, dict) and bool(payload.get("visual_session_id")) and "fallback_html" in payload
 
 
 def _build_recipe(query: str, state: AgentState) -> dict[str, str] | None:
@@ -175,6 +471,13 @@ async def execute_code_studio_fast_path(
             "[CODE_STUDIO] Recipe fast path returned tool error (%s): %s",
             recipe["call_id_prefix"],
             result[:180],
+        )
+        return None
+    if not _contains_visual_payload_result(result):
+        logger.debug(
+            "[CODE_STUDIO] Recipe fast path did not return a visual payload (%s): %s",
+            recipe["call_id_prefix"],
+            str(result)[:180],
         )
         return None
 

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
@@ -75,11 +75,12 @@ async def code_studio_node_impl(
         }.get(domain_id, domain_id)
 
     try:
-        from app.engine.multi_agent.agent_config import AgentConfigRegistry
-
         _ctx = state.get("context", {})
         explicit_provider = get_effective_provider(state)
         response = ""
+        tools: list = []
+        force_tools = False
+        runtime_context_base = None
         if looks_like_ambiguous_simulation_request(query, state):
             grounded_query = ground_simulation_query_from_visual_context(query, state)
             if grounded_query:
@@ -95,12 +96,6 @@ async def code_studio_node_impl(
                     "node": "code_studio_agent",
                     "details": {"visibility": "status_only"},
                 })
-                llm = AgentConfigRegistry.get_llm(
-                    "code_studio_agent",
-                    effort_override=state.get("thinking_effort"),
-                    provider_override=explicit_provider,
-                    requested_model=state.get("model"),
-                )
             else:
                 response = build_ambiguous_simulation_clarifier(state)
                 state["thinking_content"] = (
@@ -112,26 +107,7 @@ async def code_studio_node_impl(
                     confidence=0.9,
                     details={"response_type": "clarify", "reason": "ambiguous_simulation_request"},
                 )
-                llm = None
-        else:
-            thinking_effort = state.get("thinking_effort")
-            llm = AgentConfigRegistry.get_llm(
-                "code_studio_agent",
-                effort_override=thinking_effort,
-                provider_override=explicit_provider,
-                requested_model=state.get("model"),
-            )
-
-        if llm and getattr(settings_obj, "enable_natural_conversation", False) is True:
-            _pp = getattr(settings_obj, "llm_presence_penalty", 0.0)
-            _fp = getattr(settings_obj, "llm_frequency_penalty", 0.0)
-            if _pp or _fp:
-                try:
-                    llm = llm.bind(presence_penalty=_pp, frequency_penalty=_fp)
-                except Exception:
-                    pass
-
-        if llm:
+        if not response:
             tools, force_tools = collect_code_studio_tools(effective_query, _ctx.get("user_role", "student"))
             try:
                 from app.engine.skills.skill_recommender import select_runtime_tools
@@ -156,35 +132,6 @@ async def code_studio_node_impl(
             except Exception as _selection_err:
                 logger.debug("[CODE_STUDIO] Runtime tool selection skipped: %s", _selection_err)
 
-            bound_provider = getattr(llm, "_wiii_provider_name", None) or state.get("provider")
-            bound_model = (
-                getattr(llm, "_wiii_model_name", None)
-                or getattr(llm, "model_name", None)
-                or getattr(llm, "model", None)
-            )
-            if bound_provider and str(bound_provider).strip().lower() != "auto":
-                state["_execution_provider"] = str(bound_provider)
-            if bound_model:
-                state["_execution_model"] = str(bound_model)
-                state["model"] = str(bound_model)
-            llm_with_tools, llm_auto, forced_tool_choice = bind_direct_tools(
-                llm,
-                tools,
-                force_tools,
-                provider=bound_provider,
-                include_forced_choice=True,
-            )
-            messages = build_direct_system_messages(
-                state,
-                effective_query,
-                domain_name_vi,
-                role_name="code_studio_agent",
-                tools_context_override=build_code_studio_tools_context(
-                    settings_obj,
-                    _ctx.get("user_role", "student"),
-                    effective_query,
-                ),
-            )
             runtime_context_base = build_tool_runtime_context_fn(
                 event_bus_id=_bus_id,
                 request_id=_ctx.get("request_id"),
@@ -221,6 +168,55 @@ async def code_studio_node_impl(
                     },
                 )
             else:
+                from app.engine.multi_agent.agent_config import AgentConfigRegistry
+
+                thinking_effort = state.get("thinking_effort")
+                llm = AgentConfigRegistry.get_llm(
+                    "code_studio_agent",
+                    effort_override=thinking_effort,
+                    provider_override=explicit_provider,
+                    requested_model=state.get("model"),
+                )
+                if llm and getattr(settings_obj, "enable_natural_conversation", False) is True:
+                    _pp = getattr(settings_obj, "llm_presence_penalty", 0.0)
+                    _fp = getattr(settings_obj, "llm_frequency_penalty", 0.0)
+                    if _pp or _fp:
+                        try:
+                            llm = llm.bind(presence_penalty=_pp, frequency_penalty=_fp)
+                        except Exception:
+                            pass
+                if not llm:
+                    raise RuntimeError("Code Studio provider returned no LLM")
+
+                bound_provider = getattr(llm, "_wiii_provider_name", None) or state.get("provider")
+                bound_model = (
+                    getattr(llm, "_wiii_model_name", None)
+                    or getattr(llm, "model_name", None)
+                    or getattr(llm, "model", None)
+                )
+                if bound_provider and str(bound_provider).strip().lower() != "auto":
+                    state["_execution_provider"] = str(bound_provider)
+                if bound_model:
+                    state["_execution_model"] = str(bound_model)
+                    state["model"] = str(bound_model)
+                llm_with_tools, llm_auto, forced_tool_choice = bind_direct_tools(
+                    llm,
+                    tools,
+                    force_tools,
+                    provider=bound_provider,
+                    include_forced_choice=True,
+                )
+                messages = build_direct_system_messages(
+                    state,
+                    effective_query,
+                    domain_name_vi,
+                    role_name="code_studio_agent",
+                    tools_context_override=build_code_studio_tools_context(
+                        settings_obj,
+                        _ctx.get("user_role", "student"),
+                        effective_query,
+                    ),
+                )
                 llm_response, messages, _tc_events = await execute_code_studio_tool_rounds(
                     llm_with_tools,
                     llm_auto,

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_fallback_policy.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_fallback_policy.py
@@ -33,6 +33,7 @@ class CodeStudioScaffoldFallbackDecision:
     studio_lane: str
     artifact_kind: str
     visual_type: str
+    app_category: str
     quality_profile: str
 
     def metric_labels(self) -> dict[str, str]:
@@ -43,6 +44,7 @@ class CodeStudioScaffoldFallbackDecision:
             "policy_reason": self.policy_reason,
             "presentation_intent": self.presentation_intent,
             "visual_type": self.visual_type,
+            "app_category": self.app_category,
             "studio_lane": self.studio_lane,
         }
 
@@ -107,6 +109,7 @@ def _resolution_failure_decision(
         studio_lane="unknown",
         artifact_kind="unknown",
         visual_type="unknown",
+        app_category="unknown",
         quality_profile="unknown",
     )
 
@@ -143,6 +146,7 @@ def resolve_code_studio_scaffold_fallback(
     studio_lane = _safe_text(getattr(visual_decision, "studio_lane", ""))
     artifact_kind = _safe_text(getattr(visual_decision, "artifact_kind", ""))
     visual_type = _safe_text(getattr(visual_decision, "visual_type", ""))
+    app_category = _safe_text(getattr(visual_decision, "app_category", ""))
     quality_profile = _safe_text(getattr(visual_decision, "quality_profile", ""))
     metric_kind = _safe_kind(query, detect_kind_fn)
 
@@ -162,6 +166,7 @@ def resolve_code_studio_scaffold_fallback(
             studio_lane=studio_lane or "none",
             artifact_kind=artifact_kind or "none",
             visual_type=visual_type or "none",
+            app_category=app_category or "none",
             quality_profile=quality_profile or "standard",
         )
 
@@ -172,6 +177,9 @@ def resolve_code_studio_scaffold_fallback(
             artifact_kind=artifact_kind,
             requested_visual_type=visual_type,
             quality_profile=quality_profile,
+            app_category=app_category,
+            user_query=query,
+            planning_profile=_safe_text(getattr(visual_decision, "planning_profile", "")),
         )
     except Exception:
         return _resolution_failure_decision(
@@ -184,6 +192,9 @@ def resolve_code_studio_scaffold_fallback(
     studio_lane = _safe_text(getattr(contract, "studio_lane", studio_lane))
     artifact_kind = _safe_text(getattr(contract, "artifact_kind", artifact_kind))
     visual_type = _safe_text(getattr(contract, "resolved_visual_type", visual_type))
+    app_category = _safe_text(
+        getattr(getattr(contract, "app_intent_contract", None), "category", app_category)
+    )
     quality_profile = _safe_text(getattr(contract, "quality_profile", quality_profile))
 
     if getattr(contract, "is_blocked_for_code_studio", False):
@@ -202,6 +213,7 @@ def resolve_code_studio_scaffold_fallback(
             studio_lane=studio_lane,
             artifact_kind=artifact_kind,
             visual_type=visual_type,
+            app_category=app_category,
             quality_profile=quality_profile,
         )
 
@@ -221,6 +233,7 @@ def resolve_code_studio_scaffold_fallback(
             studio_lane=studio_lane,
             artifact_kind=artifact_kind,
             visual_type=visual_type,
+            app_category=app_category,
             quality_profile=quality_profile,
         )
 
@@ -236,5 +249,6 @@ def resolve_code_studio_scaffold_fallback(
         studio_lane=studio_lane,
         artifact_kind=artifact_kind,
         visual_type=visual_type,
+        app_category=app_category,
         quality_profile=quality_profile,
     )

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompt_tool_context.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompt_tool_context.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.visual_intent_resolver import resolve_visual_intent
+from app.engine.tools.code_studio_app_intent_contract import (
+    resolve_code_studio_app_intent_contract,
+)
 
 
 def _build_direct_tools_context(
@@ -282,10 +285,20 @@ def _build_code_studio_tools_context(
         )
         if llm_code_gen:
             if visual_decision.presentation_intent in {"code_studio_app", "artifact"}:
+                app_contract = resolve_code_studio_app_intent_contract(
+                    presentation_intent=visual_decision.presentation_intent,
+                    studio_lane=visual_decision.studio_lane or "",
+                    artifact_kind=visual_decision.artifact_kind or "",
+                    requested_visual_type=visual_decision.visual_type or "",
+                    app_category=getattr(visual_decision, "app_category", ""),
+                    user_query=query,
+                    planning_profile=visual_decision.planning_profile,
+                )
                 tool_hints.append(
                     "- tool_create_visual_code: TOOL CHINH CHO QUERY NAY. "
                     "Dung no de tao app/widget/artifact code-centric voi host-owned shell, body logic ro rang, va patch cung session."
                 )
+                tool_hints.extend(app_contract.prompt_lines())
                 tool_hints.append(
                     "- DESIGN: App/widget can su dung shell cua host, controls gon, va feedback bridge ro rang. "
                     "Khong tao dashboard/card loe loet neu bai toan la app inline trong chat."

--- a/maritime-ai-service/app/engine/multi_agent/visual_intent_presets.py
+++ b/maritime-ai-service/app/engine/multi_agent/visual_intent_presets.py
@@ -3,7 +3,13 @@
 from __future__ import annotations
 
 
-def build_artifact_decision_impl(*, decision_cls, reason: str = "artifact-request"):
+def build_artifact_decision_impl(
+    *,
+    decision_cls,
+    reason: str = "artifact-request",
+    artifact_kind: str = "html_app",
+    app_category: str = "artifact",
+):
     return decision_cls(
         mode="app",
         force_tool=True,
@@ -12,7 +18,7 @@ def build_artifact_decision_impl(*, decision_cls, reason: str = "artifact-reques
         preferred_tool="tool_create_visual_code",
         figure_budget=1,
         studio_lane="artifact",
-        artifact_kind="html_app",
+        artifact_kind=artifact_kind,
         quality_profile="premium",
         renderer_contract="host_shell",
         preferred_render_surface="html",
@@ -20,10 +26,17 @@ def build_artifact_decision_impl(*, decision_cls, reason: str = "artifact-reques
         thinking_floor="high",
         critic_policy="standard",
         living_expression_mode="subtle",
+        app_category=app_category,
     )
 
 
-def build_app_decision_impl(*, decision_cls, visual_type: str | None, reason: str):
+def build_app_decision_impl(
+    *,
+    decision_cls,
+    visual_type: str | None,
+    reason: str,
+    app_category: str = "",
+):
     is_simulation = visual_type == "simulation"
     return decision_cls(
         mode="app",
@@ -42,6 +55,7 @@ def build_app_decision_impl(*, decision_cls, visual_type: str | None, reason: st
         thinking_floor="max" if is_simulation else "high",
         critic_policy="premium" if is_simulation else "standard",
         living_expression_mode="expressive" if is_simulation else "subtle",
+        app_category=app_category or ("simulation" if is_simulation else "mini_tool"),
     )
 
 

--- a/maritime-ai-service/app/engine/multi_agent/visual_intent_resolver.py
+++ b/maritime-ai-service/app/engine/multi_agent/visual_intent_resolver.py
@@ -13,9 +13,14 @@ from app.engine.multi_agent.visual_intent_presets import (
     build_diagram_decision_impl,
 )
 from app.engine.multi_agent.visual_intent_support import (
+    CODE_WIDGET_CUES as _CODE_WIDGET_CUES,
+    DASHBOARD_APP_CUES as _DASHBOARD_APP_CUES,
+    INTERACTIVE_TABLE_CUES as _INTERACTIVE_TABLE_CUES,
     LEGACY_VISUAL_TOOL_NAMES as _LEGACY_VISUAL_TOOL_NAMES,
+    MINI_TOOL_CUES as _MINI_TOOL_CUES,
     QUIZ_WIDGET_CUES as _QUIZ_WIDGET_CUES,
     SCENE_SIMULATION_CUES as _SCENE_SIMULATION_CUES,
+    SEARCH_WIDGET_CUES as _SEARCH_WIDGET_CUES,
     SIMULATION_APP_CUES as _SIMULATION_APP_CUES,
     SIMULATION_PATCH_CUES as _SIMULATION_PATCH_CUES,
     contains_any_impl,
@@ -41,6 +46,16 @@ PreferredRenderSurface = Literal["svg", "canvas", "html", "video"]
 PlanningProfile = Literal["article_svg", "chart_svg", "simulation_canvas", "artifact_html"]
 CriticPolicy = Literal["none", "standard", "premium"]
 LivingExpressionMode = Literal["subtle", "expressive"]
+CodeStudioAppCategory = Literal[
+    "simulation",
+    "quiz",
+    "dashboard",
+    "mini_tool",
+    "interactive_table",
+    "search_widget",
+    "code_widget",
+    "artifact",
+]
 
 
 
@@ -63,6 +78,7 @@ class VisualIntentDecision:
     critic_policy: CriticPolicy = "standard"
     living_expression_mode: LivingExpressionMode = "expressive"
     renderer_kind_hint: str = ""
+    app_category: CodeStudioAppCategory | str = ""
 
 
 def _looks_like_quiz_app_request(query: str, normalized: str) -> bool:
@@ -107,6 +123,26 @@ def _infer_followup_simulation_type(normalized: str) -> str | None:
         normalized,
         contains_any=_contains_any,
     )
+
+def _infer_code_studio_app_category(normalized: str, *, visual_type: str | None = None) -> str:
+    if visual_type == "simulation" or _contains_any(
+        normalized,
+        _SIMULATION_APP_CUES + _SIMULATION_PATCH_CUES + _SCENE_SIMULATION_CUES,
+    ):
+        return "simulation"
+    if visual_type == "quiz" or _contains_any(normalized, _QUIZ_WIDGET_CUES):
+        return "quiz"
+    if visual_type == "interactive_table" or _contains_any(normalized, _INTERACTIVE_TABLE_CUES):
+        return "interactive_table"
+    if _contains_any(normalized, _SEARCH_WIDGET_CUES):
+        return "search_widget"
+    if _contains_any(normalized, _CODE_WIDGET_CUES):
+        return "code_widget"
+    if _contains_any(normalized, _DASHBOARD_APP_CUES):
+        return "dashboard"
+    if _contains_any(normalized, _MINI_TOOL_CUES):
+        return "mini_tool"
+    return "mini_tool"
 
 def detect_visual_patch_request(query: str) -> bool:
     """Return True when the query looks like a follow-up edit to an existing visual."""
@@ -310,7 +346,12 @@ def _resolve_visual_intent_core(query: str) -> VisualIntentDecision:
             "react app",
         ),
     ):
-        return build_artifact_decision_impl(decision_cls=VisualIntentDecision)
+        artifact_kind = "search_widget" if _contains_any(normalized, _SEARCH_WIDGET_CUES) else "html_app"
+        return build_artifact_decision_impl(
+            decision_cls=VisualIntentDecision,
+            artifact_kind=artifact_kind,
+            app_category="artifact" if artifact_kind == "html_app" else "search_widget",
+        )
 
     if _contains_any(
         normalized,
@@ -333,11 +374,19 @@ def _resolve_visual_intent_core(query: str) -> VisualIntentDecision:
             "drag and drop",
             "interactive table",
         ),
-    ) or _contains_any(normalized, _QUIZ_WIDGET_CUES) or _looks_like_quiz_app_request(query, normalized) or (
+    ) or _contains_any(
+        normalized,
+        _QUIZ_WIDGET_CUES
+        + _DASHBOARD_APP_CUES
+        + _MINI_TOOL_CUES
+        + _INTERACTIVE_TABLE_CUES
+        + _SEARCH_WIDGET_CUES
+        + _CODE_WIDGET_CUES,
+    ) or _looks_like_quiz_app_request(query, normalized) or (
         "app" in normalized
         and _contains_any(normalized, _SIMULATION_APP_CUES)
     ):
-        visual_type = "simulation" if _contains_any(
+        if _contains_any(
             normalized,
             (
                 "simulation",
@@ -358,11 +407,20 @@ def _resolve_visual_intent_core(query: str) -> VisualIntentDecision:
                 "van hoc",
                 "nhan vat",
             ),
-        ) else None
+        ):
+            visual_type = "simulation"
+        elif _looks_like_quiz_app_request(query, normalized) or _contains_any(normalized, _QUIZ_WIDGET_CUES):
+            visual_type = "quiz"
+        elif _contains_any(normalized, _INTERACTIVE_TABLE_CUES):
+            visual_type = "interactive_table"
+        else:
+            visual_type = "react_app"
+        app_category = _infer_code_studio_app_category(normalized, visual_type=visual_type)
         return build_app_decision_impl(
             decision_cls=VisualIntentDecision,
             visual_type=visual_type,
             reason="app-request",
+            app_category=app_category,
         )
 
     if _looks_like_app_followup_patch(normalized):
@@ -371,6 +429,7 @@ def _resolve_visual_intent_core(query: str) -> VisualIntentDecision:
             decision_cls=VisualIntentDecision,
             visual_type=visual_type,
             reason="app-followup-patch",
+            app_category=_infer_code_studio_app_category(normalized, visual_type=visual_type),
         )
 
     if _contains_any(

--- a/maritime-ai-service/app/engine/multi_agent/visual_intent_support.py
+++ b/maritime-ai-service/app/engine/multi_agent/visual_intent_support.py
@@ -150,6 +150,43 @@ QUIZ_WIDGET_CUES = (
     "mini quiz app",
 )
 
+DASHBOARD_APP_CUES = (
+    "dashboard",
+    "dashboard app",
+    "analytics",
+    "bang dieu khien",
+)
+
+MINI_TOOL_CUES = (
+    "mini tool",
+    "interactive tool",
+    "calculator",
+    "tinh toan",
+    "tool nho",
+)
+
+INTERACTIVE_TABLE_CUES = (
+    "interactive table",
+    "bang tuong tac",
+    "filter table",
+    "sortable table",
+)
+
+SEARCH_WIDGET_CUES = (
+    "search widget",
+    "search tool",
+    "widget tim kiem",
+    "cong cu tim kiem",
+)
+
+CODE_WIDGET_CUES = (
+    "code widget",
+    "code editor",
+    "snippet",
+    "playground",
+    "code playground",
+)
+
 QUIZ_CREATION_CUES = (
     "tao",
     "lam",

--- a/maritime-ai-service/app/engine/multi_agent/visual_runtime_metadata_contract.py
+++ b/maritime-ai-service/app/engine/multi_agent/visual_runtime_metadata_contract.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from app.engine.tools.code_studio_app_intent_contract import (
+    resolve_code_studio_app_intent_contract,
+)
+
 
 VISUAL_RUNTIME_MODES = frozenset({"template", "inline_html", "app", "mermaid"})
 PRESENTATION_INTENTS = frozenset(
@@ -46,6 +50,13 @@ class VisualToolRuntimeIntent:
     artifact_kind: str = ""
     renderer_contract: str = ""
     renderer_kind_hint: str = ""
+    app_category: str = ""
+    app_required_surface: str = ""
+    app_required_controls: str = ""
+    app_required_state: str = ""
+    app_feedback_hooks: str = ""
+    app_reject_if_missing: str = ""
+    app_critic_focus: str = ""
 
     def to_metadata(self) -> dict[str, Any]:
         metadata: dict[str, Any] = {
@@ -69,6 +80,13 @@ class VisualToolRuntimeIntent:
             "artifact_kind": self.artifact_kind,
             "renderer_contract": self.renderer_contract,
             "renderer_kind_hint": self.renderer_kind_hint,
+            "app_category": self.app_category,
+            "app_required_surface": self.app_required_surface,
+            "app_required_controls": self.app_required_controls,
+            "app_required_state": self.app_required_state,
+            "app_feedback_hooks": self.app_feedback_hooks,
+            "app_reject_if_missing": self.app_reject_if_missing,
+            "app_critic_focus": self.app_critic_focus,
         }
         metadata.update({key: value for key, value in optional_fields.items() if value})
         return metadata
@@ -96,6 +114,20 @@ def build_visual_tool_runtime_intent(
     if quality_profile not in QUALITY_PROFILES:
         quality_profile = "standard"
 
+    preferred_tool = _text(getattr(visual_decision, "preferred_tool", ""))
+    app_metadata: dict[str, str] = {}
+    if presentation_intent in {"code_studio_app", "artifact"} or preferred_tool == "tool_create_visual_code":
+        app_contract = resolve_code_studio_app_intent_contract(
+            presentation_intent=presentation_intent,
+            studio_lane=_text(getattr(visual_decision, "studio_lane", "")),
+            artifact_kind=_text(getattr(visual_decision, "artifact_kind", "")),
+            requested_visual_type=_text(getattr(visual_decision, "visual_type", "")),
+            app_category=_text(getattr(visual_decision, "app_category", "")),
+            user_query=query,
+            planning_profile=_text(getattr(visual_decision, "planning_profile", "")),
+        )
+        app_metadata = app_contract.metadata_text()
+
     return VisualToolRuntimeIntent(
         query=query,
         mode=mode,
@@ -109,9 +141,16 @@ def build_visual_tool_runtime_intent(
         critic_policy=_text(getattr(visual_decision, "critic_policy", "")),
         living_expression_mode=_text(getattr(visual_decision, "living_expression_mode", "")),
         visual_type=_text(getattr(visual_decision, "visual_type", "")),
-        preferred_tool=_text(getattr(visual_decision, "preferred_tool", "")),
+        preferred_tool=preferred_tool,
         studio_lane=_text(getattr(visual_decision, "studio_lane", "")),
         artifact_kind=_text(getattr(visual_decision, "artifact_kind", "")),
         renderer_contract=_text(getattr(visual_decision, "renderer_contract", "")),
         renderer_kind_hint=_text(getattr(visual_decision, "renderer_kind_hint", "")),
+        app_category=app_metadata.get("app_category", ""),
+        app_required_surface=app_metadata.get("app_required_surface", ""),
+        app_required_controls=app_metadata.get("app_required_controls", ""),
+        app_required_state=app_metadata.get("app_required_state", ""),
+        app_feedback_hooks=app_metadata.get("app_feedback_hooks", ""),
+        app_reject_if_missing=app_metadata.get("app_reject_if_missing", ""),
+        app_critic_focus=app_metadata.get("app_critic_focus", ""),
     )

--- a/maritime-ai-service/app/engine/tools/code_studio_app_intent_contract.py
+++ b/maritime-ai-service/app/engine/tools/code_studio_app_intent_contract.py
@@ -1,0 +1,244 @@
+"""Typed app-intent contract for Code Studio app/widget/artifact lanes."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Any
+
+
+CODE_STUDIO_APP_CATEGORIES = frozenset(
+    {
+        "simulation",
+        "quiz",
+        "dashboard",
+        "mini_tool",
+        "interactive_table",
+        "search_widget",
+        "code_widget",
+        "artifact",
+    }
+)
+
+
+def _text(value: Any, default: str = "") -> str:
+    cleaned = str(value if value is not None else default).strip()
+    return cleaned or default
+
+
+def _typed(value: Any, default: str = "") -> str:
+    return _text(value, default).lower()
+
+
+def _category(value: Any) -> str:
+    return _typed(value).replace("-", "_").replace(" ", "_")
+
+
+def _normalize(value: Any) -> str:
+    text = _typed(value)
+    if not text:
+        return ""
+    text = text.replace("đ", "d")
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    text = text.encode("ascii", "ignore").decode("ascii")
+    text = re.sub(r"[^a-z0-9\s/+.-]", " ", text)
+    return re.sub(r"\s+", " ", text.replace("_", " ")).strip()
+
+
+def _contains_any(text: str, needles: tuple[str, ...]) -> bool:
+    return any(needle in text for needle in needles)
+
+
+@dataclass(frozen=True, slots=True)
+class CodeStudioAppIntentContract:
+    """Host-governed contract for one Code Studio app category."""
+
+    category: str
+    required_surface: str
+    required_controls: tuple[str, ...]
+    required_state: tuple[str, ...]
+    required_feedback_hooks: tuple[str, ...]
+    reject_if_missing: tuple[str, ...]
+    critic_focus: tuple[str, ...]
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "app_category": self.category,
+            "app_required_surface": self.required_surface,
+            "app_required_controls": list(self.required_controls),
+            "app_required_state": list(self.required_state),
+            "app_feedback_hooks": list(self.required_feedback_hooks),
+            "app_reject_if_missing": list(self.reject_if_missing),
+            "app_critic_focus": list(self.critic_focus),
+        }
+
+    def metadata_text(self) -> dict[str, str]:
+        return {
+            "app_category": self.category,
+            "app_required_surface": self.required_surface,
+            "app_required_controls": ",".join(self.required_controls),
+            "app_required_state": ",".join(self.required_state),
+            "app_feedback_hooks": ",".join(self.required_feedback_hooks),
+            "app_reject_if_missing": ",".join(self.reject_if_missing),
+            "app_critic_focus": ",".join(self.critic_focus),
+        }
+
+    def prompt_lines(self) -> tuple[str, ...]:
+        controls = ", ".join(self.required_controls)
+        state = ", ".join(self.required_state)
+        feedback = ", ".join(self.required_feedback_hooks)
+        reject = ", ".join(self.reject_if_missing)
+        return (
+            f"- APP CONTRACT: category={self.category}; surface={self.required_surface}.",
+            f"- Required controls: {controls}.",
+            f"- Required state/readouts: {state}.",
+            f"- Feedback hooks: {feedback}.",
+            f"- Reject or repair if missing: {reject}.",
+        )
+
+
+_CONTRACTS: dict[str, CodeStudioAppIntentContract] = {
+    "simulation": CodeStudioAppIntentContract(
+        category="simulation",
+        required_surface="canvas_or_svg_scene",
+        required_controls=("play_pause", "reset", "parameter_control"),
+        required_state=("time_step", "entity_state", "live_readout"),
+        required_feedback_hooks=("state_changed", "checkpoint_reached"),
+        reject_if_missing=("state_model", "render_loop", "live_readout", "feedback_bridge"),
+        critic_focus=("real_causality", "not_css_only_motion", "teachable_controls"),
+    ),
+    "quiz": CodeStudioAppIntentContract(
+        category="quiz",
+        required_surface="form_or_cards",
+        required_controls=("answer_choice", "submit", "reset"),
+        required_state=("questions", "current_question", "score"),
+        required_feedback_hooks=("answer_submitted", "quiz_completed"),
+        reject_if_missing=("question_bank", "scoring_state", "result_feedback"),
+        critic_focus=("clear_question_flow", "accessible_inputs", "score_feedback"),
+    ),
+    "dashboard": CodeStudioAppIntentContract(
+        category="dashboard",
+        required_surface="dashboard_grid",
+        required_controls=("filter", "view_toggle", "reset"),
+        required_state=("dataset", "filters", "selected_view"),
+        required_feedback_hooks=("filter_changed", "view_changed"),
+        reject_if_missing=("real_data_model", "axis_or_units", "empty_state"),
+        critic_focus=("scan_density", "meaningful_metrics", "no_fake_div_bars"),
+    ),
+    "mini_tool": CodeStudioAppIntentContract(
+        category="mini_tool",
+        required_surface="tool_panel",
+        required_controls=("input", "run_or_update", "reset"),
+        required_state=("inputs", "computed_result", "validation_state"),
+        required_feedback_hooks=("result_ready", "input_changed"),
+        reject_if_missing=("input_model", "computed_output", "validation_feedback"),
+        critic_focus=("ergonomic_controls", "clear_output", "repeatable_action"),
+    ),
+    "interactive_table": CodeStudioAppIntentContract(
+        category="interactive_table",
+        required_surface="table",
+        required_controls=("sort", "filter", "row_select"),
+        required_state=("rows", "sort_state", "filter_state"),
+        required_feedback_hooks=("row_selected", "filter_changed"),
+        reject_if_missing=("table_semantics", "keyboard_navigation", "empty_state"),
+        critic_focus=("dense_but_readable", "table_accessibility", "source_or_units"),
+    ),
+    "search_widget": CodeStudioAppIntentContract(
+        category="search_widget",
+        required_surface="search_results",
+        required_controls=("query_input", "search", "filter"),
+        required_state=("query", "results", "selected_result"),
+        required_feedback_hooks=("search_submitted", "result_selected"),
+        reject_if_missing=("query_state", "results_state", "no_results_state"),
+        critic_focus=("result_relevance", "source_visibility", "keyboard_search"),
+    ),
+    "code_widget": CodeStudioAppIntentContract(
+        category="code_widget",
+        required_surface="code_workspace",
+        required_controls=("edit", "run_or_preview", "reset"),
+        required_state=("source", "preview_or_output", "error_state"),
+        required_feedback_hooks=("code_updated", "preview_ready"),
+        reject_if_missing=("source_state", "preview_state", "error_feedback"),
+        critic_focus=("safe_preview", "readable_code", "clear_error_state"),
+    ),
+    "artifact": CodeStudioAppIntentContract(
+        category="artifact",
+        required_surface="artifact_preview",
+        required_controls=("preview", "apply_or_export", "reset"),
+        required_state=("artifact_payload", "embed_state", "version"),
+        required_feedback_hooks=("artifact_ready", "artifact_exported"),
+        reject_if_missing=("artifact_payload", "preview_state", "handoff_metadata"),
+        critic_focus=("portable_output", "embed_ready", "no_session_only_assumptions"),
+    ),
+}
+
+
+def infer_code_studio_app_category(
+    *,
+    presentation_intent: str = "",
+    studio_lane: str = "",
+    artifact_kind: str = "",
+    requested_visual_type: str = "",
+    app_category: str = "",
+    user_query: str = "",
+    planning_profile: str = "",
+) -> str:
+    """Infer the stable Code Studio app category from typed and lexical cues."""
+
+    explicit = _category(app_category)
+    if explicit in CODE_STUDIO_APP_CATEGORIES:
+        return explicit
+
+    intent = _typed(presentation_intent)
+    lane = _typed(studio_lane)
+    kind = _typed(artifact_kind)
+    visual_type = _typed(requested_visual_type)
+    query = _normalize(user_query)
+    planning = _typed(planning_profile)
+
+    if intent == "artifact" or lane == "artifact":
+        if kind == "search_widget":
+            return "search_widget"
+        if kind == "code_widget":
+            return "code_widget"
+        return "artifact"
+
+    if visual_type == "simulation" or planning == "simulation_canvas":
+        return "simulation"
+    if visual_type == "quiz" or _contains_any(query, ("quiz", "quizz", "trac nghiem")):
+        return "quiz"
+    if visual_type == "interactive_table" or _contains_any(query, ("interactive table", "bang tuong tac")):
+        return "interactive_table"
+    if _contains_any(query, ("dashboard", "kpi", "metric", "analytics", "phan tich")):
+        return "dashboard"
+    if _contains_any(query, ("search widget", "tim kiem", "search tool")):
+        return "search_widget"
+    if _contains_any(query, ("code widget", "code editor", "snippet", "playground")):
+        return "code_widget"
+    return "mini_tool"
+
+
+def resolve_code_studio_app_intent_contract(
+    *,
+    presentation_intent: str = "",
+    studio_lane: str = "",
+    artifact_kind: str = "",
+    requested_visual_type: str = "",
+    app_category: str = "",
+    user_query: str = "",
+    planning_profile: str = "",
+) -> CodeStudioAppIntentContract:
+    """Resolve the Code Studio category contract used by prompts and payloads."""
+
+    category = infer_code_studio_app_category(
+        presentation_intent=presentation_intent,
+        studio_lane=studio_lane,
+        artifact_kind=artifact_kind,
+        requested_visual_type=requested_visual_type,
+        app_category=app_category,
+        user_query=user_query,
+        planning_profile=planning_profile,
+    )
+    return _CONTRACTS.get(category, _CONTRACTS["mini_tool"])

--- a/maritime-ai-service/app/engine/tools/visual_code_runtime_contract.py
+++ b/maritime-ai-service/app/engine/tools/visual_code_runtime_contract.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from app.engine.tools.code_studio_app_intent_contract import (
+    CodeStudioAppIntentContract,
+    resolve_code_studio_app_intent_contract,
+)
+
 
 BLOCKED_CODE_STUDIO_PRESENTATION_INTENTS = frozenset({"article_figure", "chart_runtime"})
 CODE_STUDIO_PRESENTATION_INTENTS = frozenset({"code_studio_app", "artifact"})
@@ -64,6 +69,7 @@ class VisualCodeRuntimeContract:
     quality_profile: str
     code_studio_version: int = 0
     renderer_contract: str = "host_shell"
+    app_intent_contract: CodeStudioAppIntentContract | None = None
 
     @property
     def is_blocked_for_code_studio(self) -> bool:
@@ -73,13 +79,16 @@ class VisualCodeRuntimeContract:
     def runtime_manifest(self) -> dict[str, Any] | None:
         if self.renderer_kind != "app":
             return None
-        return {
+        manifest = {
             "ui_runtime": "html",
             "storage": False,
             "mcp_access": False,
             "file_export": self.studio_lane == "artifact",
             "shareability": "session" if self.studio_lane == "app" else "artifact",
         }
+        if self.app_intent_contract is not None:
+            manifest.update(self.app_intent_contract.metadata())
+        return manifest
 
     def payload_metadata(self) -> dict[str, Any]:
         metadata: dict[str, Any] = {
@@ -94,6 +103,8 @@ class VisualCodeRuntimeContract:
             "quality_profile": self.quality_profile,
             "renderer_contract": self.renderer_contract,
         }
+        if self.app_intent_contract is not None:
+            metadata.update(self.app_intent_contract.metadata())
         if self.code_studio_version > 0:
             metadata["code_studio_version"] = self.code_studio_version
         return metadata
@@ -107,6 +118,9 @@ def resolve_visual_code_runtime_contract(
     requested_visual_type: str = "",
     quality_profile: str = "",
     code_studio_version: Any = 0,
+    app_category: str = "",
+    user_query: str = "",
+    planning_profile: str = "",
 ) -> VisualCodeRuntimeContract:
     """Resolve Code Studio lane metadata once, before validation and payload build."""
 
@@ -121,6 +135,17 @@ def resolve_visual_code_runtime_contract(
     requested_type = _text(requested_visual_type, "concept")
     resolved_visual_type = requested_type if requested_type in CODE_STUDIO_VISUAL_TYPES else "concept"
     renderer_kind = "app" if resolved_lane in {"app", "widget"} else "inline_html"
+    app_contract = None
+    if resolved_intent in CODE_STUDIO_PRESENTATION_INTENTS:
+        app_contract = resolve_code_studio_app_intent_contract(
+            presentation_intent=resolved_intent,
+            studio_lane=resolved_lane,
+            artifact_kind=resolved_artifact_kind,
+            requested_visual_type=resolved_visual_type,
+            app_category=app_category,
+            user_query=user_query,
+            planning_profile=planning_profile,
+        )
 
     return VisualCodeRuntimeContract(
         presentation_intent=resolved_intent,
@@ -133,4 +158,5 @@ def resolve_visual_code_runtime_contract(
         patch_strategy="app_state" if renderer_kind == "app" else "replace_html",
         quality_profile=_choice(quality_profile, CODE_STUDIO_QUALITY_PROFILES, "standard"),
         code_studio_version=_code_studio_version(code_studio_version),
+        app_intent_contract=app_contract,
     )

--- a/maritime-ai-service/app/engine/tools/visual_tool_runtime.py
+++ b/maritime-ai-service/app/engine/tools/visual_tool_runtime.py
@@ -257,6 +257,9 @@ def tool_create_visual_code_impl(
         requested_visual_type=runtime_metadata_text("visual_requested_type", "concept"),
         quality_profile=runtime_quality_profile(),
         code_studio_version=runtime_code_studio_version(),
+        app_category=runtime_metadata_text("app_category", ""),
+        user_query=runtime_metadata_text("visual_user_query", ""),
+        planning_profile=runtime_metadata_text("planning_profile", ""),
     )
     if runtime_contract.is_blocked_for_code_studio:
         return (

--- a/maritime-ai-service/tests/unit/engine/context/test_pointy_fast_path.py
+++ b/maritime-ai-service/tests/unit/engine/context/test_pointy_fast_path.py
@@ -282,6 +282,22 @@ def test_capability_inventory_prompt_does_not_emit_image_input_fast_path_action(
     assert action is None
 
 
+def test_visual_simulation_prompt_does_not_get_hijacked_by_open_term():
+    action = build_pointy_fast_path_action(
+        "Mô phỏng Quy tắc 15 COLREGs",
+        _context([
+            {
+                "id": "auto:button:giai-thich-quy-tac-15-colregs",
+                "selector": '[data-wiii-id="auto:button:giai-thich-quy-tac-15-colregs"]',
+                "label": "Giai thich Quy tac 15 COLREGs",
+                "click_safe": True,
+            }
+        ]),
+    )
+
+    assert action is None
+
+
 def test_skips_when_frontend_fast_path_already_reported_feedback():
     action = build_pointy_fast_path_action(
         "Wiii oi, nut Kham pha khoa hoc o dau?",

--- a/maritime-ai-service/tests/unit/test_code_studio_app_intent_contract.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_app_intent_contract.py
@@ -1,0 +1,60 @@
+from app.engine.tools.code_studio_app_intent_contract import (
+    infer_code_studio_app_category,
+    resolve_code_studio_app_intent_contract,
+)
+
+
+def test_resolves_simulation_contract_from_visual_type() -> None:
+    contract = resolve_code_studio_app_intent_contract(
+        presentation_intent="code_studio_app",
+        studio_lane="app",
+        requested_visual_type="simulation",
+    )
+
+    assert contract.category == "simulation"
+    assert contract.required_surface == "canvas_or_svg_scene"
+    assert "state_model" in contract.reject_if_missing
+    assert "teachable_controls" in contract.critic_focus
+
+
+def test_resolves_quiz_contract_from_query() -> None:
+    contract = resolve_code_studio_app_intent_contract(
+        presentation_intent="code_studio_app",
+        studio_lane="app",
+        user_query="Tao mot interactive quiz widget HTML",
+    )
+
+    assert contract.category == "quiz"
+    assert "question_bank" in contract.reject_if_missing
+    assert "quiz_completed" in contract.required_feedback_hooks
+
+
+def test_resolves_dashboard_contract_from_query() -> None:
+    category = infer_code_studio_app_category(
+        presentation_intent="code_studio_app",
+        user_query="Tạo dashboard app HTML cho chiến dịch này",
+    )
+
+    assert category == "dashboard"
+
+
+def test_normalizes_explicit_category_case_and_separator() -> None:
+    category = infer_code_studio_app_category(
+        presentation_intent="code_studio_app",
+        app_category="Interactive-Table",
+    )
+
+    assert category == "interactive_table"
+
+
+def test_artifact_contract_overrides_generic_html_app() -> None:
+    contract = resolve_code_studio_app_intent_contract(
+        presentation_intent="artifact",
+        studio_lane="artifact",
+        artifact_kind="html_app",
+        requested_visual_type="react_app",
+        user_query="Tao mot mini app HTML de nhung vao LMS",
+    )
+
+    assert contract.category == "artifact"
+    assert "handoff_metadata" in contract.reject_if_missing

--- a/maritime-ai-service/tests/unit/test_code_studio_fast_paths.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_fast_paths.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.engine.multi_agent import code_studio_fast_paths
+from app.engine.multi_agent.code_studio_fast_paths import (
+    _COLREG_RULE15_FAST_PATH_HTML,
+    _PENDULUM_FAST_PATH_HTML,
+    _contains_visual_payload_result,
+)
+from app.engine.multi_agent.tool_collection import _build_visual_tool_runtime_metadata
+from app.engine.tools.runtime_context import ToolRuntimeContext, tool_runtime_scope
+from app.engine.tools.visual_tools import parse_visual_payloads, tool_create_visual_code
+
+
+def _create_payloads(query: str, code_html: str):
+    metadata = _build_visual_tool_runtime_metadata({"context": {}}, query) or {}
+    with tool_runtime_scope(ToolRuntimeContext(metadata=metadata)):
+        result = tool_create_visual_code.invoke({
+            "code_html": code_html,
+            "title": "Fast path smoke",
+        })
+    return result, parse_visual_payloads(result)
+
+
+def test_colreg_fast_path_html_satisfies_visual_payload_contract() -> None:
+    result, payloads = _create_payloads(
+        "Mô phỏng Quy tắc 15 COLREGs",
+        _COLREG_RULE15_FAST_PATH_HTML,
+    )
+
+    assert _contains_visual_payload_result(result)
+    assert len(payloads) == 1
+    payload = payloads[0]
+    assert payload.type == "simulation"
+    assert payload.renderer_kind == "app"
+    assert payload.metadata["app_category"] == "simulation"
+    assert "<canvas" in (payload.fallback_html or "").lower()
+    assert "window.WiiiVisualBridge.reportResult" in (payload.fallback_html or "")
+
+
+def test_pendulum_fast_path_html_satisfies_visual_payload_contract() -> None:
+    result, payloads = _create_payloads(
+        "Hãy mô phỏng vật lý con lắc có kéo thả chuột",
+        _PENDULUM_FAST_PATH_HTML,
+    )
+
+    assert _contains_visual_payload_result(result)
+    assert len(payloads) == 1
+    payload = payloads[0]
+    assert payload.type == "simulation"
+    assert payload.renderer_kind == "app"
+    assert "<canvas" in (payload.fallback_html or "").lower()
+    assert "requestAnimationFrame" in (payload.fallback_html or "")
+
+
+@pytest.mark.asyncio
+async def test_recipe_fast_path_rejects_non_payload_tool_result(monkeypatch) -> None:
+    async def fake_invoke_tool_with_runtime(*_args, **_kwargs):
+        return "Quality score 4/10 - chua dat"
+
+    monkeypatch.setattr(
+        code_studio_fast_paths,
+        "invoke_tool_with_runtime",
+        fake_invoke_tool_with_runtime,
+    )
+
+    pushed_events = []
+
+    async def push_event(event):
+        pushed_events.append(event)
+
+    result = await code_studio_fast_paths.execute_code_studio_fast_path(
+        state={"context": {}},
+        query="Mô phỏng Quy tắc 15 COLREGs",
+        tools=[SimpleNamespace(name="tool_create_visual_code")],
+        push_event=push_event,
+        runtime_context_base=None,
+        derive_code_stream_session_id=lambda **_kwargs: "vs-test",
+        sanitize_code_studio_response=lambda text, *_args: text,
+    )
+
+    assert result is None
+    assert pushed_events == []

--- a/maritime-ai-service/tests/unit/test_code_studio_scaffold_fallback_policy.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_scaffold_fallback_policy.py
@@ -15,6 +15,7 @@ def _visual_decision(**overrides):
         "studio_lane": "app",
         "artifact_kind": "html_app",
         "visual_type": "simulation",
+        "app_category": "simulation",
         "quality_profile": "premium",
     }
     data.update(overrides)
@@ -33,6 +34,8 @@ def test_suppresses_generic_simulation_scaffold_fallback() -> None:
     assert decision.policy_reason == "app_requires_tool_generated_preview"
     assert decision.response_type == "code_studio_scaffold_suppressed"
     assert "template chung chung" in decision.response
+    assert decision.app_category == "simulation"
+    assert decision.metric_labels()["app_category"] == "simulation"
     assert decision.metric_labels()["reason"] == "llm_prose_no_tool_call"
 
 

--- a/maritime-ai-service/tests/unit/test_graph_routing.py
+++ b/maritime-ai-service/tests/unit/test_graph_routing.py
@@ -1215,6 +1215,56 @@ class TestSimulationClarifier:
         assert result["current_agent"] == "code_studio_agent"
 
 
+    @pytest.mark.asyncio
+    async def test_code_studio_node_runs_recipe_fast_path_before_provider_selection(self):
+        from app.core.exceptions import ProviderUnavailableError
+
+        state = {
+            "query": "mo phong COLREG rule 15",
+            "context": {},
+            "domain_id": "maritime",
+            "domain_config": {},
+        }
+        fake_tracer = MagicMock()
+        fast_path_result = {
+            "response": "opened deterministic visual preview",
+            "thinking_content": "deterministic code studio recipe",
+            "tool_call_events": [],
+            "tools_used": [{"name": "tool_create_visual_code"}],
+            "fast_path": "fast_colreg15",
+        }
+
+        with patch("app.engine.multi_agent.graph._get_or_create_tracer", return_value=fake_tracer), \
+             patch("app.engine.multi_agent.graph.settings") as mock_settings, \
+             patch("app.engine.multi_agent.graph._looks_like_ambiguous_simulation_request", return_value=False), \
+             patch(
+                 "app.engine.multi_agent.graph._collect_code_studio_tools",
+                 return_value=([SimpleNamespace(name="tool_create_visual_code")], True),
+             ), \
+             patch(
+                 "app.engine.multi_agent.graph._execute_pendulum_code_studio_fast_path",
+                 new=AsyncMock(return_value=fast_path_result),
+             ) as mock_fast_path, \
+             patch(
+                 "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_llm",
+                 side_effect=ProviderUnavailableError(
+                     provider="test",
+                     reason_code="not_configured",
+                     message="provider unavailable",
+                 ),
+             ) as mock_get_llm:
+            mock_settings.default_domain = "maritime"
+            mock_settings.enable_natural_conversation = False
+
+            result = await code_studio_node(state)
+
+        mock_fast_path.assert_awaited_once()
+        mock_get_llm.assert_not_called()
+        assert result["final_response"] == "opened deterministic visual preview"
+        assert result["tools_used"] == [{"name": "tool_create_visual_code"}]
+        assert result["current_agent"] == "code_studio_agent"
+
+
 class TestCodeStudioProgressHeartbeat:
     def test_code_stream_session_id_is_stable_for_same_request_id(self):
         runtime = SimpleNamespace(request_id="req-code-studio-123")

--- a/maritime-ai-service/tests/unit/test_visual_code_runtime_contract.py
+++ b/maritime-ai-service/tests/unit/test_visual_code_runtime_contract.py
@@ -23,14 +23,14 @@ def test_visual_code_contract_resolves_simulation_app_lane() -> None:
     assert contract.patch_strategy == "app_state"
     assert contract.quality_profile == "premium"
     assert contract.code_studio_version == 3
-    assert contract.runtime_manifest == {
-        "ui_runtime": "html",
-        "storage": False,
-        "mcp_access": False,
-        "file_export": False,
-        "shareability": "session",
-    }
+    assert contract.runtime_manifest is not None
+    assert contract.runtime_manifest["ui_runtime"] == "html"
+    assert contract.runtime_manifest["file_export"] is False
+    assert contract.runtime_manifest["shareability"] == "session"
+    assert contract.runtime_manifest["app_category"] == "simulation"
+    assert "state_model" in contract.runtime_manifest["app_reject_if_missing"]
     assert contract.payload_metadata()["code_studio_version"] == 3
+    assert contract.payload_metadata()["app_category"] == "simulation"
 
 
 def test_visual_code_contract_resolves_artifact_lane_as_inline_html() -> None:
@@ -51,6 +51,7 @@ def test_visual_code_contract_resolves_artifact_lane_as_inline_html() -> None:
     assert contract.patch_strategy == "replace_html"
     assert contract.runtime_manifest is None
     assert contract.payload_metadata()["presentation_intent"] == "artifact"
+    assert contract.payload_metadata()["app_category"] == "artifact"
 
 
 def test_visual_code_contract_marks_article_and_chart_lanes_blocked() -> None:
@@ -65,6 +66,10 @@ def test_visual_code_contract_marks_article_and_chart_lanes_blocked() -> None:
 
     assert article.is_blocked_for_code_studio is True
     assert chart.is_blocked_for_code_studio is True
+    assert article.app_intent_contract is None
+    assert chart.app_intent_contract is None
+    assert "app_category" not in article.payload_metadata()
+    assert "app_category" not in chart.payload_metadata()
 
 
 def test_visual_code_contract_sanitizes_unknown_runtime_values() -> None:
@@ -86,4 +91,35 @@ def test_visual_code_contract_sanitizes_unknown_runtime_values() -> None:
     assert contract.quality_profile == "standard"
     assert contract.code_studio_version == 0
     assert contract.payload_metadata()["presentation_intent"] == "code_studio_app"
+    assert contract.payload_metadata()["app_category"] == "mini_tool"
     assert "code_studio_version" not in contract.payload_metadata()
+
+
+def test_visual_code_contract_resolves_quiz_app_category() -> None:
+    contract = resolve_visual_code_runtime_contract(
+        presentation_intent="code_studio_app",
+        studio_lane="app",
+        artifact_kind="html_app",
+        requested_visual_type="quiz",
+        user_query="Tao mot interactive quiz widget trong chat",
+    )
+
+    assert contract.app_intent_contract is not None
+    assert contract.app_intent_contract.category == "quiz"
+    assert contract.payload_metadata()["app_category"] == "quiz"
+    assert "question_bank" in contract.payload_metadata()["app_reject_if_missing"]
+
+
+def test_visual_code_contract_resolves_dashboard_from_query() -> None:
+    contract = resolve_visual_code_runtime_contract(
+        presentation_intent="code_studio_app",
+        studio_lane="app",
+        artifact_kind="html_app",
+        requested_visual_type="react_app",
+        user_query="Tao dashboard app HTML cho chien dich nay",
+    )
+
+    assert contract.app_intent_contract is not None
+    assert contract.app_intent_contract.category == "dashboard"
+    assert contract.runtime_manifest is not None
+    assert "filter" in contract.runtime_manifest["app_required_controls"]

--- a/maritime-ai-service/tests/unit/test_visual_intent_resolver.py
+++ b/maritime-ai-service/tests/unit/test_visual_intent_resolver.py
@@ -122,6 +122,8 @@ def test_resolves_app_request():
     assert decision.presentation_intent == "code_studio_app"
     assert decision.preferred_tool == "tool_create_visual_code"
     assert decision.studio_lane == "app"
+    assert decision.visual_type == "react_app"
+    assert decision.app_category == "dashboard"
 
 
 def test_resolves_vietnamese_simulation_request_as_app():
@@ -136,6 +138,7 @@ def test_resolves_vietnamese_simulation_request_as_app():
     assert decision.planning_profile == "simulation_canvas"
     assert decision.thinking_floor == "max"
     assert decision.critic_policy == "premium"
+    assert decision.app_category == "simulation"
 
 
 def test_resolves_accented_vietnamese_simulation_request_as_app():
@@ -156,6 +159,7 @@ def test_resolves_english_pendulum_simulation_request_as_app():
     assert decision.presentation_intent == "code_studio_app"
     assert decision.preferred_tool == "tool_create_visual_code"
     assert decision.quality_profile == "premium"
+    assert decision.app_category == "simulation"
 
 
 def test_resolves_literary_scene_simulation_request_as_code_studio_app():
@@ -205,6 +209,7 @@ def test_resolves_embeddable_html_app_as_artifact():
     assert decision.preferred_render_surface == "html"
     assert decision.planning_profile == "artifact_html"
     assert decision.thinking_floor == "high"
+    assert decision.app_category == "artifact"
 
 
 def test_quiz_creation_request_routes_to_code_studio():
@@ -214,6 +219,8 @@ def test_quiz_creation_request_routes_to_code_studio():
     assert decision.presentation_intent == "code_studio_app"
     assert decision.preferred_tool == "tool_create_visual_code"
     assert decision.studio_lane == "app"
+    assert decision.visual_type == "quiz"
+    assert decision.app_category == "quiz"
 
 
 def test_plain_quiz_request_without_creation_verbs_stays_text():
@@ -230,6 +237,24 @@ def test_interactive_quiz_widget_request_routes_to_code_studio():
     assert decision.presentation_intent == "code_studio_app"
     assert decision.preferred_tool == "tool_create_visual_code"
     assert decision.studio_lane == "app"
+    assert decision.visual_type == "quiz"
+    assert decision.app_category == "quiz"
+
+
+def test_interactive_table_request_routes_to_typed_app_category():
+    decision = resolve_visual_intent("Tao interactive table co filter va sort cho danh sach hoc vien")
+    assert decision.mode == "app"
+    assert decision.visual_type == "interactive_table"
+    assert decision.app_category == "interactive_table"
+    assert decision.preferred_tool == "tool_create_visual_code"
+
+
+def test_search_widget_request_routes_to_typed_app_category():
+    decision = resolve_visual_intent("Tao search widget tim kiem tai lieu trong chat")
+    assert decision.mode == "app"
+    assert decision.visual_type == "react_app"
+    assert decision.app_category == "search_widget"
+    assert decision.preferred_tool == "tool_create_visual_code"
 
 
 def test_ignores_false_positive_visual_terms():

--- a/maritime-ai-service/tests/unit/test_visual_runtime_metadata_contract.py
+++ b/maritime-ai-service/tests/unit/test_visual_runtime_metadata_contract.py
@@ -45,6 +45,8 @@ def test_build_visual_tool_runtime_intent_preserves_typed_lane_metadata() -> Non
     assert metadata["artifact_kind"] == "html_app"
     assert metadata["renderer_contract"] == "host_shell"
     assert metadata["renderer_kind_hint"] == "app"
+    assert metadata["app_category"] == "simulation"
+    assert "state_model" in metadata["app_reject_if_missing"]
 
 
 def test_build_visual_tool_runtime_intent_skips_non_visual_turns() -> None:

--- a/wiii-desktop/src/__tests__/pointy-fast-path.test.ts
+++ b/wiii-desktop/src/__tests__/pointy-fast-path.test.ts
@@ -277,6 +277,19 @@ describe("pointy fast path", () => {
     ).toBeNull();
   });
 
+  it("does not hijack visual simulation prompts because of the Vietnamese 'mo' token", () => {
+    const ctx = makeHostContext([
+      {
+        id: "auto:button:giai-thich-quy-tac-15-colregs",
+        selector: "[data-wiii-id=\"auto:button:giai-thich-quy-tac-15-colregs\"]",
+        label: "Giai thich Quy tac 15 COLREGs",
+        click_safe: true,
+      },
+    ]);
+
+    expect(buildPointyFastPathAction("Mô phỏng Quy tắc 15 COLREGs", ctx)).toBeNull();
+  });
+
   it("allows embodied Pointy only for explicit Pointy-style turns", () => {
     expect(looksExplicitPointyTurn("Pointy hay chi vao nut Gui tin nhan va noi mot lan thoi.")).toBe(true);
     expect(looksExplicitPointyTurn("Pointy, chi lai nut Gui va noi that ngan thoi.")).toBe(true);

--- a/wiii-desktop/src/lib/pointy-fast-path.ts
+++ b/wiii-desktop/src/lib/pointy-fast-path.ts
@@ -50,6 +50,44 @@ const UNSAFE_CLICK_TERMS = [
   "hoan thanh",
 ];
 
+const VISUAL_DELIVERY_TERMS = [
+  "mo phong",
+  "simulate",
+  "simulation",
+  "simulator",
+  "canvas",
+  "code studio",
+  "tao visual",
+  "tao hinh",
+  "ve bieu do",
+  "draw chart",
+  "create chart",
+  "mermaid",
+  "html app",
+];
+
+const EXPLICIT_POINTY_OPERATOR_TERMS = [
+  "pointy",
+  "chi cho",
+  "chi vao",
+  "chi lai",
+  "chi giup",
+  "chi den",
+  "chi toi",
+  "tro toi",
+  "tro vao",
+  "tro den",
+  "highlight",
+  "show me where",
+  "point to",
+  "o dau",
+  "where",
+  "nut",
+  "button",
+  "bam",
+  "click",
+];
+
 interface PointyTargetAlias {
   ids: string[];
   terms: string[];
@@ -275,6 +313,12 @@ export function buildPointyFastPathAction(
 
   const normalizedPrompt = normalizePointyText(prompt);
   if (!normalizedPrompt) return null;
+  if (
+    hasAnyTerm(normalizedPrompt, VISUAL_DELIVERY_TERMS)
+    && !hasAnyTerm(normalizedPrompt, EXPLICIT_POINTY_OPERATOR_TERMS)
+  ) {
+    return null;
+  }
   const wantsLocate = hasAnyTerm(normalizedPrompt, LOCATE_TERMS);
   const wantsClick = hasAnyTerm(normalizedPrompt, CLICK_TERMS);
   if (!wantsLocate && !wantsClick) return null;


### PR DESCRIPTION
## Summary
- Add a typed Code Studio app-intent contract for simulations, quizzes, dashboards, mini tools, interactive tables, search/code widgets, and artifacts.
- Propagate app category, required surface, controls, state/readouts, feedback hooks, and reject-if-missing criteria through visual intent metadata, Code Studio payload metadata, runtime manifests, prompt hints, and scaffold fallback metrics.
- Tighten routing so charts stay on chart/article lanes while app-like requests use typed app contracts instead of broad template fallback.
- Run deterministic Code Studio recipe previews before provider selection, so safe Canvas previews can still render when the selected LLM provider is unavailable.
- Prevent Pointy fast paths from hijacking visual delivery prompts such as Vietnamese ?m? ph?ng ...?.

Closes #567

## Verification
- `cd maritime-ai-service && uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_code_studio_fast_paths.py tests/unit/test_graph_routing.py::TestSimulationClarifier tests/unit/engine/context/test_pointy_fast_path.py tests/unit/test_code_studio_app_intent_contract.py tests/unit/test_visual_code_runtime_contract.py tests/unit/test_visual_runtime_metadata_contract.py tests/unit/test_visual_intent_resolver.py tests/unit/test_code_studio_scaffold_fallback_policy.py -q --tb=short` -> 80 passed
- `cd maritime-ai-service && uv run --python 3.12 --with-requirements requirements.txt pytest tests/unit/test_visual_tools.py::TestCreateVisualCodeTool::test_code_studio_payload_metadata_canonicalizes_presentation_intent tests/unit/test_visual_tools.py::TestCreateVisualCodeTool::test_code_studio_runtime_context_promotes_followup_to_patch tests/unit/test_graph_routing.py::TestVisualRuntimeMetadata::test_chart_runtime_metadata_prefers_inline_html_svg tests/unit/test_sprint154_tech_debt.py::TestCodeStudioWave002::test_visual_runtime_metadata_reuses_active_code_studio_session_for_vietnamese_patch tests/unit/test_sprint154_tech_debt.py::TestCodeStudioWave002::test_visual_runtime_metadata_preserves_premium_quality_from_active_code_session -q --tb=short` -> 5 passed
- `cd maritime-ai-service && uv run --python 3.12 --with ruff ruff check app/ --select=E9,F63,F7` -> All checks passed
- `cd wiii-desktop && npx vitest run src/__tests__/pointy-fast-path.test.ts` -> 15 passed
- `cd wiii-desktop && npx tsc --noEmit` -> passed
- `cd wiii-desktop && npm run build:embed` -> passed; emitted existing Vite chunk-size/dynamic-import warnings only
- `git diff --check` -> passed

## Browser / Product Evidence
- `cd wiii-desktop && npx playwright test -c playwright.visual.config.ts playwright/local-chat-harness.spec.ts --reporter=list` with backend/frontend ports `8037/1437` -> 1 passed
- `cd wiii-desktop && npx playwright test -c playwright.visual.config.ts playwright/code-studio-runtime.spec.ts --grep "COLREG" --reporter=list` with backend/frontend ports `8038/1438` -> 1 passed
- The COLREG localhost harness now reaches the simulation lane and sees a visual preview/iframe instead of a chat-only safe-stop fallback.
- Dev harness still logs the expected local warning `Multi-tenant is not enabled`; no visual/runtime assertion failed.

## Risk / Rollback
- Risk: medium, because visual/app routing metadata and deterministic Code Studio recipe ordering affect prompt/tool behavior for generated app-like artifacts.
- Safety: no LMS mutation path, deployment asset, migration, auth, tenant, or approval-token behavior is changed.
- Rollback: revert this PR to return Code Studio app routing/prompt metadata and recipe ordering to the previous generic provider-dependent behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Typed app categories for interactive apps (quiz, dashboard, simulation, mini-tool, interactive table, search/code widgets, artifact) with richer runtime metadata, controls/state, feedback hooks, and reject-if-missing checks.
  * Improved fast-path interactive UIs and runtime payload handling for visual simulations/tools.

* **Improvements**
  * More accurate prompt routing and suppression to avoid hijacking visual-simulation requests.

* **Tests**
  * Expanded unit tests covering category resolution, runtime metadata, fast-paths, and prompt-routing.

* **Documentation**
  * Added/updated docs describing the app-intent contract and remaining quality notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->