### PR TITLE
Refactor Direct Node LLM execution into typed pipeline

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_llm_pipeline.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_llm_pipeline.py
@@ -1,0 +1,403 @@
+"""Typed provider/tool/fallback pipeline for the direct node."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from app.engine.multi_agent.direct_node_document_preview_runtime import (
+    execute_direct_node_document_preview_round,
+)
+from app.engine.multi_agent.direct_node_exception_fallbacks import (
+    handle_direct_node_generation_exception,
+)
+from app.engine.multi_agent.direct_node_llm_fallback import (
+    resolve_direct_node_llm_unavailable_fallback,
+)
+from app.engine.multi_agent.direct_node_llm_preflight import (
+    prepare_direct_node_llm_preflight,
+)
+from app.engine.multi_agent.direct_node_llm_tool_loop import (
+    execute_direct_node_llm_tool_loop,
+)
+from app.engine.multi_agent.direct_node_operational_fast_paths import (
+    _build_codebase_analysis_fallback_answer,
+    _build_codebase_analysis_fallback_thinking,
+)
+from app.engine.multi_agent.direct_node_thinking_snapshot import (
+    record_direct_node_thinking_snapshot,
+)
+from app.engine.multi_agent.direct_node_tool_selection import select_direct_node_tools
+from app.engine.multi_agent.direct_node_turn_policy import resolve_direct_node_turn_policy
+from app.engine.multi_agent.direct_node_uploaded_context import (
+    _build_uploaded_document_context_fallback_answer,
+    _build_uploaded_document_visual_guard_answer,
+    _looks_uploaded_document_preview_request,
+    _looks_uploaded_file_visual_inspection_query,
+    _provider_likely_supports_image_blocks,
+)
+from app.engine.multi_agent.direct_search_synthesis_fallback import (
+    build_search_template_fallback,
+)
+from app.engine.multi_agent.state import AgentState
+from app.engine.runtime.runtime_metrics import inc_counter
+
+
+@dataclass(frozen=True, slots=True)
+class DirectNodeLlmPipelineRequest:
+    """Per-turn state required by provider-backed Direct Node execution."""
+
+    query: str
+    state: AgentState
+    bus_id: str | None
+    push_event: Callable[..., Any]
+    tracer: Any
+    ctx_for_preflight: dict[str, Any]
+    has_uploaded_document_context: bool
+    domain_name_vi: str
+    sanitize_document_preview_response: Callable[[str, list[dict[str, Any]]], str]
+    explicit_web_search_turn: bool
+    enable_natural_conversation: bool
+    requested_model: str | None
+    llm_presence_penalty: float
+    llm_frequency_penalty: float
+    direct_max_rounds: int
+    host_ui_total_timeout_seconds: float
+
+
+@dataclass(frozen=True, slots=True)
+class DirectNodeLlmPipelineDependencies:
+    """Injected app contracts used by the Direct Node LLM lifecycle."""
+
+    normalize_for_intent: Callable[[str], str]
+    looks_identity_selfhood_turn: Callable[[str], bool]
+    needs_web_search: Callable[[str], bool]
+    needs_datetime: Callable[[str], bool]
+    resolve_visual_intent: Callable[[str], Any]
+    recommended_visual_thinking_effort: Callable[..., Any]
+    get_active_code_studio_session: Callable[[AgentState], Any]
+    merge_thinking_effort: Callable[[Any, Any], Any]
+    get_effective_provider: Callable[[AgentState], Any]
+    get_explicit_user_provider: Callable[[AgentState], Any]
+    collect_direct_tools: Callable[..., tuple[list[Any], bool]]
+    direct_required_tool_names: Callable[[str, str], list[str]]
+    resolve_direct_answer_timeout_profile: Callable[..., Any]
+    bind_direct_tools: Callable[..., tuple[Any, Any, Any]]
+    build_direct_system_messages: Callable[..., list[Any]]
+    build_visual_tool_runtime_metadata: Callable[..., dict[str, Any]]
+    execute_direct_tool_rounds: Callable[..., Any]
+    extract_direct_response: Callable[..., Any]
+    sanitize_structured_visual_answer_text: Callable[..., str]
+    sanitize_wiii_house_text: Callable[..., str]
+    build_direct_reasoning_summary: Callable[..., str]
+    get_phase_fallback: Callable[[AgentState], str]
+    record_thinking_snapshot_fn: Callable[..., Any]
+    logger_obj: logging.Logger
+
+
+@dataclass(slots=True)
+class DirectNodeLlmPipelineResult:
+    """Resolved Direct Node response after provider/tool/fallback execution."""
+
+    response: str | None
+    tool_call_events: list[dict[str, Any]]
+
+
+async def execute_direct_node_llm_pipeline(
+    *,
+    request: DirectNodeLlmPipelineRequest,
+    dependencies: DirectNodeLlmPipelineDependencies,
+) -> DirectNodeLlmPipelineResult:
+    """Run Direct Node policy, tool selection, provider preflight, and fallbacks."""
+
+    query = request.query
+    state = request.state
+    explicit_user_provider: str | None = None
+    llm = None
+    llm_response = None
+    messages: list[Any] = []
+    tools: list[Any] = []
+    tool_call_events: list[dict[str, Any]] = []
+    response: str | None = None
+    response_language = "vi"
+    routing_intent = ""
+    is_identity_turn = False
+    is_emotional_support_turn = False
+    explicit_web_search_turn = request.explicit_web_search_turn
+
+    try:
+        from app.engine.multi_agent.agent_config import AgentConfigRegistry
+        from app.engine.multi_agent.openai_stream_runtime import (
+            _supports_native_answer_streaming_impl,
+        )
+
+        turn_policy = resolve_direct_node_turn_policy(
+            query=query,
+            state=state,
+            has_uploaded_document_context=request.has_uploaded_document_context,
+            normalize_for_intent=dependencies.normalize_for_intent,
+            looks_identity_selfhood_turn=dependencies.looks_identity_selfhood_turn,
+            needs_web_search=dependencies.needs_web_search,
+            needs_datetime=dependencies.needs_datetime,
+            resolve_visual_intent=dependencies.resolve_visual_intent,
+            recommended_visual_thinking_effort=(
+                dependencies.recommended_visual_thinking_effort
+            ),
+            get_active_code_studio_session=dependencies.get_active_code_studio_session,
+            merge_thinking_effort=dependencies.merge_thinking_effort,
+            get_effective_provider=dependencies.get_effective_provider,
+            get_explicit_user_provider=dependencies.get_explicit_user_provider,
+            looks_uploaded_document_preview_request=(
+                _looks_uploaded_document_preview_request
+            ),
+            logger_obj=dependencies.logger_obj,
+        )
+        ctx = turn_policy.ctx
+        response_language = turn_policy.response_language
+        thinking_effort = turn_policy.thinking_effort
+        routing_intent = turn_policy.routing_intent
+        is_identity_turn = turn_policy.is_identity_turn
+        is_emotional_support_turn = turn_policy.is_emotional_support_turn
+        is_short_house_chatter = turn_policy.is_short_house_chatter
+        visual_decision = turn_policy.visual_decision
+        history_limit = turn_policy.history_limit
+        tools_context_override = turn_policy.tools_context_override
+        role_name = turn_policy.role_name
+        preferred_provider = turn_policy.preferred_provider
+        explicit_user_provider = turn_policy.explicit_user_provider
+        use_house_voice_direct = turn_policy.use_house_voice_direct
+        direct_provider_override = turn_policy.direct_provider_override
+        is_codebase_source_turn = turn_policy.is_codebase_source_turn
+        explicit_web_search_turn = turn_policy.explicit_web_search_turn
+
+        tool_selection = select_direct_node_tools(
+            query=query,
+            state=state,
+            ctx=ctx,
+            routing_intent=routing_intent,
+            is_short_house_chatter=is_short_house_chatter,
+            is_identity_turn=is_identity_turn,
+            is_emotional_support_turn=is_emotional_support_turn,
+            is_codebase_source_turn=is_codebase_source_turn,
+            explicit_web_search_turn=explicit_web_search_turn,
+            has_uploaded_document_context=request.has_uploaded_document_context,
+            needs_web_search=dependencies.needs_web_search,
+            collect_direct_tools=dependencies.collect_direct_tools,
+            direct_required_tool_names=dependencies.direct_required_tool_names,
+            logger_obj=dependencies.logger_obj,
+        )
+        tools = tool_selection.tools
+        force_tools = tool_selection.force_tools
+
+        if (
+            request.has_uploaded_document_context
+            and _looks_uploaded_document_preview_request(query)
+        ):
+            preview_result = await execute_direct_node_document_preview_round(
+                query=query,
+                state=state,
+                ctx=ctx,
+                bus_id=request.bus_id,
+                tools=tools,
+                force_tools=force_tools,
+                messages=messages,
+                push_event=request.push_event,
+                build_visual_tool_runtime_metadata=(
+                    dependencies.build_visual_tool_runtime_metadata
+                ),
+                execute_direct_tool_rounds=dependencies.execute_direct_tool_rounds,
+                extract_direct_response=dependencies.extract_direct_response,
+                sanitize_preview_response=(
+                    request.sanitize_document_preview_response
+                ),
+                failure_log_message=(
+                    "[DIRECT] Deterministic document preview pre-LLM path failed: %s"
+                ),
+                logger_obj=dependencies.logger_obj,
+            )
+            if preview_result is not None:
+                response = preview_result.response
+                messages = preview_result.messages
+                tool_call_events = preview_result.tool_call_events
+                request.tracer.end_step(
+                    result="Deterministic uploaded-document preview host action",
+                    confidence=0.9,
+                    details={
+                        "response_type": "document_preview_host_action",
+                        "tools_bound": len(tools),
+                        "force_tools": force_tools,
+                    },
+                )
+
+        llm_preflight = prepare_direct_node_llm_preflight(
+            query=query,
+            state=state,
+            ctx=ctx,
+            ctx_for_preflight=request.ctx_for_preflight,
+            has_uploaded_document_context=request.has_uploaded_document_context,
+            response=response or "",
+            is_identity_turn=is_identity_turn,
+            is_short_house_chatter=is_short_house_chatter,
+            is_emotional_support_turn=is_emotional_support_turn,
+            use_house_voice_direct=use_house_voice_direct,
+            is_codebase_source_turn=is_codebase_source_turn,
+            thinking_effort=thinking_effort,
+            direct_provider_override=direct_provider_override,
+            preferred_provider=preferred_provider,
+            requested_model=request.requested_model,
+            enable_natural_conversation=request.enable_natural_conversation,
+            presence_penalty=request.llm_presence_penalty,
+            frequency_penalty=request.llm_frequency_penalty,
+            get_native_llm=AgentConfigRegistry.get_native_llm,
+            get_llm=AgentConfigRegistry.get_llm,
+            supports_native_answer_streaming=_supports_native_answer_streaming_impl,
+            looks_uploaded_file_visual_inspection_query=(
+                _looks_uploaded_file_visual_inspection_query
+            ),
+            provider_likely_supports_image_blocks=(
+                _provider_likely_supports_image_blocks
+            ),
+            build_uploaded_document_visual_guard_answer=(
+                _build_uploaded_document_visual_guard_answer
+            ),
+            tracer=request.tracer,
+            logger_obj=dependencies.logger_obj,
+        )
+        llm = llm_preflight.llm
+        response = llm_preflight.response or None
+
+        if llm and not response:
+            llm_tool_loop = await execute_direct_node_llm_tool_loop(
+                llm=llm,
+                query=query,
+                state=state,
+                ctx=ctx,
+                bus_id=request.bus_id,
+                domain_name_vi=request.domain_name_vi,
+                role_name=role_name,
+                tools=tools,
+                force_tools=force_tools,
+                tools_context_override=tools_context_override,
+                visual_decision=visual_decision,
+                history_limit=history_limit,
+                routing_intent=routing_intent,
+                response_language=response_language,
+                is_identity_turn=is_identity_turn,
+                is_short_house_chatter=is_short_house_chatter,
+                use_house_voice_direct=use_house_voice_direct,
+                direct_provider_override=direct_provider_override,
+                preferred_provider=preferred_provider,
+                explicit_user_provider=explicit_user_provider,
+                explicit_web_search_turn=explicit_web_search_turn,
+                push_event=request.push_event,
+                needs_web_search=dependencies.needs_web_search,
+                needs_datetime=dependencies.needs_datetime,
+                resolve_direct_answer_timeout_profile=(
+                    dependencies.resolve_direct_answer_timeout_profile
+                ),
+                bind_direct_tools=dependencies.bind_direct_tools,
+                build_direct_system_messages=dependencies.build_direct_system_messages,
+                build_visual_tool_runtime_metadata=(
+                    dependencies.build_visual_tool_runtime_metadata
+                ),
+                execute_direct_tool_rounds=dependencies.execute_direct_tool_rounds,
+                extract_direct_response=dependencies.extract_direct_response,
+                sanitize_structured_visual_answer_text=(
+                    dependencies.sanitize_structured_visual_answer_text
+                ),
+                sanitize_wiii_house_text=dependencies.sanitize_wiii_house_text,
+                build_direct_reasoning_summary=(
+                    dependencies.build_direct_reasoning_summary
+                ),
+                tracer=request.tracer,
+                logger_obj=dependencies.logger_obj,
+                direct_max_rounds=request.direct_max_rounds,
+                host_ui_total_timeout_seconds=(
+                    request.host_ui_total_timeout_seconds
+                ),
+            )
+
+            response = llm_tool_loop.response
+            messages = llm_tool_loop.messages
+            tool_call_events = llm_tool_loop.tool_call_events
+        elif not response:
+            llm_fallback = resolve_direct_node_llm_unavailable_fallback(
+                query=query,
+                state=state,
+                explicit_user_provider=explicit_user_provider,
+                explicit_web_search_turn=explicit_web_search_turn,
+                enable_natural_conversation=request.enable_natural_conversation,
+                get_phase_fallback=dependencies.get_phase_fallback,
+                build_codebase_analysis_fallback_answer=(
+                    _build_codebase_analysis_fallback_answer
+                ),
+                build_codebase_analysis_fallback_thinking=(
+                    _build_codebase_analysis_fallback_thinking
+                ),
+                record_direct_node_thinking_snapshot=(
+                    record_direct_node_thinking_snapshot
+                ),
+                record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
+            )
+            response = llm_fallback.response
+            request.tracer.end_step(
+                result="Fallback (LLM unavailable)",
+                confidence=0.5,
+                details={"response_type": llm_fallback.response_type},
+            )
+    except Exception as exc:
+        llm_response = getattr(exc, "_direct_node_llm_response", llm_response)
+        messages = getattr(exc, "_direct_node_messages", messages)
+        tool_call_events = getattr(
+            exc,
+            "_direct_node_tool_call_events",
+            tool_call_events,
+        )
+        fallback_result = await handle_direct_node_generation_exception(
+            exc=exc,
+            query=query,
+            state=state,
+            ctx_for_preflight=request.ctx_for_preflight,
+            tools=tools,
+            tool_call_events=tool_call_events,
+            llm_response=llm_response,
+            messages=messages,
+            llm=llm,
+            routing_intent=routing_intent,
+            response_language=response_language,
+            is_identity_turn=is_identity_turn,
+            explicit_user_provider=explicit_user_provider,
+            explicit_web_search_turn=explicit_web_search_turn,
+            needs_web_search=dependencies.needs_web_search,
+            extract_direct_response=dependencies.extract_direct_response,
+            sanitize_structured_visual_answer_text=(
+                dependencies.sanitize_structured_visual_answer_text
+            ),
+            sanitize_wiii_house_text=dependencies.sanitize_wiii_house_text,
+            build_search_template_fallback=build_search_template_fallback,
+            build_uploaded_document_context_fallback_answer=(
+                _build_uploaded_document_context_fallback_answer
+            ),
+            build_codebase_analysis_fallback_answer=(
+                _build_codebase_analysis_fallback_answer
+            ),
+            build_codebase_analysis_fallback_thinking=(
+                _build_codebase_analysis_fallback_thinking
+            ),
+            get_phase_fallback=dependencies.get_phase_fallback,
+            record_direct_node_thinking_snapshot=record_direct_node_thinking_snapshot,
+            record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
+            tracer=request.tracer,
+            push_event=request.push_event,
+            inc_counter=inc_counter,
+            logger_obj=dependencies.logger_obj,
+        )
+        response = fallback_result.response
+        tool_call_events = fallback_result.tool_call_events
+
+    return DirectNodeLlmPipelineResult(
+        response=response,
+        tool_call_events=tool_call_events,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_runtime.py
@@ -3,53 +3,22 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from app.core.config import settings
-from app.engine.multi_agent.direct_node_document_preview_runtime import (
-    execute_direct_node_document_preview_round,
-)
 from app.engine.multi_agent.direct_node_event_sink import (
     build_direct_node_event_sink,
 )
-from app.engine.multi_agent.direct_node_llm_preflight import (
-    prepare_direct_node_llm_preflight,
-)
-from app.engine.multi_agent.direct_node_llm_tool_loop import (
-    execute_direct_node_llm_tool_loop,
-)
-from app.engine.multi_agent.direct_node_llm_fallback import (
-    resolve_direct_node_llm_unavailable_fallback,
-)
-from app.engine.multi_agent.direct_search_synthesis_fallback import (
-    build_search_template_fallback,
-)
-from app.engine.multi_agent.direct_node_exception_fallbacks import (
-    handle_direct_node_generation_exception,
-)
 from app.engine.multi_agent.direct_node_final_state import finalize_direct_node_state
-from app.engine.multi_agent.direct_node_operational_fast_paths import (
-    _build_codebase_analysis_fallback_answer,
-    _build_codebase_analysis_fallback_thinking,
+from app.engine.multi_agent.direct_node_llm_pipeline import (
+    DirectNodeLlmPipelineDependencies,
+    DirectNodeLlmPipelineRequest,
+    execute_direct_node_llm_pipeline,
 )
 from app.engine.multi_agent.direct_node_pre_llm_pipeline import (
     DirectNodePreLlmPipelineDependencies,
     DirectNodePreLlmPipelineRequest,
     execute_direct_node_pre_llm_pipeline,
 )
-from app.engine.multi_agent.direct_node_thinking_snapshot import (
-    record_direct_node_thinking_snapshot,
-)
-from app.engine.multi_agent.direct_node_tool_selection import select_direct_node_tools
-from app.engine.multi_agent.direct_node_turn_policy import resolve_direct_node_turn_policy
-from app.engine.multi_agent.direct_node_uploaded_context import (
-    _build_uploaded_document_context_fallback_answer,
-    _build_uploaded_document_visual_guard_answer,
-    _looks_uploaded_document_preview_request,
-    _looks_uploaded_file_visual_inspection_query,
-    _provider_likely_supports_image_blocks,
-)
-from app.engine.runtime.runtime_metrics import inc_counter
 from app.engine.multi_agent.state import AgentState
 from app.engine.reasoning import (
     record_thinking_snapshot,
@@ -143,23 +112,30 @@ async def direct_response_node_impl(
     )
 
     if not response:
-        explicit_user_provider: str | None = None
-        llm = None
-        llm_response = None
-        messages: list[Any] = []
-        tools: list[Any] = []
-        tool_call_events: list[dict[str, Any]] = []
-        response_language = "vi"
-        routing_intent = ""
-        is_identity_turn = False
-        is_emotional_support_turn = False
-        try:
-            from app.engine.multi_agent.agent_config import AgentConfigRegistry
-
-            turn_policy = resolve_direct_node_turn_policy(
+        llm_pipeline = await execute_direct_node_llm_pipeline(
+            request=DirectNodeLlmPipelineRequest(
                 query=query,
                 state=state,
+                bus_id=bus_id,
+                push_event=push_event,
+                tracer=tracer,
+                ctx_for_preflight=ctx_for_preflight,
                 has_uploaded_document_context=has_uploaded_document_context,
+                domain_name_vi=domain_name_vi,
+                sanitize_document_preview_response=(
+                    sanitize_document_preview_response
+                ),
+                explicit_web_search_turn=explicit_web_search_turn,
+                enable_natural_conversation=(
+                    getattr(settings, "enable_natural_conversation", False) is True
+                ),
+                requested_model=state.get("model"),
+                llm_presence_penalty=getattr(settings, "llm_presence_penalty", 0.0),
+                llm_frequency_penalty=getattr(settings, "llm_frequency_penalty", 0.0),
+                direct_max_rounds=getattr(settings, "direct_agent_max_tool_rounds", 12),
+                host_ui_total_timeout_seconds=_HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS,
+            ),
+            dependencies=DirectNodeLlmPipelineDependencies(
                 normalize_for_intent=normalize_for_intent,
                 looks_identity_selfhood_turn=looks_identity_selfhood_turn,
                 needs_web_search=needs_web_search,
@@ -170,256 +146,27 @@ async def direct_response_node_impl(
                 merge_thinking_effort=merge_thinking_effort,
                 get_effective_provider=get_effective_provider,
                 get_explicit_user_provider=get_explicit_user_provider,
-                looks_uploaded_document_preview_request=(
-                    _looks_uploaded_document_preview_request
-                ),
-                logger_obj=logger,
-            )
-            ctx = turn_policy.ctx
-            response_language = turn_policy.response_language
-            thinking_effort = turn_policy.thinking_effort
-            routing_intent = turn_policy.routing_intent
-            is_identity_turn = turn_policy.is_identity_turn
-            is_emotional_support_turn = turn_policy.is_emotional_support_turn
-            is_short_house_chatter = turn_policy.is_short_house_chatter
-            visual_decision = turn_policy.visual_decision
-            history_limit = turn_policy.history_limit
-            tools_context_override = turn_policy.tools_context_override
-            role_name = turn_policy.role_name
-            preferred_provider = turn_policy.preferred_provider
-            explicit_user_provider = turn_policy.explicit_user_provider
-            use_house_voice_direct = turn_policy.use_house_voice_direct
-            direct_provider_override = turn_policy.direct_provider_override
-            is_codebase_source_turn = turn_policy.is_codebase_source_turn
-            explicit_web_search_turn = turn_policy.explicit_web_search_turn
-
-            tool_selection = select_direct_node_tools(
-                query=query,
-                state=state,
-                ctx=ctx,
-                routing_intent=routing_intent,
-                is_short_house_chatter=is_short_house_chatter,
-                is_identity_turn=is_identity_turn,
-                is_emotional_support_turn=is_emotional_support_turn,
-                is_codebase_source_turn=is_codebase_source_turn,
-                explicit_web_search_turn=explicit_web_search_turn,
-                has_uploaded_document_context=has_uploaded_document_context,
-                needs_web_search=needs_web_search,
                 collect_direct_tools=collect_direct_tools,
                 direct_required_tool_names=direct_required_tool_names,
-                logger_obj=logger,
-            )
-            tools = tool_selection.tools
-            force_tools = tool_selection.force_tools
-            if (
-                not response
-                and has_uploaded_document_context
-                and _looks_uploaded_document_preview_request(query)
-            ):
-                preview_result = await execute_direct_node_document_preview_round(
-                    query=query,
-                    state=state,
-                    ctx=ctx,
-                    bus_id=bus_id,
-                    tools=tools,
-                    force_tools=force_tools,
-                    messages=messages,
-                    push_event=push_event,
-                    build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
-                    execute_direct_tool_rounds=execute_direct_tool_rounds,
-                    extract_direct_response=extract_direct_response,
-                    sanitize_preview_response=sanitize_document_preview_response,
-                    failure_log_message=(
-                        "[DIRECT] Deterministic document preview pre-LLM path failed: %s"
-                    ),
-                    logger_obj=logger,
-                )
-                if preview_result is not None:
-                    response = preview_result.response
-                    messages = preview_result.messages
-                    tool_call_events = preview_result.tool_call_events
-                    tracer.end_step(
-                        result="Deterministic uploaded-document preview host action",
-                        confidence=0.9,
-                        details={
-                            "response_type": "document_preview_host_action",
-                            "tools_bound": len(tools),
-                            "force_tools": force_tools,
-                        },
-                    )
-
-            from app.engine.multi_agent.openai_stream_runtime import (
-                _supports_native_answer_streaming_impl,
-            )
-
-            llm_preflight = prepare_direct_node_llm_preflight(
-                query=query,
-                state=state,
-                ctx=ctx,
-                ctx_for_preflight=ctx_for_preflight,
-                has_uploaded_document_context=has_uploaded_document_context,
-                response=response,
-                is_identity_turn=is_identity_turn,
-                is_short_house_chatter=is_short_house_chatter,
-                is_emotional_support_turn=is_emotional_support_turn,
-                use_house_voice_direct=use_house_voice_direct,
-                is_codebase_source_turn=is_codebase_source_turn,
-                thinking_effort=thinking_effort,
-                direct_provider_override=direct_provider_override,
-                preferred_provider=preferred_provider,
-                requested_model=state.get("model"),
-                enable_natural_conversation=(
-                    getattr(settings, "enable_natural_conversation", False) is True
+                resolve_direct_answer_timeout_profile=(
+                    resolve_direct_answer_timeout_profile
                 ),
-                presence_penalty=getattr(settings, "llm_presence_penalty", 0.0),
-                frequency_penalty=getattr(settings, "llm_frequency_penalty", 0.0),
-                get_native_llm=AgentConfigRegistry.get_native_llm,
-                get_llm=AgentConfigRegistry.get_llm,
-                supports_native_answer_streaming=_supports_native_answer_streaming_impl,
-                looks_uploaded_file_visual_inspection_query=(
-                    _looks_uploaded_file_visual_inspection_query
-                ),
-                provider_likely_supports_image_blocks=(
-                    _provider_likely_supports_image_blocks
-                ),
-                build_uploaded_document_visual_guard_answer=(
-                    _build_uploaded_document_visual_guard_answer
-                ),
-                tracer=tracer,
-                logger_obj=logger,
-            )
-            llm = llm_preflight.llm
-            response = llm_preflight.response
-
-            if llm and not response:
-                llm_tool_loop = await execute_direct_node_llm_tool_loop(
-                    llm=llm,
-                    query=query,
-                    state=state,
-                    ctx=ctx,
-                    bus_id=bus_id,
-                    domain_name_vi=domain_name_vi,
-                    role_name=role_name,
-                    tools=tools,
-                    force_tools=force_tools,
-                    tools_context_override=tools_context_override,
-                    visual_decision=visual_decision,
-                    history_limit=history_limit,
-                    routing_intent=routing_intent,
-                    response_language=response_language,
-                    is_identity_turn=is_identity_turn,
-                    is_short_house_chatter=is_short_house_chatter,
-                    use_house_voice_direct=use_house_voice_direct,
-                    direct_provider_override=direct_provider_override,
-                    preferred_provider=preferred_provider,
-                    explicit_user_provider=explicit_user_provider,
-                    explicit_web_search_turn=explicit_web_search_turn,
-                    push_event=push_event,
-                    needs_web_search=needs_web_search,
-                    needs_datetime=needs_datetime,
-                    resolve_direct_answer_timeout_profile=resolve_direct_answer_timeout_profile,
-                    bind_direct_tools=bind_direct_tools,
-                    build_direct_system_messages=build_direct_system_messages,
-                    build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
-                    execute_direct_tool_rounds=execute_direct_tool_rounds,
-                    extract_direct_response=extract_direct_response,
-                    sanitize_structured_visual_answer_text=(
-                        sanitize_structured_visual_answer_text
-                    ),
-                    sanitize_wiii_house_text=sanitize_wiii_house_text,
-                    build_direct_reasoning_summary=build_direct_reasoning_summary,
-                    tracer=tracer,
-                    logger_obj=logger,
-                    direct_max_rounds=getattr(
-                        settings, "direct_agent_max_tool_rounds", 12
-                    ),
-                    host_ui_total_timeout_seconds=(
-                        _HOST_UI_DIRECT_TOTAL_TIMEOUT_SECONDS
-                    ),
-                )
-
-                response = llm_tool_loop.response
-                messages = llm_tool_loop.messages
-                tool_call_events = llm_tool_loop.tool_call_events
-                force_tools = llm_tool_loop.force_tools
-            elif not response:
-                llm_fallback = resolve_direct_node_llm_unavailable_fallback(
-                    query=query,
-                    state=state,
-                    explicit_user_provider=explicit_user_provider,
-                    explicit_web_search_turn=explicit_web_search_turn,
-                    enable_natural_conversation=(
-                        getattr(settings, "enable_natural_conversation", False) is True
-                    ),
-                    get_phase_fallback=get_phase_fallback,
-                    build_codebase_analysis_fallback_answer=(
-                        _build_codebase_analysis_fallback_answer
-                    ),
-                    build_codebase_analysis_fallback_thinking=(
-                        _build_codebase_analysis_fallback_thinking
-                    ),
-                    record_direct_node_thinking_snapshot=(
-                        record_direct_node_thinking_snapshot
-                    ),
-                    record_thinking_snapshot_fn=record_thinking_snapshot,
-                )
-                response = llm_fallback.response
-                tracer.end_step(
-                    result="Fallback (LLM unavailable)",
-                    confidence=0.5,
-                    details={"response_type": llm_fallback.response_type},
-                )
-        except Exception as exc:
-            llm_response = getattr(exc, "_direct_node_llm_response", llm_response)
-            messages = getattr(exc, "_direct_node_messages", messages)
-            tool_call_events = getattr(
-                exc,
-                "_direct_node_tool_call_events",
-                tool_call_events,
-            )
-            fallback_result = await handle_direct_node_generation_exception(
-                exc=exc,
-                query=query,
-                state=state,
-                ctx_for_preflight=ctx_for_preflight,
-                tools=tools,
-                tool_call_events=tool_call_events,
-                llm_response=llm_response,
-                messages=messages,
-                llm=llm,
-                routing_intent=routing_intent,
-                response_language=response_language,
-                is_identity_turn=is_identity_turn,
-                explicit_user_provider=explicit_user_provider,
-                explicit_web_search_turn=explicit_web_search_turn,
-                needs_web_search=needs_web_search,
+                bind_direct_tools=bind_direct_tools,
+                build_direct_system_messages=build_direct_system_messages,
+                build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
+                execute_direct_tool_rounds=execute_direct_tool_rounds,
                 extract_direct_response=extract_direct_response,
                 sanitize_structured_visual_answer_text=(
                     sanitize_structured_visual_answer_text
                 ),
                 sanitize_wiii_house_text=sanitize_wiii_house_text,
-                build_search_template_fallback=build_search_template_fallback,
-                build_uploaded_document_context_fallback_answer=(
-                    _build_uploaded_document_context_fallback_answer
-                ),
-                build_codebase_analysis_fallback_answer=(
-                    _build_codebase_analysis_fallback_answer
-                ),
-                build_codebase_analysis_fallback_thinking=(
-                    _build_codebase_analysis_fallback_thinking
-                ),
+                build_direct_reasoning_summary=build_direct_reasoning_summary,
                 get_phase_fallback=get_phase_fallback,
-                record_direct_node_thinking_snapshot=(
-                    record_direct_node_thinking_snapshot
-                ),
                 record_thinking_snapshot_fn=record_thinking_snapshot,
-                tracer=tracer,
-                push_event=push_event,
-                inc_counter=inc_counter,
                 logger_obj=logger,
-            )
-            response = fallback_result.response
-            tool_call_events = fallback_result.tool_call_events
+            ),
+        )
+        response = llm_pipeline.response
 
     from app.core.org_context import get_current_org_id
 

--- a/maritime-ai-service/tests/unit/test_direct_node_llm_pipeline.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_llm_pipeline.py
@@ -1,0 +1,208 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.engine.multi_agent import direct_node_llm_pipeline as module
+from app.engine.multi_agent.direct_node_llm_pipeline import (
+    DirectNodeLlmPipelineDependencies,
+    DirectNodeLlmPipelineRequest,
+    execute_direct_node_llm_pipeline,
+)
+
+
+class _Tracer:
+    def __init__(self):
+        self.end_steps: list[dict[str, object]] = []
+
+    def end_step(self, **kwargs):
+        self.end_steps.append(kwargs)
+
+
+def _turn_policy(**overrides):
+    values = {
+        "ctx": {"user_role": "student", "response_language": "vi"},
+        "response_language": "vi",
+        "thinking_effort": None,
+        "routing_intent": "general",
+        "is_identity_turn": False,
+        "is_emotional_support_turn": False,
+        "is_short_house_chatter": False,
+        "visual_decision": SimpleNamespace(force_tool=False),
+        "history_limit": 10,
+        "tools_context_override": None,
+        "role_name": "direct_agent",
+        "preferred_provider": None,
+        "explicit_user_provider": None,
+        "use_house_voice_direct": False,
+        "direct_provider_override": None,
+        "is_codebase_source_turn": False,
+        "explicit_web_search_turn": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _request(**overrides):
+    values = {
+        "query": "Giup minh hoc Hang hai",
+        "state": {
+            "query": "Giup minh hoc Hang hai",
+            "context": {"user_role": "student", "response_language": "vi"},
+        },
+        "bus_id": "bus-1",
+        "push_event": lambda *_args, **_kwargs: None,
+        "tracer": _Tracer(),
+        "ctx_for_preflight": {"user_role": "student", "response_language": "vi"},
+        "has_uploaded_document_context": False,
+        "domain_name_vi": "Hang hai",
+        "sanitize_document_preview_response": lambda text, *_args, **_kwargs: text,
+        "explicit_web_search_turn": False,
+        "enable_natural_conversation": True,
+        "requested_model": None,
+        "llm_presence_penalty": 0.0,
+        "llm_frequency_penalty": 0.0,
+        "direct_max_rounds": 12,
+        "host_ui_total_timeout_seconds": 45.0,
+    }
+    values.update(overrides)
+    return DirectNodeLlmPipelineRequest(**values)
+
+
+def _dependencies(**overrides):
+    values = {
+        "normalize_for_intent": lambda text: text.lower(),
+        "looks_identity_selfhood_turn": lambda _text: False,
+        "needs_web_search": lambda _text: False,
+        "needs_datetime": lambda _text: False,
+        "resolve_visual_intent": lambda _text: SimpleNamespace(force_tool=False),
+        "recommended_visual_thinking_effort": lambda *_args, **_kwargs: None,
+        "get_active_code_studio_session": lambda _state: None,
+        "merge_thinking_effort": lambda current, other: other or current,
+        "get_effective_provider": lambda _state: None,
+        "get_explicit_user_provider": lambda _state: None,
+        "collect_direct_tools": lambda *_args, **_kwargs: ([], False),
+        "direct_required_tool_names": lambda *_args, **_kwargs: [],
+        "resolve_direct_answer_timeout_profile": lambda **_kwargs: None,
+        "bind_direct_tools": lambda *_args, **_kwargs: (object(), object(), None),
+        "build_direct_system_messages": lambda *_args, **_kwargs: [],
+        "build_visual_tool_runtime_metadata": lambda *_args, **_kwargs: {},
+        "execute_direct_tool_rounds": lambda *_args, **_kwargs: None,
+        "extract_direct_response": lambda *_args, **_kwargs: ("", "", []),
+        "sanitize_structured_visual_answer_text": lambda text, *_args, **_kwargs: text,
+        "sanitize_wiii_house_text": lambda text, *_args, **_kwargs: text,
+        "build_direct_reasoning_summary": lambda *_args, **_kwargs: "",
+        "get_phase_fallback": lambda _state: "Fallback tu phase.",
+        "record_thinking_snapshot_fn": lambda *_args, **_kwargs: None,
+        "logger_obj": MagicMock(),
+    }
+    values.update(overrides)
+    return DirectNodeLlmPipelineDependencies(**values)
+
+
+@pytest.mark.asyncio
+async def test_execute_direct_node_llm_pipeline_returns_typed_unavailable_fallback(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        module,
+        "resolve_direct_node_turn_policy",
+        lambda **_kwargs: _turn_policy(),
+    )
+    monkeypatch.setattr(
+        module,
+        "select_direct_node_tools",
+        lambda **_kwargs: SimpleNamespace(tools=[], force_tools=False),
+    )
+    monkeypatch.setattr(
+        module,
+        "prepare_direct_node_llm_preflight",
+        lambda **_kwargs: SimpleNamespace(llm=None, response=""),
+    )
+    monkeypatch.setattr(
+        module,
+        "resolve_direct_node_llm_unavailable_fallback",
+        lambda **_kwargs: SimpleNamespace(
+            response="Fallback co contract.",
+            response_type="fallback",
+        ),
+    )
+
+    request = _request()
+    result = await execute_direct_node_llm_pipeline(
+        request=request,
+        dependencies=_dependencies(),
+    )
+
+    assert result.response == "Fallback co contract."
+    assert result.tool_call_events == []
+    assert request.tracer.end_steps == [
+        {
+            "result": "Fallback (LLM unavailable)",
+            "confidence": 0.5,
+            "details": {"response_type": "fallback"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_direct_node_llm_pipeline_runs_tool_loop_with_typed_inputs(
+    monkeypatch,
+):
+    llm = object()
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        module,
+        "resolve_direct_node_turn_policy",
+        lambda **_kwargs: _turn_policy(
+            preferred_provider="qwen",
+            direct_provider_override="qwen",
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "select_direct_node_tools",
+        lambda **_kwargs: SimpleNamespace(
+            tools=[SimpleNamespace(name="tool_knowledge_search")],
+            force_tools=True,
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "prepare_direct_node_llm_preflight",
+        lambda **_kwargs: SimpleNamespace(llm=llm, response=""),
+    )
+
+    async def _execute_tool_loop(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            response="Da tra loi bang LLM.",
+            messages=["system", "assistant"],
+            tool_call_events=[{"name": "tool_knowledge_search", "status": "ok"}],
+            force_tools=True,
+        )
+
+    monkeypatch.setattr(module, "execute_direct_node_llm_tool_loop", _execute_tool_loop)
+    monkeypatch.setattr(
+        module,
+        "resolve_direct_node_llm_unavailable_fallback",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("fallback must not run when LLM exists")
+        ),
+    )
+
+    request = _request(direct_max_rounds=9, host_ui_total_timeout_seconds=30.0)
+    result = await execute_direct_node_llm_pipeline(
+        request=request,
+        dependencies=_dependencies(),
+    )
+
+    assert result.response == "Da tra loi bang LLM."
+    assert result.tool_call_events == [
+        {"name": "tool_knowledge_search", "status": "ok"}
+    ]
+    assert captured["llm"] is llm
+    assert captured["force_tools"] is True
+    assert captured["preferred_provider"] == "qwen"
+    assert captured["direct_max_rounds"] == 9
+    assert captured["host_ui_total_timeout_seconds"] == 30.0


### PR DESCRIPTION
## Summary
- Extract Direct Node provider/tool/fallback execution into direct_node_llm_pipeline.py with typed request/dependencies/result contracts.
- Keep direct_node_runtime.py focused on event sink, pre-LLM pipeline, typed LLM pipeline call, and final state.
- Add unit coverage for unavailable fallback and LLM tool-loop execution through the new contract.

Closes #599.

## Verification
- cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_direct_node_llm_pipeline.py tests/unit/test_direct_node_provider_errors.py tests/unit/test_direct_node_llm_tool_loop.py -q --tb=short -> 39 passed.
- cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_direct_node_pre_llm_pipeline.py tests/unit/test_direct_node_document_preview_runtime.py tests/unit/test_direct_node_image_input_preflight.py -q --tb=short -> 8 passed.
- cd maritime-ai-service && uv run --python 3.12 --extra dev ruff check app/engine/multi_agent/direct_node_llm_pipeline.py app/engine/multi_agent/direct_node_runtime.py tests/unit/test_direct_node_llm_pipeline.py -> passed.
- git diff --check -> passed.

## Risk
High-risk surfaces touched: Direct Node provider selection, tool routing, uploaded-document preview host action fallback, exception fallback, and streaming/tool-loop parity. Behavior is intended to be extraction-only; existing regression tests cover provider errors and document preflight.

## Rollback
Revert this PR to restore the inline LLM execution block in direct_node_runtime.py.