### PR TITLE
Refactor Code Studio provider execution into typed contract

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-
+from app.engine.multi_agent.code_studio_provider_execution import (
+    CodeStudioProviderExecutionDependencies,
+    CodeStudioProviderExecutionRequest,
+    execute_code_studio_provider_execution,
+)
 from app.engine.multi_agent.code_studio_scaffold_fallback_policy import (
     resolve_code_studio_scaffold_fallback,
 )
@@ -150,141 +154,40 @@ async def code_studio_node_impl(
                     },
                 )
             else:
-                from app.engine.multi_agent.agent_config import AgentConfigRegistry
-
-                thinking_effort = state.get("thinking_effort")
-                llm = AgentConfigRegistry.get_llm(
-                    "code_studio_agent",
-                    effort_override=thinking_effort,
-                    provider_override=explicit_provider,
-                    requested_model=state.get("model"),
-                )
-                if llm and getattr(settings_obj, "enable_natural_conversation", False) is True:
-                    _pp = getattr(settings_obj, "llm_presence_penalty", 0.0)
-                    _fp = getattr(settings_obj, "llm_frequency_penalty", 0.0)
-                    if _pp or _fp:
-                        try:
-                            llm = llm.bind(presence_penalty=_pp, frequency_penalty=_fp)
-                        except Exception:
-                            pass
-                if not llm:
-                    raise RuntimeError("Code Studio provider returned no LLM")
-
-                bound_provider = getattr(llm, "_wiii_provider_name", None) or state.get("provider")
-                bound_model = (
-                    getattr(llm, "_wiii_model_name", None)
-                    or getattr(llm, "model_name", None)
-                    or getattr(llm, "model", None)
-                )
-                if bound_provider and str(bound_provider).strip().lower() != "auto":
-                    state["_execution_provider"] = str(bound_provider)
-                if bound_model:
-                    state["_execution_model"] = str(bound_model)
-                    state["model"] = str(bound_model)
-                llm_with_tools, llm_auto, forced_tool_choice = bind_direct_tools(
-                    llm,
-                    tools,
-                    force_tools,
-                    provider=bound_provider,
-                    include_forced_choice=True,
-                )
-                messages = build_direct_system_messages(
-                    state,
-                    effective_query,
-                    domain_name_vi,
-                    role_name="code_studio_agent",
-                    tools_context_override=build_code_studio_tools_context(
-                        settings_obj,
-                        _ctx.get("user_role", "student"),
-                        effective_query,
+                provider_execution = await execute_code_studio_provider_execution(
+                    request=CodeStudioProviderExecutionRequest(
+                        effective_query=effective_query,
+                        state=state,
+                        ctx=_ctx,
+                        domain_name_vi=domain_name_vi,
+                        explicit_provider=explicit_provider,
+                        tools=tools,
+                        force_tools=force_tools,
+                        runtime_context_base=runtime_context_base,
+                        event_queue_present=bool(_event_queue),
+                        push_event=_push_event,
+                        settings_obj=settings_obj,
+                        requested_model=state.get("model"),
+                    ),
+                    dependencies=CodeStudioProviderExecutionDependencies(
+                        bind_direct_tools=bind_direct_tools,
+                        build_direct_system_messages=build_direct_system_messages,
+                        build_code_studio_tools_context=build_code_studio_tools_context,
+                        execute_code_studio_tool_rounds=execute_code_studio_tool_rounds,
+                        extract_direct_response=extract_direct_response,
+                        build_code_studio_stream_summary_messages=(
+                            build_code_studio_stream_summary_messages
+                        ),
+                        stream_answer_with_fallback=stream_answer_with_fallback,
+                        sanitize_code_studio_response=sanitize_code_studio_response,
+                        build_code_studio_reasoning_summary=(
+                            build_code_studio_reasoning_summary
+                        ),
+                        direct_tool_names=direct_tool_names,
+                        logger_obj=logger,
                     ),
                 )
-                llm_response, messages, _tc_events = await execute_code_studio_tool_rounds(
-                    llm_with_tools,
-                    llm_auto,
-                    messages,
-                    tools,
-                    _push_event,
-                    runtime_context_base=runtime_context_base,
-                    query=effective_query,
-                    state=state,
-                    provider=state.get("provider"),
-                    runtime_provider=bound_provider,
-                    forced_tool_choice=forced_tool_choice,
-                )
-
-                if _tc_events:
-                    state["tool_call_events"] = _tc_events
-
-                response, thinking_content, tools_used = extract_direct_response(llm_response, messages)
-                streamed_code_studio_answer = False
-                if _event_queue and _tc_events:
-                    try:
-                        summary_provider = (
-                            bound_provider
-                            if bound_provider and str(bound_provider).strip().lower() != "auto"
-                            else state.get("provider")
-                        )
-                        from app.engine.llm_pool import (
-                            ThinkingTier,
-                            get_llm_for_provider,
-                        )
-
-                        summary_llm = get_llm_for_provider(
-                            summary_provider,
-                            default_tier=ThinkingTier.MODERATE,
-                            strict_pin=bool(
-                                summary_provider
-                                and str(summary_provider).strip().lower() != "auto"
-                            ),
-                        )
-                        summary_messages = build_code_studio_stream_summary_messages(
-                            state,
-                            effective_query,
-                            domain_name_vi,
-                            tool_call_events=_tc_events,
-                        )
-                        streamed_summary_response, streamed_code_studio_answer = await stream_answer_with_fallback(
-                            summary_llm,
-                            summary_messages,
-                            _push_event,
-                            provider=summary_provider,
-                            node="code_studio_agent",
-                        )
-                        streamed_response, _summary_thinking, _summary_tools = extract_direct_response(
-                            streamed_summary_response,
-                            summary_messages,
-                        )
-                        if streamed_response:
-                            response = streamed_response
-                    except Exception as _summary_err:
-                        logger.warning(
-                            "[CODE_STUDIO] Final streamed delivery summary failed, using buffered response: %s",
-                            _summary_err,
-                        )
-                response = sanitize_code_studio_response(response, _tc_events, state)
-
-                _safe_thinking = await build_code_studio_reasoning_summary(
-                    effective_query,
-                    state,
-                    direct_tool_names(tools_used),
-                )
-                if _safe_thinking:
-                    state["thinking_content"] = resolve_visible_thinking_from_lifecycle(
-                        state,
-                        fallback=_safe_thinking,
-                        default_node="code_studio_agent",
-                    )
-                    if state.get("thinking_content"):
-                        record_thinking_snapshot(
-                            state,
-                            state.get("thinking_content"),
-                            node="code_studio_agent",
-                            provenance="aligned_cleanup",
-                        )
-
-                if tools_used:
-                    state["tools_used"] = tools_used
+                response = provider_execution.response
 
                 tracer.end_step(
                     result=f"Code studio response: {len(response)} chars",
@@ -293,7 +196,7 @@ async def code_studio_node_impl(
                         "response_type": "capability_generated",
                         "tools_bound": len(tools),
                         "force_tools": force_tools,
-                        "streamed_delivery": streamed_code_studio_answer,
+                        "streamed_delivery": provider_execution.streamed_delivery,
                     },
                 )
         elif not response:

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_provider_execution.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_provider_execution.py
@@ -1,0 +1,256 @@
+"""Typed provider-backed execution contract for Code Studio."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from app.engine.multi_agent.state import AgentState
+from app.engine.reasoning import (
+    record_thinking_snapshot,
+    resolve_visible_thinking_from_lifecycle,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CodeStudioProviderExecutionRequest:
+    """Per-turn state required for provider-backed Code Studio execution."""
+
+    effective_query: str
+    state: AgentState
+    ctx: dict[str, Any]
+    domain_name_vi: str
+    explicit_provider: str | None
+    tools: list[Any]
+    force_tools: bool
+    runtime_context_base: Any | None
+    event_queue_present: bool
+    push_event: Callable[[dict[str, Any]], Any]
+    settings_obj: Any
+    requested_model: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class CodeStudioProviderExecutionDependencies:
+    """Injected app contracts used by provider-backed Code Studio execution."""
+
+    bind_direct_tools: Callable[..., tuple[Any, Any, Any]]
+    build_direct_system_messages: Callable[..., list[Any]]
+    build_code_studio_tools_context: Callable[..., str]
+    execute_code_studio_tool_rounds: Callable[..., Any]
+    extract_direct_response: Callable[..., tuple[str, str, list[Any]]]
+    build_code_studio_stream_summary_messages: Callable[..., list[Any]]
+    stream_answer_with_fallback: Callable[..., Any]
+    sanitize_code_studio_response: Callable[..., str]
+    build_code_studio_reasoning_summary: Callable[..., Any]
+    direct_tool_names: Callable[[list[Any]], list[str]]
+    logger_obj: logging.Logger
+    get_agent_llm: Callable[..., Any] | None = None
+    get_summary_llm_for_provider: Callable[..., Any] | None = None
+    record_thinking_snapshot_fn: Callable[..., Any] = record_thinking_snapshot
+    resolve_visible_thinking_fn: Callable[..., str] = (
+        resolve_visible_thinking_from_lifecycle
+    )
+
+
+@dataclass(slots=True)
+class CodeStudioProviderExecutionResult:
+    """Resolved Code Studio response after provider/tool/summary execution."""
+
+    response: str
+    tool_call_events: list[dict[str, Any]]
+    tools_used: list[Any]
+    streamed_delivery: bool
+    bound_provider: str | None
+    bound_model: str | None
+
+
+def _resolve_agent_llm(dependencies: CodeStudioProviderExecutionDependencies):
+    if dependencies.get_agent_llm is not None:
+        return dependencies.get_agent_llm
+    from app.engine.multi_agent.agent_config import AgentConfigRegistry
+
+    return AgentConfigRegistry.get_llm
+
+
+def _resolve_summary_llm_provider(
+    dependencies: CodeStudioProviderExecutionDependencies,
+):
+    if dependencies.get_summary_llm_for_provider is not None:
+        return dependencies.get_summary_llm_for_provider
+    from app.engine.llm_pool import get_llm_for_provider
+
+    return get_llm_for_provider
+
+
+async def execute_code_studio_provider_execution(
+    *,
+    request: CodeStudioProviderExecutionRequest,
+    dependencies: CodeStudioProviderExecutionDependencies,
+) -> CodeStudioProviderExecutionResult:
+    """Run the provider-backed Code Studio tool loop and final response cleanup."""
+
+    state = request.state
+    thinking_effort = state.get("thinking_effort")
+    get_agent_llm = _resolve_agent_llm(dependencies)
+    llm = get_agent_llm(
+        "code_studio_agent",
+        effort_override=thinking_effort,
+        provider_override=request.explicit_provider,
+        requested_model=request.requested_model,
+    )
+    if (
+        llm
+        and getattr(request.settings_obj, "enable_natural_conversation", False) is True
+    ):
+        presence_penalty = getattr(request.settings_obj, "llm_presence_penalty", 0.0)
+        frequency_penalty = getattr(request.settings_obj, "llm_frequency_penalty", 0.0)
+        if presence_penalty or frequency_penalty:
+            try:
+                llm = llm.bind(
+                    presence_penalty=presence_penalty,
+                    frequency_penalty=frequency_penalty,
+                )
+            except Exception:
+                pass
+    if not llm:
+        raise RuntimeError("Code Studio provider returned no LLM")
+
+    bound_provider = getattr(llm, "_wiii_provider_name", None) or state.get("provider")
+    bound_model = (
+        getattr(llm, "_wiii_model_name", None)
+        or getattr(llm, "model_name", None)
+        or getattr(llm, "model", None)
+    )
+    if bound_provider and str(bound_provider).strip().lower() != "auto":
+        state["_execution_provider"] = str(bound_provider)
+    if bound_model:
+        state["_execution_model"] = str(bound_model)
+        state["model"] = str(bound_model)
+
+    llm_with_tools, llm_auto, forced_tool_choice = dependencies.bind_direct_tools(
+        llm,
+        request.tools,
+        request.force_tools,
+        provider=bound_provider,
+        include_forced_choice=True,
+    )
+    messages = dependencies.build_direct_system_messages(
+        state,
+        request.effective_query,
+        request.domain_name_vi,
+        role_name="code_studio_agent",
+        tools_context_override=dependencies.build_code_studio_tools_context(
+            request.settings_obj,
+            request.ctx.get("user_role", "student"),
+            request.effective_query,
+        ),
+    )
+    llm_response, messages, tool_call_events = (
+        await dependencies.execute_code_studio_tool_rounds(
+            llm_with_tools,
+            llm_auto,
+            messages,
+            request.tools,
+            request.push_event,
+            runtime_context_base=request.runtime_context_base,
+            query=request.effective_query,
+            state=state,
+            provider=state.get("provider"),
+            runtime_provider=bound_provider,
+            forced_tool_choice=forced_tool_choice,
+        )
+    )
+
+    if tool_call_events:
+        state["tool_call_events"] = tool_call_events
+
+    response, _thinking_content, tools_used = dependencies.extract_direct_response(
+        llm_response,
+        messages,
+    )
+    streamed_code_studio_answer = False
+    if request.event_queue_present and tool_call_events:
+        try:
+            summary_provider = (
+                bound_provider
+                if bound_provider and str(bound_provider).strip().lower() != "auto"
+                else state.get("provider")
+            )
+            from app.engine.llm_pool import ThinkingTier
+
+            summary_llm = _resolve_summary_llm_provider(dependencies)(
+                summary_provider,
+                default_tier=ThinkingTier.MODERATE,
+                strict_pin=bool(
+                    summary_provider
+                    and str(summary_provider).strip().lower() != "auto"
+                ),
+            )
+            summary_messages = dependencies.build_code_studio_stream_summary_messages(
+                state,
+                request.effective_query,
+                request.domain_name_vi,
+                tool_call_events=tool_call_events,
+            )
+            streamed_summary_response, streamed_code_studio_answer = (
+                await dependencies.stream_answer_with_fallback(
+                    summary_llm,
+                    summary_messages,
+                    request.push_event,
+                    provider=summary_provider,
+                    node="code_studio_agent",
+                )
+            )
+            streamed_response, _summary_thinking, _summary_tools = (
+                dependencies.extract_direct_response(
+                    streamed_summary_response,
+                    summary_messages,
+                )
+            )
+            if streamed_response:
+                response = streamed_response
+        except Exception as summary_error:
+            dependencies.logger_obj.warning(
+                "[CODE_STUDIO] Final streamed delivery summary failed, "
+                "using buffered response: %s",
+                summary_error,
+            )
+    response = dependencies.sanitize_code_studio_response(
+        response,
+        tool_call_events,
+        state,
+    )
+
+    safe_thinking = await dependencies.build_code_studio_reasoning_summary(
+        request.effective_query,
+        state,
+        dependencies.direct_tool_names(tools_used),
+    )
+    if safe_thinking:
+        state["thinking_content"] = dependencies.resolve_visible_thinking_fn(
+            state,
+            fallback=safe_thinking,
+            default_node="code_studio_agent",
+        )
+        if state.get("thinking_content"):
+            dependencies.record_thinking_snapshot_fn(
+                state,
+                state.get("thinking_content"),
+                node="code_studio_agent",
+                provenance="aligned_cleanup",
+            )
+
+    if tools_used:
+        state["tools_used"] = tools_used
+
+    return CodeStudioProviderExecutionResult(
+        response=response,
+        tool_call_events=tool_call_events,
+        tools_used=tools_used,
+        streamed_delivery=streamed_code_studio_answer,
+        bound_provider=str(bound_provider) if bound_provider else None,
+        bound_model=str(bound_model) if bound_model else None,
+    )

--- a/maritime-ai-service/tests/unit/test_code_studio_provider_execution.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_provider_execution.py
@@ -1,0 +1,180 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.engine.multi_agent.code_studio_provider_execution import (
+    CodeStudioProviderExecutionDependencies,
+    CodeStudioProviderExecutionRequest,
+    execute_code_studio_provider_execution,
+)
+
+
+class _FakeLlm:
+    _wiii_provider_name = "qwen"
+    _wiii_model_name = "qwen3-next"
+
+    def bind(self, **kwargs):
+        return SimpleNamespace(
+            _wiii_provider_name=self._wiii_provider_name,
+            _wiii_model_name=self._wiii_model_name,
+            bound_penalties=kwargs,
+        )
+
+
+def _request(**overrides):
+    values = {
+        "effective_query": "Tao mo phong COLREG",
+        "state": {
+            "query": "Tao mo phong COLREG",
+            "provider": "qwen",
+            "context": {"user_role": "teacher"},
+        },
+        "ctx": {"user_role": "teacher"},
+        "domain_name_vi": "Hang hai",
+        "explicit_provider": "qwen",
+        "tools": [SimpleNamespace(name="tool_create_visual_code")],
+        "force_tools": True,
+        "runtime_context_base": {"request_id": "req-1"},
+        "event_queue_present": False,
+        "push_event": lambda *_args, **_kwargs: None,
+        "settings_obj": SimpleNamespace(
+            enable_natural_conversation=True,
+            llm_presence_penalty=0.1,
+            llm_frequency_penalty=0.2,
+        ),
+        "requested_model": None,
+    }
+    values.update(overrides)
+    return CodeStudioProviderExecutionRequest(**values)
+
+
+def _dependencies(**overrides):
+    calls: dict[str, object] = {}
+
+    def bind_direct_tools(llm, tools, force_tools, **kwargs):
+        calls["bound_llm"] = llm
+        calls["bind_kwargs"] = kwargs
+        return "llm-with-tools", "llm-auto", "tool_create_visual_code"
+
+    async def execute_code_studio_tool_rounds(*args, **kwargs):
+        calls["tool_round_args"] = args
+        calls["tool_round_kwargs"] = kwargs
+        return (
+            SimpleNamespace(content="raw tool response"),
+            ["system", "assistant"],
+            [{"name": "tool_create_visual_code", "status": "ok"}],
+        )
+
+    def extract_direct_response(response, _messages):
+        content = getattr(response, "content", "")
+        if content == "summary response":
+            return "Summary da stream.", "", []
+        return "Raw da tao preview.", "", ["tool_create_visual_code"]
+
+    async def build_code_studio_reasoning_summary(*_args, **_kwargs):
+        return "Minh dang giu preview that va tranh template chung chung."
+
+    values = {
+        "bind_direct_tools": bind_direct_tools,
+        "build_direct_system_messages": lambda *_args, **_kwargs: ["system"],
+        "build_code_studio_tools_context": lambda *_args, **_kwargs: "tools context",
+        "execute_code_studio_tool_rounds": execute_code_studio_tool_rounds,
+        "extract_direct_response": extract_direct_response,
+        "build_code_studio_stream_summary_messages": (
+            lambda *_args, **_kwargs: ["summary system"]
+        ),
+        "stream_answer_with_fallback": lambda *_args, **_kwargs: None,
+        "sanitize_code_studio_response": lambda text, *_args, **_kwargs: text.strip(),
+        "build_code_studio_reasoning_summary": build_code_studio_reasoning_summary,
+        "direct_tool_names": lambda tools: [str(tool) for tool in tools],
+        "logger_obj": MagicMock(),
+        "get_agent_llm": lambda *_args, **_kwargs: _FakeLlm(),
+        "get_summary_llm_for_provider": lambda *_args, **_kwargs: "summary-llm",
+        "record_thinking_snapshot_fn": lambda *_args, **_kwargs: calls.setdefault(
+            "snapshot_recorded",
+            True,
+        ),
+        "resolve_visible_thinking_fn": (
+            lambda _state, *, fallback, default_node: f"{default_node}: {fallback}"
+        ),
+    }
+    values.update(overrides)
+    return CodeStudioProviderExecutionDependencies(**values), calls
+
+
+@pytest.mark.asyncio
+async def test_execute_code_studio_provider_execution_returns_typed_result():
+    request = _request()
+    dependencies, calls = _dependencies()
+
+    result = await execute_code_studio_provider_execution(
+        request=request,
+        dependencies=dependencies,
+    )
+
+    assert result.response == "Raw da tao preview."
+    assert result.tool_call_events == [
+        {"name": "tool_create_visual_code", "status": "ok"}
+    ]
+    assert result.tools_used == ["tool_create_visual_code"]
+    assert result.streamed_delivery is False
+    assert result.bound_provider == "qwen"
+    assert result.bound_model == "qwen3-next"
+    assert request.state["_execution_provider"] == "qwen"
+    assert request.state["_execution_model"] == "qwen3-next"
+    assert request.state["model"] == "qwen3-next"
+    assert request.state["tool_call_events"] == result.tool_call_events
+    assert request.state["tools_used"] == ["tool_create_visual_code"]
+    assert "code_studio_agent:" in request.state["thinking_content"]
+    assert calls["snapshot_recorded"] is True
+    assert calls["bind_kwargs"]["provider"] == "qwen"
+    assert calls["tool_round_kwargs"]["runtime_provider"] == "qwen"
+    assert calls["tool_round_kwargs"]["forced_tool_choice"] == "tool_create_visual_code"
+
+
+@pytest.mark.asyncio
+async def test_execute_code_studio_provider_execution_uses_streamed_summary():
+    summary_calls: dict[str, object] = {}
+
+    async def stream_answer_with_fallback(llm, messages, push_event, **kwargs):
+        summary_calls["llm"] = llm
+        summary_calls["messages"] = messages
+        summary_calls["kwargs"] = kwargs
+        summary_calls["push_event"] = push_event
+        return SimpleNamespace(content="summary response"), True
+
+    def get_summary_llm_for_provider(provider, **kwargs):
+        summary_calls["provider"] = provider
+        summary_calls["summary_kwargs"] = kwargs
+        return "summary-llm"
+
+    dependencies, _calls = _dependencies(
+        stream_answer_with_fallback=stream_answer_with_fallback,
+        get_summary_llm_for_provider=get_summary_llm_for_provider,
+    )
+
+    result = await execute_code_studio_provider_execution(
+        request=_request(event_queue_present=True),
+        dependencies=dependencies,
+    )
+
+    assert result.response == "Summary da stream."
+    assert result.streamed_delivery is True
+    assert summary_calls["provider"] == "qwen"
+    assert summary_calls["llm"] == "summary-llm"
+    assert summary_calls["messages"] == ["summary system"]
+    assert summary_calls["kwargs"]["provider"] == "qwen"
+    assert summary_calls["kwargs"]["node"] == "code_studio_agent"
+    assert summary_calls["summary_kwargs"]["strict_pin"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_code_studio_provider_execution_fails_when_llm_missing():
+    dependencies, _calls = _dependencies(get_agent_llm=lambda *_args, **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match="provider returned no LLM"):
+        await execute_code_studio_provider_execution(
+            request=_request(),
+            dependencies=dependencies,
+        )


### PR DESCRIPTION
## Summary
- Extract provider-backed Code Studio execution into code_studio_provider_execution.py with typed request/dependencies/result contracts.
- Keep code_studio_node_runtime.py focused on ambiguity handling, tool setup, fast paths, scaffold fallback policy, and final state.
- Add contract tests for successful tool execution, streamed summary replacement, and missing-LLM failure.

Closes #601.

## Verification
- cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_code_studio_provider_execution.py tests/unit/test_code_studio_tool_setup.py tests/unit/test_code_studio_fast_paths.py tests/unit/test_code_studio_scaffold_fallback_policy.py -q --tb=short -> 17 passed.
- cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_graph_routing.py -q --tb=short -> 75 passed.
- cd maritime-ai-service && uv run --python 3.12 --extra dev ruff check app/engine/multi_agent/code_studio_provider_execution.py app/engine/multi_agent/code_studio_node_runtime.py tests/unit/test_code_studio_provider_execution.py -> passed.
- git diff --check -> passed.

## Risk
High-risk surfaces touched: Code Studio visual/tool routing, provider metadata propagation, tool result streaming, streamed summary replacement, response sanitization, and thinking snapshots. This is intended to be extraction-only; graph routing and scaffold fallback policy tests were run.

## Rollback
Revert this PR to restore the inline provider execution block in code_studio_node_runtime.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Code Studio execution by consolidating provider-backed operation handling into a unified, type-safe execution framework for improved maintainability.

* **Tests**
  * Added comprehensive unit tests for Code Studio provider execution, covering non-streamed paths, streamed summary generation, and error handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->