### PR TITLE
refactor(backend): type direct node pre-LLM pipeline

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_pre_llm_pipeline.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_pre_llm_pipeline.py
@@ -48,6 +48,49 @@ class DirectNodePreLlmPipelineResult:
     sanitize_document_preview_response: Callable[[str, list[dict[str, Any]]], str]
 
 
+@dataclass(frozen=True, slots=True)
+class DirectNodePreLlmPipelineRequest:
+    """Per-turn input for deterministic direct-node pre-LLM stages."""
+
+    query: str
+    state: AgentState
+    bus_id: str | None
+    push_event: Callable[..., Any]
+    tracer: Any
+    enable_natural_conversation: bool
+    default_domain: str
+
+
+@dataclass(frozen=True, slots=True)
+class DirectNodePreLlmPipelineDependencies:
+    """Injected contracts used by document/image/fast-response pre-LLM stages."""
+
+    get_domain_greetings: Callable[[str], dict[str, str]]
+    normalize_for_intent: Callable[[str], str]
+    needs_web_search: Callable[[str], bool]
+    needs_datetime: Callable[[str], bool]
+    build_visual_tool_runtime_metadata: Callable[..., dict[str, Any]]
+    execute_direct_tool_rounds: Callable[..., Any]
+    extract_direct_response: Callable[..., Any]
+    sanitize_structured_visual_answer_text: Callable[..., str]
+    sanitize_wiii_house_text: Callable[..., str]
+    record_thinking_snapshot_fn: Callable[..., Any]
+    logger_obj: logging.Logger
+    start_turn_fn: Callable[..., Any] = start_direct_node_turn
+    has_uploaded_document_context_fn: Callable[[dict[str, Any]], bool] = (
+        _has_uploaded_document_context
+    )
+    build_preview_sanitizer_fn: Callable[..., Callable[..., str]] = (
+        build_document_preview_response_sanitizer
+    )
+    record_document_plan_fn: Callable[..., None] = record_uploaded_document_context_plan
+    document_preview_preflight_fn: Callable[..., Any] = (
+        execute_direct_node_document_preview_preflight
+    )
+    image_input_preflight_fn: Callable[..., Any] = execute_direct_node_image_input_preflight
+    fast_response_fn: Callable[..., Any] = resolve_direct_node_fast_response
+
+
 def _resolve_domain_name_vi(
     *,
     state: AgentState,
@@ -67,66 +110,40 @@ def _resolve_domain_name_vi(
 
 async def execute_direct_node_pre_llm_pipeline(
     *,
-    query: str,
-    state: AgentState,
-    bus_id: str | None,
-    push_event: Callable[..., Any],
-    tracer: Any,
-    enable_natural_conversation: bool,
-    default_domain: str,
-    get_domain_greetings: Callable[[str], dict[str, str]],
-    normalize_for_intent: Callable[[str], str],
-    needs_web_search: Callable[[str], bool],
-    needs_datetime: Callable[[str], bool],
-    build_visual_tool_runtime_metadata: Callable[..., dict[str, Any]],
-    execute_direct_tool_rounds: Callable[..., Any],
-    extract_direct_response: Callable[..., Any],
-    sanitize_structured_visual_answer_text: Callable[..., str],
-    sanitize_wiii_house_text: Callable[..., str],
-    record_thinking_snapshot_fn: Callable[..., Any],
-    logger_obj: logging.Logger,
-    start_turn_fn: Callable[..., Any] = start_direct_node_turn,
-    has_uploaded_document_context_fn: Callable[[dict[str, Any]], bool] = (
-        _has_uploaded_document_context
-    ),
-    build_preview_sanitizer_fn: Callable[..., Callable[..., str]] = (
-        build_document_preview_response_sanitizer
-    ),
-    record_document_plan_fn: Callable[..., None] = (
-        record_uploaded_document_context_plan
-    ),
-    document_preview_preflight_fn: Callable[..., Any] = (
-        execute_direct_node_document_preview_preflight
-    ),
-    image_input_preflight_fn: Callable[..., Any] = (
-        execute_direct_node_image_input_preflight
-    ),
-    fast_response_fn: Callable[..., Any] = resolve_direct_node_fast_response,
+    request: DirectNodePreLlmPipelineRequest,
+    dependencies: DirectNodePreLlmPipelineDependencies,
 ) -> DirectNodePreLlmPipelineResult:
     """Run deterministic direct-node work before provider/tool-loop execution."""
 
-    turn_start = start_turn_fn(
+    query = request.query
+    state = request.state
+    ctx_for_preflight = (
+        state.get("context", {}) if isinstance(state.get("context"), dict) else {}
+    )
+
+    turn_start = dependencies.start_turn_fn(
         query=query,
         state=state,
-        enable_natural_conversation=enable_natural_conversation,
-        default_domain=default_domain,
-        get_domain_greetings=get_domain_greetings,
-        record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+        enable_natural_conversation=request.enable_natural_conversation,
+        default_domain=request.default_domain,
+        get_domain_greetings=dependencies.get_domain_greetings,
+        record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
     )
     query_lower = turn_start.query_lower
     response = turn_start.response
     response_type = turn_start.response_type
     explicit_web_search_turn = turn_start.explicit_web_search_turn
 
-    ctx_for_preflight = (
-        state.get("context", {}) if isinstance(state.get("context"), dict) else {}
+    has_uploaded_document_context = dependencies.has_uploaded_document_context_fn(
+        ctx_for_preflight
     )
-    has_uploaded_document_context = has_uploaded_document_context_fn(ctx_for_preflight)
 
-    sanitize_document_preview_response = build_preview_sanitizer_fn(
+    sanitize_document_preview_response = dependencies.build_preview_sanitizer_fn(
         query=query,
-        sanitize_structured_visual_answer_text=sanitize_structured_visual_answer_text,
-        sanitize_wiii_house_text=sanitize_wiii_house_text,
+        sanitize_structured_visual_answer_text=(
+            dependencies.sanitize_structured_visual_answer_text
+        ),
+        sanitize_wiii_house_text=dependencies.sanitize_wiii_house_text,
         strip_direct_inline_private_asides=_strip_direct_inline_private_asides,
         strip_dsml_residue=_strip_dsml_residue,
     )
@@ -136,60 +153,62 @@ async def execute_direct_node_pre_llm_pipeline(
         "nên ưu tiên đối chiếu marker, bảng và các dòng trong document_context trước khi suy luận thêm. "
         "Nếu phần nào không có trong file, Wiii phải nói rõ thay vì bịa."
     )
-    record_document_plan_fn(
+    dependencies.record_document_plan_fn(
         state=state,
         response_present=bool(response),
         has_uploaded_document_context=has_uploaded_document_context,
         document_thinking=document_thinking,
-        record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+        record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
     )
 
-    document_preflight_result = await document_preview_preflight_fn(
+    document_preflight_result = await dependencies.document_preview_preflight_fn(
         query=query,
         state=state,
         ctx=ctx_for_preflight,
-        bus_id=bus_id,
+        bus_id=request.bus_id,
         response_present=bool(response),
         has_uploaded_document_context=has_uploaded_document_context,
         looks_uploaded_document_preview_request=_looks_uploaded_document_preview_request,
-        push_event=push_event,
-        build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
-        execute_direct_tool_rounds=execute_direct_tool_rounds,
-        extract_direct_response=extract_direct_response,
+        push_event=request.push_event,
+        build_visual_tool_runtime_metadata=(
+            dependencies.build_visual_tool_runtime_metadata
+        ),
+        execute_direct_tool_rounds=dependencies.execute_direct_tool_rounds,
+        extract_direct_response=dependencies.extract_direct_response,
         sanitize_preview_response=sanitize_document_preview_response,
         fallback_response=(
             "Mình đã gửi bản preview bài học sang LMS. "
             "Giáo viên cần xem phần so sánh thay đổi và nguồn trích dẫn rồi bấm Áp dụng để cấp approval_token."
         ),
-        logger_obj=logger_obj,
+        logger_obj=dependencies.logger_obj,
     )
     if document_preflight_result is not None:
         response = document_preflight_result.response
         response_type = document_preflight_result.response_type
 
-    image_preflight_result = await image_input_preflight_fn(
+    image_preflight_result = await dependencies.image_input_preflight_fn(
         query=query,
         state=state,
         ctx=ctx_for_preflight,
         response_present=bool(response),
         has_uploaded_document_context=has_uploaded_document_context,
-        record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+        record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
     )
     if image_preflight_result is not None:
         response = image_preflight_result.response
         response_type = image_preflight_result.response_type
 
     if not response:
-        fast_response = fast_response_fn(
+        fast_response = dependencies.fast_response_fn(
             query=query,
             state=state,
             ctx=ctx_for_preflight,
             has_uploaded_document_context=has_uploaded_document_context,
-            normalize_for_intent=normalize_for_intent,
-            needs_web_search=needs_web_search,
-            needs_datetime=needs_datetime,
-            record_thinking_snapshot_fn=record_thinking_snapshot_fn,
-            logger_obj=logger_obj,
+            normalize_for_intent=dependencies.normalize_for_intent,
+            needs_web_search=dependencies.needs_web_search,
+            needs_datetime=dependencies.needs_datetime,
+            record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
+            logger_obj=dependencies.logger_obj,
         )
         if fast_response is not None:
             response = fast_response.response
@@ -197,11 +216,11 @@ async def execute_direct_node_pre_llm_pipeline(
 
     domain_name_vi = _resolve_domain_name_vi(
         state=state,
-        default_domain=default_domain,
+        default_domain=request.default_domain,
     )
 
     if response:
-        tracer.end_step(
+        request.tracer.end_step(
             result=f"Direct fast response: {response[:50]}...",
             confidence=1.0,
             details={"response_type": response_type or "greeting", "query": query_lower},

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -33,6 +33,8 @@ from app.engine.multi_agent.direct_node_operational_fast_paths import (
     _build_codebase_analysis_fallback_thinking,
 )
 from app.engine.multi_agent.direct_node_pre_llm_pipeline import (
+    DirectNodePreLlmPipelineDependencies,
+    DirectNodePreLlmPipelineRequest,
     execute_direct_node_pre_llm_pipeline,
 )
 from app.engine.multi_agent.direct_node_thinking_snapshot import (
@@ -106,26 +108,30 @@ async def direct_response_node_impl(
     tracer.start_step(direct_response_step_name, "Tao phan hoi truc tiep")
 
     pre_llm_pipeline = await execute_direct_node_pre_llm_pipeline(
-        query=query,
-        state=state,
-        bus_id=bus_id,
-        push_event=push_event,
-        tracer=tracer,
-        enable_natural_conversation=(
-            getattr(settings, "enable_natural_conversation", False) is True
+        request=DirectNodePreLlmPipelineRequest(
+            query=query,
+            state=state,
+            bus_id=bus_id,
+            push_event=push_event,
+            tracer=tracer,
+            enable_natural_conversation=(
+                getattr(settings, "enable_natural_conversation", False) is True
+            ),
+            default_domain=settings.default_domain,
         ),
-        default_domain=settings.default_domain,
-        get_domain_greetings=get_domain_greetings,
-        normalize_for_intent=normalize_for_intent,
-        needs_web_search=needs_web_search,
-        needs_datetime=needs_datetime,
-        build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
-        execute_direct_tool_rounds=execute_direct_tool_rounds,
-        extract_direct_response=extract_direct_response,
-        sanitize_structured_visual_answer_text=sanitize_structured_visual_answer_text,
-        sanitize_wiii_house_text=sanitize_wiii_house_text,
-        record_thinking_snapshot_fn=record_thinking_snapshot,
-        logger_obj=logger,
+        dependencies=DirectNodePreLlmPipelineDependencies(
+            get_domain_greetings=get_domain_greetings,
+            normalize_for_intent=normalize_for_intent,
+            needs_web_search=needs_web_search,
+            needs_datetime=needs_datetime,
+            build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
+            execute_direct_tool_rounds=execute_direct_tool_rounds,
+            extract_direct_response=extract_direct_response,
+            sanitize_structured_visual_answer_text=sanitize_structured_visual_answer_text,
+            sanitize_wiii_house_text=sanitize_wiii_house_text,
+            record_thinking_snapshot_fn=record_thinking_snapshot,
+            logger_obj=logger,
+        ),
     )
     response = pre_llm_pipeline.response
     explicit_web_search_turn = pre_llm_pipeline.explicit_web_search_turn

--- a/maritime-ai-service/tests/unit/test_direct_node_pre_llm_pipeline.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_pre_llm_pipeline.py
@@ -4,8 +4,42 @@ from unittest.mock import MagicMock
 import pytest
 
 from app.engine.multi_agent.direct_node_pre_llm_pipeline import (
+    DirectNodePreLlmPipelineDependencies,
+    DirectNodePreLlmPipelineRequest,
     execute_direct_node_pre_llm_pipeline,
 )
+
+
+def _build_request(**overrides):
+    values = {
+        "query": "tao bai hoc",
+        "state": {"context": {}},
+        "bus_id": None,
+        "push_event": lambda *_args, **_kwargs: None,
+        "tracer": MagicMock(),
+        "enable_natural_conversation": True,
+        "default_domain": "maritime",
+    }
+    values.update(overrides)
+    return DirectNodePreLlmPipelineRequest(**values)
+
+
+def _build_dependencies(**overrides):
+    values = {
+        "get_domain_greetings": lambda _domain: {},
+        "normalize_for_intent": lambda text: text,
+        "needs_web_search": lambda _text: False,
+        "needs_datetime": lambda _text: False,
+        "build_visual_tool_runtime_metadata": lambda *_args, **_kwargs: {},
+        "execute_direct_tool_rounds": lambda *_args, **_kwargs: None,
+        "extract_direct_response": lambda *_args, **_kwargs: "",
+        "sanitize_structured_visual_answer_text": lambda text, *_args, **_kwargs: text,
+        "sanitize_wiii_house_text": lambda text, *_args, **_kwargs: text,
+        "record_thinking_snapshot_fn": lambda *_args, **_kwargs: None,
+        "logger_obj": MagicMock(),
+    }
+    values.update(overrides)
+    return DirectNodePreLlmPipelineDependencies(**values)
 
 
 @pytest.mark.asyncio
@@ -50,31 +84,16 @@ async def test_pre_llm_pipeline_preserves_document_then_image_order():
         raise AssertionError("fast response should not run after document preview")
 
     result = await execute_direct_node_pre_llm_pipeline(
-        query="tao bai hoc",
-        state=state,
-        bus_id="bus-1",
-        push_event=lambda *_args, **_kwargs: None,
-        tracer=tracer,
-        enable_natural_conversation=True,
-        default_domain="maritime",
-        get_domain_greetings=lambda _domain: {},
-        normalize_for_intent=lambda text: text,
-        needs_web_search=lambda _text: False,
-        needs_datetime=lambda _text: False,
-        build_visual_tool_runtime_metadata=lambda *_args, **_kwargs: {},
-        execute_direct_tool_rounds=lambda *_args, **_kwargs: None,
-        extract_direct_response=lambda *_args, **_kwargs: "",
-        sanitize_structured_visual_answer_text=lambda text, *_args, **_kwargs: text,
-        sanitize_wiii_house_text=lambda text, *_args, **_kwargs: text,
-        record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
-        logger_obj=MagicMock(),
-        start_turn_fn=start_turn_fn,
-        has_uploaded_document_context_fn=lambda _ctx: True,
-        build_preview_sanitizer_fn=build_preview_sanitizer_fn,
-        record_document_plan_fn=record_document_plan_fn,
-        document_preview_preflight_fn=document_preview_preflight_fn,
-        image_input_preflight_fn=image_input_preflight_fn,
-        fast_response_fn=fast_response_fn,
+        request=_build_request(state=state, bus_id="bus-1", tracer=tracer),
+        dependencies=_build_dependencies(
+            start_turn_fn=start_turn_fn,
+            has_uploaded_document_context_fn=lambda _ctx: True,
+            build_preview_sanitizer_fn=build_preview_sanitizer_fn,
+            record_document_plan_fn=record_document_plan_fn,
+            document_preview_preflight_fn=document_preview_preflight_fn,
+            image_input_preflight_fn=image_input_preflight_fn,
+            fast_response_fn=fast_response_fn,
+        ),
     )
 
     assert result.response == "Preview da gui."
@@ -99,37 +118,26 @@ async def test_pre_llm_pipeline_uses_fast_response_when_preflights_do_not_answer
         return None
 
     result = await execute_direct_node_pre_llm_pipeline(
-        query="wiii pipeline la gi",
-        state={"context": {}, "domain_id": "custom_domain"},
-        bus_id=None,
-        push_event=lambda *_args, **_kwargs: None,
-        tracer=tracer,
-        enable_natural_conversation=True,
-        default_domain="maritime",
-        get_domain_greetings=lambda _domain: {},
-        normalize_for_intent=lambda text: text,
-        needs_web_search=lambda _text: False,
-        needs_datetime=lambda _text: False,
-        build_visual_tool_runtime_metadata=lambda *_args, **_kwargs: {},
-        execute_direct_tool_rounds=lambda *_args, **_kwargs: None,
-        extract_direct_response=lambda *_args, **_kwargs: "",
-        sanitize_structured_visual_answer_text=lambda text, *_args, **_kwargs: text,
-        sanitize_wiii_house_text=lambda text, *_args, **_kwargs: text,
-        record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
-        logger_obj=MagicMock(),
-        start_turn_fn=lambda **_kwargs: SimpleNamespace(
-            query_lower="wiii pipeline la gi",
-            response=None,
-            response_type="",
-            explicit_web_search_turn=True,
+        request=_build_request(
+            query="wiii pipeline la gi",
+            state={"context": {}, "domain_id": "custom_domain"},
+            tracer=tracer,
         ),
-        has_uploaded_document_context_fn=lambda _ctx: False,
-        record_document_plan_fn=lambda **_kwargs: None,
-        document_preview_preflight_fn=no_document_answer,
-        image_input_preflight_fn=no_image_answer,
-        fast_response_fn=lambda **_kwargs: SimpleNamespace(
-            response="Fast answer.",
-            response_type="wiii_pipeline_meta",
+        dependencies=_build_dependencies(
+            start_turn_fn=lambda **_kwargs: SimpleNamespace(
+                query_lower="wiii pipeline la gi",
+                response=None,
+                response_type="",
+                explicit_web_search_turn=True,
+            ),
+            has_uploaded_document_context_fn=lambda _ctx: False,
+            record_document_plan_fn=lambda **_kwargs: None,
+            document_preview_preflight_fn=no_document_answer,
+            image_input_preflight_fn=no_image_answer,
+            fast_response_fn=lambda **_kwargs: SimpleNamespace(
+                response="Fast answer.",
+                response_type="wiii_pipeline_meta",
+            ),
         ),
     )
 


### PR DESCRIPTION
Closes #591.

## Summary
- Add DirectNodePreLlmPipelineRequest and DirectNodePreLlmPipelineDependencies contracts around deterministic pre-LLM stages.
- Route document preview, image-input preflight, and deterministic fast-response wiring through that typed contract instead of a wide keyword list.
- Update pipeline tests to exercise the new contract boundary while preserving document -> image -> fast-response ordering.

## Verification
- cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_direct_node_pre_llm_pipeline.py tests/unit/test_direct_node_image_input_preflight.py tests/unit/test_direct_node_document_preview_runtime.py -q --tb=short -> 8 passed
- cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_direct_node_provider_errors.py -q --tb=short -> 35 passed
- cd maritime-ai-service && uv run --python 3.12 --extra dev ruff check app/engine/multi_agent/direct_node_pre_llm_pipeline.py app/engine/multi_agent/direct_node_runtime.py tests/unit/test_direct_node_pre_llm_pipeline.py --select=E9,F63,F7,F82 -> passed
- git diff --check -> passed

## Risk / Rollback
- Risk is moderate because this touches direct-node turn setup, but behavior should remain equivalent: stage order and injected functions are unchanged.
- Rollback by reverting this PR if direct-node pre-LLM preview/image/fast-response routing regresses.