### PR TITLE
Type direct node exception fallback contract

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_exception_fallback_contract.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_exception_fallback_contract.py
@@ -1,0 +1,63 @@
+"""Typed contracts for Direct Node exception fallback handling."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from app.engine.multi_agent.state import AgentState
+
+
+@dataclass(frozen=True, slots=True)
+class DirectNodeExceptionFallbackRequest:
+    """Per-turn state captured when Direct Node generation fails."""
+
+    exc: Exception
+    query: str
+    state: AgentState
+    ctx_for_preflight: dict[str, Any]
+    tools: list[Any]
+    tool_call_events: list[dict[str, Any]]
+    llm_response: Any
+    messages: list[Any]
+    llm: Any
+    routing_intent: str
+    response_language: str
+    is_identity_turn: bool
+    explicit_user_provider: str | None
+    explicit_web_search_turn: bool
+    tracer: Any
+    push_event: Callable[..., Any]
+
+
+@dataclass(frozen=True, slots=True)
+class DirectNodeExceptionFallbackDependencies:
+    """Injected app contracts used by Direct Node exception fallback recovery."""
+
+    needs_web_search: Callable[[str], bool]
+    extract_direct_response: Callable[..., Any]
+    sanitize_structured_visual_answer_text: Callable[..., str]
+    sanitize_wiii_house_text: Callable[..., str]
+    build_search_template_fallback: Callable[..., str]
+    build_uploaded_document_context_fallback_answer: Callable[..., str]
+    build_codebase_analysis_fallback_answer: Callable[[str], str]
+    build_codebase_analysis_fallback_thinking: Callable[[str], str]
+    get_phase_fallback: Callable[[AgentState], str]
+    record_direct_node_thinking_snapshot: Callable[..., str]
+    record_thinking_snapshot_fn: Callable[..., Any]
+    inc_counter: Callable[..., Any]
+    logger_obj: logging.Logger
+    salvage_direct_turn_from_final_result_fn: Callable[..., Any] | None = None
+    emergency_search_fallback_fn: Callable[..., Any] | None = None
+    emit_synthetic_tool_events_fn: Callable[..., Any] | None = None
+    classify_failover_reason_fn: Callable[..., dict[str, Any]] | None = None
+
+
+@dataclass(frozen=True)
+class DirectNodeExceptionFallbackResult:
+    """Recovered direct-node response after an exception path."""
+
+    response: str
+    tool_call_events: list[dict[str, Any]]

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_exception_fallbacks.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_exception_fallbacks.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from typing import Any, Callable
 
 from app.core.config import settings
@@ -14,75 +13,64 @@ from app.engine.multi_agent.direct_node_emergency_fallbacks import (
     _emit_synthetic_tool_events,
     _salvage_direct_turn_from_final_result,
 )
+from app.engine.multi_agent.direct_node_exception_fallback_contract import (
+    DirectNodeExceptionFallbackDependencies,
+    DirectNodeExceptionFallbackRequest,
+    DirectNodeExceptionFallbackResult,
+)
 from app.engine.multi_agent.direct_reasoning import _is_codebase_analysis_query
 from app.engine.multi_agent.state import AgentState
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
-class DirectNodeExceptionFallbackResult:
-    """Recovered direct-node response after an exception path."""
-
-    response: str
-    tool_call_events: list[dict[str, Any]]
-
-
 async def handle_direct_node_generation_exception(
     *,
-    exc: Exception,
-    query: str,
-    state: AgentState,
-    ctx_for_preflight: dict[str, Any],
-    tools: list[Any],
-    tool_call_events: list[dict[str, Any]],
-    llm_response: Any,
-    messages: list[Any],
-    llm: Any,
-    routing_intent: str,
-    response_language: str,
-    is_identity_turn: bool,
-    explicit_user_provider: str | None,
-    explicit_web_search_turn: bool,
-    needs_web_search: Callable[[str], bool],
-    extract_direct_response: Callable[..., Any],
-    sanitize_structured_visual_answer_text: Callable[..., str],
-    sanitize_wiii_house_text: Callable[..., str],
-    build_search_template_fallback: Callable[..., str],
-    build_uploaded_document_context_fallback_answer: Callable[..., str],
-    build_codebase_analysis_fallback_answer: Callable[[str], str],
-    build_codebase_analysis_fallback_thinking: Callable[[str], str],
-    get_phase_fallback: Callable[[AgentState], str],
-    record_direct_node_thinking_snapshot: Callable[..., str],
-    record_thinking_snapshot_fn: Callable[..., Any],
-    tracer: Any,
-    push_event: Callable[..., Any],
-    inc_counter: Callable[..., Any],
-    logger_obj: logging.Logger | None = None,
-    salvage_direct_turn_from_final_result_fn: Callable[..., Any] | None = None,
-    emergency_search_fallback_fn: Callable[..., Any] | None = None,
-    emit_synthetic_tool_events_fn: Callable[..., Any] | None = None,
-    classify_failover_reason_fn: Callable[..., dict[str, Any]] | None = None,
+    request: DirectNodeExceptionFallbackRequest,
+    dependencies: DirectNodeExceptionFallbackDependencies,
 ) -> DirectNodeExceptionFallbackResult:
     """Recover or re-raise after direct-node LLM/tool generation fails."""
 
-    log = logger_obj or logger
+    exc = request.exc
+    query = request.query
+    state = request.state
+    ctx_for_preflight = request.ctx_for_preflight
+    tools = request.tools
+    tool_call_events = request.tool_call_events
+    llm_response = request.llm_response
+    messages = request.messages
+    llm = request.llm
+    routing_intent = request.routing_intent
+    response_language = request.response_language
+    is_identity_turn = request.is_identity_turn
+    explicit_user_provider = request.explicit_user_provider
+    explicit_web_search_turn = request.explicit_web_search_turn
+    tracer = request.tracer
+    push_event = request.push_event
+
+    log = dependencies.logger_obj or logger
     salvage_direct_turn = (
-        salvage_direct_turn_from_final_result_fn
+        dependencies.salvage_direct_turn_from_final_result_fn
         or _salvage_direct_turn_from_final_result
     )
-    emergency_search = emergency_search_fallback_fn or _emergency_search_fallback
-    emit_synthetic_events = emit_synthetic_tool_events_fn or _emit_synthetic_tool_events
+    emergency_search = (
+        dependencies.emergency_search_fallback_fn or _emergency_search_fallback
+    )
+    emit_synthetic_events = (
+        dependencies.emit_synthetic_tool_events_fn or _emit_synthetic_tool_events
+    )
     classify_failover_reason = (
-        classify_failover_reason_fn or classify_failover_reason_impl
+        dependencies.classify_failover_reason_fn or classify_failover_reason_impl
     )
 
     salvaged = await salvage_direct_turn(
         llm_response=llm_response,
         messages=messages,
-        extract_direct_response=extract_direct_response,
-        sanitize_structured_visual_answer_text=sanitize_structured_visual_answer_text,
-        sanitize_wiii_house_text=sanitize_wiii_house_text,
+        extract_direct_response=dependencies.extract_direct_response,
+        sanitize_structured_visual_answer_text=(
+            dependencies.sanitize_structured_visual_answer_text
+        ),
+        sanitize_wiii_house_text=dependencies.sanitize_wiii_house_text,
         tool_call_events=tool_call_events,
         query=query,
         is_identity_turn=is_identity_turn,
@@ -95,11 +83,11 @@ async def handle_direct_node_generation_exception(
         if salvaged_tools:
             state["tools_used"] = salvaged_tools
         if salvaged_thinking:
-            record_direct_node_thinking_snapshot(
+            dependencies.record_direct_node_thinking_snapshot(
                 state=state,
                 thinking=salvaged_thinking,
                 provenance="final_snapshot",
-                record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+                record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
             )
         log.warning(
             "[DIRECT] Post-processing failed but salvaged final result: %s",
@@ -120,7 +108,7 @@ async def handle_direct_node_generation_exception(
 
     uploaded_fallback = ""
     if isinstance(exc, ProviderUnavailableError):
-        uploaded_fallback = build_uploaded_document_context_fallback_answer(
+        uploaded_fallback = dependencies.build_uploaded_document_context_fallback_answer(
             query,
             ctx_for_preflight,
         )
@@ -147,7 +135,7 @@ async def handle_direct_node_generation_exception(
         template_response = _build_template_response(
             query=query,
             tool_call_events=tool_call_events,
-            build_search_template_fallback=build_search_template_fallback,
+            build_search_template_fallback=dependencies.build_search_template_fallback,
             log=log,
             warning_message="[DIRECT] Provider unavailable and search fallback build failed: %s",
         )
@@ -177,7 +165,7 @@ async def handle_direct_node_generation_exception(
             tool_call_events=tool_call_events,
         )
 
-    if isinstance(exc, ProviderUnavailableError) and needs_web_search(query):
+    if isinstance(exc, ProviderUnavailableError) and dependencies.needs_web_search(query):
         fallback_events = await _run_emergency_search(
             query=query,
             tools=tools,
@@ -193,7 +181,7 @@ async def handle_direct_node_generation_exception(
                     push_event=push_event,
                 )
                 state["tool_call_events"] = fallback_events
-                template_response = build_search_template_fallback(
+                template_response = dependencies.build_search_template_fallback(
                     query=query,
                     tool_call_events=fallback_events,
                 )
@@ -229,7 +217,7 @@ async def handle_direct_node_generation_exception(
             tool_call_events=fallback_events,
         )
 
-    if explicit_user_provider and needs_web_search(query):
+    if explicit_user_provider and dependencies.needs_web_search(query):
         return await _handle_explicit_provider_web_failure(
             exc=exc,
             query=query,
@@ -237,7 +225,7 @@ async def handle_direct_node_generation_exception(
             tools=tools,
             tool_call_events=tool_call_events,
             explicit_user_provider=explicit_user_provider,
-            build_search_template_fallback=build_search_template_fallback,
+            build_search_template_fallback=dependencies.build_search_template_fallback,
             emergency_search=emergency_search,
             emit_synthetic_events=emit_synthetic_events,
             push_event=push_event,
@@ -247,7 +235,7 @@ async def handle_direct_node_generation_exception(
         )
 
     if explicit_user_provider:
-        uploaded_fallback = build_uploaded_document_context_fallback_answer(
+        uploaded_fallback = dependencies.build_uploaded_document_context_fallback_answer(
             query,
             ctx_for_preflight,
         )
@@ -296,20 +284,24 @@ async def handle_direct_node_generation_exception(
         tools=tools,
         tool_call_events=tool_call_events,
         explicit_web_search_turn=explicit_web_search_turn,
-        needs_web_search=needs_web_search,
-        build_search_template_fallback=build_search_template_fallback,
+        needs_web_search=dependencies.needs_web_search,
+        build_search_template_fallback=dependencies.build_search_template_fallback,
         build_uploaded_document_context_fallback_answer=(
-            build_uploaded_document_context_fallback_answer
+            dependencies.build_uploaded_document_context_fallback_answer
         ),
-        build_codebase_analysis_fallback_answer=build_codebase_analysis_fallback_answer,
+        build_codebase_analysis_fallback_answer=(
+            dependencies.build_codebase_analysis_fallback_answer
+        ),
         build_codebase_analysis_fallback_thinking=(
-            build_codebase_analysis_fallback_thinking
+            dependencies.build_codebase_analysis_fallback_thinking
         ),
-        get_phase_fallback=get_phase_fallback,
-        record_direct_node_thinking_snapshot=record_direct_node_thinking_snapshot,
-        record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+        get_phase_fallback=dependencies.get_phase_fallback,
+        record_direct_node_thinking_snapshot=(
+            dependencies.record_direct_node_thinking_snapshot
+        ),
+        record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
         emergency_search=emergency_search,
-        inc_counter=inc_counter,
+        inc_counter=dependencies.inc_counter,
         tracer=tracer,
         log=log,
     )

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_llm_pipeline.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_llm_pipeline.py
@@ -13,6 +13,10 @@ from app.engine.multi_agent.direct_node_document_preview_runtime import (
 from app.engine.multi_agent.direct_node_exception_fallbacks import (
     handle_direct_node_generation_exception,
 )
+from app.engine.multi_agent.direct_node_exception_fallback_contract import (
+    DirectNodeExceptionFallbackDependencies,
+    DirectNodeExceptionFallbackRequest,
+)
 from app.engine.multi_agent.direct_node_llm_fallback import (
     resolve_direct_node_llm_unavailable_fallback,
 )
@@ -356,43 +360,49 @@ async def execute_direct_node_llm_pipeline(
             tool_call_events,
         )
         fallback_result = await handle_direct_node_generation_exception(
-            exc=exc,
-            query=query,
-            state=state,
-            ctx_for_preflight=request.ctx_for_preflight,
-            tools=tools,
-            tool_call_events=tool_call_events,
-            llm_response=llm_response,
-            messages=messages,
-            llm=llm,
-            routing_intent=routing_intent,
-            response_language=response_language,
-            is_identity_turn=is_identity_turn,
-            explicit_user_provider=explicit_user_provider,
-            explicit_web_search_turn=explicit_web_search_turn,
-            needs_web_search=dependencies.needs_web_search,
-            extract_direct_response=dependencies.extract_direct_response,
-            sanitize_structured_visual_answer_text=(
-                dependencies.sanitize_structured_visual_answer_text
+            request=DirectNodeExceptionFallbackRequest(
+                exc=exc,
+                query=query,
+                state=state,
+                ctx_for_preflight=request.ctx_for_preflight,
+                tools=tools,
+                tool_call_events=tool_call_events,
+                llm_response=llm_response,
+                messages=messages,
+                llm=llm,
+                routing_intent=routing_intent,
+                response_language=response_language,
+                is_identity_turn=is_identity_turn,
+                explicit_user_provider=explicit_user_provider,
+                explicit_web_search_turn=explicit_web_search_turn,
+                tracer=request.tracer,
+                push_event=request.push_event,
             ),
-            sanitize_wiii_house_text=dependencies.sanitize_wiii_house_text,
-            build_search_template_fallback=build_search_template_fallback,
-            build_uploaded_document_context_fallback_answer=(
-                _build_uploaded_document_context_fallback_answer
+            dependencies=DirectNodeExceptionFallbackDependencies(
+                needs_web_search=dependencies.needs_web_search,
+                extract_direct_response=dependencies.extract_direct_response,
+                sanitize_structured_visual_answer_text=(
+                    dependencies.sanitize_structured_visual_answer_text
+                ),
+                sanitize_wiii_house_text=dependencies.sanitize_wiii_house_text,
+                build_search_template_fallback=build_search_template_fallback,
+                build_uploaded_document_context_fallback_answer=(
+                    _build_uploaded_document_context_fallback_answer
+                ),
+                build_codebase_analysis_fallback_answer=(
+                    _build_codebase_analysis_fallback_answer
+                ),
+                build_codebase_analysis_fallback_thinking=(
+                    _build_codebase_analysis_fallback_thinking
+                ),
+                get_phase_fallback=dependencies.get_phase_fallback,
+                record_direct_node_thinking_snapshot=(
+                    record_direct_node_thinking_snapshot
+                ),
+                record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
+                inc_counter=inc_counter,
+                logger_obj=dependencies.logger_obj,
             ),
-            build_codebase_analysis_fallback_answer=(
-                _build_codebase_analysis_fallback_answer
-            ),
-            build_codebase_analysis_fallback_thinking=(
-                _build_codebase_analysis_fallback_thinking
-            ),
-            get_phase_fallback=dependencies.get_phase_fallback,
-            record_direct_node_thinking_snapshot=record_direct_node_thinking_snapshot,
-            record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
-            tracer=request.tracer,
-            push_event=request.push_event,
-            inc_counter=inc_counter,
-            logger_obj=dependencies.logger_obj,
         )
         response = fallback_result.response
         tool_call_events = fallback_result.tool_call_events

--- a/maritime-ai-service/tests/unit/test_direct_node_exception_fallbacks.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_exception_fallbacks.py
@@ -4,6 +4,10 @@ import pytest
 
 from app.core.config import settings
 from app.core.exceptions import ProviderUnavailableError
+from app.engine.multi_agent.direct_node_exception_fallback_contract import (
+    DirectNodeExceptionFallbackDependencies,
+    DirectNodeExceptionFallbackRequest,
+)
 from app.engine.multi_agent.direct_node_exception_fallbacks import (
     handle_direct_node_generation_exception,
 )
@@ -24,16 +28,13 @@ def _record_snapshot(*, state, thinking, provenance, record_thinking_snapshot_fn
     return thinking
 
 
-def _base_kwargs(**overrides):
+def _base_request(**overrides):
     tracer = overrides.pop("tracer", _Tracer())
 
     async def _push_event(_event):
         return None
 
-    async def _no_salvage(**_kwargs):
-        return None
-
-    kwargs = {
+    values = {
         "exc": RuntimeError("boom"),
         "query": "gia dau hom nay",
         "state": {},
@@ -48,6 +49,18 @@ def _base_kwargs(**overrides):
         "is_identity_turn": False,
         "explicit_user_provider": None,
         "explicit_web_search_turn": False,
+        "tracer": tracer,
+        "push_event": _push_event,
+    }
+    values.update(overrides)
+    return DirectNodeExceptionFallbackRequest(**values)
+
+
+def _base_dependencies(**overrides):
+    async def _no_salvage(**_kwargs):
+        return None
+
+    values = {
         "needs_web_search": lambda _query: False,
         "extract_direct_response": lambda *_args, **_kwargs: ("", "", []),
         "sanitize_structured_visual_answer_text": lambda text, **_kwargs: text,
@@ -59,14 +72,12 @@ def _base_kwargs(**overrides):
         "get_phase_fallback": lambda _state: "phase fallback",
         "record_direct_node_thinking_snapshot": _record_snapshot,
         "record_thinking_snapshot_fn": lambda *_args, **_kwargs: None,
-        "tracer": tracer,
-        "push_event": _push_event,
         "inc_counter": lambda *_args, **_kwargs: None,
         "logger_obj": logging.getLogger("test.direct_node_exception_fallbacks"),
         "salvage_direct_turn_from_final_result_fn": _no_salvage,
     }
-    kwargs.update(overrides)
-    return kwargs
+    values.update(overrides)
+    return DirectNodeExceptionFallbackDependencies(**values)
 
 
 @pytest.mark.asyncio
@@ -78,11 +89,13 @@ async def test_exception_fallback_records_salvaged_final_result():
         return "Recovered answer", "Recovered thinking", [{"name": "tool_x"}]
 
     result = await handle_direct_node_generation_exception(
-        **_base_kwargs(
+        request=_base_request(
             state=state,
             tracer=tracer,
+        ),
+        dependencies=_base_dependencies(
             salvage_direct_turn_from_final_result_fn=_salvage,
-        )
+        ),
     )
 
     assert result.response == "Recovered answer"
@@ -101,7 +114,7 @@ async def test_provider_unavailable_with_tool_events_returns_source_template():
     ]
 
     result = await handle_direct_node_generation_exception(
-        **_base_kwargs(
+        request=_base_request(
             exc=ProviderUnavailableError(
                 provider="nvidia",
                 reason_code="busy",
@@ -109,8 +122,10 @@ async def test_provider_unavailable_with_tool_events_returns_source_template():
             ),
             state=state,
             tool_call_events=events,
+        ),
+        dependencies=_base_dependencies(
             build_search_template_fallback=lambda **_kwargs: "Source-backed answer",
-        )
+        ),
     )
 
     assert result.response == "Source-backed answer"
@@ -140,14 +155,16 @@ async def test_explicit_provider_web_failure_runs_emergency_search_and_emits_eve
         await push_event({"type": "synthetic"})
 
     result = await handle_direct_node_generation_exception(
-        **_base_kwargs(
+        request=_base_request(
             explicit_user_provider="nvidia",
+            state=state,
+        ),
+        dependencies=_base_dependencies(
             needs_web_search=lambda _query: True,
             emergency_search_fallback_fn=_emergency,
             emit_synthetic_tool_events_fn=_emit,
             build_search_template_fallback=lambda **_kwargs: "Emergency answer",
-            state=state,
-        )
+        ),
     )
 
     assert result.response == "Emergency answer"
@@ -162,10 +179,12 @@ async def test_default_generation_failure_preserves_plain_fallback_when_natural_
     monkeypatch.setattr(settings, "enable_natural_conversation", False)
 
     result = await handle_direct_node_generation_exception(
-        **_base_kwargs(
+        request=_base_request(
             query="hello",
+        ),
+        dependencies=_base_dependencies(
             build_codebase_analysis_fallback_answer=lambda _query: "",
-        )
+        ),
     )
 
     assert result.response == "Xin chao! Toi co the giup gi cho ban?"


### PR DESCRIPTION
## Summary
- Add a typed Direct Node exception fallback request/dependencies contract.
- Route `execute_direct_node_llm_pipeline` through that contract instead of the previous wide keyword-only fallback surface.
- Update fallback tests around salvage, provider-unavailable, explicit-provider emergency search, and default fallback behavior.

Closes #605

## Verification
- `cd maritime-ai-service`
- `uv run --python 3.12 --extra dev pytest tests/unit/test_direct_node_exception_fallbacks.py tests/unit/test_direct_node_llm_pipeline.py tests/unit/test_direct_node_provider_errors.py tests/unit/test_direct_node_pre_llm_pipeline.py tests/unit/test_direct_node_fast_response_runtime.py -q --tb=short` -> 47 passed
- `uv run --python 3.12 --extra dev ruff check app/engine/multi_agent/direct_node_exception_fallback_contract.py app/engine/multi_agent/direct_node_exception_fallbacks.py app/engine/multi_agent/direct_node_llm_pipeline.py tests/unit/test_direct_node_exception_fallbacks.py` -> passed
- `git diff --check` -> passed

## Risk
Medium-low. This touches provider exception recovery, source-backed search fallback, uploaded-document fallback, and salvage flow signatures, but does not change fallback policy or generated user-facing behavior.

## Rollback
Revert this PR to restore the previous keyword-only exception fallback signature and direct LLM pipeline call site.