### PR TITLE
test(desktop): stabilize local E2E chat harness

### DIFF
--- a/docs/operations/WIII_LOCAL_E2E_HARNESS.md
+++ b/docs/operations/WIII_LOCAL_E2E_HARNESS.md
@@ -1,0 +1,70 @@
+# Wiii Local E2E Harness
+
+Status: Active
+
+Owner: Project leadership
+
+Last updated: 2026-05-24
+
+## Purpose
+
+The local E2E harness exists to prove that Wiii can enter the real chat UI on
+localhost before longer visual, Code Studio, LMS, or voice scenarios run. A
+test failure should say whether auth/bootstrap is broken or whether the product
+runtime under test is broken.
+
+## Contract
+
+- Playwright visual tests start a local backend and frontend through
+  `wiii-desktop/playwright.visual.config.ts`.
+- The backend test server is forced into `ENVIRONMENT=development` with
+  `ENABLE_DEV_LOGIN=true`.
+- The frontend test server receives `VITE_API_URL` pointing at that backend.
+- Browser tests authenticate by calling the real `/api/v1/auth/dev-login`
+  endpoint through Playwright's request context, then seed the same
+  `auth_state` and secure token stores that `loginWithTokens()` writes. They do
+  not fake a legacy `local-dev-key` session in localStorage.
+- Production auth is not bypassed. `/auth/dev-login` remains gated by backend
+  settings, production validation, and private-source checks.
+
+## Smoke Command
+
+```bash
+cd wiii-desktop
+npx playwright test -c playwright.visual.config.ts playwright/local-chat-harness.spec.ts
+```
+
+To avoid an already-running local app, use isolated ports. PowerShell:
+
+```powershell
+cd wiii-desktop
+$env:WIII_PLAYWRIGHT_BACKEND_PORT="8030"
+$env:WIII_PLAYWRIGHT_FRONTEND_PORT="1430"
+$env:WIII_PLAYWRIGHT_SERVER_URL="http://127.0.0.1:8030"
+$env:WIII_PLAYWRIGHT_BASE_URL="http://127.0.0.1:1430"
+npx playwright test -c playwright.visual.config.ts playwright/local-chat-harness.spec.ts
+```
+
+## Visual Runtime Command
+
+```bash
+cd wiii-desktop
+npx playwright test -c playwright.visual.config.ts
+```
+
+This runs the lightweight auth harness first, then the visual runtime and Code
+Studio runtime specs.
+
+## Expected Evidence
+
+- `local-chat-harness.spec.ts` reaches `[data-wiii-id="chat-textarea"]`.
+- Login screen text is absent after bootstrap.
+- Backend `/api/v1/auth/dev-login/status` reports enabled for the local test
+  server.
+- If a test stops at login, treat it as harness/auth failure before debugging
+  visual runtime.
+
+## Rollback
+
+Revert the harness commit. The product auth surface is unaffected because all
+dev-login behavior remains behind existing backend gates.

--- a/wiii-desktop/playwright.visual.config.ts
+++ b/wiii-desktop/playwright.visual.config.ts
@@ -1,8 +1,19 @@
 import { defineConfig } from "@playwright/test";
 
