### PR TITLE
Tighten Code Studio session context and inline card UX

### DIFF
--- a/wiii-desktop/src/__tests__/code-studio-store.test.ts
+++ b/wiii-desktop/src/__tests__/code-studio-store.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useCodeStudioStore } from "@/stores/code-studio-store";
+import {
+  buildCodeStudioActiveSessionContext,
+  useCodeStudioStore,
+} from "@/stores/code-studio-store";
 
 function resetStore() {
   useCodeStudioStore.setState({
@@ -186,6 +189,43 @@ describe("code-studio-store", () => {
   });
 
   describe("getActiveSessionContext", () => {
+    it("builds a typed active-session context payload", () => {
+      const store = useCodeStudioStore.getState();
+      store.openSession("vs_typed", "Typed Preview", "html", 2, {
+        studioLane: "app",
+        artifactKind: "html_app",
+        qualityProfile: "premium",
+        rendererContract: "host_shell",
+        requestedView: "preview",
+      });
+      store.completeSession(
+        "vs_typed",
+        "<main />",
+        "html",
+        2,
+        { id: "vp-typed" } as any,
+      );
+
+      const session = useCodeStudioStore.getState().sessions["vs_typed"];
+      expect(buildCodeStudioActiveSessionContext(session)).toEqual({
+        active_session: {
+          session_id: "vs_typed",
+          title: "Typed Preview",
+          status: "complete",
+          active_version: 2,
+          version_count: 1,
+          language: "html",
+          studio_lane: "app",
+          artifact_kind: "html_app",
+          quality_profile: "premium",
+          renderer_contract: "host_shell",
+          requested_view: "preview",
+          has_preview: true,
+        },
+        requested_view: "preview",
+      });
+    });
+
     it("returns active session metadata for follow-up turns", () => {
       const store = useCodeStudioStore.getState();
       store.openSession("vs_1", "Pendulum", "html", 1, {

--- a/wiii-desktop/src/__tests__/tool-execution-strip.test.tsx
+++ b/wiii-desktop/src/__tests__/tool-execution-strip.test.tsx
@@ -33,6 +33,7 @@ describe("ToolExecutionStrip", () => {
           activeVersion: 1,
           chunkCount: 1,
           totalBytes: 14,
+          visualSessionId: "vs_app_1",
           createdAt: Date.now(),
           metadata: { studioLane: "app" },
         },
@@ -58,7 +59,8 @@ describe("ToolExecutionStrip", () => {
     render(<ToolExecutionStrip block={block} />);
 
     expect(screen.getByText("Pendulum App")).toBeTruthy();
-    expect(screen.getByText("Xem code")).toBeTruthy();
+    expect(screen.getByText("Xem mã")).toBeTruthy();
+    expect(screen.getByText("Xem trước")).toBeTruthy();
   });
 
   it("renders CodeStudioCard via _code_studio_session_id injected by SSE handler", () => {
@@ -70,7 +72,10 @@ describe("ToolExecutionStrip", () => {
           title: "Wave Simulation",
           language: "html",
           status: "streaming",
-          code: "<div>streaming...</div>",
+          code: [
+            "<style></style><canvas></canvas><button>Run</button>",
+            "<script>window.WiiiVisualBridge.reportResult()</script>",
+          ].join(""),
           versions: [],
           activeVersion: 1,
           chunkCount: 3,
@@ -98,6 +103,8 @@ describe("ToolExecutionStrip", () => {
     render(<ToolExecutionStrip block={block} />);
 
     expect(screen.getByText("Wave Simulation")).toBeTruthy();
+    expect(screen.getByText(/Điều khiển/)).toBeTruthy();
+    expect(screen.getByText(/Kết nối/)).toBeTruthy();
   });
 
   it("hides raw python code and filesystem paths by default", () => {

--- a/wiii-desktop/src/components/chat/CodeStudioCard.tsx
+++ b/wiii-desktop/src/components/chat/CodeStudioCard.tsx
@@ -34,8 +34,8 @@ export const CodeStudioCard = memo(function CodeStudioCard({
       { label: "Giao di\u1EC7n", done: code.includes("<style") },
       { label: "Canvas", done: code.includes("<canvas") || code.includes("<svg") },
       { label: "Logic", done: code.includes("<script") || code.includes("function") },
-      { label: "Controls", done: code.includes('type="range"') || code.includes("<button") },
-      { label: "Bridge", done: code.includes("wiiivisualbridge") || code.includes("reportresult") },
+      { label: "\u0110i\u1EC1u khi\u1EC3n", done: code.includes('type="range"') || code.includes("<button") },
+      { label: "K\u1EBFt n\u1ED1i", done: code.includes("wiiivisualbridge") || code.includes("reportresult") },
     ];
   }, [session?.code]);
 
@@ -134,14 +134,14 @@ export const CodeStudioCard = memo(function CodeStudioCard({
                 onClick={handleOpen}
                 className="flex items-center gap-1 px-2 py-1 rounded-md text-[10px] font-medium bg-surface-tertiary hover:bg-border text-text-secondary transition-colors"
               >
-                <Code2 size={11} /> Xem code
+                <Code2 size={11} /> Xem mã
               </button>
               {session?.visualSessionId && (
                 <button
                   onClick={handlePreview}
                   className="flex items-center gap-1 px-2 py-1 rounded-md text-[10px] font-medium bg-[var(--accent)]/10 hover:bg-[var(--accent)]/20 text-[var(--accent)] transition-colors"
                 >
-                  <Eye size={11} /> Xem preview
+                  <Eye size={11} /> Xem trước
                 </button>
               )}
             </div>

--- a/wiii-desktop/src/stores/code-studio-store.ts
+++ b/wiii-desktop/src/stores/code-studio-store.ts
@@ -9,14 +9,18 @@
  * Backend uses code_studio_context.active_session for quality/session decisions.
  */
 import { create } from "zustand";
-import type { VisualPayload } from "@/api/types";
+import type { ChatCodeStudioContext, VisualPayload } from "@/api/types";
 
 /** Metadata from backend code_open/code_complete events — session-level, not per-version. */
+type ChatCodeStudioActiveSession = NonNullable<
+  ChatCodeStudioContext["active_session"]
+>;
+
 export interface CodeStudioMetadata {
-  studioLane?: string;
-  artifactKind?: string;
-  qualityProfile?: string;
-  rendererContract?: string;
+  studioLane?: ChatCodeStudioActiveSession["studio_lane"];
+  artifactKind?: ChatCodeStudioActiveSession["artifact_kind"];
+  qualityProfile?: ChatCodeStudioActiveSession["quality_profile"];
+  rendererContract?: ChatCodeStudioActiveSession["renderer_contract"];
   requestedView?: "code" | "preview";
 }
 
@@ -48,6 +52,40 @@ export interface CodeStudioSession {
   metadata: CodeStudioMetadata;
 }
 
+export interface CodeStudioActiveSessionContext extends ChatCodeStudioContext {
+  active_session: ChatCodeStudioActiveSession & {
+    requested_view?: "code" | "preview";
+  };
+}
+
+function resolveStudioLane(
+  lane: CodeStudioMetadata["studioLane"],
+): ChatCodeStudioActiveSession["studio_lane"] {
+  return lane || "app";
+}
+
+export function buildCodeStudioActiveSessionContext(
+  session: CodeStudioSession,
+): CodeStudioActiveSessionContext {
+  return {
+    active_session: {
+      session_id: session.sessionId,
+      title: session.title,
+      status: session.status,
+      active_version: session.activeVersion,
+      version_count: session.versions.length,
+      language: session.language,
+      studio_lane: resolveStudioLane(session.metadata.studioLane),
+      artifact_kind: session.metadata.artifactKind,
+      quality_profile: session.metadata.qualityProfile,
+      renderer_contract: session.metadata.rendererContract,
+      requested_view: session.metadata.requestedView,
+      has_preview: Boolean(session.visualPayload),
+    },
+    requested_view: session.metadata.requestedView,
+  };
+}
+
 interface CodeStudioState {
   activeSessionId: string | null;
   sessions: Record<string, CodeStudioSession>;
@@ -59,7 +97,7 @@ interface CodeStudioState {
   setActiveSession: (sessionId: string | null) => void;
   setRequestedView: (sessionId: string, requestedView?: "code" | "preview") => void;
   /** Serialize active session info for backend context injection */
-  getActiveSessionContext: () => Record<string, unknown> | undefined;
+  getActiveSessionContext: () => CodeStudioActiveSessionContext | undefined;
   clearSessions: () => void;
 }
 
@@ -236,24 +274,8 @@ export const useCodeStudioStore = create<CodeStudioState>((set, get) => ({
     if (!activeSessionId) return undefined;
     const session = sessions[activeSessionId];
     if (!session) return undefined;
-    return {
-      active_session: {
-        session_id: session.sessionId,
-        title: session.title,
-        status: session.status,
-        active_version: session.activeVersion,
-        version_count: session.versions.length,
-        language: session.language,
-          studio_lane: session.metadata.studioLane,
-          artifact_kind: session.metadata.artifactKind,
-          quality_profile: session.metadata.qualityProfile,
-          renderer_contract: session.metadata.rendererContract,
-          requested_view: session.metadata.requestedView,
-          has_preview: Boolean(session.visualPayload),
-        },
-        requested_view: session.metadata.requestedView,
-      };
-    },
+    return buildCodeStudioActiveSessionContext(session);
+  },
 
   clearSessions: () => set({ activeSessionId: null, sessions: {} }),
 }));


### PR DESCRIPTION
## Summary
- Add a typed Code Studio active-session context builder and return type for follow-up turns.
- Keep the backend-facing context payload stable while making `studio_lane` satisfy the chat request contract.
- Polish inline Code Studio card labels to Vietnamese-first copy (`Xem mã`, `Xem trước`, `Điều khiển`, `Kết nối`).

Closes #607

## Verification
- `cd wiii-desktop`
- `npx vitest run src/__tests__/code-studio-store.test.ts src/__tests__/tool-execution-strip.test.tsx src/__tests__/code-studio-panel.test.tsx src/__tests__/inline-visual-frame-rendering.test.tsx --pool forks --maxWorkers=1` -> 4 files passed, 32 tests passed
- `npx tsc --noEmit` -> passed
- `git diff --check` -> passed

## Risk
Low. This is frontend-only context typing and visible copy polish. It does not alter SSE event names, iframe bridge messages, visual payload rendering, provider routing, LMS host actions, or approval-token flow.

## Rollback
Revert this PR to restore the previous inline context object construction and Code Studio card labels.

## Visual Evidence
No screenshot attached because this patch only changes small inline labels already asserted in DOM tests, plus a typed store helper. It does not change layout, frame sizing, or iframe rendering behavior.