### PR TITLE
fix(desktop): type visual frame sizing

### DIFF
--- a/wiii-desktop/playwright/code-studio-runtime.spec.ts
+++ b/wiii-desktop/playwright/code-studio-runtime.spec.ts
@@ -42,6 +42,12 @@ test.describe("code studio runtime", () => {
       .toBe(true);
 
     await expect(panel.locator("iframe").first()).toBeVisible({ timeout: 120_000 });
+    await expect(panel.locator('[data-inline-visual-sizing="viewport"]').first()).toBeVisible({ timeout: 120_000 });
+    await expect
+      .poll(async () =>
+        panel.locator("iframe").first().evaluate((node) => (node as HTMLIFrameElement).style.height),
+      )
+      .toBe("100%");
     await expect(inlineCard.getByRole("button", { name: /xem code/i })).toBeVisible();
 
     await sendPrompt(page, FOLLOWUP_PROMPT);
@@ -61,6 +67,7 @@ test.describe("code studio runtime", () => {
       .toEqual(["v1", "v2"]);
 
     await expect(panel.locator("iframe").first()).toBeVisible({ timeout: 120_000 });
+    await expect(panel.locator('[data-inline-visual-sizing="viewport"]').first()).toBeVisible({ timeout: 120_000 });
     await expect(inlineCard.getByRole("button", { name: /xem code/i })).toBeVisible();
 
     await page.screenshot({
@@ -178,6 +185,15 @@ test.describe("Phase 8 routing", () => {
 
     const hasApp = csCount > 0 || (visualCount > 0 && iframeCount > 0);
     expect(hasApp).toBe(true);
+    if (csCount > 0) {
+      const panel = page.locator(".code-studio-panel").first();
+      await expect(panel.locator('[data-inline-visual-sizing="viewport"]').first()).toBeVisible({ timeout: 30_000 });
+      await expect
+        .poll(async () =>
+          panel.locator("iframe").first().evaluate((node) => (node as HTMLIFrameElement).style.height),
+        )
+        .toBe("100%");
+    }
 
     await page.screenshot({ path: testInfo.outputPath("routing-pendulum.png"), fullPage: true });
   });

--- a/wiii-desktop/src/__tests__/code-studio-panel.test.tsx
+++ b/wiii-desktop/src/__tests__/code-studio-panel.test.tsx
@@ -134,6 +134,7 @@ describe("CodeStudioPanel", () => {
     expect(inlineVisualFrameSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
         frameKind: "app",
+        sizingMode: "viewport",
         shellVariant: "immersive",
         hostShellMode: "force",
         className: "w-full h-full",

--- a/wiii-desktop/src/__tests__/inline-visual-frame-rendering.test.tsx
+++ b/wiii-desktop/src/__tests__/inline-visual-frame-rendering.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { InlineVisualFrame } from "@/components/common/InlineVisualFrame";
+
+const originalCreateObjectUrl = URL.createObjectURL;
+const originalRevokeObjectUrl = URL.revokeObjectURL;
+
+describe("InlineVisualFrame rendering contract", () => {
+  beforeEach(() => {
+    URL.createObjectURL = vi.fn(() => "blob:wiii-visual-frame");
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectUrl;
+    URL.revokeObjectURL = originalRevokeObjectUrl;
+  });
+
+  it("renders Code Studio viewport previews as full-height sandbox frames", async () => {
+    render(
+      <InlineVisualFrame
+        html="<main style='height:1400px'>Tall app</main>"
+        title="Tall app"
+        frameKind="app"
+        sizingMode="viewport"
+        shellVariant="immersive"
+        className="h-full"
+      />,
+    );
+
+    const iframe = await screen.findByTitle("Tall app");
+    await waitFor(() => expect(iframe.getAttribute("src")).toBe("blob:wiii-visual-frame"));
+
+    expect(iframe.parentElement?.getAttribute("data-inline-visual-sizing")).toBe("viewport");
+    expect((iframe as HTMLIFrameElement).style.height).toBe("100%");
+    expect((iframe as HTMLIFrameElement).style.minHeight).toBe("0px");
+  });
+
+  it("keeps normal inline app visuals content-sized", async () => {
+    render(
+      <InlineVisualFrame
+        html="<main>Inline app</main>"
+        title="Inline app"
+        frameKind="app"
+        shellVariant="immersive"
+      />,
+    );
+
+    const iframe = await screen.findByTitle("Inline app");
+
+    expect(iframe.parentElement?.getAttribute("data-inline-visual-sizing")).toBe("content");
+    expect((iframe as HTMLIFrameElement).style.height).toBe("520px");
+    expect((iframe as HTMLIFrameElement).style.minHeight).toBe("360px");
+  });
+});

--- a/wiii-desktop/src/__tests__/inline-visual-frame.test.ts
+++ b/wiii-desktop/src/__tests__/inline-visual-frame.test.ts
@@ -60,5 +60,7 @@ describe("InlineVisualFrame host shell", () => {
 
     expect(wrapped).toContain("overflow: auto;");
     expect(wrapped).toContain("overscroll-behavior: contain;");
+    expect(wrapped).toContain("function measureHeight()");
+    expect(wrapped).toContain("resizeObserver.observe(document.documentElement)");
   });
 });

--- a/wiii-desktop/src/__tests__/visual-frame-contract.test.ts
+++ b/wiii-desktop/src/__tests__/visual-frame-contract.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampVisualFrameContentHeight,
+  getVisualFrameHeightProfile,
+  parseVisualFrameBridgeMessage,
+  resolveVisualFrameCssHeight,
+} from "@/lib/visual-frame-contract";
+
+describe("visual frame contract", () => {
+  it("keeps inline app frames content-sized by default", () => {
+    const profile = getVisualFrameHeightProfile("app", "content");
+
+    expect(profile).toMatchObject({
+      initialHeight: 520,
+      minHeight: 360,
+      maxHeight: 1120,
+      sizingMode: "content",
+    });
+    expect(clampVisualFrameContentHeight(1400, profile)).toBe(1120);
+    expect(resolveVisualFrameCssHeight(720, profile)).toBe("720px");
+  });
+
+  it("uses viewport sizing for Code Studio panel previews", () => {
+    const profile = getVisualFrameHeightProfile("app", "viewport");
+
+    expect(profile).toMatchObject({
+      initialHeight: 520,
+      minHeight: 0,
+      maxHeight: 1120,
+      sizingMode: "viewport",
+    });
+    expect(clampVisualFrameContentHeight(1400, profile)).toBeNull();
+    expect(resolveVisualFrameCssHeight(720, profile)).toBe("100%");
+  });
+
+  it("parses iframe bridge messages into typed host events", () => {
+    expect(parseVisualFrameBridgeMessage({ type: "__edit_mode_available" })).toEqual({
+      kind: "tweaks_available",
+    });
+    expect(parseVisualFrameBridgeMessage({
+      type: "wiii-frame-resize",
+      payload: { height: 640, sessionId: "vs_1" },
+    })).toEqual({ kind: "resize", height: 640, sessionId: "vs_1" });
+    expect(parseVisualFrameBridgeMessage({
+      type: "wiii-frame-result",
+      payload: { summary: "Hoàn thành", sessionId: "vs_1" },
+    })).toEqual({
+      kind: "bridge",
+      bridgeType: "result",
+      detail: {
+        bridgeType: "result",
+        summary: "Hoàn thành",
+        sessionId: "vs_1",
+      },
+    });
+    expect(parseVisualFrameBridgeMessage({
+      type: "wiii-frame-resize",
+      payload: { height: "640" },
+    })).toBeNull();
+  });
+});

--- a/wiii-desktop/src/components/common/InlineVisualFrame.tsx
+++ b/wiii-desktop/src/components/common/InlineVisualFrame.tsx
@@ -1,5 +1,13 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { VisualRuntimeManifest, VisualShellVariant } from "@/api/types";
+import {
+  clampVisualFrameContentHeight,
+  getVisualFrameHeightProfile,
+  parseVisualFrameBridgeMessage,
+  resolveVisualFrameCssHeight,
+  resolveVisualFrameSizingMode,
+} from "@/lib/visual-frame-contract";
+import type { VisualFrameKind, VisualFrameSizingMode } from "@/lib/visual-frame-contract";
 
 const ALLOWED_CDNS = [
   "https://cdn.jsdelivr.net",
@@ -66,7 +74,8 @@ interface InlineVisualFrameProps {
   summary?: string;
   sessionId?: string;
   shellVariant?: VisualShellVariant;
-  frameKind?: "legacy" | "inline_html" | "app";
+  frameKind?: VisualFrameKind;
+  sizingMode?: VisualFrameSizingMode;
   runtimeManifest?: VisualRuntimeManifest | null;
   showFrameIntro?: boolean;
   hostShellMode?: "auto" | "force";
@@ -285,8 +294,29 @@ export function buildVisualFrameDocument(
         parent.postMessage({ type: type, payload: payload || {} }, '*');
       }
 
+      function measureHeight() {
+        var body = document.body || {};
+        var doc = document.documentElement || {};
+        var rectHeight = body.getBoundingClientRect ? body.getBoundingClientRect().height : 0;
+        return Math.ceil(Math.max(
+          body.scrollHeight || 0,
+          body.offsetHeight || 0,
+          doc.scrollHeight || 0,
+          doc.offsetHeight || 0,
+          rectHeight || 0
+        ));
+      }
+
       function notifyResize() {
-        post('wiii-frame-resize', { height: document.body.scrollHeight, sessionId: state.sessionId });
+        post('wiii-frame-resize', { height: measureHeight(), sessionId: state.sessionId });
+      }
+
+      function queueResize() {
+        if (window.requestAnimationFrame) {
+          window.requestAnimationFrame(notifyResize);
+        } else {
+          setTimeout(notifyResize, 0);
+        }
       }
 
       window.WiiiVisualBridge = {
@@ -330,7 +360,9 @@ export function buildVisualFrameDocument(
       window.addEventListener('load', function () {
         notifyResize();
         if (window.ResizeObserver) {
-          new ResizeObserver(function () { notifyResize(); }).observe(document.body);
+          var resizeObserver = new ResizeObserver(function () { queueResize(); });
+          resizeObserver.observe(document.body);
+          resizeObserver.observe(document.documentElement);
         }
         setTimeout(notifyResize, 120);
         setTimeout(notifyResize, 500);
@@ -630,11 +662,20 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
   hostShellMode = frameKind === "legacy" ? "auto" : "force",
   onBridgeEvent,
   showTweaksToggle = false,
+  sizingMode: requestedSizingMode,
 }: InlineVisualFrameProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const blobUrlRef = useRef<string | null>(null);
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
-  const [height, setHeight] = useState(frameKind === "app" ? 520 : 320);
+  const sizingMode = useMemo(
+    () => resolveVisualFrameSizingMode(frameKind, requestedSizingMode),
+    [frameKind, requestedSizingMode],
+  );
+  const heightProfile = useMemo(
+    () => getVisualFrameHeightProfile(frameKind, sizingMode),
+    [frameKind, sizingMode],
+  );
+  const [height, setHeight] = useState(heightProfile.initialHeight);
   const [error, setError] = useState<string | null>(null);
   const [tweaksAvailable, setTweaksAvailable] = useState(false);
   const [tweaksActive, setTweaksActive] = useState(false);
@@ -689,44 +730,46 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
   }, [wrappedHtml]);
 
   useEffect(() => {
+    setHeight(heightProfile.initialHeight);
+  }, [heightProfile.initialHeight, html, sizingMode]);
+
+  useEffect(() => {
     const handler = (event: MessageEvent) => {
       if (iframeRef.current && event.source !== iframeRef.current.contentWindow)
         return;
-      const data = event.data;
-      if (!data || typeof data !== "object") return;
+      const message = parseVisualFrameBridgeMessage(event.data);
+      if (!message) return;
 
       // Tweaks protocol: iframe announces edit mode availability
-      if (data.type === "__edit_mode_available") {
+      if (message.kind === "tweaks_available") {
         setTweaksAvailable(true);
         return;
       }
 
       // Tweaks protocol: collect persisted edits
-      if (data.type === "__edit_mode_set_keys" && data.edits) {
+      if (message.kind === "tweaks_persist") {
         // Fire a bridge event so the host can persist tweaks if desired
-        onBridgeEvent?.({ bridgeType: "tweaks_persist", edits: data.edits });
+        onBridgeEvent?.({ bridgeType: "tweaks_persist", edits: message.edits });
         window.dispatchEvent(
           new CustomEvent("wiii:visual-frame", {
-            detail: { bridgeType: "tweaks_persist", edits: data.edits },
+            detail: { bridgeType: "tweaks_persist", edits: message.edits },
           }),
         );
         return;
       }
 
-      if (data.type === "wiii-frame-resize") {
-        const nextHeight = (data.payload as { height?: number } | undefined)
-          ?.height;
-        if (typeof nextHeight === "number" && nextHeight > 0) {
-          const minHeight = frameKind === "app" ? 360 : 120;
-          const maxHeight = frameKind === "app" ? 1120 : 880;
-          setHeight(
-            Math.min(Math.max(nextHeight + 10, minHeight), maxHeight),
-          );
+      if (message.kind === "resize") {
+        const nextHeight = clampVisualFrameContentHeight(
+          message.height,
+          heightProfile,
+        );
+        if (nextHeight !== null) {
+          setHeight(nextHeight);
         }
         return;
       }
       if (
-        data.type === "wiii-frame-ready" &&
+        message.kind === "ready" &&
         iframeRef.current?.contentWindow
       ) {
         iframeRef.current.contentWindow.postMessage(
@@ -743,31 +786,16 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
         );
         return;
       }
-      if (
-        data.type === "wiii-frame-telemetry" ||
-        data.type === "wiii-frame-interaction" ||
-        data.type === "wiii-frame-control" ||
-        data.type === "wiii-frame-focus" ||
-        data.type === "wiii-frame-result"
-      ) {
-        const bridgeType =
-          data.type === "wiii-frame-telemetry"
-            ? "telemetry"
-            : data.type === "wiii-frame-control"
-              ? "control"
-              : data.type === "wiii-frame-focus"
-                ? "focus"
-                : data.type === "wiii-frame-result"
-                  ? "result"
-                  : "interaction";
-        const detail = { bridgeType, ...(data.payload || {}) };
-        onBridgeEvent?.(detail);
-        window.dispatchEvent(new CustomEvent("wiii:visual-frame", { detail }));
+      if (message.kind === "bridge") {
+        onBridgeEvent?.(message.detail);
+        window.dispatchEvent(
+          new CustomEvent("wiii:visual-frame", { detail: message.detail }),
+        );
       }
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
-  }, [frameKind, onBridgeEvent, runtimeManifest, sessionId, shellVariant]);
+  }, [frameKind, heightProfile, onBridgeEvent, runtimeManifest, sessionId, shellVariant]);
 
   // Tweaks toggle: send activate/deactivate to iframe
   const handleTweaksToggle = useCallback(() => {
@@ -809,17 +837,14 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
       : shellVariant === "editorial"
         ? "overflow-visible bg-transparent"
         : "overflow-clip rounded-2xl bg-transparent";
-  const iframeMinHeight = frameKind === "app" ? 360 : 120;
-  const iframeHeight =
-    frameKind === "app" && /\bh-full\b/.test(className)
-      ? `max(${height}px, 100%)`
-      : `${height}px`;
+  const iframeHeight = resolveVisualFrameCssHeight(height, heightProfile);
 
   return (
     <div
       className={`${wrapperClassName} ${className}`.trim()}
       data-inline-visual-frame={frameKind}
       data-inline-visual-shell={shellVariant}
+      data-inline-visual-sizing={sizingMode}
       style={{ position: "relative" }}
     >
       {/* eslint-disable-next-line react/iframe-missing-sandbox */}
@@ -832,7 +857,7 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
         style={{
           width: "100%",
           height: iframeHeight,
-          minHeight: `${iframeMinHeight}px`,
+          minHeight: `${heightProfile.minHeight}px`,
           border: "none",
           display: "block",
           background: "transparent",

--- a/wiii-desktop/src/components/layout/CodeStudioPanel.tsx
+++ b/wiii-desktop/src/components/layout/CodeStudioPanel.tsx
@@ -371,13 +371,14 @@ function PreviewTab({ session }: { session: CodeStudioSession }) {
   }
 
   return (
-    <div className="h-full">
+    <div className="h-full min-h-0 code-studio-panel__preview">
       <InlineVisualFrame
         html={session.code}
         title={session.title}
         sessionId={session.sessionId}
         className="w-full h-full"
         frameKind="app"
+        sizingMode="viewport"
         shellVariant="immersive"
         hostShellMode="force"
         showTweaksToggle

--- a/wiii-desktop/src/lib/visual-frame-contract.ts
+++ b/wiii-desktop/src/lib/visual-frame-contract.ts
@@ -1,0 +1,127 @@
+export type VisualFrameKind = "legacy" | "inline_html" | "app";
+export type VisualFrameSizingMode = "content" | "viewport";
+
+export interface VisualFrameHeightProfile {
+  initialHeight: number;
+  minHeight: number;
+  maxHeight: number;
+  sizingMode: VisualFrameSizingMode;
+}
+
+export type VisualFrameBridgeMessage =
+  | { kind: "tweaks_available" }
+  | { kind: "tweaks_persist"; edits: Record<string, unknown> }
+  | { kind: "resize"; height: number; sessionId?: string }
+  | { kind: "ready" }
+  | {
+      kind: "bridge";
+      bridgeType: "telemetry" | "interaction" | "control" | "focus" | "result";
+      detail: Record<string, unknown>;
+    };
+
+const CONTENT_FRAME_HEIGHT: Record<VisualFrameKind, Omit<VisualFrameHeightProfile, "sizingMode">> = {
+  legacy: { initialHeight: 320, minHeight: 120, maxHeight: 880 },
+  inline_html: { initialHeight: 320, minHeight: 120, maxHeight: 880 },
+  app: { initialHeight: 520, minHeight: 360, maxHeight: 1120 },
+};
+
+const VIEWPORT_FRAME_HEIGHT: Record<VisualFrameKind, Omit<VisualFrameHeightProfile, "sizingMode">> = {
+  legacy: { initialHeight: 320, minHeight: 0, maxHeight: 880 },
+  inline_html: { initialHeight: 320, minHeight: 0, maxHeight: 880 },
+  app: { initialHeight: 520, minHeight: 0, maxHeight: 1120 },
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function resolveVisualFrameSizingMode(
+  _frameKind: VisualFrameKind,
+  requested?: VisualFrameSizingMode,
+): VisualFrameSizingMode {
+  if (requested) return requested;
+  return "content";
+}
+
+export function getVisualFrameHeightProfile(
+  frameKind: VisualFrameKind,
+  sizingMode: VisualFrameSizingMode,
+): VisualFrameHeightProfile {
+  const source =
+    sizingMode === "viewport"
+      ? VIEWPORT_FRAME_HEIGHT[frameKind]
+      : CONTENT_FRAME_HEIGHT[frameKind];
+  return { ...source, sizingMode };
+}
+
+export function clampVisualFrameContentHeight(
+  nextHeight: number,
+  profile: VisualFrameHeightProfile,
+): number | null {
+  if (!Number.isFinite(nextHeight) || nextHeight <= 0) return null;
+  if (profile.sizingMode === "viewport") return null;
+  return Math.min(Math.max(nextHeight + 10, profile.minHeight), profile.maxHeight);
+}
+
+export function resolveVisualFrameCssHeight(
+  height: number,
+  profile: VisualFrameHeightProfile,
+): string {
+  if (profile.sizingMode === "viewport") return "100%";
+  return `${height}px`;
+}
+
+export function parseVisualFrameBridgeMessage(
+  data: unknown,
+): VisualFrameBridgeMessage | null {
+  const record = asRecord(data);
+  if (!record || typeof record.type !== "string") return null;
+
+  if (record.type === "__edit_mode_available") {
+    return { kind: "tweaks_available" };
+  }
+
+  if (record.type === "__edit_mode_set_keys") {
+    const edits = asRecord(record.edits);
+    return edits ? { kind: "tweaks_persist", edits } : null;
+  }
+
+  if (record.type === "wiii-frame-resize") {
+    const payload = asRecord(record.payload);
+    if (!payload) return null;
+    const height = payload.height;
+    if (typeof height !== "number") return null;
+    return {
+      kind: "resize",
+      height,
+      sessionId:
+        typeof payload.sessionId === "string" ? payload.sessionId : undefined,
+    };
+  }
+
+  if (record.type === "wiii-frame-ready") {
+    return { kind: "ready" };
+  }
+
+  const bridgeType =
+    record.type === "wiii-frame-telemetry"
+      ? "telemetry"
+      : record.type === "wiii-frame-control"
+        ? "control"
+        : record.type === "wiii-frame-focus"
+          ? "focus"
+          : record.type === "wiii-frame-result"
+            ? "result"
+            : record.type === "wiii-frame-interaction"
+              ? "interaction"
+              : null;
+
+  if (!bridgeType) return null;
+  return {
+    kind: "bridge",
+    bridgeType,
+    detail: { bridgeType, ...(asRecord(record.payload) || {}) },
+  };
+}

--- a/wiii-desktop/src/styles/globals.css
+++ b/wiii-desktop/src/styles/globals.css
@@ -1083,6 +1083,16 @@ html.dark .shiki span {
   background: color-mix(in srgb, var(--surface-secondary) 50%, var(--surface));
 }
 
+.code-studio-panel__preview {
+  height: 100%;
+  min-height: 0;
+}
+
+.code-studio-panel__preview [data-inline-visual-sizing="viewport"] {
+  height: 100%;
+  min-height: 0;
+}
+
 /* Blinking cursor during streaming */
 .code-studio-cursor {
   display: inline-block;


### PR DESCRIPTION
## Summary
- Extract typed visual-frame sizing and bridge-message helpers for iframe runtime events.
- Keep inline visuals content-sized by default, while Code Studio preview uses viewport sizing so tall app content scrolls inside the sandbox instead of being clipped by the host panel.
- Add vitest rendering/contract coverage and Playwright assertions that Code Studio iframe previews expose `data-inline-visual-sizing="viewport"` and `height: 100%`.

Closes #579

## Scope
In scope:
- `InlineVisualFrame` sizing/bridge handling.
- `CodeStudioPanel` preview sizing mode.
- Focused vitest + Playwright harness updates.

Out of scope:
- Backend visual generation prompts.
- LMS host action contracts.
- Deployment changes.

## Verification
- `cd wiii-desktop && npx vitest run src/__tests__/visual-frame-contract.test.ts src/__tests__/inline-visual-frame.test.ts src/__tests__/inline-visual-frame-rendering.test.tsx src/__tests__/code-studio-panel.test.tsx` -> 4 files / 12 tests passed.
- `cd wiii-desktop && npx tsc --noEmit` -> passed.
- `cd wiii-desktop && npm run build:embed` -> passed; existing Vite chunk-size/dynamic-import warnings only.
- `cd wiii-desktop && npx playwright test -c playwright.visual.config.ts playwright/code-studio-runtime.spec.ts --grep "simulation: con l?c"` -> 1 passed.
- `git diff --check` and `git diff --cached --check` -> passed.

## Visual Evidence
- Local Playwright screenshot captured at `wiii-desktop/test-results/code-studio-runtime-Phase--5f5c0-?-Code-Studio-or-iframe-app/routing-pendulum.png`.

## Risk / Rollback
Frontend-only iframe sizing contract change. No backend, auth, memory, tenant, database, or deployment behavior is changed. Roll back by reverting this PR if a preview regression appears.

## Reviewer Focus
- Confirm `viewport` sizing is only used by Code Studio panel previews.
- Confirm inline app/article visuals preserve content-fit behavior.
- Confirm bridge-message parsing stays backward compatible with existing iframe events.