+const frontendPort = process.env.WIII_PLAYWRIGHT_FRONTEND_PORT || "1420";
+const backendPort = process.env.WIII_PLAYWRIGHT_BACKEND_PORT || "8000";
+const baseURL =
+  process.env.WIII_PLAYWRIGHT_BASE_URL || `http://127.0.0.1:${frontendPort}`;
+const backendURL =
+  process.env.WIII_PLAYWRIGHT_SERVER_URL || `http://127.0.0.1:${backendPort}`;
+
 export default defineConfig({
   testDir: "./playwright",
-  testMatch: ["visual-runtime.spec.ts", "code-studio-runtime.spec.ts"],
+  testMatch: [
+    "local-chat-harness.spec.ts",
+    "visual-runtime.spec.ts",
+    "code-studio-runtime.spec.ts",
+  ],
   fullyParallel: false,
   workers: 1,
   timeout: 180_000,
@@ -11,7 +22,7 @@ export default defineConfig({
   },
   reporter: [["list"]],
   use: {
-    baseURL: "http://127.0.0.1:1420",
+    baseURL,
     browserName: "chromium",
     headless: true,
     trace: "retain-on-failure",
@@ -21,13 +32,13 @@ export default defineConfig({
   webServer: [
     {
       command: "node scripts/start-visual-backend.mjs",
-      url: "http://127.0.0.1:8000/api/v1/health/live",
+      url: `${backendURL}/api/v1/health/live`,
       reuseExistingServer: true,
       timeout: 180_000,
     },
     {
       command: "node scripts/start-visual-frontend.mjs",
-      url: "http://127.0.0.1:1420",
+      url: baseURL,
       reuseExistingServer: true,
       timeout: 180_000,
     },

--- a/wiii-desktop/playwright/code-studio-runtime.spec.ts
+++ b/wiii-desktop/playwright/code-studio-runtime.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { bootstrapLocalChat, chatComposer, sendPrompt } from "./support/local-chat-harness";
 
 const INITIAL_PROMPT =
   "Build a mini pendulum physics app in chat with drag interaction. Use Code Studio and keep it inline with the conversation.";
@@ -13,45 +14,13 @@ const VN_FOLLOWUP_PROMPT_2 =
 const VN_SHOW_CODE_PROMPT =
   "Cho tôi xem code đang được sinh ra";
 
-function buildInitScript(serverUrl: string, userId: string, displayName: string) {
-  const settingsPayload = {
-    server_url: serverUrl,
-    api_key: "local-dev-key",
-    user_id: userId,
-    user_role: "admin",
-    display_name: displayName,
-    llm_provider: "google",
-    theme: "light",
-    default_domain: "maritime",
-  };
-  const authPayload = {
-    data: {
-      user: null,
-      authMode: "legacy",
-    },
-  };
-
-  return `
-    localStorage.clear();
-    sessionStorage.clear();
-    localStorage.setItem('wiii:app_settings', JSON.stringify(${JSON.stringify(settingsPayload)}));
-    localStorage.setItem('wiii:auth_state', JSON.stringify(${JSON.stringify(authPayload)}));
-  `;
-}
-
-async function sendPrompt(page, prompt: string) {
-  const inputBox = page.locator("textarea[aria-label]").first();
-  await inputBox.waitFor({ state: "visible", timeout: 60_000 });
-  await inputBox.fill(prompt);
-  await inputBox.press("Enter");
-}
-
 test.describe("code studio runtime", () => {
   test("streams a code studio app inline and versions follow-up patches", async ({ page }, testInfo) => {
     const uniqueUser = `code-studio-e2e-${Date.now()}`;
-    await page.addInitScript(buildInitScript("http://127.0.0.1:8000", uniqueUser, "Code Studio Smoke"));
-    await page.goto("/", { waitUntil: "domcontentloaded", timeout: 60_000 });
-    await page.waitForLoadState("networkidle", { timeout: 60_000 });
+    await bootstrapLocalChat(page, {
+      userId: uniqueUser,
+      displayName: "Code Studio Smoke",
+    });
 
     await sendPrompt(page, INITIAL_PROMPT);
 
@@ -102,9 +71,10 @@ test.describe("code studio runtime", () => {
 
   test("supports vietnamese follow-up app edits and explicit code view", async ({ page }, testInfo) => {
     const uniqueUser = `code-studio-vn-${Date.now()}`;
-    await page.addInitScript(buildInitScript("http://127.0.0.1:8000", uniqueUser, "Code Studio VN Smoke"));
-    await page.goto("/", { waitUntil: "domcontentloaded", timeout: 60_000 });
-    await page.waitForLoadState("networkidle", { timeout: 60_000 });
+    await bootstrapLocalChat(page, {
+      userId: uniqueUser,
+      displayName: "Code Studio VN Smoke",
+    });
 
     const panel = page.locator(".code-studio-panel").first();
 
@@ -165,7 +135,7 @@ test.describe("code studio runtime", () => {
 
 async function sendAndSettle(page, prompt: string) {
   await sendPrompt(page, prompt);
-  const input = page.locator("textarea[aria-label]").first();
+  const input = chatComposer(page);
   await expect
     .poll(
       async () => page.locator('[aria-label="Dừng tạo phản hồi"]').count(),
@@ -178,9 +148,10 @@ async function sendAndSettle(page, prompt: string) {
 
 async function setupFresh(page, label: string) {
   const uid = `routing-${label}-${Date.now()}`;
-  await page.addInitScript(buildInitScript("http://127.0.0.1:8000", uid, `Routing ${label}`));
-  await page.goto("/", { waitUntil: "domcontentloaded", timeout: 60_000 });
-  await page.waitForLoadState("networkidle", { timeout: 60_000 });
+  await bootstrapLocalChat(page, {
+    userId: uid,
+    displayName: `Routing ${label}`,
+  });
 }
 
 test.describe("Phase 8 routing", () => {

--- a/wiii-desktop/playwright/local-chat-harness.spec.ts
+++ b/wiii-desktop/playwright/local-chat-harness.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "@playwright/test";
+import { bootstrapLocalChat, chatComposer } from "./support/local-chat-harness";
+
+test.describe("local chat harness", () => {
+  test("uses dev-login to reach the chat composer on localhost", async ({ page }) => {
+    const result = await bootstrapLocalChat(page, {
+      userId: `harness-smoke-${Date.now()}`,
+      displayName: "Harness Smoke",
+    });
+
+    expect(result.authenticatedBy).toBe("dev-login-api");
+    await expect(chatComposer(page)).toBeVisible();
+    await expect(page.getByText("Chào mừng đến Wiii")).toHaveCount(0);
+  });
+});

--- a/wiii-desktop/playwright/support/local-chat-harness.ts
+++ b/wiii-desktop/playwright/support/local-chat-harness.ts
@@ -1,0 +1,153 @@
+import { expect, type Page } from "@playwright/test";
+
+type BootstrapOptions = {
+  serverUrl?: string;
+  userId?: string;
+  displayName?: string;
+};
+
+type BootstrapResult = {
+  serverUrl: string;
+  userId: string;
+  authenticatedBy: "dev-login-api";
+};
+
+function defaultServerUrl(): string {
+  return process.env.WIII_PLAYWRIGHT_SERVER_URL || "http://127.0.0.1:8000";
+}
+
+function uniqueUserId(base = "playwright-chat"): string {
+  return `${base}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function settingsPayload(serverUrl: string, userId: string, displayName: string) {
+  return {
+    server_url: serverUrl,
+    api_key: "",
+    user_id: userId,
+    user_role: "admin",
+    display_name: displayName,
+    llm_provider: "google",
+    theme: "light",
+    default_domain: "maritime",
+    show_thinking: true,
+    show_reasoning_trace: false,
+    streaming_version: "v3",
+  };
+}
+
+function safeEmail(userId: string): string {
+  const localPart = userId.toLowerCase().replace(/[^a-z0-9-]+/g, "-").slice(0, 48);
+  return `${localPart || "playwright"}@localhost`;
+}
+
+async function createDevLoginSession(page: Page, serverUrl: string, userId: string, displayName: string) {
+  const response = await page.request.post(`${serverUrl}/api/v1/auth/dev-login`, {
+    data: {
+      email: safeEmail(userId),
+      name: displayName,
+      role: "admin",
+    },
+    timeout: 30_000,
+  });
+  if (!response.ok()) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`Local dev-login failed (${response.status()}): ${body}`);
+  }
+  return await response.json();
+}
+
+export function chatComposer(page: Page) {
+  return page.locator('[data-wiii-id="chat-textarea"]').first();
+}
+
+export async function sendPrompt(page: Page, prompt: string): Promise<void> {
+  const input = chatComposer(page);
+  await input.waitFor({ state: "visible", timeout: 60_000 });
+  await expect(input).toBeEnabled({ timeout: 60_000 });
+  await input.fill(prompt);
+  await input.press("Enter");
+}
+
+async function assertDevLoginEnabled(page: Page, serverUrl: string): Promise<void> {
+  const response = await page.request.get(`${serverUrl}/api/v1/auth/dev-login/status`, {
+    timeout: 30_000,
+  });
+  if (!response.ok()) {
+    throw new Error(
+      `Local dev-login status probe failed (${response.status()}). ` +
+        `Start the visual backend with ENABLE_DEV_LOGIN=true and ENVIRONMENT=development.`,
+    );
+  }
+  const data = await response.json().catch(() => ({}));
+  if (!data?.enabled) {
+    throw new Error(
+      "Local dev-login is disabled. The visual E2E harness requires " +
+        "ENABLE_DEV_LOGIN=true on the local backend.",
+    );
+  }
+}
+
+export async function bootstrapLocalChat(
+  page: Page,
+  options: BootstrapOptions = {},
+): Promise<BootstrapResult> {
+  const serverUrl = options.serverUrl || defaultServerUrl();
+  const userId = options.userId || uniqueUserId();
+  const displayName = options.displayName || "Wiii Playwright";
+
+  await assertDevLoginEnabled(page, serverUrl);
+  const session = await createDevLoginSession(page, serverUrl, userId, displayName);
+  const user = {
+    id: session.user?.id || userId,
+    email: session.user?.email || safeEmail(userId),
+    name: session.user?.name || displayName,
+    avatar_url: session.user?.avatar_url || "",
+    role: session.user?.role || "admin",
+    legacy_role: session.user?.legacy_role || session.user?.role || "admin",
+    platform_role: session.user?.platform_role || "platform_admin",
+    organization_role: session.user?.organization_role || "",
+    host_role: session.user?.host_role || "",
+    role_source: session.user?.role_source || "platform",
+    active_organization_id: session.user?.active_organization_id || session.organization_id || "",
+    connector_id: "",
+    identity_version: "2",
+  };
+  const effectiveSettings = {
+    ...settingsPayload(serverUrl, user.id, user.name || displayName),
+    user_role: user.role,
+    organization_id: user.active_organization_id || undefined,
+  };
+  const authState = {
+    data: {
+      user,
+      authMode: "oauth",
+    },
+  };
+  const tokenState = {
+    tokens: {
+      access_token: session.access_token,
+      refresh_token: session.refresh_token,
+      expires_at: Date.now() + Number(session.expires_in || 900) * 1000,
+    },
+  };
+
+  await page.addInitScript(
+    ({ settings, auth, tokens }) => {
+      localStorage.clear();
+      sessionStorage.clear();
+      localStorage.setItem("wiii:app_settings", JSON.stringify(settings));
+      localStorage.setItem("wiii:auth_state", JSON.stringify(auth));
+      localStorage.setItem("wiii:wiii_auth_tokens", JSON.stringify(tokens));
+    },
+    { settings: effectiveSettings, auth: authState, tokens: tokenState },
+  );
+
+  await page.goto("/", { waitUntil: "domcontentloaded", timeout: 60_000 });
+
+  const composer = chatComposer(page);
+  await composer.waitFor({ state: "visible", timeout: 60_000 });
+  await expect(composer).toBeEnabled({ timeout: 60_000 });
+
+  return { serverUrl, userId: user.id, authenticatedBy: "dev-login-api" };
+}

--- a/wiii-desktop/playwright/support/local-chat-harness.ts
+++ b/wiii-desktop/playwright/support/local-chat-harness.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from "@playwright/test";
+import { randomUUID } from "node:crypto";
 
 type BootstrapOptions = {
   serverUrl?: string;
@@ -17,7 +18,7 @@ function defaultServerUrl(): string {
 }
 
 function uniqueUserId(base = "playwright-chat"): string {
-  return `${base}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return `${base}-${Date.now()}-${randomUUID().slice(0, 8)}`;
 }
 
 function settingsPayload(serverUrl: string, userId: string, displayName: string) {

--- a/wiii-desktop/playwright/visual-runtime.spec.ts
+++ b/wiii-desktop/playwright/visual-runtime.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { bootstrapLocalChat, sendPrompt } from "./support/local-chat-harness";
 
 const FIRST_PROMPTS = [
   "Explain Kimi linear attention in charts. Use 2 to 3 small inline figures, each proving one claim: the problem, the mechanism, and the result.",
@@ -18,39 +19,6 @@ const TECHNICAL_LEAKS = [
   "template",
   "de tom tat nhanh noi dung",
 ];
-
-function buildInitScript(serverUrl: string, userId: string, displayName: string) {
-  const settingsPayload = {
-    server_url: serverUrl,
-    api_key: "local-dev-key",
-    user_id: userId,
-    user_role: "admin",
-    display_name: displayName,
-    llm_provider: "google",
-    theme: "light",
-    default_domain: "maritime",
-  };
-  const authPayload = {
-    data: {
-      user: null,
-      authMode: "legacy",
-    },
-  };
-
-  return `
-    localStorage.clear();
-    sessionStorage.clear();
-    localStorage.setItem('wiii:app_settings', JSON.stringify(${JSON.stringify(settingsPayload)}));
-    localStorage.setItem('wiii:auth_state', JSON.stringify(${JSON.stringify(authPayload)}));
-  `;
-}
-
-async function sendPrompt(page, prompt: string) {
-  const inputBox = page.locator("textarea[aria-label]").first();
-  await inputBox.waitFor({ state: "visible", timeout: 60_000 });
-  await inputBox.fill(prompt);
-  await inputBox.press("Enter");
-}
 
 async function visualSnapshot(page) {
   const visual = page.getByTestId("visual-block").last();
@@ -184,9 +152,10 @@ function hasTechnicalLeak(text: string) {
 
 async function runVisualScenario(page, testInfo, viewportLabel: string) {
   const uniqueUser = `visual-e2e-${viewportLabel}-${Date.now()}`;
-  await page.addInitScript(buildInitScript("http://127.0.0.1:8000", uniqueUser, `Visual ${viewportLabel}`));
-  await page.goto("/", { waitUntil: "domcontentloaded", timeout: 60_000 });
-  await page.waitForLoadState("networkidle", { timeout: 60_000 });
+  await bootstrapLocalChat(page, {
+    userId: uniqueUser,
+    displayName: `Visual ${viewportLabel}`,
+  });
 
   if (viewportLabel === "mobile") {
     await expect(page.getByLabel("Menu")).toBeVisible();

--- a/wiii-desktop/scripts/run-web-visual-smoke.mjs
+++ b/wiii-desktop/scripts/run-web-visual-smoke.mjs
@@ -7,6 +7,18 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..", "..");
 
+function commandWorks(command, args = ["--version"]) {
+  try {
+    const result = spawnSync(command, args, {
+      stdio: "ignore",
+      shell: process.platform === "win32",
+    });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
 const candidates = [
   process.env.WIII_PLAYWRIGHT_PYTHON,
   path.join(repoRoot, "maritime-ai-service", ".venv", "Scripts", "python.exe"),
@@ -14,21 +26,32 @@ const candidates = [
   "python",
 ].filter(Boolean);
 
-const python = candidates.find((candidate) => candidate === "python" || existsSync(candidate));
+const explicitPython = process.env.WIII_PLAYWRIGHT_PYTHON;
+const uvCommand = process.env.WIII_PLAYWRIGHT_UV || "uv";
+const useUv =
+  !explicitPython &&
+  process.env.WIII_PLAYWRIGHT_PYTHON_USE_UV !== "0" &&
+  commandWorks(uvCommand);
+const python = explicitPython || candidates.find((candidate) => candidate === "python" || existsSync(candidate));
 
-if (!python) {
-  console.error("Could not find a Python executable for web_visual_smoke.py");
+if (!useUv && !python) {
+  console.error("Could not find Python or uv for web_visual_smoke.py");
   process.exit(1);
 }
 
 const smokeScript = path.join(__dirname, "web_visual_smoke.py");
-const result = spawnSync(python, [smokeScript, ...process.argv.slice(2)], {
+const command = useUv ? uvCommand : python;
+const args = useUv
+  ? ["run", "--no-project", "--with", "playwright", "python", smokeScript, ...process.argv.slice(2)]
+  : [smokeScript, ...process.argv.slice(2)];
+const result = spawnSync(command, args, {
   stdio: "inherit",
   cwd: repoRoot,
   env: {
     ...process.env,
     PYTHONUTF8: "1",
   },
+  shell: process.platform === "win32" && useUv,
 });
 
 if (typeof result.status === "number") {

--- a/wiii-desktop/scripts/start-visual-backend.mjs
+++ b/wiii-desktop/scripts/start-visual-backend.mjs
@@ -1,13 +1,27 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..", "..");
 const backendDir = path.join(repoRoot, "maritime-ai-service");
+const backendPort = process.env.WIII_PLAYWRIGHT_BACKEND_PORT || "8000";
+const frontendPort = process.env.WIII_PLAYWRIGHT_FRONTEND_PORT || "1420";
+
+function commandWorks(command, args = ["--version"]) {
+  try {
+    const result = spawnSync(command, args, {
+      cwd: backendDir,
+      stdio: "ignore",
+    });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
 
 const pythonCandidates = [
   process.env.WIII_PLAYWRIGHT_PYTHON,
@@ -16,23 +30,73 @@ const pythonCandidates = [
   "python",
 ].filter(Boolean);
 
-const python = pythonCandidates.find((candidate) => candidate === "python" || existsSync(candidate));
+const explicitPython = process.env.WIII_PLAYWRIGHT_PYTHON;
+const uvCommand = process.env.WIII_PLAYWRIGHT_UV || "uv";
+const useUv =
+  !explicitPython &&
+  process.env.WIII_PLAYWRIGHT_BACKEND_USE_UV !== "0" &&
+  commandWorks(uvCommand);
+const python = explicitPython || pythonCandidates.find((candidate) => candidate === "python" || existsSync(candidate));
 
-if (!python) {
+if (!useUv && !python) {
   console.error("Could not find a Python executable for the visual backend.");
   process.exit(1);
 }
 
+const command = useUv ? uvCommand : python;
+const args = useUv
+  ? [
+      "run",
+      "--no-project",
+      "--python",
+      "3.12",
+      "--with-requirements",
+      "requirements.txt",
+      "uvicorn",
+      "app.main:app",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      backendPort,
+      "--log-level",
+      "warning",
+    ]
+  : [
+      "-m",
+      "uvicorn",
+      "app.main:app",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      backendPort,
+      "--log-level",
+      "warning",
+    ];
+
 const child = spawn(
-  python,
-  ["-m", "uvicorn", "app.main:app", "--host", "127.0.0.1", "--port", "8000", "--log-level", "warning"],
+  command,
+  args,
   {
     cwd: backendDir,
     stdio: "inherit",
     env: {
       ...process.env,
+      ENVIRONMENT: "development",
+      ENABLE_DEV_LOGIN: "true",
+      DEV_LOGIN_DEFAULT_EMAIL: process.env.DEV_LOGIN_DEFAULT_EMAIL || "playwright@localhost",
+      DEV_LOGIN_DEFAULT_ROLE: process.env.DEV_LOGIN_DEFAULT_ROLE || "admin",
+      JWT_SECRET_KEY:
+        process.env.JWT_SECRET_KEY ||
+        "local-playwright-dev-secret-at-least-32-bytes",
+      CORS_ORIGINS:
+        process.env.CORS_ORIGINS ||
+        JSON.stringify([
+          `http://localhost:${frontendPort}`,
+          `http://127.0.0.1:${frontendPort}`,
+        ]),
       ENABLE_STRUCTURED_VISUALS: "true",
       ENABLE_CODE_STUDIO_STREAMING: "true",
+      VITE_API_URL: process.env.VITE_API_URL || `http://127.0.0.1:${backendPort}`,
       PYTHONIOENCODING: "utf-8",
     },
   },

--- a/wiii-desktop/scripts/start-visual-frontend.mjs
+++ b/wiii-desktop/scripts/start-visual-frontend.mjs
@@ -6,10 +6,12 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const desktopDir = path.resolve(__dirname, "..");
+const frontendPort = process.env.WIII_PLAYWRIGHT_FRONTEND_PORT || "1420";
+const backendPort = process.env.WIII_PLAYWRIGHT_BACKEND_PORT || "8000";
 const command = process.platform === "win32" ? "cmd.exe" : "npm";
 const args = process.platform === "win32"
-  ? ["/d", "/s", "/c", "npm run dev -- --host 127.0.0.1 --port 1420"]
-  : ["run", "dev", "--", "--host", "127.0.0.1", "--port", "1420"];
+  ? ["/d", "/s", "/c", `npm run dev -- --host 127.0.0.1 --port ${frontendPort}`]
+  : ["run", "dev", "--", "--host", "127.0.0.1", "--port", frontendPort];
 
 const child = spawn(
   command,
@@ -17,7 +19,10 @@ const child = spawn(
   {
     cwd: desktopDir,
     stdio: "inherit",
-    env: process.env,
+    env: {
+      ...process.env,
+      VITE_API_URL: process.env.VITE_API_URL || `http://127.0.0.1:${backendPort}`,
+    },
   },
 );
 

--- a/wiii-desktop/scripts/web_visual_smoke.py
+++ b/wiii-desktop/scripts/web_visual_smoke.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import re
 import sys
 import time
 from pathlib import Path
@@ -78,7 +79,7 @@ def dump_json(path: Path, payload: object) -> None:
 
 
 def send_prompt(page, prompt: str) -> None:
-    input_box = page.locator("textarea[aria-label]").first
+    input_box = page.locator('[data-wiii-id="chat-textarea"]').first
     input_box.wait_for(state="visible", timeout=60_000)
     input_box.fill(prompt)
     input_box.press("Enter")
@@ -120,21 +121,46 @@ def build_effective_user_id(base_user_id: str, stable_user_id: bool) -> str:
     return f"{base_user_id}-{int(time.time() * 1000)}"
 
 
-def build_init_script(server_url: str, user_id: str, display_name: str) -> str:
+def safe_email(user_id: str) -> str:
+    local_part = re.sub(r"[^a-z0-9-]+", "-", user_id.lower())[:48]
+    return f"{local_part or 'playwright'}@localhost"
+
+
+def build_authenticated_init_script(server_url: str, user_id: str, display_name: str, session: dict) -> str:
+    user = session.get("user") or {}
+    auth_user = {
+        "id": user.get("id") or user_id,
+        "email": user.get("email") or safe_email(user_id),
+        "name": user.get("name") or display_name,
+        "avatar_url": user.get("avatar_url") or "",
+        "role": user.get("role") or "admin",
+        "legacy_role": user.get("legacy_role") or user.get("role") or "admin",
+        "platform_role": user.get("platform_role") or "platform_admin",
+        "organization_role": user.get("organization_role") or "",
+        "host_role": user.get("host_role") or "",
+        "role_source": user.get("role_source") or "platform",
+        "active_organization_id": user.get("active_organization_id") or session.get("organization_id") or "",
+        "connector_id": "",
+        "identity_version": "2",
+    }
     settings_payload = {
         "server_url": server_url,
-        "api_key": "local-dev-key",
-        "user_id": user_id,
-        "user_role": "admin",
-        "display_name": display_name,
+        "api_key": "",
+        "user_id": auth_user["id"],
+        "user_role": auth_user["role"],
+        "display_name": auth_user["name"],
         "llm_provider": "google",
         "theme": "light",
         "default_domain": "maritime",
     }
-    auth_payload = {
-        "data": {
-            "user": None,
-            "authMode": "legacy",
+    if auth_user["active_organization_id"]:
+        settings_payload["organization_id"] = auth_user["active_organization_id"]
+    auth_payload = {"data": {"user": auth_user, "authMode": "oauth"}}
+    token_payload = {
+        "tokens": {
+            "access_token": session["access_token"],
+            "refresh_token": session["refresh_token"],
+            "expires_at": int(time.time() * 1000) + int(session.get("expires_in") or 900) * 1000,
         }
     }
     return (
@@ -142,7 +168,38 @@ def build_init_script(server_url: str, user_id: str, display_name: str) -> str:
         "sessionStorage.clear();"
         f"localStorage.setItem('wiii:app_settings', JSON.stringify({json.dumps(settings_payload)}));"
         f"localStorage.setItem('wiii:auth_state', JSON.stringify({json.dumps(auth_payload)}));"
+        f"localStorage.setItem('wiii:wiii_auth_tokens', JSON.stringify({json.dumps(token_payload)}));"
     )
+
+
+def bootstrap_local_chat(page, base_url: str, server_url: str, user_id: str, display_name: str) -> None:
+    status = page.request.get(
+        f"{server_url}/api/v1/auth/dev-login/status",
+        timeout=30_000,
+    )
+    if not status.ok:
+        raise RuntimeError(
+            f"dev-login status probe failed ({status.status}); "
+            "start the local backend with ENABLE_DEV_LOGIN=true",
+        )
+    status_json = status.json()
+    if not status_json.get("enabled"):
+        raise RuntimeError("dev-login is disabled; visual smoke requires ENABLE_DEV_LOGIN=true")
+
+    login = page.request.post(
+        f"{server_url}/api/v1/auth/dev-login",
+        data={"email": safe_email(user_id), "name": display_name, "role": "admin"},
+        timeout=30_000,
+    )
+    if not login.ok:
+        raise RuntimeError(f"dev-login failed ({login.status}): {login.text()}")
+
+    page.add_init_script(
+        build_authenticated_init_script(server_url, user_id, display_name, login.json())
+    )
+    page.goto(base_url, wait_until="domcontentloaded", timeout=60_000)
+    composer = page.locator('[data-wiii-id="chat-textarea"]').first
+    composer.wait_for(state="visible", timeout=60_000)
 
 
 def main() -> int:
@@ -170,11 +227,9 @@ def main() -> int:
         context = browser.new_context(
             viewport={"width": args.viewport_width, "height": args.viewport_height},
         )
-        context.add_init_script(build_init_script(args.server_url, effective_user_id, args.display_name))
         page = context.new_page()
 
-        page.goto(args.base_url, wait_until="domcontentloaded", timeout=60_000)
-        page.wait_for_load_state("networkidle", timeout=60_000)
+        bootstrap_local_chat(page, args.base_url, args.server_url, effective_user_id, args.display_name)
 
         send_prompt(page, args.first_prompt)
         first_visual = page.locator('[data-testid="visual-block"]').first


### PR DESCRIPTION
## Summary
- Add a shared Playwright local chat harness that authenticates through the real `/api/v1/auth/dev-login` endpoint and seeds the same auth/token stores used by `loginWithTokens()`.
- Update visual and Code Studio runtime specs to reuse the harness instead of faking a legacy `local-dev-key` session.
- Make visual backend/frontend test servers configurable by port, force backend dev-login to development-only mode, and document the local E2E harness contract.
- Keep the Python visual smoke path aligned with the same dev-login JWT bootstrap and make its runner able to provide Python Playwright via `uv`.

Closes #569

## In Scope
- Desktop/web Playwright harness startup.
- Local dev-login auth bootstrap for tests only.
- Visual runtime and Code Studio spec bootstrap reuse.
- Harness documentation.

## Out of Scope
- Production auth behavior.
- LMS preview/apply behavior.
- Visual runtime routing or generated artifact quality.
- Deployment changes.

## Verification
- `cd wiii-desktop && $env:WIII_PLAYWRIGHT_BACKEND_PORT='8030'; $env:WIII_PLAYWRIGHT_FRONTEND_PORT='1430'; $env:WIII_PLAYWRIGHT_SERVER_URL='http://127.0.0.1:8030'; $env:WIII_PLAYWRIGHT_BASE_URL='http://127.0.0.1:1430'; npx playwright test -c playwright.visual.config.ts playwright/local-chat-harness.spec.ts --reporter=list` -> 1 passed
- `cd wiii-desktop && npx tsc --noEmit` -> passed
- `cd wiii-desktop && npx vitest run src/__tests__/login-screen-dev-login.test.tsx src/__tests__/local-preview-bootstrap.test.ts` -> 2 files passed, 9 tests passed
- `python -m py_compile wiii-desktop/scripts/web_visual_smoke.py` -> passed
- `node --check wiii-desktop/scripts/start-visual-backend.mjs; node --check wiii-desktop/scripts/start-visual-frontend.mjs; node --check wiii-desktop/scripts/run-web-visual-smoke.mjs` -> passed
- `cd wiii-desktop && npm run test:web:visual -- --help` -> passed and showed smoke CLI help
- `git diff --check` -> passed

## Browser Evidence
- Local harness smoke started isolated ports `1430/8030` and reached `[data-wiii-id=chat-textarea]` in 4.9s.
- Remaining console warning during smoke: organizations fetch returns `Multi-tenant is not enabled`; this does not block chat composer bootstrap and is unrelated to auth harness readiness.

## Risk / Rollback
- Risk: medium because this is auth-adjacent test tooling.
- Safety: no production auth bypass is added. The harness only uses the existing `/auth/dev-login` endpoint, while the local backend server script forces `ENVIRONMENT=development` and `ENABLE_DEV_LOGIN=true` for Playwright runs. Backend production validation and private-source checks remain unchanged.
- Rollback: revert this commit to restore the previous Playwright localStorage legacy bootstrap and fixed-port server scripts.