### PR TITLE
refactor(backend): type direct node pre-LLM pipeline

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_pre_llm_pipeline.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_pre_llm_pipeline.py
@@ -1,0 +1,219 @@
+"""Direct-node deterministic pre-LLM pipeline."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from app.engine.multi_agent.document_preview_contract import (
+    has_uploaded_document_context as _has_uploaded_document_context,
+)
+from app.engine.multi_agent.direct_node_document_preflight import (
+    build_document_preview_response_sanitizer,
+    execute_direct_node_document_preview_preflight,
+    record_uploaded_document_context_plan,
+)
+from app.engine.multi_agent.direct_node_fast_response_runtime import (
+    resolve_direct_node_fast_response,
+)
+from app.engine.multi_agent.direct_node_image_input_preflight import (
+    execute_direct_node_image_input_preflight,
+)
+from app.engine.multi_agent.direct_node_operational_fast_paths import (
+    _strip_dsml_residue,
+)
+from app.engine.multi_agent.direct_node_turn_start import start_direct_node_turn
+from app.engine.multi_agent.direct_node_uploaded_context import (
+    _looks_uploaded_document_preview_request,
+)
+from app.engine.multi_agent.direct_node_visible_thought import (
+    _strip_direct_inline_private_asides,
+)
+from app.engine.multi_agent.state import AgentState
+
+
+@dataclass(slots=True)
+class DirectNodePreLlmPipelineResult:
+    """Resolved deterministic state before direct-node provider execution."""
+
+    query_lower: str
+    response: str | None
+    response_type: str
+    explicit_web_search_turn: bool
+    ctx_for_preflight: dict[str, Any]
+    has_uploaded_document_context: bool
+    domain_name_vi: str
+    sanitize_document_preview_response: Callable[[str, list[dict[str, Any]]], str]
+
+
+def _resolve_domain_name_vi(
+    *,
+    state: AgentState,
+    default_domain: str,
+) -> str:
+    domain_config = state.get("domain_config", {})
+    domain_name_vi = domain_config.get("name_vi", "") if isinstance(domain_config, dict) else ""
+    if domain_name_vi:
+        return str(domain_name_vi)
+
+    domain_id = state.get("domain_id", default_domain)
+    return {
+        "maritime": "Hang hai",
+        "traffic_law": "Luat Giao thong",
+    }.get(domain_id, str(domain_id))
+
+
+async def execute_direct_node_pre_llm_pipeline(
+    *,
+    query: str,
+    state: AgentState,
+    bus_id: str | None,
+    push_event: Callable[..., Any],
+    tracer: Any,
+    enable_natural_conversation: bool,
+    default_domain: str,
+    get_domain_greetings: Callable[[str], dict[str, str]],
+    normalize_for_intent: Callable[[str], str],
+    needs_web_search: Callable[[str], bool],
+    needs_datetime: Callable[[str], bool],
+    build_visual_tool_runtime_metadata: Callable[..., dict[str, Any]],
+    execute_direct_tool_rounds: Callable[..., Any],
+    extract_direct_response: Callable[..., Any],
+    sanitize_structured_visual_answer_text: Callable[..., str],
+    sanitize_wiii_house_text: Callable[..., str],
+    record_thinking_snapshot_fn: Callable[..., Any],
+    logger_obj: logging.Logger,
+    start_turn_fn: Callable[..., Any] = start_direct_node_turn,
+    has_uploaded_document_context_fn: Callable[[dict[str, Any]], bool] = (
+        _has_uploaded_document_context
+    ),
+    build_preview_sanitizer_fn: Callable[..., Callable[..., str]] = (
+        build_document_preview_response_sanitizer
+    ),
+    record_document_plan_fn: Callable[..., None] = (
+        record_uploaded_document_context_plan
+    ),
+    document_preview_preflight_fn: Callable[..., Any] = (
+        execute_direct_node_document_preview_preflight
+    ),
+    image_input_preflight_fn: Callable[..., Any] = (
+        execute_direct_node_image_input_preflight
+    ),
+    fast_response_fn: Callable[..., Any] = resolve_direct_node_fast_response,
+) -> DirectNodePreLlmPipelineResult:
+    """Run deterministic direct-node work before provider/tool-loop execution."""
+
+    turn_start = start_turn_fn(
+        query=query,
+        state=state,
+        enable_natural_conversation=enable_natural_conversation,
+        default_domain=default_domain,
+        get_domain_greetings=get_domain_greetings,
+        record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+    )
+    query_lower = turn_start.query_lower
+    response = turn_start.response
+    response_type = turn_start.response_type
+    explicit_web_search_turn = turn_start.explicit_web_search_turn
+
+    ctx_for_preflight = (
+        state.get("context", {}) if isinstance(state.get("context"), dict) else {}
+    )
+    has_uploaded_document_context = has_uploaded_document_context_fn(ctx_for_preflight)
+
+    sanitize_document_preview_response = build_preview_sanitizer_fn(
+        query=query,
+        sanitize_structured_visual_answer_text=sanitize_structured_visual_answer_text,
+        sanitize_wiii_house_text=sanitize_wiii_house_text,
+        strip_direct_inline_private_asides=_strip_direct_inline_private_asides,
+        strip_dsml_residue=_strip_dsml_residue,
+    )
+
+    document_thinking = (
+        "Mình nhận đây là lượt hỏi có tài liệu upload đã được parse thành Markdown, "
+        "nên ưu tiên đối chiếu marker, bảng và các dòng trong document_context trước khi suy luận thêm. "
+        "Nếu phần nào không có trong file, Wiii phải nói rõ thay vì bịa."
+    )
+    record_document_plan_fn(
+        state=state,
+        response_present=bool(response),
+        has_uploaded_document_context=has_uploaded_document_context,
+        document_thinking=document_thinking,
+        record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+    )
+
+    document_preflight_result = await document_preview_preflight_fn(
+        query=query,
+        state=state,
+        ctx=ctx_for_preflight,
+        bus_id=bus_id,
+        response_present=bool(response),
+        has_uploaded_document_context=has_uploaded_document_context,
+        looks_uploaded_document_preview_request=_looks_uploaded_document_preview_request,
+        push_event=push_event,
+        build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
+        execute_direct_tool_rounds=execute_direct_tool_rounds,
+        extract_direct_response=extract_direct_response,
+        sanitize_preview_response=sanitize_document_preview_response,
+        fallback_response=(
+            "Mình đã gửi bản preview bài học sang LMS. "
+            "Giáo viên cần xem phần so sánh thay đổi và nguồn trích dẫn rồi bấm Áp dụng để cấp approval_token."
+        ),
+        logger_obj=logger_obj,
+    )
+    if document_preflight_result is not None:
+        response = document_preflight_result.response
+        response_type = document_preflight_result.response_type
+
+    image_preflight_result = await image_input_preflight_fn(
+        query=query,
+        state=state,
+        ctx=ctx_for_preflight,
+        response_present=bool(response),
+        has_uploaded_document_context=has_uploaded_document_context,
+        record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+    )
+    if image_preflight_result is not None:
+        response = image_preflight_result.response
+        response_type = image_preflight_result.response_type
+
+    if not response:
+        fast_response = fast_response_fn(
+            query=query,
+            state=state,
+            ctx=ctx_for_preflight,
+            has_uploaded_document_context=has_uploaded_document_context,
+            normalize_for_intent=normalize_for_intent,
+            needs_web_search=needs_web_search,
+            needs_datetime=needs_datetime,
+            record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+            logger_obj=logger_obj,
+        )
+        if fast_response is not None:
+            response = fast_response.response
+            response_type = fast_response.response_type
+
+    domain_name_vi = _resolve_domain_name_vi(
+        state=state,
+        default_domain=default_domain,
+    )
+
+    if response:
+        tracer.end_step(
+            result=f"Direct fast response: {response[:50]}...",
+            confidence=1.0,
+            details={"response_type": response_type or "greeting", "query": query_lower},
+        )
+
+    return DirectNodePreLlmPipelineResult(
+        query_lower=query_lower,
+        response=response,
+        response_type=response_type,
+        explicit_web_search_turn=explicit_web_search_turn,
+        ctx_for_preflight=ctx_for_preflight,
+        has_uploaded_document_context=has_uploaded_document_context,
+        domain_name_vi=domain_name_vi,
+        sanitize_document_preview_response=sanitize_document_preview_response,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -6,25 +6,11 @@ import logging
 from typing import Any
 
 from app.core.config import settings
-from app.engine.multi_agent.document_preview_contract import (
-    has_uploaded_document_context as _has_uploaded_document_context,
-)
 from app.engine.multi_agent.direct_node_document_preview_runtime import (
     execute_direct_node_document_preview_round,
 )
-from app.engine.multi_agent.direct_node_document_preflight import (
-    build_document_preview_response_sanitizer,
-    execute_direct_node_document_preview_preflight,
-    record_uploaded_document_context_plan,
-)
-from app.engine.multi_agent.direct_node_fast_response_runtime import (
-    resolve_direct_node_fast_response,
-)
 from app.engine.multi_agent.direct_node_event_sink import (
     build_direct_node_event_sink,
-)
-from app.engine.multi_agent.direct_node_image_input_preflight import (
-    execute_direct_node_image_input_preflight,
 )
 from app.engine.multi_agent.direct_node_llm_preflight import (
     prepare_direct_node_llm_preflight,
@@ -45,23 +31,21 @@ from app.engine.multi_agent.direct_node_final_state import finalize_direct_node_
 from app.engine.multi_agent.direct_node_operational_fast_paths import (
     _build_codebase_analysis_fallback_answer,
     _build_codebase_analysis_fallback_thinking,
-    _strip_dsml_residue,
+)
+from app.engine.multi_agent.direct_node_pre_llm_pipeline import (
+    execute_direct_node_pre_llm_pipeline,
 )
 from app.engine.multi_agent.direct_node_thinking_snapshot import (
     record_direct_node_thinking_snapshot,
 )
 from app.engine.multi_agent.direct_node_tool_selection import select_direct_node_tools
 from app.engine.multi_agent.direct_node_turn_policy import resolve_direct_node_turn_policy
-from app.engine.multi_agent.direct_node_turn_start import start_direct_node_turn
 from app.engine.multi_agent.direct_node_uploaded_context import (
     _build_uploaded_document_context_fallback_answer,
     _build_uploaded_document_visual_guard_answer,
     _looks_uploaded_document_preview_request,
     _looks_uploaded_file_visual_inspection_query,
     _provider_likely_supports_image_blocks,
-)
-from app.engine.multi_agent.direct_node_visible_thought import (
-    _strip_direct_inline_private_asides,
 )
 from app.engine.runtime.runtime_metrics import inc_counter
 from app.engine.multi_agent.state import AgentState
@@ -121,111 +105,38 @@ async def direct_response_node_impl(
     tracer = get_or_create_tracer(state)
     tracer.start_step(direct_response_step_name, "Tao phan hoi truc tiep")
 
-    turn_start = start_direct_node_turn(
+    pre_llm_pipeline = await execute_direct_node_pre_llm_pipeline(
         query=query,
         state=state,
+        bus_id=bus_id,
+        push_event=push_event,
+        tracer=tracer,
         enable_natural_conversation=(
             getattr(settings, "enable_natural_conversation", False) is True
         ),
         default_domain=settings.default_domain,
         get_domain_greetings=get_domain_greetings,
-        record_thinking_snapshot_fn=record_thinking_snapshot,
-    )
-    query_lower = turn_start.query_lower
-    response = turn_start.response
-    response_type = turn_start.response_type
-    explicit_web_search_turn = turn_start.explicit_web_search_turn
-
-    ctx_for_preflight = state.get("context", {}) if isinstance(state.get("context"), dict) else {}
-    has_uploaded_document_context = _has_uploaded_document_context(ctx_for_preflight)
-
-    sanitize_document_preview_response = build_document_preview_response_sanitizer(
-        query=query,
-        sanitize_structured_visual_answer_text=sanitize_structured_visual_answer_text,
-        sanitize_wiii_house_text=sanitize_wiii_house_text,
-        strip_direct_inline_private_asides=_strip_direct_inline_private_asides,
-        strip_dsml_residue=_strip_dsml_residue,
-    )
-
-    document_thinking = (
-        "Mình nhận đây là lượt hỏi có tài liệu upload đã được parse thành Markdown, "
-        "nên ưu tiên đối chiếu marker, bảng và các dòng trong document_context trước khi suy luận thêm. "
-        "Nếu phần nào không có trong file, Wiii phải nói rõ thay vì bịa."
-    )
-    record_uploaded_document_context_plan(
-        state=state,
-        response_present=bool(response),
-        has_uploaded_document_context=has_uploaded_document_context,
-        document_thinking=document_thinking,
-        record_thinking_snapshot_fn=record_thinking_snapshot,
-    )
-    document_preflight_result = await execute_direct_node_document_preview_preflight(
-        query=query,
-        state=state,
-        ctx=ctx_for_preflight,
-        bus_id=bus_id,
-        response_present=bool(response),
-        has_uploaded_document_context=has_uploaded_document_context,
-        looks_uploaded_document_preview_request=_looks_uploaded_document_preview_request,
-        push_event=push_event,
+        normalize_for_intent=normalize_for_intent,
+        needs_web_search=needs_web_search,
+        needs_datetime=needs_datetime,
         build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
         execute_direct_tool_rounds=execute_direct_tool_rounds,
         extract_direct_response=extract_direct_response,
-        sanitize_preview_response=sanitize_document_preview_response,
-        fallback_response=(
-            "Mình đã gửi bản preview bài học sang LMS. "
-            "Giáo viên cần xem phần so sánh thay đổi và nguồn trích dẫn rồi bấm Áp dụng để cấp approval_token."
-        ),
+        sanitize_structured_visual_answer_text=sanitize_structured_visual_answer_text,
+        sanitize_wiii_house_text=sanitize_wiii_house_text,
+        record_thinking_snapshot_fn=record_thinking_snapshot,
         logger_obj=logger,
     )
-    if document_preflight_result is not None:
-        response = document_preflight_result.response
-        response_type = document_preflight_result.response_type
-
-    image_preflight_result = await execute_direct_node_image_input_preflight(
-        query=query,
-        state=state,
-        ctx=ctx_for_preflight,
-        response_present=bool(response),
-        has_uploaded_document_context=has_uploaded_document_context,
-        record_thinking_snapshot_fn=record_thinking_snapshot,
+    response = pre_llm_pipeline.response
+    explicit_web_search_turn = pre_llm_pipeline.explicit_web_search_turn
+    ctx_for_preflight = pre_llm_pipeline.ctx_for_preflight
+    has_uploaded_document_context = pre_llm_pipeline.has_uploaded_document_context
+    domain_name_vi = pre_llm_pipeline.domain_name_vi
+    sanitize_document_preview_response = (
+        pre_llm_pipeline.sanitize_document_preview_response
     )
-    if image_preflight_result is not None:
-        response = image_preflight_result.response
-        response_type = image_preflight_result.response_type
 
     if not response:
-        fast_response = resolve_direct_node_fast_response(
-            query=query,
-            state=state,
-            ctx=ctx_for_preflight,
-            has_uploaded_document_context=has_uploaded_document_context,
-            normalize_for_intent=normalize_for_intent,
-            needs_web_search=needs_web_search,
-            needs_datetime=needs_datetime,
-            record_thinking_snapshot_fn=record_thinking_snapshot,
-            logger_obj=logger,
-        )
-        if fast_response is not None:
-            response = fast_response.response
-            response_type = fast_response.response_type
-
-    domain_config = state.get("domain_config", {})
-    domain_name_vi = domain_config.get("name_vi", "")
-    if not domain_name_vi:
-        domain_id = state.get("domain_id", settings.default_domain)
-        domain_name_vi = {
-            "maritime": "Hang hai",
-            "traffic_law": "Luat Giao thong",
-        }.get(domain_id, domain_id)
-
-    if response:
-        tracer.end_step(
-            result=f"Direct fast response: {response[:50]}...",
-            confidence=1.0,
-            details={"response_type": response_type or "greeting", "query": query_lower},
-        )
-    else:
         explicit_user_provider: str | None = None
         llm = None
         llm_response = None

--- a/maritime-ai-service/tests/unit/test_direct_node_pre_llm_pipeline.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_pre_llm_pipeline.py
@@ -1,0 +1,144 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.engine.multi_agent.direct_node_pre_llm_pipeline import (
+    execute_direct_node_pre_llm_pipeline,
+)
+
+
+@pytest.mark.asyncio
+async def test_pre_llm_pipeline_preserves_document_then_image_order():
+    state = {"context": {"document_context": {"documents": [{"id": "doc-1"}]}}}
+    calls: list[str] = []
+    tracer = MagicMock()
+
+    def start_turn_fn(**_kwargs):
+        calls.append("start")
+        return SimpleNamespace(
+            query_lower="tao bai hoc",
+            response=None,
+            response_type="",
+            explicit_web_search_turn=False,
+        )
+
+    def build_preview_sanitizer_fn(**_kwargs):
+        calls.append("build_sanitizer")
+        return lambda text, _events: f"clean:{text}"
+
+    def record_document_plan_fn(**kwargs):
+        calls.append("record_plan")
+        assert kwargs["has_uploaded_document_context"] is True
+        assert "Wiii" in kwargs["document_thinking"]
+
+    async def document_preview_preflight_fn(**kwargs):
+        calls.append("document")
+        assert kwargs["response_present"] is False
+        assert kwargs["sanitize_preview_response"]("ok", []) == "clean:ok"
+        return SimpleNamespace(
+            response="Preview da gui.",
+            response_type="document_preview_host_action",
+        )
+
+    async def image_input_preflight_fn(**kwargs):
+        calls.append("image")
+        assert kwargs["response_present"] is True
+        return None
+
+    def fast_response_fn(**_kwargs):
+        raise AssertionError("fast response should not run after document preview")
+
+    result = await execute_direct_node_pre_llm_pipeline(
+        query="tao bai hoc",
+        state=state,
+        bus_id="bus-1",
+        push_event=lambda *_args, **_kwargs: None,
+        tracer=tracer,
+        enable_natural_conversation=True,
+        default_domain="maritime",
+        get_domain_greetings=lambda _domain: {},
+        normalize_for_intent=lambda text: text,
+        needs_web_search=lambda _text: False,
+        needs_datetime=lambda _text: False,
+        build_visual_tool_runtime_metadata=lambda *_args, **_kwargs: {},
+        execute_direct_tool_rounds=lambda *_args, **_kwargs: None,
+        extract_direct_response=lambda *_args, **_kwargs: "",
+        sanitize_structured_visual_answer_text=lambda text, *_args, **_kwargs: text,
+        sanitize_wiii_house_text=lambda text, *_args, **_kwargs: text,
+        record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
+        logger_obj=MagicMock(),
+        start_turn_fn=start_turn_fn,
+        has_uploaded_document_context_fn=lambda _ctx: True,
+        build_preview_sanitizer_fn=build_preview_sanitizer_fn,
+        record_document_plan_fn=record_document_plan_fn,
+        document_preview_preflight_fn=document_preview_preflight_fn,
+        image_input_preflight_fn=image_input_preflight_fn,
+        fast_response_fn=fast_response_fn,
+    )
+
+    assert result.response == "Preview da gui."
+    assert result.response_type == "document_preview_host_action"
+    assert result.has_uploaded_document_context is True
+    assert result.domain_name_vi == "Hang hai"
+    assert calls == ["start", "build_sanitizer", "record_plan", "document", "image"]
+    tracer.end_step.assert_called_once()
+    assert tracer.end_step.call_args.kwargs["details"]["response_type"] == (
+        "document_preview_host_action"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pre_llm_pipeline_uses_fast_response_when_preflights_do_not_answer():
+    tracer = MagicMock()
+
+    async def no_document_answer(**_kwargs):
+        return None
+
+    async def no_image_answer(**_kwargs):
+        return None
+
+    result = await execute_direct_node_pre_llm_pipeline(
+        query="wiii pipeline la gi",
+        state={"context": {}, "domain_id": "custom_domain"},
+        bus_id=None,
+        push_event=lambda *_args, **_kwargs: None,
+        tracer=tracer,
+        enable_natural_conversation=True,
+        default_domain="maritime",
+        get_domain_greetings=lambda _domain: {},
+        normalize_for_intent=lambda text: text,
+        needs_web_search=lambda _text: False,
+        needs_datetime=lambda _text: False,
+        build_visual_tool_runtime_metadata=lambda *_args, **_kwargs: {},
+        execute_direct_tool_rounds=lambda *_args, **_kwargs: None,
+        extract_direct_response=lambda *_args, **_kwargs: "",
+        sanitize_structured_visual_answer_text=lambda text, *_args, **_kwargs: text,
+        sanitize_wiii_house_text=lambda text, *_args, **_kwargs: text,
+        record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
+        logger_obj=MagicMock(),
+        start_turn_fn=lambda **_kwargs: SimpleNamespace(
+            query_lower="wiii pipeline la gi",
+            response=None,
+            response_type="",
+            explicit_web_search_turn=True,
+        ),
+        has_uploaded_document_context_fn=lambda _ctx: False,
+        record_document_plan_fn=lambda **_kwargs: None,
+        document_preview_preflight_fn=no_document_answer,
+        image_input_preflight_fn=no_image_answer,
+        fast_response_fn=lambda **_kwargs: SimpleNamespace(
+            response="Fast answer.",
+            response_type="wiii_pipeline_meta",
+        ),
+    )
+
+    assert result.response == "Fast answer."
+    assert result.response_type == "wiii_pipeline_meta"
+    assert result.explicit_web_search_turn is True
+    assert result.domain_name_vi == "custom_domain"
+    tracer.end_step.assert_called_once()
+    assert tracer.end_step.call_args.kwargs["details"] == {
+        "response_type": "wiii_pipeline_meta",
+        "query": "wiii pipeline la gi",
+    }


### PR DESCRIPTION
## Summary
- Extracts direct-node pre-LLM deterministic work into `direct_node_pre_llm_pipeline.py`.
- The typed result now carries response state, uploaded-document context, domain display name, explicit web-search state, and the document-preview sanitizer needed by the later preview round.
- Preserves ordering across turn start, document preview preflight, image input preflight, and deterministic fast responses.

## Linked Issue
Closes #577.

## In Scope
- Backend direct-node lifecycle refactor.
- Focused unit harness for pre-LLM pipeline ordering and fast-response behavior.

## Out of Scope
- Provider routing policy changes.
- Tool-loop changes.
- Prompt/persona changes.
- Frontend/Code Studio changes.

## Verification
- `cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_direct_node_pre_llm_pipeline.py -q --tb=short` -> 2 passed.
- `cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_direct_node_pre_llm_pipeline.py tests/unit/test_direct_node_provider_errors.py -q --tb=short` -> 37 passed.
- `cd maritime-ai-service && uv run --python 3.12 --extra dev ruff check app/engine/multi_agent/direct_node_runtime.py app/engine/multi_agent/direct_node_pre_llm_pipeline.py tests/unit/test_direct_node_pre_llm_pipeline.py` -> passed.
- `cd maritime-ai-service && uv run --python 3.12 --extra dev ruff check app/ --select=E9,F63,F7` -> passed.
- `git diff --check` and `git diff --cached --check` -> passed.

## Risk
Medium runtime risk because this touches direct-node pre-LLM routing, especially uploaded-document preview and image-input turns. Existing provider regression tests pass.

## Rollback
Revert this PR. No schema, data, prompt, provider config, or deployment assets are changed.

## Reviewer Focus
- Confirm document preview preflight still wins before image/fast-response paths.
- Confirm the later deterministic document preview round still receives the sanitizer from the typed pre-LLM result.