### PR TITLE
refactor(backend): extract Code Studio tool setup

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 from app.engine.multi_agent.code_studio_scaffold_fallback_policy import (
     resolve_code_studio_scaffold_fallback,
 )
+from app.engine.multi_agent.code_studio_tool_setup import (
+    prepare_code_studio_tool_setup,
+)
 from app.engine.multi_agent.state import AgentState
 from app.engine.reasoning import (
     record_thinking_snapshot,
@@ -108,41 +111,20 @@ async def code_studio_node_impl(
                     details={"response_type": "clarify", "reason": "ambiguous_simulation_request"},
                 )
         if not response:
-            tools, force_tools = collect_code_studio_tools(effective_query, _ctx.get("user_role", "student"))
-            try:
-                from app.engine.skills.skill_recommender import select_runtime_tools
-
-                selected_tools = select_runtime_tools(
-                    tools,
-                    query=effective_query,
-                    intent=(state.get("routing_metadata") or {}).get("intent"),
-                    user_role=_ctx.get("user_role", "student"),
-                    max_tools=min(len(tools), 8),
-                    must_include=code_studio_required_tool_names(
-                        effective_query,
-                        _ctx.get("user_role", "student"),
-                    ),
-                )
-                if selected_tools:
-                    tools = selected_tools
-                    logger.info(
-                        "[CODE_STUDIO] Runtime-selected tools: %s",
-                        [getattr(tool, "name", getattr(tool, "__name__", "unknown")) for tool in tools],
-                    )
-            except Exception as _selection_err:
-                logger.debug("[CODE_STUDIO] Runtime tool selection skipped: %s", _selection_err)
-
-            runtime_context_base = build_tool_runtime_context_fn(
-                event_bus_id=_bus_id,
-                request_id=_ctx.get("request_id"),
-                session_id=state.get("session_id"),
-                organization_id=state.get("organization_id"),
-                user_id=state.get("user_id"),
-                user_role=_ctx.get("user_role", "student"),
-                node="code_studio_agent",
-                source="agentic_loop",
-                metadata=build_visual_tool_runtime_metadata(state, effective_query),
+            tool_setup = prepare_code_studio_tool_setup(
+                effective_query=effective_query,
+                state=state,
+                ctx=_ctx,
+                bus_id=_bus_id,
+                collect_code_studio_tools=collect_code_studio_tools,
+                code_studio_required_tool_names=code_studio_required_tool_names,
+                build_tool_runtime_context_fn=build_tool_runtime_context_fn,
+                build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
+                logger_obj=logger,
             )
+            tools = tool_setup.tools
+            force_tools = tool_setup.force_tools
+            runtime_context_base = tool_setup.runtime_context_base
 
             fast_path_result = await execute_code_studio_fast_path(
                 state=state,

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_tool_setup.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_tool_setup.py
@@ -1,0 +1,90 @@
+"""Typed tool setup contract for the Code Studio node."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any, Callable
+
+from app.engine.multi_agent.state import AgentState
+from app.engine.skills.skill_recommender import select_runtime_tools
+
+
+@dataclass(frozen=True, slots=True)
+class CodeStudioToolSetupResult:
+    """Resolved Code Studio tools and runtime context for one turn."""
+
+    tools: list[Any]
+    force_tools: bool
+    runtime_context_base: Any
+
+
+CollectCodeStudioTools = Callable[[str, str], tuple[list[Any], bool]]
+RequiredToolNames = Callable[[str, str], list[str]]
+BuildToolRuntimeContext = Callable[..., Any]
+BuildVisualToolRuntimeMetadata = Callable[[AgentState, str], dict[str, Any]]
+RuntimeToolSelector = Callable[..., list[Any] | None]
+
+
+def prepare_code_studio_tool_setup(
+    *,
+    effective_query: str,
+    state: AgentState,
+    ctx: dict[str, Any],
+    bus_id: str | None,
+    collect_code_studio_tools: CollectCodeStudioTools,
+    code_studio_required_tool_names: RequiredToolNames,
+    build_tool_runtime_context_fn: BuildToolRuntimeContext,
+    build_visual_tool_runtime_metadata: BuildVisualToolRuntimeMetadata,
+    logger_obj: logging.Logger,
+    select_runtime_tools_fn: RuntimeToolSelector = select_runtime_tools,
+) -> CodeStudioToolSetupResult:
+    """Collect, optionally narrow, and bind Code Studio tools for this turn."""
+
+    user_role = str(ctx.get("user_role", "student") or "student")
+    tools, force_tools = collect_code_studio_tools(effective_query, user_role)
+
+    try:
+        selected_tools = select_runtime_tools_fn(
+            tools,
+            query=effective_query,
+            intent=(state.get("routing_metadata") or {}).get("intent"),
+            user_role=user_role,
+            max_tools=min(len(tools), 8),
+            must_include=code_studio_required_tool_names(
+                effective_query,
+                user_role,
+            ),
+        )
+        if selected_tools:
+            tools = selected_tools
+            logger_obj.info(
+                "[CODE_STUDIO] Runtime-selected tools: %s",
+                [
+                    getattr(tool, "name", getattr(tool, "__name__", "unknown"))
+                    for tool in tools
+                ],
+            )
+    except Exception as selection_error:  # noqa: BLE001
+        logger_obj.debug(
+            "[CODE_STUDIO] Runtime tool selection skipped: %s",
+            selection_error,
+        )
+
+    runtime_context_base = build_tool_runtime_context_fn(
+        event_bus_id=bus_id,
+        request_id=ctx.get("request_id"),
+        session_id=state.get("session_id"),
+        organization_id=state.get("organization_id"),
+        user_id=state.get("user_id"),
+        user_role=user_role,
+        node="code_studio_agent",
+        source="agentic_loop",
+        metadata=build_visual_tool_runtime_metadata(state, effective_query),
+    )
+
+    return CodeStudioToolSetupResult(
+        tools=tools,
+        force_tools=force_tools,
+        runtime_context_base=runtime_context_base,
+    )

--- a/maritime-ai-service/tests/unit/test_code_studio_tool_setup.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_tool_setup.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from app.engine.multi_agent.code_studio_tool_setup import (
+    CodeStudioToolSetupResult,
+    prepare_code_studio_tool_setup,
+)
+
+
+def test_prepare_code_studio_tool_setup_selects_tools_and_builds_runtime_context() -> None:
+    original_tools = [
+        SimpleNamespace(name="tool_create_visual_code"),
+        SimpleNamespace(name="tool_python"),
+    ]
+    selected_tools = [original_tools[0]]
+    runtime_context = SimpleNamespace(runtime="ctx")
+
+    def select_runtime_tools_fn(tools, **kwargs):
+        assert tools == original_tools
+        assert kwargs["query"] == "build a simulation"
+        assert kwargs["intent"] == "visual_app"
+        assert kwargs["user_role"] == "teacher"
+        assert kwargs["max_tools"] == 2
+        assert kwargs["must_include"] == ["tool_create_visual_code"]
+        return selected_tools
+
+    def build_tool_runtime_context_fn(**kwargs):
+        assert kwargs["event_bus_id"] == "bus-1"
+        assert kwargs["request_id"] == "req-1"
+        assert kwargs["session_id"] == "session-1"
+        assert kwargs["organization_id"] == "org-1"
+        assert kwargs["user_id"] == "user-1"
+        assert kwargs["user_role"] == "teacher"
+        assert kwargs["node"] == "code_studio_agent"
+        assert kwargs["source"] == "agentic_loop"
+        assert kwargs["metadata"] == {"visual": True}
+        return runtime_context
+
+    result = prepare_code_studio_tool_setup(
+        effective_query="build a simulation",
+        state={
+            "routing_metadata": {"intent": "visual_app"},
+            "session_id": "session-1",
+            "organization_id": "org-1",
+            "user_id": "user-1",
+        },
+        ctx={"user_role": "teacher", "request_id": "req-1"},
+        bus_id="bus-1",
+        collect_code_studio_tools=lambda _query, _role: (original_tools, True),
+        code_studio_required_tool_names=lambda _query, _role: ["tool_create_visual_code"],
+        build_tool_runtime_context_fn=build_tool_runtime_context_fn,
+        build_visual_tool_runtime_metadata=lambda _state, _query: {"visual": True},
+        logger_obj=MagicMock(),
+        select_runtime_tools_fn=select_runtime_tools_fn,
+    )
+
+    assert isinstance(result, CodeStudioToolSetupResult)
+    assert result.tools == selected_tools
+    assert result.force_tools is True
+    assert result.runtime_context_base is runtime_context
+
+
+def test_prepare_code_studio_tool_setup_keeps_tools_when_selection_fails() -> None:
+    tools = [SimpleNamespace(name="tool_create_visual_code")]
+    logger = MagicMock()
+
+    def select_runtime_tools_fn(*_args, **_kwargs):
+        raise RuntimeError("selector unavailable")
+
+    result = prepare_code_studio_tool_setup(
+        effective_query="build a simulation",
+        state={},
+        ctx={},
+        bus_id=None,
+        collect_code_studio_tools=lambda _query, _role: (tools, False),
+        code_studio_required_tool_names=lambda _query, _role: [],
+        build_tool_runtime_context_fn=lambda **kwargs: kwargs,
+        build_visual_tool_runtime_metadata=lambda _state, _query: {},
+        logger_obj=logger,
+        select_runtime_tools_fn=select_runtime_tools_fn,
+    )
+
+    assert result.tools == tools
+    assert result.force_tools is False
+    assert result.runtime_context_base["user_role"] == "student"
+    logger.debug.assert_called_once()


### PR DESCRIPTION
Closes #597.

## Summary
- Add a typed CodeStudioToolSetupResult contract and prepare_code_studio_tool_setup helper.
- Move Code Studio tool collection, runtime selection, and runtime context construction out of code_studio_node_runtime.
- Add focused unit tests for selected-tool and selector-failure setup paths.

## Verification
- cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_code_studio_tool_setup.py tests/unit/test_code_studio_fast_paths.py tests/unit/test_graph_routing.py -q --tb=short -> 82 passed
- cd maritime-ai-service && uv run --python 3.12 --extra dev ruff check app/engine/multi_agent/code_studio_tool_setup.py app/engine/multi_agent/code_studio_node_runtime.py tests/unit/test_code_studio_tool_setup.py --select=E9,F63,F7,F82 -> passed
- git diff --check -> passed

## Risk / Rollback
- Risk is moderate and scoped to Code Studio tool setup. Tool selection, required tool inclusion, metadata, and runtime context arguments are preserved.
- Rollback by reverting this PR if Code Studio loses required tools or runtime metadata.