### PR TITLE
fix(desktop): harden visual iframe runtime harness

### DIFF
--- a/wiii-desktop/src/__tests__/inline-visual-frame-rendering.test.tsx
+++ b/wiii-desktop/src/__tests__/inline-visual-frame-rendering.test.tsx
@@ -32,6 +32,8 @@ describe("InlineVisualFrame rendering contract", () => {
     await waitFor(() => expect(iframe.getAttribute("src")).toBe("blob:wiii-visual-frame"));
 
     expect(iframe.parentElement?.getAttribute("data-inline-visual-sizing")).toBe("viewport");
+    expect(iframe.parentElement?.style.height).toBe("100%");
+    expect(iframe.parentElement?.style.minHeight).toBe("0px");
     expect((iframe as HTMLIFrameElement).style.height).toBe("100%");
     expect((iframe as HTMLIFrameElement).style.minHeight).toBe("0px");
   });

--- a/wiii-desktop/src/__tests__/inline-visual-frame.test.ts
+++ b/wiii-desktop/src/__tests__/inline-visual-frame.test.ts
@@ -63,4 +63,32 @@ describe("InlineVisualFrame host shell", () => {
     expect(wrapped).toContain("function measureHeight()");
     expect(wrapped).toContain("resizeObserver.observe(document.documentElement)");
   });
+
+  it("strips blocked external font assets before applying the iframe CSP", () => {
+    const wrapped = buildVisualFrameDocument(
+      [
+        "<!DOCTYPE html>",
+        "<html>",
+        "<head>",
+        "<link rel=\"preconnect\" href=\"https://fonts.gstatic.com\">",
+        "<link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css?family=Open+Sans:300,400,600\">",
+        "<style>@import url('https://fonts.googleapis.com/css?family=Roboto'); body{font-family:sans-serif}</style>",
+        "</head>",
+        "<body><main>Preview</main></body>",
+        "</html>",
+      ].join(""),
+      {
+        title: "Preview",
+        sessionId: "vs-fonts",
+        shellVariant: "immersive",
+        frameKind: "app",
+        hostShellMode: "force",
+      },
+    );
+
+    expect(wrapped).not.toContain("fonts.googleapis.com");
+    expect(wrapped).not.toContain("fonts.gstatic.com");
+    expect(wrapped).toContain("Content-Security-Policy");
+    expect(wrapped).toContain("body{font-family:sans-serif}");
+  });
 });

--- a/wiii-desktop/src/__tests__/visual-frame-contract.test.ts
+++ b/wiii-desktop/src/__tests__/visual-frame-contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildVisualFrameHostSyncMessage,
   clampVisualFrameContentHeight,
   getVisualFrameHeightProfile,
   parseVisualFrameBridgeMessage,
@@ -57,5 +58,22 @@ describe("visual frame contract", () => {
       type: "wiii-frame-resize",
       payload: { height: "640" },
     })).toBeNull();
+  });
+
+  it("builds a typed host sync message for app frames", () => {
+    expect(buildVisualFrameHostSyncMessage({
+      sessionId: "vs_1",
+      frameKind: "app",
+      shellVariant: "immersive",
+      runtimeManifest: { storage: "ephemeral" },
+    })).toEqual({
+      type: "wiii-visual-sync",
+      payload: {
+        sessionId: "vs_1",
+        frameKind: "app",
+        shellVariant: "immersive",
+        runtimeManifest: { storage: "ephemeral" },
+      },
+    });
   });
 });

--- a/wiii-desktop/src/components/common/InlineVisualFrame.tsx
+++ b/wiii-desktop/src/components/common/InlineVisualFrame.tsx
@@ -6,6 +6,7 @@ import {
   readHostThemeOverrides,
 } from "@/lib/visual-frame-document";
 import {
+  buildVisualFrameHostSyncMessage,
   clampVisualFrameContentHeight,
   getVisualFrameHeightProfile,
   parseVisualFrameBridgeMessage,
@@ -153,20 +154,14 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
         }
         return;
       }
