### PR TITLE
refactor(backend): type direct node LLM preflight

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_llm_preflight.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_llm_preflight.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from typing import Any, Callable
 
 from app.engine.multi_agent.graph_runtime_helpers import (
@@ -25,6 +26,16 @@ class DirectNodeUploadedVisualGuard:
     response: str
     provider: str | None
     model: str | None
+
+
+@dataclass(slots=True)
+class DirectNodeLlmPreflightResult:
+    """Resolved direct-node LLM state before the tool loop executes."""
+
+    llm: Any | None
+    response: str
+    selection: DirectNodeLlmSelection
+    visual_guard: DirectNodeUploadedVisualGuard | None
 
 
 def select_direct_node_llm(
@@ -161,3 +172,109 @@ def apply_direct_node_natural_conversation_penalties(
         )
     except Exception:
         return llm
+
+
+def prepare_direct_node_llm_preflight(
+    *,
+    query: str,
+    state: AgentState,
+    ctx: dict[str, Any],
+    ctx_for_preflight: dict[str, Any],
+    has_uploaded_document_context: bool,
+    response: str,
+    is_identity_turn: bool,
+    is_short_house_chatter: bool,
+    is_emotional_support_turn: bool,
+    use_house_voice_direct: bool,
+    is_codebase_source_turn: bool,
+    thinking_effort: str | None,
+    direct_provider_override: str | None,
+    preferred_provider: str | None,
+    requested_model: str | None,
+    enable_natural_conversation: bool,
+    presence_penalty: float,
+    frequency_penalty: float,
+    get_native_llm: Callable[..., Any],
+    get_llm: Callable[..., Any],
+    supports_native_answer_streaming: Callable[[str | None], bool],
+    looks_uploaded_file_visual_inspection_query: Callable[[str], bool],
+    provider_likely_supports_image_blocks: Callable[[str | None, str | None], bool],
+    build_uploaded_document_visual_guard_answer: Callable[[str, dict[str, Any]], str],
+    tracer: Any,
+    logger_obj: logging.Logger,
+    select_llm_fn: Callable[..., DirectNodeLlmSelection] = select_direct_node_llm,
+    build_visual_guard_fn: Callable[
+        ...,
+        DirectNodeUploadedVisualGuard | None,
+    ] = maybe_build_uploaded_visual_guard,
+    apply_penalties_fn: Callable[..., Any | None] = (
+        apply_direct_node_natural_conversation_penalties
+    ),
+) -> DirectNodeLlmPreflightResult:
+    """Select an LLM, apply uploaded-file guards, then bind safe penalties."""
+
+    selection = select_llm_fn(
+        is_identity_turn=is_identity_turn,
+        ctx=ctx,
+        is_short_house_chatter=is_short_house_chatter,
+        is_emotional_support_turn=is_emotional_support_turn,
+        use_house_voice_direct=use_house_voice_direct,
+        is_codebase_source_turn=is_codebase_source_turn,
+        response_present=bool(response),
+        thinking_effort=thinking_effort,
+        direct_provider_override=direct_provider_override,
+        requested_model=requested_model,
+        get_native_llm=get_native_llm,
+        get_llm=get_llm,
+        supports_native_answer_streaming=supports_native_answer_streaming,
+    )
+    llm = selection.llm
+
+    visual_guard = build_visual_guard_fn(
+        llm=llm,
+        query=query,
+        state=state,
+        ctx_for_preflight=ctx_for_preflight,
+        has_uploaded_document_context=has_uploaded_document_context,
+        direct_provider_override=direct_provider_override,
+        preferred_provider=preferred_provider,
+        looks_uploaded_file_visual_inspection_query=(
+            looks_uploaded_file_visual_inspection_query
+        ),
+        provider_likely_supports_image_blocks=provider_likely_supports_image_blocks,
+        build_uploaded_document_visual_guard_answer=(
+            build_uploaded_document_visual_guard_answer
+        ),
+    )
+    if visual_guard is not None:
+        response = visual_guard.response
+        logger_obj.info(
+            "[DIRECT] Uploaded video frame question routed to text-only provider; "
+            "returned visual guard fallback (provider=%s model=%s)",
+            visual_guard.provider,
+            visual_guard.model,
+        )
+        tracer.end_step(
+            result="Uploaded-file visual guard fallback (text-only provider)",
+            confidence=0.7,
+            details={
+                "response_type": "uploaded_file_visual_guard_fallback",
+                "provider": visual_guard.provider,
+                "model": visual_guard.model,
+            },
+        )
+
+    llm = apply_penalties_fn(
+        llm,
+        response_present=bool(response),
+        enable_natural_conversation=enable_natural_conversation,
+        presence_penalty=presence_penalty,
+        frequency_penalty=frequency_penalty,
+    )
+
+    return DirectNodeLlmPreflightResult(
+        llm=llm,
+        response=response,
+        selection=selection,
+        visual_guard=visual_guard,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -27,9 +27,7 @@ from app.engine.multi_agent.direct_node_image_input_preflight import (
     execute_direct_node_image_input_preflight,
 )
 from app.engine.multi_agent.direct_node_llm_preflight import (
-    apply_direct_node_natural_conversation_penalties,
-    maybe_build_uploaded_visual_guard,
-    select_direct_node_llm,
+    prepare_direct_node_llm_preflight,
 )
 from app.engine.multi_agent.direct_node_llm_tool_loop import (
     execute_direct_node_llm_tool_loop,
@@ -337,31 +335,30 @@ async def direct_response_node_impl(
                 _supports_native_answer_streaming_impl,
             )
 
-            llm_selection = select_direct_node_llm(
-                is_identity_turn=is_identity_turn,
+            llm_preflight = prepare_direct_node_llm_preflight(
+                query=query,
+                state=state,
                 ctx=ctx,
+                ctx_for_preflight=ctx_for_preflight,
+                has_uploaded_document_context=has_uploaded_document_context,
+                response=response,
+                is_identity_turn=is_identity_turn,
                 is_short_house_chatter=is_short_house_chatter,
                 is_emotional_support_turn=is_emotional_support_turn,
                 use_house_voice_direct=use_house_voice_direct,
                 is_codebase_source_turn=is_codebase_source_turn,
-                response_present=bool(response),
                 thinking_effort=thinking_effort,
                 direct_provider_override=direct_provider_override,
+                preferred_provider=preferred_provider,
                 requested_model=state.get("model"),
+                enable_natural_conversation=(
+                    getattr(settings, "enable_natural_conversation", False) is True
+                ),
+                presence_penalty=getattr(settings, "llm_presence_penalty", 0.0),
+                frequency_penalty=getattr(settings, "llm_frequency_penalty", 0.0),
                 get_native_llm=AgentConfigRegistry.get_native_llm,
                 get_llm=AgentConfigRegistry.get_llm,
                 supports_native_answer_streaming=_supports_native_answer_streaming_impl,
-            )
-            llm = llm_selection.llm
-
-            visual_guard = maybe_build_uploaded_visual_guard(
-                llm=llm,
-                query=query,
-                state=state,
-                ctx_for_preflight=ctx_for_preflight,
-                has_uploaded_document_context=has_uploaded_document_context,
-                direct_provider_override=direct_provider_override,
-                preferred_provider=preferred_provider,
                 looks_uploaded_file_visual_inspection_query=(
                     _looks_uploaded_file_visual_inspection_query
                 ),
@@ -371,34 +368,11 @@ async def direct_response_node_impl(
                 build_uploaded_document_visual_guard_answer=(
                     _build_uploaded_document_visual_guard_answer
                 ),
+                tracer=tracer,
+                logger_obj=logger,
             )
-            if visual_guard is not None:
-                response = visual_guard.response
-                logger.info(
-                    "[DIRECT] Uploaded video frame question routed to text-only provider; "
-                    "returned visual guard fallback (provider=%s model=%s)",
-                    visual_guard.provider,
-                    visual_guard.model,
-                )
-                tracer.end_step(
-                    result="Uploaded-file visual guard fallback (text-only provider)",
-                    confidence=0.7,
-                    details={
-                        "response_type": "uploaded_file_visual_guard_fallback",
-                        "provider": visual_guard.provider,
-                        "model": visual_guard.model,
-                    },
-                )
-
-            llm = apply_direct_node_natural_conversation_penalties(
-                llm,
-                response_present=bool(response),
-                enable_natural_conversation=(
-                    getattr(settings, "enable_natural_conversation", False) is True
-                ),
-                presence_penalty=getattr(settings, "llm_presence_penalty", 0.0),
-                frequency_penalty=getattr(settings, "llm_frequency_penalty", 0.0),
-            )
+            llm = llm_preflight.llm
+            response = llm_preflight.response
 
             if llm and not response:
                 llm_tool_loop = await execute_direct_node_llm_tool_loop(

--- a/maritime-ai-service/tests/unit/test_direct_node_llm_preflight.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_llm_preflight.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from typing import Any
 
 from app.engine.multi_agent.direct_node_llm_preflight import (
+    DirectNodeLlmSelection,
     apply_direct_node_natural_conversation_penalties,
     maybe_build_uploaded_visual_guard,
+    prepare_direct_node_llm_preflight,
     select_direct_node_llm,
 )
 
@@ -133,3 +135,118 @@ def test_apply_natural_conversation_penalties_skips_native_llm() -> None:
 
     assert result is llm
     assert llm.bind_kwargs is None
+
+
+def test_prepare_direct_node_llm_preflight_applies_uploaded_visual_guard_before_penalties():
+    llm = _Llm(provider="text-only", model="text-model")
+    ctx_for_preflight = {"images": [{"url": "frame.png"}]}
+    tracer_calls: list[dict[str, Any]] = []
+
+    class _Tracer:
+        def end_step(self, **kwargs: Any) -> None:
+            tracer_calls.append(kwargs)
+
+    penalty_calls: list[dict[str, Any]] = []
+
+    def apply_penalties_fn(candidate_llm: Any, **kwargs: Any) -> Any:
+        penalty_calls.append(kwargs)
+        return candidate_llm
+
+    result = prepare_direct_node_llm_preflight(
+        query="anh trong video noi gi",
+        state={"model": "state-model"},
+        ctx={},
+        ctx_for_preflight=ctx_for_preflight,
+        has_uploaded_document_context=True,
+        response="",
+        is_identity_turn=False,
+        is_short_house_chatter=False,
+        is_emotional_support_turn=False,
+        use_house_voice_direct=False,
+        is_codebase_source_turn=False,
+        thinking_effort="medium",
+        direct_provider_override=None,
+        preferred_provider="qwen",
+        requested_model="qwen3-next",
+        enable_natural_conversation=True,
+        presence_penalty=0.2,
+        frequency_penalty=0.1,
+        get_native_llm=lambda *_args, **_kwargs: None,
+        get_llm=lambda *_args, **_kwargs: llm,
+        supports_native_answer_streaming=lambda _provider: False,
+        looks_uploaded_file_visual_inspection_query=lambda _query: True,
+        provider_likely_supports_image_blocks=lambda _provider, _model: False,
+        build_uploaded_document_visual_guard_answer=lambda _query, _ctx: "need vision",
+        tracer=_Tracer(),
+        logger_obj=type("_Logger", (), {"info": lambda *_args, **_kwargs: None})(),
+        apply_penalties_fn=apply_penalties_fn,
+    )
+
+    assert result.llm is llm
+    assert result.response == "need vision"
+    assert result.visual_guard is not None
+    assert result.visual_guard.provider == "text-only"
+    assert ctx_for_preflight["images"] == []
+    assert penalty_calls == [
+        {
+            "response_present": True,
+            "enable_natural_conversation": True,
+            "presence_penalty": 0.2,
+            "frequency_penalty": 0.1,
+        }
+    ]
+    assert tracer_calls == [
+        {
+            "result": "Uploaded-file visual guard fallback (text-only provider)",
+            "confidence": 0.7,
+            "details": {
+                "response_type": "uploaded_file_visual_guard_fallback",
+                "provider": "text-only",
+                "model": "text-model",
+            },
+        }
+    ]
+
+
+def test_prepare_direct_node_llm_preflight_allows_selection_injection():
+    selected_llm = _Llm(provider="qwen")
+    selection = DirectNodeLlmSelection(
+        direct_node_id="direct",
+        native_direct_possible=True,
+        llm=selected_llm,
+    )
+
+    result = prepare_direct_node_llm_preflight(
+        query="xin chao",
+        state={},
+        ctx={},
+        ctx_for_preflight={},
+        has_uploaded_document_context=False,
+        response="",
+        is_identity_turn=False,
+        is_short_house_chatter=False,
+        is_emotional_support_turn=False,
+        use_house_voice_direct=False,
+        is_codebase_source_turn=False,
+        thinking_effort=None,
+        direct_provider_override=None,
+        preferred_provider=None,
+        requested_model=None,
+        enable_natural_conversation=False,
+        presence_penalty=0.0,
+        frequency_penalty=0.0,
+        get_native_llm=lambda *_args, **_kwargs: None,
+        get_llm=lambda *_args, **_kwargs: None,
+        supports_native_answer_streaming=lambda _provider: False,
+        looks_uploaded_file_visual_inspection_query=lambda _query: False,
+        provider_likely_supports_image_blocks=lambda _provider, _model: True,
+        build_uploaded_document_visual_guard_answer=lambda _query, _ctx: "",
+        tracer=type("_Tracer", (), {"end_step": lambda *_args, **_kwargs: None})(),
+        logger_obj=type("_Logger", (), {"info": lambda *_args, **_kwargs: None})(),
+        select_llm_fn=lambda **_kwargs: selection,
+    )
+
+    assert result.selection is selection
+    assert result.llm is selected_llm
+    assert result.response == ""
+    assert result.visual_guard is None


### PR DESCRIPTION
## Summary
- Adds a typed `DirectNodeLlmPreflightResult` for direct-node LLM selection, uploaded-file visual guard, and penalty binding.
- Delegates the main runtime preflight sequence through the new helper so ordering is explicit and testable.
- Adds unit coverage for guard-before-penalty ordering and selection injection.

## Linked Issue
Closes #575.

## In Scope
- Backend direct-node preflight refactor.
- Unit harness for the combined LLM preflight contract.

## Out of Scope
- Provider routing policy changes.
- Prompt/persona changes.
- Tool-loop execution changes.
- Frontend/desktop changes.

## Verification
- `cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_direct_node_llm_preflight.py tests/unit/test_direct_node_provider_errors.py -q --tb=short` -> 42 passed.
- `cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_direct_node_llm_preflight.py tests/unit/test_direct_node_llm_tool_loop.py tests/unit/test_direct_node_provider_errors.py -q --tb=short` -> 44 passed.
- `cd maritime-ai-service && uv run --python 3.12 --extra dev ruff check app/ --select=E9,F63,F7` -> passed.
- `git diff --check` and `git diff --cached --check` -> passed.

## Risk
Medium runtime risk because this touches direct-node LLM preflight ordering. Behavior is intended to be preserving and direct-node provider regression tests pass.

## Rollback
Revert this PR. No schema, data, prompt, provider config, or deployment assets are changed.

## Reviewer Focus
- Confirm uploaded-file visual guard still runs before natural-conversation penalty binding.
- Confirm direct-node runtime remains a thin orchestrator without changing provider selection behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the LLM preflight process to improve modularity and code maintainability
  * Consolidated LLM selection, visual handling, and penalty application into a unified workflow that executes before the main operation begins
  * Streamlined the runtime initialization sequence to reduce code duplication

* **Tests**
  * Added comprehensive unit tests for the refactored preflight workflow, including scenarios with visual handling fallback and LLM selection injection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->