### PR TITLE
refactor(backend): isolate direct node LLM tool loop

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_llm_tool_loop.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_llm_tool_loop.py
@@ -1,0 +1,189 @@
+"""Direct-node LLM tool-loop lifecycle."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from app.engine.multi_agent.direct_node_execution_prep import (
+    prepare_direct_node_tool_execution,
+)
+from app.engine.multi_agent.direct_node_host_timeout import (
+    run_direct_node_execution_with_host_timeout,
+)
+from app.engine.multi_agent.direct_node_llm_execution_finalization import (
+    finalize_direct_node_llm_execution,
+)
+from app.engine.multi_agent.state import AgentState
+
+
+@dataclass(slots=True)
+class DirectNodeLlmToolLoopResult:
+    """Typed state returned after a provider-backed direct-node tool loop."""
+
+    response: str
+    messages: list[Any]
+    tool_call_events: list[dict[str, Any]]
+    force_tools: bool
+
+
+async def execute_direct_node_llm_tool_loop(
+    *,
+    llm: Any,
+    query: str,
+    state: AgentState,
+    ctx: dict[str, Any],
+    bus_id: str | None,
+    domain_name_vi: str,
+    role_name: str,
+    tools: list[Any],
+    force_tools: bool,
+    tools_context_override: str | None,
+    visual_decision: Any,
+    history_limit: int,
+    routing_intent: str,
+    response_language: str,
+    is_identity_turn: bool,
+    is_short_house_chatter: bool,
+    use_house_voice_direct: bool,
+    direct_provider_override: str | None,
+    preferred_provider: str | None,
+    explicit_user_provider: str | None,
+    explicit_web_search_turn: bool,
+    push_event: Callable[..., Any],
+    needs_web_search: Callable[[str], bool],
+    needs_datetime: Callable[[str], bool],
+    resolve_direct_answer_timeout_profile: Callable[..., Any],
+    bind_direct_tools: Callable[..., tuple[Any, Any, Any]],
+    build_direct_system_messages: Callable[..., list[Any]],
+    build_visual_tool_runtime_metadata: Callable[..., dict[str, Any]],
+    execute_direct_tool_rounds: Callable[..., Any],
+    extract_direct_response: Callable[..., Any],
+    sanitize_structured_visual_answer_text: Callable[..., str],
+    sanitize_wiii_house_text: Callable[..., str],
+    build_direct_reasoning_summary: Callable[..., str],
+    tracer: Any,
+    logger_obj: logging.Logger,
+    direct_max_rounds: int,
+    host_ui_total_timeout_seconds: float,
+    prepare_tool_execution_fn: Callable[..., Any] = prepare_direct_node_tool_execution,
+    run_with_host_timeout_fn: Callable[..., Any] = run_direct_node_execution_with_host_timeout,
+    finalize_llm_execution_fn: Callable[..., Any] = finalize_direct_node_llm_execution,
+) -> DirectNodeLlmToolLoopResult:
+    """Execute and finalize the provider-backed direct-node tool loop."""
+
+    logger_obj.warning(
+        "[DIRECT] tools=%d, force=%s, web=%s, dt=%s, query='%s'",
+        len(tools),
+        force_tools,
+        needs_web_search(query),
+        needs_datetime(query),
+        query[:60],
+    )
+
+    execution_prep = prepare_tool_execution_fn(
+        llm=llm,
+        tools=tools,
+        force_tools=force_tools,
+        query=query,
+        state=state,
+        ctx=ctx,
+        bus_id=bus_id,
+        domain_name_vi=domain_name_vi,
+        role_name=role_name,
+        tools_context_override=tools_context_override,
+        visual_decision=visual_decision,
+        history_limit=history_limit,
+        routing_intent=routing_intent,
+        is_identity_turn=is_identity_turn,
+        is_short_house_chatter=is_short_house_chatter,
+        use_house_voice_direct=use_house_voice_direct,
+        direct_provider_override=direct_provider_override,
+        preferred_provider=preferred_provider,
+        explicit_user_provider=explicit_user_provider,
+        needs_web_search=needs_web_search,
+        needs_datetime=needs_datetime,
+        resolve_direct_answer_timeout_profile=resolve_direct_answer_timeout_profile,
+        bind_direct_tools=bind_direct_tools,
+        build_direct_system_messages=build_direct_system_messages,
+        build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
+        logger_obj=logger_obj,
+    )
+
+    force_tools = execution_prep.force_tools
+    native_direct_messages = execution_prep.native_direct_messages
+    messages = execution_prep.messages
+
+    direct_execution = execute_direct_tool_rounds(
+        execution_prep.llm_with_tools,
+        execution_prep.llm_auto,
+        messages,
+        tools,
+        push_event,
+        runtime_context_base=execution_prep.runtime_context_base,
+        max_rounds=direct_max_rounds,
+        query=query,
+        state=state,
+        provider=explicit_user_provider,
+        forced_tool_choice=execution_prep.forced_tool_choice,
+        llm_base=llm,
+        direct_answer_timeout_profile=execution_prep.direct_answer_timeout_profile,
+        direct_answer_primary_timeout=execution_prep.direct_answer_primary_timeout,
+        allowed_fallback_providers=(
+            execution_prep.direct_allowed_fallback_providers
+        ),
+        native_tool_messages=native_direct_messages,
+    )
+    llm_response, messages, tool_call_events = await run_with_host_timeout_fn(
+        direct_execution=direct_execution,
+        routing_intent=routing_intent,
+        state=state,
+        messages=messages,
+        push_event=push_event,
+        timeout_seconds=host_ui_total_timeout_seconds,
+        logger_obj=logger_obj,
+    )
+
+    try:
+        llm_finalization = await finalize_llm_execution_fn(
+            query=query,
+            state=state,
+            llm_response=llm_response,
+            messages=messages,
+            tool_call_events=tool_call_events,
+            llm=llm,
+            routing_intent=routing_intent,
+            response_language=response_language,
+            is_identity_turn=is_identity_turn,
+            explicit_web_search_turn=explicit_web_search_turn,
+            extract_direct_response=extract_direct_response,
+            sanitize_structured_visual_answer_text=sanitize_structured_visual_answer_text,
+            sanitize_wiii_house_text=sanitize_wiii_house_text,
+            build_direct_reasoning_summary=build_direct_reasoning_summary,
+            logger_obj=logger_obj,
+        )
+    except Exception as exc:
+        setattr(exc, "_direct_node_llm_response", llm_response)
+        setattr(exc, "_direct_node_messages", messages)
+        setattr(exc, "_direct_node_tool_call_events", tool_call_events)
+        raise
+    response = llm_finalization.response
+
+    tracer.end_step(
+        result=f"Phan hoi LLM: {len(response)} chars",
+        confidence=0.85,
+        details={
+            "response_type": "llm_generated",
+            "tools_bound": len(tools),
+            "force_tools": force_tools,
+        },
+    )
+
+    return DirectNodeLlmToolLoopResult(
+        response=response,
+        messages=messages,
+        tool_call_events=tool_call_events,
+        force_tools=force_tools,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -23,25 +23,19 @@ from app.engine.multi_agent.direct_node_fast_response_runtime import (
 from app.engine.multi_agent.direct_node_event_sink import (
     build_direct_node_event_sink,
 )
-from app.engine.multi_agent.direct_node_host_timeout import (
-    run_direct_node_execution_with_host_timeout,
-)
 from app.engine.multi_agent.direct_node_image_input_preflight import (
     execute_direct_node_image_input_preflight,
-)
-from app.engine.multi_agent.direct_node_execution_prep import (
-    prepare_direct_node_tool_execution,
 )
 from app.engine.multi_agent.direct_node_llm_preflight import (
     apply_direct_node_natural_conversation_penalties,
     maybe_build_uploaded_visual_guard,
     select_direct_node_llm,
 )
+from app.engine.multi_agent.direct_node_llm_tool_loop import (
+    execute_direct_node_llm_tool_loop,
+)
 from app.engine.multi_agent.direct_node_llm_fallback import (
     resolve_direct_node_llm_unavailable_fallback,
-)
-from app.engine.multi_agent.direct_node_llm_execution_finalization import (
-    finalize_direct_node_llm_execution,
 )
 from app.engine.multi_agent.direct_search_synthesis_fallback import (
     build_search_template_fallback,
@@ -79,7 +73,7 @@ from app.engine.reasoning import (
 
 logger = logging.getLogger(__name__)
 
-_HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS = 45.0  # Phase F3 (2026-05-06): bumped 24→45s. NVIDIA DeepSeek tool-heavy pointy turns (inventory + show + synthesis) regularly hit 25-35s; 24s caused canned fallback even when LLM was actively succeeding.
+_HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS = 45.0  # Phase F3 (2026-05-06): bumped 24->45s. Tool-heavy pointy turns regularly hit 25-35s; 24s caused canned fallback even when LLM was actively succeeding.
 
 async def direct_response_node_impl(
     state: AgentState,
@@ -407,130 +401,56 @@ async def direct_response_node_impl(
             )
 
             if llm and not response:
-                logger.warning(
-                    "[DIRECT] tools=%d, force=%s, web=%s, dt=%s, query='%s'",
-                    len(tools),
-                    force_tools,
-                    needs_web_search(query),
-                    needs_datetime(query),
-                    query[:60],
-                )
-
-                execution_prep = prepare_direct_node_tool_execution(
+                llm_tool_loop = await execute_direct_node_llm_tool_loop(
                     llm=llm,
-                    tools=tools,
-                    force_tools=force_tools,
                     query=query,
                     state=state,
                     ctx=ctx,
                     bus_id=bus_id,
                     domain_name_vi=domain_name_vi,
                     role_name=role_name,
+                    tools=tools,
+                    force_tools=force_tools,
                     tools_context_override=tools_context_override,
                     visual_decision=visual_decision,
                     history_limit=history_limit,
                     routing_intent=routing_intent,
+                    response_language=response_language,
                     is_identity_turn=is_identity_turn,
                     is_short_house_chatter=is_short_house_chatter,
                     use_house_voice_direct=use_house_voice_direct,
                     direct_provider_override=direct_provider_override,
                     preferred_provider=preferred_provider,
                     explicit_user_provider=explicit_user_provider,
+                    explicit_web_search_turn=explicit_web_search_turn,
+                    push_event=push_event,
                     needs_web_search=needs_web_search,
                     needs_datetime=needs_datetime,
                     resolve_direct_answer_timeout_profile=resolve_direct_answer_timeout_profile,
                     bind_direct_tools=bind_direct_tools,
                     build_direct_system_messages=build_direct_system_messages,
                     build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
-                    logger_obj=logger,
-                )
-
-                force_tools = execution_prep.force_tools
-                direct_answer_timeout_profile = execution_prep.direct_answer_timeout_profile
-                direct_answer_primary_timeout = execution_prep.direct_answer_primary_timeout
-                direct_allowed_fallback_providers = (
-                    execution_prep.direct_allowed_fallback_providers
-                )
-                llm_with_tools = execution_prep.llm_with_tools
-                llm_auto = execution_prep.llm_auto
-                forced_tool_choice = execution_prep.forced_tool_choice
-                # v9.0 F18 (2026-05-07) — when pointy is force-bound, the
-                # tool's selector is already enum-constrained at JSON-schema
-                # layer (Literal[...] in tool_pointy_show args). That's
-                # SeeAct's textual-choice grounding applied at argument
-                # layer. We DON'T need to override tool_choice to specific
-                # tool name (caused NVIDIA bind_tools incompat in early
-                # tests) — the existing `_resolve_tool_choice("any")` is
-                # sufficient because force_tools=True ensures SOME tool
-                # is invoked, and the enum-constrained pointy tool wins
-                # when query is UI-related (other tools have unrelated
-                # signatures).
-                native_direct_messages = execution_prep.native_direct_messages
-                messages = execution_prep.messages
-                runtime_context_base = execution_prep.runtime_context_base
-
-                # Wiii Pointy v2.6 — adaptive max rounds. Loop tự exit
-                # khi LLM ngừng gọi tool; cap chỉ là runaway protection.
-                # Default 12 (Anthropic Computer Use ref dùng 10), settings
-                # override cho power-users / autonomous flows.
-                _direct_max_rounds = getattr(settings, "direct_agent_max_tool_rounds", 12)
-
-                direct_execution = execute_direct_tool_rounds(
-                    llm_with_tools,
-                    llm_auto,
-                    messages,
-                    tools,
-                    push_event,
-                    runtime_context_base=runtime_context_base,
-                    max_rounds=_direct_max_rounds,
-                    query=query,
-                    state=state,
-                    provider=explicit_user_provider,
-                    forced_tool_choice=forced_tool_choice,
-                    llm_base=llm,
-                    direct_answer_timeout_profile=direct_answer_timeout_profile,
-                    direct_answer_primary_timeout=direct_answer_primary_timeout,
-                    allowed_fallback_providers=direct_allowed_fallback_providers,
-                    native_tool_messages=native_direct_messages,
-                )
-                llm_response, messages, tool_call_events = await run_direct_node_execution_with_host_timeout(
-                    direct_execution=direct_execution,
-                    routing_intent=routing_intent,
-                    state=state,
-                    messages=messages,
-                    push_event=push_event,
-                    timeout_seconds=_HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS,
-                    logger_obj=logger,
-                )
-
-                llm_finalization = await finalize_direct_node_llm_execution(
-                    query=query,
-                    state=state,
-                    llm_response=llm_response,
-                    messages=messages,
-                    tool_call_events=tool_call_events,
-                    llm=llm,
-                    routing_intent=routing_intent,
-                    response_language=response_language,
-                    is_identity_turn=is_identity_turn,
-                    explicit_web_search_turn=explicit_web_search_turn,
+                    execute_direct_tool_rounds=execute_direct_tool_rounds,
                     extract_direct_response=extract_direct_response,
-                    sanitize_structured_visual_answer_text=sanitize_structured_visual_answer_text,
+                    sanitize_structured_visual_answer_text=(
+                        sanitize_structured_visual_answer_text
+                    ),
                     sanitize_wiii_house_text=sanitize_wiii_house_text,
                     build_direct_reasoning_summary=build_direct_reasoning_summary,
+                    tracer=tracer,
                     logger_obj=logger,
+                    direct_max_rounds=getattr(
+                        settings, "direct_agent_max_tool_rounds", 12
+                    ),
+                    host_ui_total_timeout_seconds=(
+                        _HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS
+                    ),
                 )
-                response = llm_finalization.response
 
-                tracer.end_step(
-                    result=f"Phan hoi LLM: {len(response)} chars",
-                    confidence=0.85,
-                    details={
-                        "response_type": "llm_generated",
-                        "tools_bound": len(tools),
-                        "force_tools": force_tools,
-                    },
-                )
+                response = llm_tool_loop.response
+                messages = llm_tool_loop.messages
+                tool_call_events = llm_tool_loop.tool_call_events
+                force_tools = llm_tool_loop.force_tools
             elif not response:
                 llm_fallback = resolve_direct_node_llm_unavailable_fallback(
                     query=query,
@@ -559,6 +479,13 @@ async def direct_response_node_impl(
                     details={"response_type": llm_fallback.response_type},
                 )
         except Exception as exc:
+            llm_response = getattr(exc, "_direct_node_llm_response", llm_response)
+            messages = getattr(exc, "_direct_node_messages", messages)
+            tool_call_events = getattr(
+                exc,
+                "_direct_node_tool_call_events",
+                tool_call_events,
+            )
             fallback_result = await handle_direct_node_generation_exception(
                 exc=exc,
                 query=query,

--- a/maritime-ai-service/tests/unit/test_direct_node_llm_tool_loop.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_llm_tool_loop.py
@@ -1,0 +1,198 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.engine.multi_agent.direct_node_llm_tool_loop import (
+    execute_direct_node_llm_tool_loop,
+)
+
+
+@pytest.mark.asyncio
+async def test_execute_direct_node_llm_tool_loop_returns_typed_execution_state():
+    calls: dict[str, object] = {}
+    tracer = MagicMock()
+    llm = object()
+    state = {"query": "kiem tra tool loop"}
+    tools = [SimpleNamespace(name="tool_a"), SimpleNamespace(name="tool_b")]
+
+    def prepare_tool_execution_fn(**kwargs):
+        calls["prepare"] = kwargs
+        return SimpleNamespace(
+            force_tools=True,
+            direct_answer_timeout_profile={"primary": 3},
+            direct_answer_primary_timeout=3,
+            direct_allowed_fallback_providers=["qwen"],
+            llm_with_tools="llm-with-tools",
+            llm_auto="llm-auto",
+            forced_tool_choice={"type": "any"},
+            native_direct_messages=True,
+            messages=["system-message"],
+            runtime_context_base={"request_id": "req-1"},
+        )
+
+    def execute_direct_tool_rounds(*args, **kwargs):
+        calls["tool_round_args"] = args
+        calls["tool_round_kwargs"] = kwargs
+        return "direct-execution"
+
+    async def run_with_host_timeout_fn(**kwargs):
+        calls["host_timeout"] = kwargs
+        return (
+            SimpleNamespace(content="raw response"),
+            ["system-message", "tool-message"],
+            [{"name": "tool_a", "status": "ok"}],
+        )
+
+    async def finalize_llm_execution_fn(**kwargs):
+        calls["finalize"] = kwargs
+        return SimpleNamespace(response="Da xu ly xong.")
+
+    async def push_event(_event):
+        calls["event_pushed"] = True
+
+    result = await execute_direct_node_llm_tool_loop(
+        llm=llm,
+        query="kiem tra tool loop",
+        state=state,
+        ctx={"request_id": "req-1"},
+        bus_id="bus-1",
+        domain_name_vi="Hang hai",
+        role_name="direct_agent",
+        tools=tools,
+        force_tools=False,
+        tools_context_override=None,
+        visual_decision=SimpleNamespace(force_tool=False),
+        history_limit=10,
+        routing_intent="learning",
+        response_language="vi",
+        is_identity_turn=False,
+        is_short_house_chatter=False,
+        use_house_voice_direct=False,
+        direct_provider_override=None,
+        preferred_provider="qwen",
+        explicit_user_provider=None,
+        explicit_web_search_turn=False,
+        push_event=push_event,
+        needs_web_search=lambda _query: False,
+        needs_datetime=lambda _query: False,
+        resolve_direct_answer_timeout_profile=lambda **_kwargs: {"primary": 3},
+        bind_direct_tools=lambda *_args, **_kwargs: (None, None, None),
+        build_direct_system_messages=lambda *_args, **_kwargs: [],
+        build_visual_tool_runtime_metadata=lambda *_args, **_kwargs: {},
+        execute_direct_tool_rounds=execute_direct_tool_rounds,
+        extract_direct_response=lambda *_args, **_kwargs: "",
+        sanitize_structured_visual_answer_text=lambda text, *_args, **_kwargs: text,
+        sanitize_wiii_house_text=lambda text, *_args, **_kwargs: text,
+        build_direct_reasoning_summary=lambda *_args, **_kwargs: "",
+        tracer=tracer,
+        logger_obj=MagicMock(),
+        direct_max_rounds=7,
+        host_ui_total_timeout_seconds=45.0,
+        prepare_tool_execution_fn=prepare_tool_execution_fn,
+        run_with_host_timeout_fn=run_with_host_timeout_fn,
+        finalize_llm_execution_fn=finalize_llm_execution_fn,
+    )
+
+    assert result.response == "Da xu ly xong."
+    assert result.messages == ["system-message", "tool-message"]
+    assert result.tool_call_events == [{"name": "tool_a", "status": "ok"}]
+    assert result.force_tools is True
+
+    assert calls["prepare"]["role_name"] == "direct_agent"
+    assert calls["tool_round_args"][:5] == (
+        "llm-with-tools",
+        "llm-auto",
+        ["system-message"],
+        tools,
+        push_event,
+    )
+    assert calls["tool_round_kwargs"]["max_rounds"] == 7
+    assert calls["tool_round_kwargs"]["allowed_fallback_providers"] == ["qwen"]
+    assert calls["tool_round_kwargs"]["native_tool_messages"] is True
+    assert calls["host_timeout"]["direct_execution"] == "direct-execution"
+    assert calls["host_timeout"]["timeout_seconds"] == 45.0
+    assert calls["finalize"]["response_language"] == "vi"
+    assert calls["finalize"]["explicit_web_search_turn"] is False
+    tracer.end_step.assert_called_once_with(
+        result="Phan hoi LLM: 14 chars",
+        confidence=0.85,
+        details={
+            "response_type": "llm_generated",
+            "tools_bound": 2,
+            "force_tools": True,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_direct_node_llm_tool_loop_preserves_partial_state_on_finalize_error():
+    async def run_with_host_timeout_fn(**_kwargs):
+        return (
+            SimpleNamespace(content="salvage me"),
+            ["message-before-cleanup"],
+            [{"name": "tool_a"}],
+        )
+
+    async def finalize_llm_execution_fn(**_kwargs):
+        raise RuntimeError("cleanup boom")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await execute_direct_node_llm_tool_loop(
+            llm=object(),
+            query="kiem tra salvage",
+            state={},
+            ctx={},
+            bus_id=None,
+            domain_name_vi="Hang hai",
+            role_name="direct_agent",
+            tools=[],
+            force_tools=False,
+            tools_context_override=None,
+            visual_decision=SimpleNamespace(force_tool=False),
+            history_limit=10,
+            routing_intent="learning",
+            response_language="vi",
+            is_identity_turn=False,
+            is_short_house_chatter=False,
+            use_house_voice_direct=False,
+            direct_provider_override=None,
+            preferred_provider=None,
+            explicit_user_provider=None,
+            explicit_web_search_turn=False,
+            push_event=lambda *_args, **_kwargs: None,
+            needs_web_search=lambda _query: False,
+            needs_datetime=lambda _query: False,
+            resolve_direct_answer_timeout_profile=lambda **_kwargs: None,
+            bind_direct_tools=lambda *_args, **_kwargs: (None, None, None),
+            build_direct_system_messages=lambda *_args, **_kwargs: [],
+            build_visual_tool_runtime_metadata=lambda *_args, **_kwargs: {},
+            execute_direct_tool_rounds=lambda *_args, **_kwargs: "direct-execution",
+            extract_direct_response=lambda *_args, **_kwargs: "",
+            sanitize_structured_visual_answer_text=lambda text, *_args, **_kwargs: text,
+            sanitize_wiii_house_text=lambda text, *_args, **_kwargs: text,
+            build_direct_reasoning_summary=lambda *_args, **_kwargs: "",
+            tracer=MagicMock(),
+            logger_obj=MagicMock(),
+            direct_max_rounds=1,
+            host_ui_total_timeout_seconds=45.0,
+            prepare_tool_execution_fn=lambda **_kwargs: SimpleNamespace(
+                force_tools=False,
+                direct_answer_timeout_profile=None,
+                direct_answer_primary_timeout=None,
+                direct_allowed_fallback_providers=None,
+                llm_with_tools="llm-with-tools",
+                llm_auto="llm-auto",
+                forced_tool_choice=None,
+                native_direct_messages=False,
+                messages=["message-before-cleanup"],
+                runtime_context_base=None,
+            ),
+            run_with_host_timeout_fn=run_with_host_timeout_fn,
+            finalize_llm_execution_fn=finalize_llm_execution_fn,
+        )
+
+    exc = exc_info.value
+    assert getattr(exc, "_direct_node_llm_response").content == "salvage me"
+    assert getattr(exc, "_direct_node_messages") == ["message-before-cleanup"]
+    assert getattr(exc, "_direct_node_tool_call_events") == [{"name": "tool_a"}]


### PR DESCRIPTION
## Summary
- Isolates the direct-node provider-backed LLM tool loop into `direct_node_llm_tool_loop.py`.
- Returns typed lifecycle state to the graph shell: response, messages, tool-call events, and final force-tools status.
- Preserves partial LLM execution state on finalization errors so existing salvage fallback behavior remains intact.
- Adds a focused unit harness for the helper contract.

## Linked Issue
Closes #573.

## In Scope
- Backend direct-node refactor only.
- Unit harness for helper lifecycle and partial-state salvage behavior.

## Out of Scope
- Provider routing changes.
- Prompt/persona changes.
- LMS preview/apply changes.
- Code Studio visual recipe behavior.

## Verification
- `cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_direct_node_llm_tool_loop.py -q --tb=short` -> 2 passed after final helper test was added through the combined run below.
- `cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_direct_node_llm_tool_loop.py tests/unit/test_direct_node_provider_errors.py -q --tb=short` -> 37 passed.
- `cd maritime-ai-service && uv run --python 3.12 --extra dev ruff check app/ --select=E9,F63,F7` -> passed.
- `git diff --check` / `git diff --cached --check` -> passed.

## Risk
Medium runtime risk because this touches direct chat/tool turn lifecycle, but behavior is intended to be preserving and direct-node provider regression tests pass.

## Rollback
Revert this PR. No schema, data, prompt, provider config, or deployment assets are changed.

## Reviewer Focus
- Confirm partial execution state is preserved when finalization/post-processing fails.
- Confirm direct-node runtime remains a thin orchestrator and does not lose tool-call events before exception fallback.