### PR TITLE
fix(desktop): restore Vietnamese visual UI copy

### DIFF
--- a/wiii-desktop/src/__tests__/inline-visual-frame-rendering.test.tsx
+++ b/wiii-desktop/src/__tests__/inline-visual-frame-rendering.test.tsx
@@ -52,4 +52,14 @@ describe("InlineVisualFrame rendering contract", () => {
     expect((iframe as HTMLIFrameElement).style.height).toBe("520px");
     expect((iframe as HTMLIFrameElement).style.minHeight).toBe("360px");
   });
+
+  it("uses Vietnamese copy for frame creation errors", async () => {
+    URL.createObjectURL = vi.fn(() => {
+      throw new Error("blob failed");
+    });
+
+    render(<InlineVisualFrame html="<main>Broken</main>" title="Broken" />);
+
+    expect(await screen.findByText("Lỗi frame: blob failed")).toBeTruthy();
+  });
 });

--- a/wiii-desktop/src/__tests__/visual-block-copy.test.tsx
+++ b/wiii-desktop/src/__tests__/visual-block-copy.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { VisualBlock } from "@/components/chat/VisualBlock";
+import type { VisualBlockData, VisualPayload } from "@/api/types";
+import { useChatStore } from "@/stores/chat-store";
+import { useCodeStudioStore } from "@/stores/code-studio-store";
+import { useUIStore } from "@/stores/ui-store";
+
+vi.mock("@/components/common/InlineVisualFrame", () => ({
+  InlineVisualFrame: ({ title }: { title?: string }) => (
+    <div data-testid="inline-visual-frame">{title}</div>
+  ),
+}));
+
+vi.mock("@/hooks/useReducedMotion", () => ({
+  useReducedMotion: () => true,
+}));
+
+function makeVisual(overrides: Partial<VisualPayload> = {}): VisualPayload {
+  return {
+    id: "visual-copy-1",
+    visual_session_id: "vs-copy-1",
+    type: "concept",
+    renderer_kind: "app",
+    shell_variant: "immersive",
+    patch_strategy: "app_state",
+    figure_group_id: "fg-copy",
+    figure_index: 1,
+    figure_total: 1,
+    pedagogical_role: "mechanism",
+    chrome_mode: "app",
+    claim: "Mô phỏng tương tác",
+    presentation_intent: "code_studio_app",
+    figure_budget: 1,
+    quality_profile: "standard",
+    renderer_contract: "host_shell",
+    studio_lane: "app",
+    artifact_kind: "html_app",
+    narrative_anchor: "after-lead",
+    runtime: "sandbox_html",
+    title: "Mô phỏng tương tác",
+    summary: "Khung mô phỏng có thể mở thành artifact.",
+    spec: {},
+    scene: { kind: "concept", nodes: [], links: [] },
+    controls: [],
+    annotations: [],
+    interaction_mode: "static",
+    ephemeral: true,
+    lifecycle_event: "visual_open",
+    fallback_html: "<main>Mô phỏng</main>",
+    artifact_handoff_available: true,
+    artifact_handoff_mode: "followup_prompt",
+    artifact_handoff_label: null,
+    artifact_handoff_prompt: "Mở visual này thành artifact",
+    ...overrides,
+  };
+}
+
+describe("VisualBlock copy", () => {
+  beforeEach(() => {
+    useChatStore.setState({
+      visualSessions: {},
+      isStreaming: false,
+    });
+    useCodeStudioStore.setState({
+      activeSessionId: null,
+      sessions: {},
+    });
+    useUIStore.setState({
+      codeStudioPanelOpen: false,
+    });
+  });
+
+  it("uses Vietnamese copy for the default artifact handoff action", () => {
+    const block: VisualBlockData = {
+      type: "visual",
+      id: "block-copy-1",
+      visual: makeVisual(),
+      status: "committed",
+    };
+
+    render(<VisualBlock block={block} onSuggestedQuestion={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Mở thành Artifact" })).toBeTruthy();
+  });
+});

--- a/wiii-desktop/src/components/chat/VisualBlock.tsx
+++ b/wiii-desktop/src/components/chat/VisualBlock.tsx
@@ -530,10 +530,10 @@ function VisualActionBar({
           className="visual-action-bar__button visual-action-bar__button--artifact"
           onClick={requestArtifactHandoff}
           disabled={isStreaming}
-          aria-label={artifactHandoffLabel || "Mo thanh Artifact"}
+          aria-label={artifactHandoffLabel || "Mở thành Artifact"}
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M12 3l1.8 4.5L18 9.3l-4.2 1.8L12 15.6l-1.8-4.5L6 9.3l4.2-1.8L12 3z"/><path d="M19 14l.9 2.1L22 17l-2.1.9L19 20l-.9-2.1L16 17l2.1-.9L19 14z"/><path d="M5 14l.6 1.5L7 16l-1.4.5L5 18l-.6-1.5L3 16l1.4-.5L5 14z"/></svg>
-          {artifactHandoffLabel || "Mo thanh Artifact"}
+          {artifactHandoffLabel || "Mở thành Artifact"}
         </button>
       )}
       {hasCodeStudioSession && (

--- a/wiii-desktop/src/components/common/InlineVisualFrame.tsx
+++ b/wiii-desktop/src/components/common/InlineVisualFrame.tsx
@@ -205,7 +205,7 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
       <div
         className={`rounded-[20px] border border-red-200 bg-red-50 px-4 py-4 text-sm text-red-700 ${className}`}
       >
-        Loi frame: {error}
+        Lỗi frame: {error}
       </div>
     );
   }
@@ -260,8 +260,8 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
               ? "bg-[var(--accent)] text-white shadow-md"
               : "bg-white/90 text-text-secondary border border-border shadow-sm hover:bg-white hover:border-[var(--accent)]/40"
           }`}
-          title={tweaksActive ? "Tat Tweaks" : "Tuy chinh Tweaks"}
-          aria-label={tweaksActive ? "Deactivate Tweaks" : "Activate Tweaks"}
+          title={tweaksActive ? "Tắt Tweaks" : "Tùy chỉnh Tweaks"}
+          aria-label={tweaksActive ? "Tắt Tweaks" : "Bật Tweaks"}
           aria-pressed={tweaksActive}
         >
           <svg


### PR DESCRIPTION
## Summary
- restore Vietnamese-first copy in the visual iframe error state, Tweaks labels, and default artifact handoff action
- add regression coverage for iframe error copy and VisualBlock artifact handoff copy
- keep markdown cleanup coverage with real Vietnamese accented text

## Verification
- `cd wiii-desktop && npx vitest run src/__tests__/inline-visual-frame-rendering.test.tsx src/__tests__/visual-block-copy.test.tsx src/__tests__/assistant-markdown.test.ts src/__tests__/assistant-markdown-rendering.test.tsx` -> 4 files / 10 tests passed
- `cd wiii-desktop && npx tsc --noEmit` -> passed
- `git diff --check` -> passed

## Risk / Rollback
- Risk is limited to visible UI copy and tests around visual frames/action labels.
- Rollback is revert of this PR; no backend, migration, deployment, or persisted state change.

Closes #585