### PR TITLE
refactor(backend): type Code Studio fast-path results

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/code_studio_fast_paths.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_fast_paths.py
@@ -42,6 +42,17 @@ class CodeStudioFastPathRecipe:
         return {"code_html": self.code_html, "title": self.title}
 
 
+@dataclass(frozen=True, slots=True)
+class CodeStudioFastPathResult:
+    """Typed result emitted by an audited Code Studio fast path."""
+
+    response: str
+    thinking_content: str
+    tool_call_events: list[dict[str, Any]]
+    tools_used: list[dict[str, Any]]
+    fast_path: str
+
+
 _PENDULUM_FAST_PATH_HTML = """
 <div class="pendulum-prototype">
   <style>
@@ -454,7 +465,7 @@ async def execute_code_studio_fast_path(
     runtime_context_base: Any,
     derive_code_stream_session_id: Callable[..., str],
     sanitize_code_studio_response: Callable[[str, list[dict[str, Any]] | None, AgentState | None], str],
-) -> dict[str, Any] | None:
+) -> CodeStudioFastPathResult | None:
     matched = get_tool_by_name(tools, "tool_create_visual_code")
     if not matched:
         return None
@@ -549,14 +560,14 @@ async def execute_code_studio_fast_path(
         or getattr(matched, "__name__", None)
         or "tool_create_visual_code"
     )
-    return {
-        "response": sanitize_code_studio_response(recipe.response, tool_call_events, state),
-        "thinking_content": recipe.thinking_content,
-        "tool_call_events": tool_call_events,
+    return CodeStudioFastPathResult(
+        response=sanitize_code_studio_response(recipe.response, tool_call_events, state),
+        thinking_content=recipe.thinking_content,
+        tool_call_events=tool_call_events,
         # Presenter contract: tools_used must be a list of dicts with at
         # least a "name" key (see chat_response_presenter.py). Storing the
         # raw LangChain Tool object here used to crash the pendulum
         # fast-path turn with "'Tool' object has no attribute 'get'".
-        "tools_used": [{"name": str(matched_name)}],
-        "fast_path": recipe.call_id_prefix,
-    }
+        tools_used=[{"name": str(matched_name)}],
+        fast_path=recipe.call_id_prefix,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
@@ -153,18 +153,18 @@ async def code_studio_node_impl(
             )
 
             if fast_path_result:
-                response = fast_path_result["response"]
-                state["thinking_content"] = fast_path_result["thinking_content"]
-                state["tool_call_events"] = fast_path_result["tool_call_events"]
-                state["tools_used"] = fast_path_result["tools_used"]
+                response = fast_path_result.response
+                state["thinking_content"] = fast_path_result.thinking_content
+                state["tool_call_events"] = fast_path_result.tool_call_events
+                state["tools_used"] = fast_path_result.tools_used
                 tracer.end_step(
-                    result=f"Code studio fast path: {fast_path_result.get('fast_path', 'recipe_scaffold')}",
+                    result=f"Code studio fast path: {fast_path_result.fast_path}",
                     confidence=0.91,
                     details={
                         "response_type": "capability_generated",
                         "tools_bound": len(tools),
                         "force_tools": force_tools,
-                        "fast_path": fast_path_result.get("fast_path", "recipe_scaffold"),
+                        "fast_path": fast_path_result.fast_path,
                     },
                 )
             else:

--- a/maritime-ai-service/tests/unit/test_code_studio_fast_paths.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_fast_paths.py
@@ -5,6 +5,7 @@ import pytest
 from app.engine.multi_agent import code_studio_fast_paths
 from app.engine.multi_agent.code_studio_fast_paths import (
     CodeStudioFastPathRecipe,
+    CodeStudioFastPathResult,
     _COLREG_RULE15_FAST_PATH_HTML,
     _PENDULUM_FAST_PATH_HTML,
     _build_recipe,
@@ -65,6 +66,52 @@ def test_fast_path_recipe_contract_builds_tool_args() -> None:
         "code_html": _COLREG_RULE15_FAST_PATH_HTML,
         "title": "COLREGs Rule 15 Simulation",
     }
+
+
+@pytest.mark.asyncio
+async def test_recipe_fast_path_returns_typed_result(monkeypatch) -> None:
+    async def fake_invoke_tool_with_runtime(*_args, **_kwargs):
+        return '{"visual_session_id":"vs-fast","fallback_html":"<canvas></canvas>"}'
+
+    async def fake_maybe_emit_visual_event(**_kwargs):
+        return ["vs-fast"], []
+
+    async def fake_emit_visual_commit_events(**_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        code_studio_fast_paths,
+        "invoke_tool_with_runtime",
+        fake_invoke_tool_with_runtime,
+    )
+    monkeypatch.setattr(
+        code_studio_fast_paths,
+        "_maybe_emit_visual_event",
+        fake_maybe_emit_visual_event,
+    )
+    monkeypatch.setattr(
+        code_studio_fast_paths,
+        "_emit_visual_commit_events",
+        fake_emit_visual_commit_events,
+    )
+
+    async def push_event(*_args, **_kwargs):
+        return None
+
+    result = await code_studio_fast_paths.execute_code_studio_fast_path(
+        state={"context": {}},
+        query="simulate COLREG rule 15 crossing situation",
+        tools=[SimpleNamespace(name="tool_create_visual_code")],
+        push_event=push_event,
+        runtime_context_base=None,
+        derive_code_stream_session_id=lambda **_kwargs: "vs-test",
+        sanitize_code_studio_response=lambda text, *_args: text,
+    )
+
+    assert isinstance(result, CodeStudioFastPathResult)
+    assert result.fast_path == "fast_colreg15"
+    assert result.tools_used == [{"name": "tool_create_visual_code"}]
+    assert result.tool_call_events[0]["type"] == "call"
 
 
 @pytest.mark.asyncio

--- a/maritime-ai-service/tests/unit/test_graph_routing.py
+++ b/maritime-ai-service/tests/unit/test_graph_routing.py
@@ -15,6 +15,7 @@ from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch, MagicMock
 
+from app.engine.multi_agent.code_studio_fast_paths import CodeStudioFastPathResult
 from app.engine.multi_agent.graph import (
     route_decision,
     _ainvoke_with_fallback,
@@ -1226,13 +1227,13 @@ class TestSimulationClarifier:
             "domain_config": {},
         }
         fake_tracer = MagicMock()
-        fast_path_result = {
-            "response": "opened deterministic visual preview",
-            "thinking_content": "deterministic code studio recipe",
-            "tool_call_events": [],
-            "tools_used": [{"name": "tool_create_visual_code"}],
-            "fast_path": "fast_colreg15",
-        }
+        fast_path_result = CodeStudioFastPathResult(
+            response="opened deterministic visual preview",
+            thinking_content="deterministic code studio recipe",
+            tool_call_events=[],
+            tools_used=[{"name": "tool_create_visual_code"}],
+            fast_path="fast_colreg15",
+        )
 
         with patch("app.engine.multi_agent.graph._get_or_create_tracer", return_value=fake_tracer), \
              patch("app.engine.multi_agent.graph.settings") as mock_settings, \


### PR DESCRIPTION
Closes #595.

## Summary
- Add a frozen CodeStudioFastPathResult contract for audited Code Studio fast-path execution output.
- Update code_studio_node_runtime to consume fast-path output through attributes instead of loose dictionary keys.
- Extend fast-path tests and update graph routing regression mocks to use the typed contract.

## Verification
- cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_code_studio_fast_paths.py tests/unit/test_graph_routing.py -q --tb=short -> 80 passed
- cd maritime-ai-service && uv run --python 3.12 --extra dev ruff check app/engine/multi_agent/code_studio_fast_paths.py app/engine/multi_agent/code_studio_node_runtime.py tests/unit/test_code_studio_fast_paths.py tests/unit/test_graph_routing.py --select=E9,F63,F7,F82 -> passed
- git diff --check -> passed

## Risk / Rollback
- Risk is low-to-moderate and scoped to Code Studio recipe fast-path handoff. Generated HTML, routing predicates, and tool execution remain unchanged.
- Rollback by reverting this PR if Code Studio fast-path turns fail to populate final response/tool metadata.