### PR TITLE
refactor(backend): unify visual app category inference

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/visual_intent_resolver.py
+++ b/maritime-ai-service/app/engine/multi_agent/visual_intent_resolver.py
@@ -35,6 +35,9 @@ from app.engine.multi_agent.visual_intent_support import (
     metadata_value_impl,
     normalize_impl,
 )
+from app.engine.tools.code_studio_app_intent_contract import (
+    infer_code_studio_app_category as infer_code_studio_app_category_contract,
+)
 VisualMode = Literal["text", "mermaid", "template", "inline_html", "app"]
 PresentationIntent = Literal["text", "article_figure", "chart_runtime", "code_studio_app", "artifact"]
 StudioLane = Literal["app", "artifact", "widget"]
@@ -125,24 +128,13 @@ def _infer_followup_simulation_type(normalized: str) -> str | None:
     )
 
 def _infer_code_studio_app_category(normalized: str, *, visual_type: str | None = None) -> str:
-    if visual_type == "simulation" or _contains_any(
-        normalized,
-        _SIMULATION_APP_CUES + _SIMULATION_PATCH_CUES + _SCENE_SIMULATION_CUES,
-    ):
-        return "simulation"
-    if visual_type == "quiz" or _contains_any(normalized, _QUIZ_WIDGET_CUES):
-        return "quiz"
-    if visual_type == "interactive_table" or _contains_any(normalized, _INTERACTIVE_TABLE_CUES):
-        return "interactive_table"
-    if _contains_any(normalized, _SEARCH_WIDGET_CUES):
-        return "search_widget"
-    if _contains_any(normalized, _CODE_WIDGET_CUES):
-        return "code_widget"
-    if _contains_any(normalized, _DASHBOARD_APP_CUES):
-        return "dashboard"
-    if _contains_any(normalized, _MINI_TOOL_CUES):
-        return "mini_tool"
-    return "mini_tool"
+    return infer_code_studio_app_category_contract(
+        presentation_intent="code_studio_app",
+        studio_lane="app",
+        requested_visual_type=visual_type or "",
+        user_query=normalized,
+        planning_profile="simulation_canvas" if visual_type == "simulation" else "",
+    )
 
 def detect_visual_patch_request(query: str) -> bool:
     """Return True when the query looks like a follow-up edit to an existing visual."""

--- a/maritime-ai-service/tests/unit/test_visual_intent_resolver.py
+++ b/maritime-ai-service/tests/unit/test_visual_intent_resolver.py
@@ -6,6 +6,7 @@ from app.engine.multi_agent.visual_intent_resolver import (
     preferred_visual_tool_name,
     resolve_visual_intent,
 )
+from app.engine.tools.code_studio_app_intent_contract import infer_code_studio_app_category
 
 
 def test_resolves_comparison_visual():
@@ -255,6 +256,32 @@ def test_search_widget_request_routes_to_typed_app_category():
     assert decision.visual_type == "react_app"
     assert decision.app_category == "search_widget"
     assert decision.preferred_tool == "tool_create_visual_code"
+
+
+def test_code_studio_app_categories_match_typed_contract():
+    cases = (
+        ("Hay mo phong vat ly con lac co the keo tha", "simulation"),
+        ("Tao cho minh quizz gom 30 cau hoi ve tieng Trung de luyen tap", "quiz"),
+        ("Tao dashboard app HTML cho chien dich nay", "dashboard"),
+        ("Tao interactive table co filter va sort cho danh sach hoc vien", "interactive_table"),
+        ("Tao search widget tim kiem tai lieu trong chat", "search_widget"),
+        ("Tao code widget HTML co editor va preview trong chat", "code_widget"),
+        ("Tao mini tool tinh toan do lech hang hai", "mini_tool"),
+    )
+
+    for prompt, expected_category in cases:
+        decision = resolve_visual_intent(prompt)
+        contract_category = infer_code_studio_app_category(
+            presentation_intent=decision.presentation_intent,
+            studio_lane=decision.studio_lane or "",
+            requested_visual_type=decision.visual_type or "",
+            user_query=prompt,
+            planning_profile=decision.planning_profile,
+        )
+
+        assert decision.presentation_intent == "code_studio_app"
+        assert decision.app_category == expected_category
+        assert contract_category == expected_category
 
 
 def test_ignores_false_positive_visual_terms():


### PR DESCRIPTION
## Summary
- delegate visual resolver app-category inference to the typed Code Studio app-intent contract
- keep resolver lane selection unchanged while removing duplicate category cue logic
- add a drift-prevention test covering simulation, quiz, dashboard, table, search widget, code widget, and mini tool categories

## Verification
- `cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_visual_intent_resolver.py tests/unit/test_code_studio_app_intent_contract.py tests/unit/test_visual_code_runtime_contract.py tests/unit/test_code_studio_scaffold_fallback_policy.py -q --tb=short` -> 53 passed
- `cd maritime-ai-service && uv run --python 3.12 --extra dev ruff check app/engine/multi_agent/visual_intent_resolver.py tests/unit/test_visual_intent_resolver.py --select=E9,F63,F7,F82` -> passed
- `git diff --check` -> passed

## Risk / Rollback
- Risk: app category metadata could shift if the typed contract has different lexical coverage than the previous private helper. Existing and new targeted tests cover the important Code Studio categories.
- Rollback: revert this PR; no migration, deployment config, or persistent data shape changes.

Closes #583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Upgraded the presentation intent categorization system from rule-based heuristics to contract-driven validation approach, enhancing accuracy, consistency, and maintainability of app category determination across the system

* **Tests**
  * Added comprehensive validation tests ensuring proper app categorization against specification contracts, covering diverse user input scenarios and category matching requirements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->