### PR TITLE
Polish Code Studio visual UX copy and markdown regression

### DIFF
--- a/wiii-desktop/src/__tests__/assistant-markdown.test.ts
+++ b/wiii-desktop/src/__tests__/assistant-markdown.test.ts
@@ -63,4 +63,18 @@ describe("normalizeAssistantMarkdown", () => {
     expect(normalized).toContain("Cậu chỉ cần nói:\n> “Mình thấy nút Khóa học”");
     expect(normalized).toContain("hoặc\n\n> “Mình không thấy gì cả”");
   });
+
+  it("repairs collapsed Vietnamese maritime tables after prose prefixes", () => {
+    const input =
+      "Ví dụ đời thường: Giống như bạn không được đốt than trong nhà. --- 🔍 So sánh nhanh: | Tiêu chí | Annex I | Annex VI |---------|----------|---------| | Ô nhiễm | Dầu ra biển | Khí thải ra không khí | Chất gây hại | Dầu, hydrocarbon | SOx, NOx, PM, CO₂ | Giới hạn chính | Không xả dầu | Hàm lượng lưu huỳnh ≤0.50% | --- 💡 Mẹo nhớ: đọc theo từng cột.";
+
+    const normalized = normalizeAssistantMarkdown(input);
+
+    expect(normalized).toContain("Ví dụ đời thường: Giống như bạn không được đốt than trong nhà.");
+    expect(normalized).toContain("\n\n---\n\n🔍 So sánh nhanh:");
+    expect(normalized).toContain("| Tiêu chí | Annex I | Annex VI |");
+    expect(normalized).toContain("| Ô nhiễm | Dầu ra biển | Khí thải ra không khí |");
+    expect(normalized).toContain("| Giới hạn chính | Không xả dầu | Hàm lượng lưu huỳnh ≤0.50% |");
+    expect(normalized).toContain("\n\n---\n\n💡 Mẹo nhớ:");
+  });
 });

--- a/wiii-desktop/src/__tests__/code-studio-panel.test.tsx
+++ b/wiii-desktop/src/__tests__/code-studio-panel.test.tsx
@@ -113,7 +113,7 @@ describe("CodeStudioPanel", () => {
 
     render(<CodeStudioPanel />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+    fireEvent.click(screen.getByRole("button", { name: "Xem trước" }));
 
     await waitFor(() => {
       expect(screen.getByTestId("inline-visual-frame")).toBeTruthy();
@@ -140,5 +140,18 @@ describe("CodeStudioPanel", () => {
         className: "w-full h-full",
       }),
     );
+  });
+
+  it("uses Vietnamese-first labels in the Code Studio surface", async () => {
+    seedCompleteSession("code");
+
+    render(<CodeStudioPanel />);
+
+    expect(await screen.findByRole("button", { name: "Mã" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Xem trước" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Đóng Code Studio" })).toBeTruthy();
+    expect(screen.getByText("Đã xong")).toBeTruthy();
+    expect(screen.getByText(/1 dòng · \d+ byte/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Sao chép" })).toBeTruthy();
   });
 });

--- a/wiii-desktop/src/components/layout/CodeStudioPanel.tsx
+++ b/wiii-desktop/src/components/layout/CodeStudioPanel.tsx
@@ -114,7 +114,7 @@ const CodeStudioContent = memo(function CodeStudioContent({
         done: code.includes("<script") || code.includes("function"),
       },
       {
-        label: "Controls tương tác",
+        label: "Điều khiển tương tác",
         done: code.includes('type="range"') || code.includes("<button"),
       },
       {
@@ -180,13 +180,13 @@ const CodeStudioContent = memo(function CodeStudioContent({
       <div className="flex border-b border-border shrink-0">
         <TabButton
           icon={Code2}
-          label="Code"
+          label="Mã"
           active={activeTab === "code"}
           onClick={() => handleSelectTab("code")}
         />
         <TabButton
           icon={Eye}
-          label="Preview"
+          label="Xem trước"
           active={activeTab === "preview"}
           onClick={() => handleSelectTab("preview")}
           disabled={isStreaming}
@@ -302,7 +302,7 @@ function CodeTab({ session }: { session: CodeStudioSession }) {
       {/* Toolbar */}
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-border/50 shrink-0">
         <span className="text-[10px] text-text-tertiary">
-          {lineCount} dòng · {session.code.length} bytes
+          {lineCount} dòng · {session.code.length} byte
           {isStreaming && session.totalBytes > 0 && (
             <>
               {" "}
@@ -322,7 +322,7 @@ function CodeTab({ session }: { session: CodeStudioSession }) {
             ) : (
               <Copy size={12} />
             )}
-            {copied ? "Đã chép" : "Copy"}
+            {copied ? "Đã chép" : "Sao chép"}
           </button>
           <button
             onClick={handleDownload}
@@ -355,7 +355,7 @@ function PreviewTab({ session }: { session: CodeStudioSession }) {
       <div className="flex flex-col items-center justify-center h-full text-text-tertiary py-16">
         <Loader2 size={32} className="mb-3 animate-spin opacity-50" />
         <p className="text-sm">
-          Đang tạo code, preview sẽ hiện sau khi hoàn thành.
+          Đang tạo mã, bản xem trước sẽ hiện sau khi hoàn thành.
         </p>
       </div>
     );
@@ -365,7 +365,7 @@ function PreviewTab({ session }: { session: CodeStudioSession }) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-text-tertiary py-16">
         <Eye size={32} className="mb-3 opacity-50" />
-        <p className="text-sm">Không có code để preview.</p>
+        <p className="text-sm">Không có mã để xem trước.</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Switch Code Studio visible tabs/actions/status copy to Vietnamese-first wording.
- Tighten streaming and empty-preview text so Code Studio no longer mixes English UX terms into Vietnamese surfaces.
- Add markdown normalization regression coverage for collapsed Vietnamese maritime table prose.

Closes #603

## Verification
- `cd wiii-desktop`
- `npx vitest run src/__tests__/code-studio-panel.test.tsx src/__tests__/assistant-markdown.test.ts src/__tests__/assistant-markdown-rendering.test.tsx src/__tests__/inline-visual-frame-rendering.test.tsx --pool forks --maxWorkers=1` -> 4 files passed, 15 tests passed
- `npx tsc --noEmit` -> passed
- `git diff --check` -> passed

## Risk
Low. This is limited to frontend-visible copy and regression tests. It does not change SSE, iframe bridge contracts, provider routing, generated visual payloads, LMS mutation, or approval-token behavior.

## Rollback
Revert this PR to restore previous English labels/copy and remove the markdown regression test.

## Visual Evidence
Not applicable for this narrow copy/regression patch. Existing panel rendering is covered by the CodeStudioPanel unit tests; iframe rendering remains covered by `inline-visual-frame-rendering.test.tsx`.