### PR TITLE
fix(desktop): normalize dense assistant markdown

### DIFF
--- a/wiii-desktop/src/__tests__/assistant-markdown-rendering.test.tsx
+++ b/wiii-desktop/src/__tests__/assistant-markdown-rendering.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+describe("MarkdownRenderer assistant cleanup", () => {
+  it("renders dense assistant table and quotes as structured markdown", async () => {
+    const { MarkdownRenderer } = await import("@/components/common/MarkdownRenderer");
+    const content = [
+      "--- 🔍 So sánh nhanh: | Tiêu chí | Annex I | Annex VI |---------|----------|---------| | Ô nhiễm | Dầu ra biển | Khí thải ra không khí | Ghi chép | Oil Record Book | FONAR, EIAPP | --- 💡 Mẹo nhớ: đọc theo từng cột.",
+      "Cậu chỉ cần nói: > “Mình thấy nút Khóa học” hoặc > “Mình không thấy gì cả”",
+    ].join("\n\n");
+
+    render(<MarkdownRenderer content={content} />);
+
+    const table = await screen.findByRole("table");
+    expect(within(table).getByText("Tiêu chí")).toBeTruthy();
+    expect(within(table).getByText("Annex I")).toBeTruthy();
+    expect(within(table).getByText("Khí thải ra không khí")).toBeTruthy();
+    expect(screen.getByText("💡 Mẹo nhớ: đọc theo từng cột.")).toBeTruthy();
+    expect(screen.getByText("“Mình thấy nút Khóa học”")).toBeTruthy();
+    expect(screen.getByText("“Mình không thấy gì cả”")).toBeTruthy();
+  });
+});

--- a/wiii-desktop/src/__tests__/assistant-markdown.test.ts
+++ b/wiii-desktop/src/__tests__/assistant-markdown.test.ts
@@ -9,7 +9,7 @@ describe("normalizeAssistantMarkdown", () => {
     const normalized = normalizeAssistantMarkdown(input);
 
     expect(normalized).toContain("So sánh nhanh:\n\n| Tiêu chí | Annex I | Annex VI |");
-    expect(normalized).toContain("\n|------|------|------|");
+    expect(normalized).toContain("\n| ------ | ------ | ------ |");
     expect(normalized).toContain("\n| Ô nhiễm | Dầu ra biển | Khí thải |");
     expect(normalized).toContain("\n\n---\n\nMẹo nhớ:");
   });
@@ -39,5 +39,28 @@ describe("normalizeAssistantMarkdown", () => {
 
     expect(normalized).toContain("Các bước:\n- Mở lớp\n- Chọn bài\n- Áp dụng");
     expect(normalized).toContain("câu A - B vẫn là văn xuôi");
+  });
+  it("rebuilds dense product-style tables whose rows were collapsed into one line", () => {
+    const input =
+      "--- 🔍 So sánh nhanh: | Tiêu chí | Annex I | Annex VI |---------|----------|---------| | Ô nhiễm | Dầu ra biển | Khí thải ra không khí | Chất gây hại | Dầu, hydrocarbon | SOx, NOx, PM, CO₂ | Ghi chép | Oil Record Book | FONAR, EIAPP | --- 💡 Mẹo nhớ: đọc theo từng cột.";
+
+    const normalized = normalizeAssistantMarkdown(input);
+
+    expect(normalized).toContain("---\n\n🔍 So sánh nhanh:");
+    expect(normalized).toContain("| Tiêu chí | Annex I | Annex VI |");
+    expect(normalized).toContain("| --------- | ---------- | --------- |");
+    expect(normalized).toContain("| Ô nhiễm | Dầu ra biển | Khí thải ra không khí |");
+    expect(normalized).toContain("| Ghi chép | Oil Record Book | FONAR, EIAPP |");
+    expect(normalized).toContain("\n\n---\n\n💡 Mẹo nhớ:");
+  });
+
+  it("promotes inline blockquotes after Vietnamese quote prompts", () => {
+    const input =
+      "Cậu chỉ cần nói: > “Mình thấy nút Khóa học” hoặc > “Mình không thấy gì cả”";
+
+    const normalized = normalizeAssistantMarkdown(input);
+
+    expect(normalized).toContain("Cậu chỉ cần nói:\n> “Mình thấy nút Khóa học”");
+    expect(normalized).toContain("hoặc\n\n> “Mình không thấy gì cả”");
   });
 });

--- a/wiii-desktop/src/lib/assistant-markdown.ts
+++ b/wiii-desktop/src/lib/assistant-markdown.ts
@@ -1,6 +1,7 @@
 const FENCED_BLOCK_RE = /(```[\s\S]*?```|~~~[\s\S]*?~~~)/g;
 const TABLE_SEPARATOR_ROW_RE =
   /\|\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?/;