-      if (
-        message.kind === "ready" &&
-        iframeRef.current?.contentWindow
-      ) {
+      if (message.kind === "ready" && iframeRef.current?.contentWindow) {
         iframeRef.current.contentWindow.postMessage(
-          {
-            type: "wiii-visual-sync",
-            payload: {
-              sessionId,
-              frameKind,
-              shellVariant,
-              runtimeManifest: runtimeManifest || null,
-            },
-          },
+          buildVisualFrameHostSyncMessage({
+            sessionId,
+            frameKind,
+            shellVariant,
+            runtimeManifest: runtimeManifest || null,
+          }),
           "*",
         );
         return;
@@ -230,7 +225,10 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
       data-inline-visual-frame={frameKind}
       data-inline-visual-shell={shellVariant}
       data-inline-visual-sizing={sizingMode}
-      style={{ position: "relative" }}
+      style={{
+        position: "relative",
+        ...(sizingMode === "viewport" ? { height: "100%", minHeight: "0px" } : {}),
+      }}
     >
       {/* eslint-disable-next-line react/iframe-missing-sandbox */}
       <iframe

--- a/wiii-desktop/src/lib/visual-frame-contract.ts
+++ b/wiii-desktop/src/lib/visual-frame-contract.ts
@@ -1,6 +1,18 @@
 export type VisualFrameKind = "legacy" | "inline_html" | "app";
 export type VisualFrameSizingMode = "content" | "viewport";
 
+export interface VisualFrameHostSyncPayload {
+  sessionId: string;
+  frameKind: VisualFrameKind;
+  shellVariant: string;
+  runtimeManifest: unknown | null;
+}
+
+export interface VisualFrameHostSyncMessage {
+  type: "wiii-visual-sync";
+  payload: VisualFrameHostSyncPayload;
+}
+
 export interface VisualFrameHeightProfile {
   initialHeight: number;
   minHeight: number;
@@ -71,6 +83,15 @@ export function resolveVisualFrameCssHeight(
 ): string {
   if (profile.sizingMode === "viewport") return "100%";
   return `${height}px`;
+}
+
+export function buildVisualFrameHostSyncMessage(
+  payload: VisualFrameHostSyncPayload,
+): VisualFrameHostSyncMessage {
+  return {
+    type: "wiii-visual-sync",
+    payload,
+  };
 }
 
 export function parseVisualFrameBridgeMessage(

--- a/wiii-desktop/src/lib/visual-frame-document.ts
+++ b/wiii-desktop/src/lib/visual-frame-document.ts
@@ -25,6 +25,11 @@ const ALLOWED_CDNS = [
 
 const FRAME_CSP = `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' blob: ${ALLOWED_CDNS.join(" ")}; style-src 'unsafe-inline' ${ALLOWED_CDNS.join(" ")}; img-src blob: data: ${ALLOWED_CDNS.join(" ")}; font-src data: ${ALLOWED_CDNS.join(" ")}; connect-src 'none';">`;
 
+const BLOCKED_EXTERNAL_FONT_LINK_RE =
+  /<link\b[^>]*href=(["'])https:\/\/fonts\.(?:googleapis|gstatic)\.com(?:\/[^"']*)?\1[^>]*>/gi;
+const BLOCKED_EXTERNAL_FONT_IMPORT_RE =
+  /@import\s+(?:url\()?["']?https:\/\/fonts\.googleapis\.com\/[^"')]+["']?\)?\s*;?/gi;
+
 const STORAGE_SHIM = `
 <script>
   (function () {
@@ -79,6 +84,12 @@ function escapeHtml(value: string): string {
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&#39;");
+}
+
+function stripBlockedExternalFontAssets(content: string): string {
+  return content
+    .replace(BLOCKED_EXTERNAL_FONT_LINK_RE, "")
+    .replace(BLOCKED_EXTERNAL_FONT_IMPORT_RE, "");
 }
 
 /**
@@ -247,8 +258,9 @@ export function buildVisualFrameDocument(
     showFrameIntro = false,
     hostShellMode = frameKind === "legacy" ? "auto" : "force",
     hostThemeOverrides = undefined,
-  }: VisualFrameDocumentOptions = {},
+}: VisualFrameDocumentOptions = {},
 ): string {
+  const sanitizedContent = stripBlockedExternalFontAssets(content);
   const hasIntro = showFrameIntro && Boolean(title || summary);
   const bridgeScript = `
   <script>
@@ -551,14 +563,14 @@ export function buildVisualFrameDocument(
   // defaults so they win the cascade without breaking standalone preview.
   const themeOverrideBlock = renderHostThemeOverrideBlock(hostThemeOverrides);
 
-  if (/<html/i.test(content)) {
+  if (/<html/i.test(sanitizedContent)) {
     const headInjected = injectIntoHead(
-      content,
+      sanitizedContent,
       `${FRAME_CSP}\n${STORAGE_SHIM}\n${shellStyle}${themeOverrideBlock}`,
     );
     const shouldWrapBody =
       hostShellMode === "force" &&
-      !/wiii-frame-shell|data-wiii-host-shell/i.test(content);
+      !/wiii-frame-shell|data-wiii-host-shell/i.test(sanitizedContent);
 
     if (
       shouldWrapBody &&
@@ -614,7 +626,7 @@ export function buildVisualFrameDocument(
 <body class="${hostShellMode === "force" ? "wiii-host-shell-active" : ""}" data-wiii-host-shell="${hostShellMode === "force" ? "true" : "false"}" data-wiii-has-intro="${hasIntro ? "true" : "false"}">
   <div class="wiii-frame-shell" data-wiii-frame-kind="${escapeHtml(frameKind)}" data-wiii-shell-variant="${escapeHtml(shellVariant)}">
     ${intro}
-    <div class="wiii-frame-content">${content}</div>
+    <div class="wiii-frame-content">${sanitizedContent}</div>
   </div>
   ${bridgeScript}
   ${TWEAKS_INJECT}


### PR DESCRIPTION
Closes #593.

## Summary
- Add a typed buildVisualFrameHostSyncMessage contract for host-to-iframe visual lifecycle sync.
- Make viewport-sized app frames enforce full-height container constraints, so Code Studio previews do not depend only on external class names.
- Strip blocked Google Fonts/preconnect assets before iframe CSP injection to reduce noisy product console failures while preserving local system-font rendering.
- Extend visual frame and Code Studio harness tests.

## Verification
- cd wiii-desktop && npx vitest run src/__tests__/visual-frame-contract.test.ts src/__tests__/inline-visual-frame.test.ts src/__tests__/inline-visual-frame-rendering.test.tsx src/__tests__/code-studio-panel.test.tsx -> 4 files / 15 tests passed
- cd wiii-desktop && npx tsc --noEmit -> passed
- git diff --check -> passed

## Risk / Rollback
- Risk is moderate and scoped to visual iframe wrapping/sync. The generated app HTML still runs in the same sandbox and CSP; only blocked font assets are removed before render.
- Rollback by reverting this PR if an iframe lifecycle regression appears in Code Studio previews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked external Google Fonts from loading in iframes for enhanced security and performance.
  * Fixed viewport sizing behavior for inline visual frames, ensuring proper height and minimum height styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->