+const TABLE_SEPARATOR_CELL_RE = /^:?-{3,}:?$/;
 
 function splitCodeSafe(content: string): string[] {
   return content.split(FENCED_BLOCK_RE);
@@ -12,7 +13,10 @@ function isFencedBlock(segment: string): boolean {
 
 function normalizeInlineSeparators(segment: string): string {
   const promoted = segment
+    .replace(/(^|\n)(---|\*\*\*|___)[ \t]+(?=\S)/g, "$1$2\n\n")
     .replace(/([^|\n])\s+(---|\*\*\*|___)\s+(?=\S)/g, "$1\n\n$2\n\n")
+    .replace(/(>\s+[^\n>]+?)\s+(ho(?:a|ặ)c)[ \t]+>[ \t]+(?=\S)/gi, "$1\n\n$2\n\n> ")
+    .replace(/([:.!?)]|ho(?:a|ặ)c)[ \t]+>[ \t]+(?=\S)/gi, "$1\n> ")
     .replace(/[ \t]+([0-9]{1,2}[.)])[ \t]+(?=\S)/g, "\n$1 ")
     .replace(/[ \t]+([-*+])[ \t]+(?=\S)/g, (match, marker, offset, source) => {
       const before = source.slice(Math.max(0, offset - 24), offset);
@@ -36,6 +40,71 @@ function normalizeInlineSeparators(segment: string): string {
   return next;
 }
 
+function splitPipeCells(source: string): string[] {
+  return source
+    .split("|")
+    .map((cell) => cell.trim())
+    .filter(Boolean);
+}
+
+function findSeparatorRun(cells: string[]): { start: number; count: number } | null {
+  for (let start = 0; start < cells.length; start += 1) {
+    if (!TABLE_SEPARATOR_CELL_RE.test(cells[start])) continue;
+    let count = 0;
+    while (
+      start + count < cells.length
+      && TABLE_SEPARATOR_CELL_RE.test(cells[start + count])
+    ) {
+      count += 1;
+    }
+    if (count >= 2) return { start, count };
+    start += count;
+  }
+  return null;
+}
+
+function splitTrailingInlineRule(source: string): { tableSource: string; trailing: string } {
+  const match = source.match(/\|\s+(---|\*\*\*|___)[ \t]+([\s\S]+)$/);
+  if (!match || match.index === undefined) {
+    return { tableSource: source, trailing: "" };
+  }
+  return {
+    tableSource: `${source.slice(0, match.index)}|`,
+    trailing: `\n\n${match[1]}\n\n${match[2].trim()}`,
+  };
+}
+
+function rebuildCollapsedPipeTable(source: string): string | null {
+  const { tableSource, trailing } = splitTrailingInlineRule(source);
+  const cells = splitPipeCells(tableSource);
+  const separatorRun = findSeparatorRun(cells);
+  if (!separatorRun) return null;
+
+  const columnCount = separatorRun.count;
+  const headerStart = separatorRun.start - columnCount;
+  if (headerStart < 0) return null;
+
+  const header = cells.slice(headerStart, separatorRun.start);
+  if (header.length !== columnCount || header.some((cell) => TABLE_SEPARATOR_CELL_RE.test(cell))) {
+    return null;
+  }
+
+  const separators = cells.slice(separatorRun.start, separatorRun.start + columnCount);
+  const bodyCells = cells.slice(separatorRun.start + columnCount);
+  const rows: string[][] = [];
+  for (let index = 0; index + columnCount <= bodyCells.length; index += columnCount) {
+    rows.push(bodyCells.slice(index, index + columnCount));
+  }
+
+  const tableRows = [
+    header,
+    separators,
+    ...rows,
+  ].map((row) => `| ${row.join(" | ")} |`);
+
+  return `${tableRows.join("\n")}${trailing}`;
+}
+
 function normalizeCollapsedPipeTableLine(line: string): string {
   if (!TABLE_SEPARATOR_ROW_RE.test(line)) return line;
 
@@ -43,15 +112,16 @@ function normalizeCollapsedPipeTableLine(line: string): string {
   if (firstPipe < 0) return line;
 
   const prefix = line.slice(0, firstPipe).trimEnd();
-  const table = line
-    .slice(firstPipe)
-    .trim()
-    .replace(/\|\s+\|(?=\s*\S)/g, "|\n|")
-    .replace(/\|\s+(---|\*\*\*|___)\s+(?=\S)/g, "|\n\n$1\n\n")
-    .split("\n")
-    .map((row) => row.trim())
-    .filter(Boolean)
-    .join("\n");
+  const tableSource = line.slice(firstPipe).trim();
+  const rebuiltTable = rebuildCollapsedPipeTable(tableSource);
+  const table = rebuiltTable
+    || tableSource
+      .replace(/\|\s+\|(?=\s*\S)/g, "|\n|")
+      .replace(/\|\s+(---|\*\*\*|___)\s+(?=\S)/g, "|\n\n$1\n\n")
+      .split("\n")
+      .map((row) => row.trim())
+      .filter(Boolean)
+      .join("\n");
 
   if (!prefix) return table;
   return `${prefix}\n\n${table}`;


### PR DESCRIPTION
## Summary
- Rebuild dense one-line pipe tables by inferring columns from Markdown separator rows.
- Promote inline horizontal rules and Vietnamese quote prompts into structured Markdown blocks before rendering.
- Add normalization and rendered DOM regressions for product-style table/blockquote responses.

Closes #571

## Verification
- cd wiii-desktop && npx vitest run src/__tests__/assistant-markdown.test.ts src/__tests__/assistant-markdown-rendering.test.tsx -> 2 files, 6 tests passed
- cd wiii-desktop && npx vitest run src/__tests__/inline-visual-frame.test.ts src/__tests__/code-studio-panel.test.tsx src/__tests__/code-studio-store.test.ts -> 3 files, 25 tests passed
- cd wiii-desktop && npx tsc --noEmit -> passed
- cd wiii-desktop && npm run build:embed -> passed; existing Vite chunk-size/dynamic-import warnings only
- git diff --check -> passed

## Browser Evidence
- cd wiii-desktop && npx playwright test -c playwright.visual.config.ts playwright/local-chat-harness.spec.ts --reporter=list with backend/frontend ports 8039/1439 -> 1 passed
- Dev harness still logs expected local warning Multi-tenant is not enabled.

## Risk / Rollback
- Risk: low-to-medium, frontend-only Markdown normalization affects chat and embed rendering.
- Safety: fenced code blocks remain byte-stable; no backend, LMS mutation, auth, tenant, or provider behavior changed.
- Rollback: revert this PR to return assistant Markdown normalization to the previous conservative table/separator handling.
