### PR TITLE
refactor(backend): type direct node pre-LLM stages

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_document_preflight.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_document_preflight.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any, Callable
 
+from app.engine.multi_agent.direct_node_pre_llm_stage_contract import (
+    DirectDocumentPreviewPreflightDependencies,
+    DirectDocumentPreviewPreflightRequest,
+    DirectDocumentPreviewPreflightResult,
+)
 from app.engine.multi_agent.direct_node_document_preview_rebind import (
     _rebind_document_preview_host_action_tool,
 )
@@ -15,12 +19,6 @@ from app.engine.multi_agent.direct_node_thinking_snapshot import (
     record_direct_node_thinking_snapshot,
 )
 from app.engine.multi_agent.state import AgentState
-
-
-@dataclass(frozen=True)
-class DirectDocumentPreviewPreflightResult:
-    response: str
-    response_type: str = "document_preview_host_action"
 
 
 def build_document_preview_response_sanitizer(
@@ -70,65 +68,57 @@ def record_uploaded_document_context_plan(
 
 async def execute_direct_node_document_preview_preflight(
     *,
-    query: str,
-    state: AgentState,
-    ctx: dict[str, Any],
-    bus_id: str | None,
-    response_present: bool,
-    has_uploaded_document_context: bool,
-    looks_uploaded_document_preview_request: Callable[[str], bool],
-    push_event,
-    build_visual_tool_runtime_metadata,
-    execute_direct_tool_rounds,
-    extract_direct_response,
-    sanitize_preview_response,
-    fallback_response: str,
-    logger_obj,
+    request: DirectDocumentPreviewPreflightRequest,
+    dependencies: DirectDocumentPreviewPreflightDependencies,
 ) -> DirectDocumentPreviewPreflightResult | None:
     if (
-        response_present
-        or not has_uploaded_document_context
-        or not looks_uploaded_document_preview_request(query)
+        request.response_present
+        or not request.has_uploaded_document_context
+        or not dependencies.looks_uploaded_document_preview_request(request.query)
     ):
         return None
 
-    routing_meta = state.get("routing_metadata")
+    routing_meta = request.state.get("routing_metadata")
     if not isinstance(routing_meta, dict):
         routing_meta = {}
-        state["routing_metadata"] = routing_meta
+        request.state["routing_metadata"] = routing_meta
     preview_tools, preview_force_tools, doc_preview_debug = (
         _rebind_document_preview_host_action_tool(
             tools=[],
             force_tools=False,
-            query=query,
-            state=state,
-            ctx=ctx,
+            query=request.query,
+            state=request.state,
+            ctx=request.ctx,
         )
     )
     routing_meta["doc_preview_preflight"] = doc_preview_debug
     preview_result = await execute_direct_node_document_preview_round(
-        query=query,
-        state=state,
-        ctx=ctx,
-        bus_id=bus_id,
+        query=request.query,
+        state=request.state,
+        ctx=request.ctx,
+        bus_id=request.bus_id,
         tools=preview_tools,
         force_tools=preview_force_tools,
         messages=[],
-        push_event=push_event,
-        build_visual_tool_runtime_metadata=build_visual_tool_runtime_metadata,
-        execute_direct_tool_rounds=execute_direct_tool_rounds,
-        extract_direct_response=extract_direct_response,
-        sanitize_preview_response=sanitize_preview_response,
-        fallback_response=fallback_response,
+        push_event=request.push_event,
+        build_visual_tool_runtime_metadata=(
+            dependencies.build_visual_tool_runtime_metadata
+        ),
+        execute_direct_tool_rounds=dependencies.execute_direct_tool_rounds,
+        extract_direct_response=dependencies.extract_direct_response,
+        sanitize_preview_response=dependencies.sanitize_preview_response,
+        fallback_response=dependencies.fallback_response,
         debug=doc_preview_debug,
         routing_metadata_key="doc_preview_preflight",
         success_status="executed",
         failure_status="execution_failed",
         failure_log_message="[DIRECT] Early document preview host action failed: %s",
-        logger_obj=logger_obj,
+        logger_obj=dependencies.logger_obj,
     )
     if preview_result is None:
         return None
 
-    logger_obj.info("[DIRECT] Executed LMS document preview host action before planner LLM")
+    dependencies.logger_obj.info(
+        "[DIRECT] Executed LMS document preview host action before planner LLM"
+    )
     return DirectDocumentPreviewPreflightResult(response=preview_result.response)

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_fast_response_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_fast_response_runtime.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-from dataclasses import dataclass
 from typing import Any, Callable
 
 from app.engine.multi_agent.direct_node_chatter_runtime import (
@@ -33,6 +31,11 @@ from app.engine.multi_agent.direct_node_operational_fast_paths import (
 from app.engine.multi_agent.direct_node_thinking_snapshot import (
     record_direct_node_thinking_snapshot,
 )
+from app.engine.multi_agent.direct_node_pre_llm_stage_contract import (
+    DirectNodeFastResponse,
+    DirectNodeFastResponseDependencies,
+    DirectNodeFastResponseRequest,
+)
 from app.engine.multi_agent.direct_node_uploaded_context import (
     _build_uploaded_document_context_fallback_answer,
     _looks_uploaded_context_fact_query,
@@ -56,17 +59,7 @@ from app.engine.multi_agent.supervisor_runtime_support import (
 )
 
 
-TextPredicate = Callable[[str], bool]
-NormalizeForIntent = Callable[[str], str]
 RecordThinkingSnapshot = Callable[..., Any]
-
-
-@dataclass(frozen=True)
-class DirectNodeFastResponse:
-    """Resolved deterministic fast response for a direct turn."""
-
-    response: str
-    response_type: str
 
 
 def _record_fast_thinking(
@@ -88,23 +81,19 @@ def _record_fast_thinking(
 
 def resolve_direct_node_fast_response(
     *,
-    query: str,
-    state: AgentState,
-    ctx: dict[str, Any],
-    has_uploaded_document_context: bool,
-    normalize_for_intent: NormalizeForIntent,
-    needs_web_search: TextPredicate,
-    needs_datetime: TextPredicate,
-    record_thinking_snapshot_fn: RecordThinkingSnapshot,
-    logger_obj: logging.Logger | None = None,
+    request: DirectNodeFastResponseRequest,
+    dependencies: DirectNodeFastResponseDependencies,
 ) -> DirectNodeFastResponse | None:
     """Resolve deterministic fast responses before the planner/provider path."""
 
+    query = request.query
+    state = request.state
+    ctx = request.ctx
     try:
         routing_meta_for_fast = state.get("routing_metadata") or {}
         fast_method = str(routing_meta_for_fast.get("method") or "").strip().lower()
         fast_intent = str(routing_meta_for_fast.get("intent") or "").strip().lower()
-        normalized_for_fast = normalize_for_intent(query)
+        normalized_for_fast = dependencies.normalize_for_intent(query)
         if state.get("_pointy_fast_path_action"):
             response = _extract_pointy_fast_path_answer(state)
             if response:
@@ -112,7 +101,9 @@ def resolve_direct_node_fast_response(
                     state=state,
                     thinking=_build_pointy_fast_path_thinking(state),
                     provenance="deterministic_pointy_fast_path",
-                    record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+                    record_thinking_snapshot_fn=(
+                        dependencies.record_thinking_snapshot_fn
+                    ),
                 )
                 return DirectNodeFastResponse(response, "pointy_fast_path")
         elif _pointy_requested_without_inventory(state):
@@ -121,37 +112,37 @@ def resolve_direct_node_fast_response(
                 state=state,
                 thinking=_build_pointy_missing_inventory_thinking(query),
                 provenance="deterministic_pointy_missing_inventory",
-                record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+                record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
             )
             return DirectNodeFastResponse(response, "pointy_missing_inventory")
         elif (
             _looks_self_feeling_probe_turn(query)
-            and not needs_web_search(query)
-            and not needs_datetime(query)
+            and not dependencies.needs_web_search(query)
+            and not dependencies.needs_datetime(query)
         ):
             response = _build_self_feeling_probe_answer(query)
             _record_fast_thinking(
                 state=state,
                 thinking=_build_self_feeling_probe_thinking(query),
                 provenance="deterministic_self_feeling_probe",
-                record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+                record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
             )
             return DirectNodeFastResponse(response, "self_feeling_probe")
         elif (
             _looks_wiii_capability_inventory_turn(_fold_direct_text(query))
-            and not needs_web_search(query)
-            and not needs_datetime(query)
+            and not dependencies.needs_web_search(query)
+            and not dependencies.needs_datetime(query)
         ):
             response = _build_wiii_capability_inventory_answer(query)
             _record_fast_thinking(
                 state=state,
                 thinking=_build_wiii_capability_inventory_thinking(query),
                 provenance="deterministic_wiii_capability_inventory",
-                record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+                record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
             )
             return DirectNodeFastResponse(response, "wiii_capability_inventory")
         elif (
-            has_uploaded_document_context
+            request.has_uploaded_document_context
             and _looks_uploaded_context_fact_query(query, ctx)
             and not _looks_uploaded_file_visual_inspection_query(query)
         ):
@@ -168,7 +159,9 @@ def resolve_direct_node_fast_response(
                         "nên ưu tiên dữ kiện parser đã trích ra thay vì gọi LLM suy diễn."
                     ),
                     provenance="deterministic_uploaded_file_context_fact",
-                    record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+                    record_thinking_snapshot_fn=(
+                        dependencies.record_thinking_snapshot_fn
+                    ),
                 )
                 return DirectNodeFastResponse(response, "uploaded_file_context_fact")
         elif (
@@ -181,7 +174,7 @@ def resolve_direct_node_fast_response(
                 state=state,
                 thinking=_build_reasoning_safety_meta_thinking(query),
                 provenance="deterministic_reasoning_safety_meta",
-                record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+                record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
             )
             return DirectNodeFastResponse(response, "reasoning_safety_meta")
         elif (
@@ -194,7 +187,7 @@ def resolve_direct_node_fast_response(
                 state=state,
                 thinking=_build_wiii_pipeline_meta_thinking(query),
                 provenance="deterministic_wiii_pipeline_meta",
-                record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+                record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
             )
             return DirectNodeFastResponse(response, "wiii_pipeline_meta")
         elif (
@@ -212,7 +205,7 @@ def resolve_direct_node_fast_response(
                     "nên ưu tiên đọc lịch sử gần nhất thay vì ghi thêm memory mới."
                 ),
                 provenance="deterministic_session_memory_recall",
-                record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+                record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
             )
             return DirectNodeFastResponse(response, "session_memory_recall")
         elif (
@@ -228,7 +221,7 @@ def resolve_direct_node_fast_response(
                     "đúng một câu như bạn yêu cầu."
                 ),
                 provenance="deterministic_session_ack",
-                record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+                record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
             )
             return DirectNodeFastResponse(response, "session_memory_ack")
         elif _looks_session_memory_write_turn(normalized_for_fast):
@@ -240,7 +233,7 @@ def resolve_direct_node_fast_response(
                 state=state,
                 thinking=_build_session_memory_write_thinking(query),
                 provenance="deterministic_session_memory_write",
-                record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+                record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
             )
             return DirectNodeFastResponse(response, "session_memory_write")
         elif (
@@ -256,24 +249,29 @@ def resolve_direct_node_fast_response(
                         "mẫu thông tin bạn vừa yêu cầu Wiii giữ."
                     ),
                     provenance="deterministic_session_memory_recall",
-                    record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+                    record_thinking_snapshot_fn=(
+                        dependencies.record_thinking_snapshot_fn
+                    ),
                 )
                 return DirectNodeFastResponse(response, "session_memory_recall")
         elif (
             _looks_hunger_chatter_turn(normalized_for_fast)
             and not _looks_session_memory_write_turn(normalized_for_fast)
-            and not needs_web_search(query)
-            and not needs_datetime(query)
+            and not dependencies.needs_web_search(query)
+            and not dependencies.needs_datetime(query)
         ):
             response = _build_hunger_chatter_answer(query)
             _record_fast_thinking(
                 state=state,
                 thinking=_build_hunger_chatter_thinking(query),
                 provenance="deterministic_hunger_chatter",
-                record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+                record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
             )
             return DirectNodeFastResponse(response, "hunger_chatter")
     except Exception as exc:  # noqa: BLE001
-        if logger_obj is not None:
-            logger_obj.debug("[DIRECT] Session memory ack fast response skipped: %s", exc)
+        if dependencies.logger_obj is not None:
+            dependencies.logger_obj.debug(
+                "[DIRECT] Session memory ack fast response skipped: %s",
+                exc,
+            )
     return None

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_image_input_preflight.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_image_input_preflight.py
@@ -2,67 +2,60 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Callable
-
 from app.engine.multi_agent.direct_node_operational_fast_paths import (
     _build_image_input_thinking,
     _build_image_input_unavailable_answer,
     _build_image_input_unavailable_thinking,
 )
+from app.engine.multi_agent.direct_node_pre_llm_stage_contract import (
+    DirectImageInputPreflightDependencies,
+    DirectImageInputPreflightRequest,
+    DirectImageInputPreflightResult,
+)
 from app.engine.multi_agent.direct_node_thinking_snapshot import (
     record_direct_node_thinking_snapshot,
 )
 from app.engine.multi_agent.direct_node_uploaded_context import _build_image_input_answer
-from app.engine.multi_agent.state import AgentState
-
-
-@dataclass(frozen=True)
-class DirectImageInputPreflightResult:
-    response: str
-    response_type: str
 
 
 async def execute_direct_node_image_input_preflight(
     *,
-    query: str,
-    state: AgentState,
-    ctx: dict[str, Any],
-    response_present: bool,
-    has_uploaded_document_context: bool,
-    record_thinking_snapshot_fn: Callable[..., Any],
+    request: DirectImageInputPreflightRequest,
+    dependencies: DirectImageInputPreflightDependencies,
 ) -> DirectImageInputPreflightResult | None:
     """Resolve image-input turns before the direct node falls through to an LLM."""
 
-    if ctx.get("image_input_error") and has_uploaded_document_context:
+    ctx = request.ctx
+    state = request.state
+    if ctx.get("image_input_error") and request.has_uploaded_document_context:
         ctx["images"] = []
-    if response_present:
+    if request.response_present:
         return None
 
-    if ctx.get("image_input_error") and not has_uploaded_document_context:
+    if ctx.get("image_input_error") and not request.has_uploaded_document_context:
         fast_thinking = _build_image_input_unavailable_thinking()
         record_direct_node_thinking_snapshot(
             state=state,
             thinking=fast_thinking,
             provenance="deterministic_image_input_unavailable",
-            record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+            record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
         )
         return DirectImageInputPreflightResult(
-            response=_build_image_input_unavailable_answer(query),
+            response=_build_image_input_unavailable_answer(request.query),
             response_type="image_input_unavailable",
         )
 
-    if ctx.get("images") and not has_uploaded_document_context:
-        fast_thinking = _build_image_input_thinking(query)
+    if ctx.get("images") and not request.has_uploaded_document_context:
+        fast_thinking = _build_image_input_thinking(request.query)
         record_direct_node_thinking_snapshot(
             state=state,
             thinking=fast_thinking,
             provenance="deterministic_image_input",
-            record_thinking_snapshot_fn=record_thinking_snapshot_fn,
+            record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
         )
         return DirectImageInputPreflightResult(
             response=await _build_image_input_answer(
-                query,
+                request.query,
                 list(ctx.get("images") or []),
             ),
             response_type="image_input",

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_pre_llm_pipeline.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_pre_llm_pipeline.py
@@ -24,6 +24,14 @@ from app.engine.multi_agent.direct_node_image_input_preflight import (
 from app.engine.multi_agent.direct_node_operational_fast_paths import (
     _strip_dsml_residue,
 )
+from app.engine.multi_agent.direct_node_pre_llm_stage_contract import (
+    DirectDocumentPreviewPreflightDependencies,
+    DirectDocumentPreviewPreflightRequest,
+    DirectImageInputPreflightDependencies,
+    DirectImageInputPreflightRequest,
+    DirectNodeFastResponseDependencies,
+    DirectNodeFastResponseRequest,
+)
 from app.engine.multi_agent.direct_node_turn_start import start_direct_node_turn
 from app.engine.multi_agent.direct_node_uploaded_context import (
     _looks_uploaded_document_preview_request,
@@ -162,37 +170,47 @@ async def execute_direct_node_pre_llm_pipeline(
     )
 
     document_preflight_result = await dependencies.document_preview_preflight_fn(
-        query=query,
-        state=state,
-        ctx=ctx_for_preflight,
-        bus_id=request.bus_id,
-        response_present=bool(response),
-        has_uploaded_document_context=has_uploaded_document_context,
-        looks_uploaded_document_preview_request=_looks_uploaded_document_preview_request,
-        push_event=request.push_event,
-        build_visual_tool_runtime_metadata=(
-            dependencies.build_visual_tool_runtime_metadata
+        request=DirectDocumentPreviewPreflightRequest(
+            query=query,
+            state=state,
+            ctx=ctx_for_preflight,
+            bus_id=request.bus_id,
+            response_present=bool(response),
+            has_uploaded_document_context=has_uploaded_document_context,
+            push_event=request.push_event,
         ),
-        execute_direct_tool_rounds=dependencies.execute_direct_tool_rounds,
-        extract_direct_response=dependencies.extract_direct_response,
-        sanitize_preview_response=sanitize_document_preview_response,
-        fallback_response=(
-            "Mình đã gửi bản preview bài học sang LMS. "
-            "Giáo viên cần xem phần so sánh thay đổi và nguồn trích dẫn rồi bấm Áp dụng để cấp approval_token."
+        dependencies=DirectDocumentPreviewPreflightDependencies(
+            looks_uploaded_document_preview_request=(
+                _looks_uploaded_document_preview_request
+            ),
+            build_visual_tool_runtime_metadata=(
+                dependencies.build_visual_tool_runtime_metadata
+            ),
+            execute_direct_tool_rounds=dependencies.execute_direct_tool_rounds,
+            extract_direct_response=dependencies.extract_direct_response,
+            sanitize_preview_response=sanitize_document_preview_response,
+            fallback_response=(
+                "Mình đã gửi bản preview bài học sang LMS. "
+                "Giáo viên cần xem phần so sánh thay đổi và nguồn trích dẫn rồi bấm Áp dụng để cấp approval_token."
+            ),
+            logger_obj=dependencies.logger_obj,
         ),
-        logger_obj=dependencies.logger_obj,
     )
     if document_preflight_result is not None:
         response = document_preflight_result.response
         response_type = document_preflight_result.response_type
 
     image_preflight_result = await dependencies.image_input_preflight_fn(
-        query=query,
-        state=state,
-        ctx=ctx_for_preflight,
-        response_present=bool(response),
-        has_uploaded_document_context=has_uploaded_document_context,
-        record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
+        request=DirectImageInputPreflightRequest(
+            query=query,
+            state=state,
+            ctx=ctx_for_preflight,
+            response_present=bool(response),
+            has_uploaded_document_context=has_uploaded_document_context,
+        ),
+        dependencies=DirectImageInputPreflightDependencies(
+            record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
+        ),
     )
     if image_preflight_result is not None:
         response = image_preflight_result.response
@@ -200,15 +218,19 @@ async def execute_direct_node_pre_llm_pipeline(
 
     if not response:
         fast_response = dependencies.fast_response_fn(
-            query=query,
-            state=state,
-            ctx=ctx_for_preflight,
-            has_uploaded_document_context=has_uploaded_document_context,
-            normalize_for_intent=dependencies.normalize_for_intent,
-            needs_web_search=dependencies.needs_web_search,
-            needs_datetime=dependencies.needs_datetime,
-            record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
-            logger_obj=dependencies.logger_obj,
+            request=DirectNodeFastResponseRequest(
+                query=query,
+                state=state,
+                ctx=ctx_for_preflight,
+                has_uploaded_document_context=has_uploaded_document_context,
+            ),
+            dependencies=DirectNodeFastResponseDependencies(
+                normalize_for_intent=dependencies.normalize_for_intent,
+                needs_web_search=dependencies.needs_web_search,
+                needs_datetime=dependencies.needs_datetime,
+                record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
+                logger_obj=dependencies.logger_obj,
+            ),
         )
         if fast_response is not None:
             response = fast_response.response

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_pre_llm_stage_contract.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_pre_llm_stage_contract.py
@@ -1,0 +1,99 @@
+"""Typed contracts for deterministic Direct Node pre-LLM stages."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from app.engine.multi_agent.state import AgentState
+
+
+@dataclass(frozen=True, slots=True)
+class DirectDocumentPreviewPreflightRequest:
+    """Per-turn state for the uploaded-document preview host-action preflight."""
+
+    query: str
+    state: AgentState
+    ctx: dict[str, Any]
+    bus_id: str | None
+    response_present: bool
+    has_uploaded_document_context: bool
+    push_event: Callable[..., Any]
+
+
+@dataclass(frozen=True, slots=True)
+class DirectDocumentPreviewPreflightDependencies:
+    """Injected runtime functions for the document preview host-action preflight."""
+
+    looks_uploaded_document_preview_request: Callable[[str], bool]
+    build_visual_tool_runtime_metadata: Callable[..., dict[str, Any]]
+    execute_direct_tool_rounds: Callable[..., Any]
+    extract_direct_response: Callable[..., Any]
+    sanitize_preview_response: Callable[[str, list[dict[str, Any]]], str]
+    fallback_response: str
+    logger_obj: logging.Logger
+
+
+@dataclass(frozen=True, slots=True)
+class DirectDocumentPreviewPreflightResult:
+    """Document preview host action was emitted before the provider loop."""
+
+    response: str
+    response_type: str = "document_preview_host_action"
+
+
+@dataclass(frozen=True, slots=True)
+class DirectImageInputPreflightRequest:
+    """Per-turn state for deterministic image-input handling before the LLM."""
+
+    query: str
+    state: AgentState
+    ctx: dict[str, Any]
+    response_present: bool
+    has_uploaded_document_context: bool
+
+
+@dataclass(frozen=True, slots=True)
+class DirectImageInputPreflightDependencies:
+    """Injected runtime functions for deterministic image-input handling."""
+
+    record_thinking_snapshot_fn: Callable[..., Any]
+
+
+@dataclass(frozen=True, slots=True)
+class DirectImageInputPreflightResult:
+    """Image-input preflight answered the turn before the provider loop."""
+
+    response: str
+    response_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class DirectNodeFastResponseRequest:
+    """Per-turn state for deterministic fast responses before provider execution."""
+
+    query: str
+    state: AgentState
+    ctx: dict[str, Any]
+    has_uploaded_document_context: bool
+
+
+@dataclass(frozen=True, slots=True)
+class DirectNodeFastResponseDependencies:
+    """Injected runtime functions for deterministic fast-response selection."""
+
+    normalize_for_intent: Callable[[str], str]
+    needs_web_search: Callable[[str], bool]
+    needs_datetime: Callable[[str], bool]
+    record_thinking_snapshot_fn: Callable[..., Any]
+    logger_obj: logging.Logger | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DirectNodeFastResponse:
+    """Resolved deterministic fast response for a direct turn."""
+
+    response: str
+    response_type: str

--- a/maritime-ai-service/tests/unit/test_direct_node_fast_response_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_fast_response_runtime.py
@@ -1,4 +1,8 @@
 from app.engine.multi_agent.direct_intent import _normalize_for_intent
+from app.engine.multi_agent.direct_node_pre_llm_stage_contract import (
+    DirectNodeFastResponseDependencies,
+    DirectNodeFastResponseRequest,
+)
 
 
 def _record_snapshot_calls():
@@ -10,26 +14,47 @@ def _record_snapshot_calls():
     return calls, record_snapshot
 
 
-def test_fast_response_resolves_pointy_missing_inventory_without_llm():
+def _resolve_fast_response(
+    *,
+    query: str,
+    state: dict,
+    ctx: dict,
+    has_uploaded_document_context: bool,
+    record_snapshot,
+):
     from app.engine.multi_agent.direct_node_fast_response_runtime import (
         resolve_direct_node_fast_response,
     )
 
+    return resolve_direct_node_fast_response(
+        request=DirectNodeFastResponseRequest(
+            query=query,
+            state=state,
+            ctx=ctx,
+            has_uploaded_document_context=has_uploaded_document_context,
+        ),
+        dependencies=DirectNodeFastResponseDependencies(
+            normalize_for_intent=_normalize_for_intent,
+            needs_web_search=lambda _query: False,
+            needs_datetime=lambda _query: False,
+            record_thinking_snapshot_fn=record_snapshot,
+        ),
+    )
+
+
+def test_fast_response_resolves_pointy_missing_inventory_without_llm():
     calls, record_snapshot = _record_snapshot_calls()
     state: dict = {
         "force_skills": ["wiii-pointy"],
         "context": {"force_skills": ["wiii-pointy"]},
     }
 
-    result = resolve_direct_node_fast_response(
+    result = _resolve_fast_response(
         query="show send button",
         state=state,
         ctx={},
         has_uploaded_document_context=False,
-        normalize_for_intent=_normalize_for_intent,
-        needs_web_search=lambda _query: False,
-        needs_datetime=lambda _query: False,
-        record_thinking_snapshot_fn=record_snapshot,
+        record_snapshot=record_snapshot,
     )
 
     assert result is not None
@@ -40,10 +65,6 @@ def test_fast_response_resolves_pointy_missing_inventory_without_llm():
 
 
 def test_fast_response_session_ack_sets_ack_flag_and_snapshot():
-    from app.engine.multi_agent.direct_node_fast_response_runtime import (
-        resolve_direct_node_fast_response,
-    )
-
     calls, record_snapshot = _record_snapshot_calls()
     state: dict = {
         "routing_metadata": {
@@ -56,15 +77,12 @@ def test_fast_response_session_ack_sets_ack_flag_and_snapshot():
         "Tra loi chi: Da ghi nhan."
     )
 
-    result = resolve_direct_node_fast_response(
+    result = _resolve_fast_response(
         query=query,
         state=state,
         ctx={},
         has_uploaded_document_context=False,
-        normalize_for_intent=_normalize_for_intent,
-        needs_web_search=lambda _query: False,
-        needs_datetime=lambda _query: False,
-        record_thinking_snapshot_fn=record_snapshot,
+        record_snapshot=record_snapshot,
     )
 
     assert result is not None
@@ -75,10 +93,6 @@ def test_fast_response_session_ack_sets_ack_flag_and_snapshot():
 
 
 def test_fast_response_uploaded_document_fact_uses_document_context():
-    from app.engine.multi_agent.direct_node_fast_response_runtime import (
-        resolve_direct_node_fast_response,
-    )
-
     calls, record_snapshot = _record_snapshot_calls()
     state: dict = {"routing_metadata": {"intent": "uploaded_file_context"}}
     ctx = {
@@ -97,15 +111,12 @@ def test_fast_response_uploaded_document_fact_uses_document_context():
         }
     }
 
-    result = resolve_direct_node_fast_response(
+    result = _resolve_fast_response(
         query="Tai lieu vua upload co marker nao?",
         state=state,
         ctx=ctx,
         has_uploaded_document_context=True,
-        normalize_for_intent=_normalize_for_intent,
-        needs_web_search=lambda _query: False,
-        needs_datetime=lambda _query: False,
-        record_thinking_snapshot_fn=record_snapshot,
+        record_snapshot=record_snapshot,
     )
 
     assert result is not None
@@ -115,22 +126,15 @@ def test_fast_response_uploaded_document_fact_uses_document_context():
 
 
 def test_fast_response_returns_none_for_regular_learning_turn():
-    from app.engine.multi_agent.direct_node_fast_response_runtime import (
-        resolve_direct_node_fast_response,
-    )
-
     calls, record_snapshot = _record_snapshot_calls()
     state: dict = {"routing_metadata": {"intent": "learning"}}
 
-    result = resolve_direct_node_fast_response(
+    result = _resolve_fast_response(
         query="Giai thich quy tac COLREG 15",
         state=state,
         ctx={},
         has_uploaded_document_context=False,
-        normalize_for_intent=_normalize_for_intent,
-        needs_web_search=lambda _query: False,
-        needs_datetime=lambda _query: False,
-        record_thinking_snapshot_fn=record_snapshot,
+        record_snapshot=record_snapshot,
     )
 
     assert result is None

--- a/maritime-ai-service/tests/unit/test_direct_node_image_input_preflight.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_image_input_preflight.py
@@ -1,5 +1,10 @@
 import pytest
 
+from app.engine.multi_agent.direct_node_pre_llm_stage_contract import (
+    DirectImageInputPreflightDependencies,
+    DirectImageInputPreflightRequest,
+)
+
 
 @pytest.mark.asyncio
 async def test_image_preflight_clears_images_when_document_context_owns_turn():
@@ -13,12 +18,16 @@ async def test_image_preflight_clears_images_when_document_context_owns_turn():
     }
 
     result = await execute_direct_node_image_input_preflight(
-        query="tao bai giang tu file vua upload",
-        state={},
-        ctx=ctx,
-        response_present=False,
-        has_uploaded_document_context=True,
-        record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
+        request=DirectImageInputPreflightRequest(
+            query="tao bai giang tu file vua upload",
+            state={},
+            ctx=ctx,
+            response_present=False,
+            has_uploaded_document_context=True,
+        ),
+        dependencies=DirectImageInputPreflightDependencies(
+            record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
+        ),
     )
 
     assert result is None
@@ -35,13 +44,17 @@ async def test_image_preflight_returns_vision_unavailable_without_llm():
     state = {}
 
     result = await execute_direct_node_image_input_preflight(
-        query="Nhin anh nay va mo ta giup minh",
-        state=state,
-        ctx={"image_input_error": "vision_disabled"},
-        response_present=False,
-        has_uploaded_document_context=False,
-        record_thinking_snapshot_fn=lambda *args, **kwargs: snapshots.append(
-            (args, kwargs)
+        request=DirectImageInputPreflightRequest(
+            query="Nhin anh nay va mo ta giup minh",
+            state=state,
+            ctx={"image_input_error": "vision_disabled"},
+            response_present=False,
+            has_uploaded_document_context=False,
+        ),
+        dependencies=DirectImageInputPreflightDependencies(
+            record_thinking_snapshot_fn=lambda *args, **kwargs: snapshots.append(
+                (args, kwargs)
+            ),
         ),
     )
 
@@ -65,12 +78,16 @@ async def test_image_preflight_analyzes_base64_images_before_llm(monkeypatch):
 
     state = {}
     result = await module.execute_direct_node_image_input_preflight(
-        query="Nhin anh nay",
-        state=state,
-        ctx={"images": [{"type": "base64", "data": "abc"}]},
-        response_present=False,
-        has_uploaded_document_context=False,
-        record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
+        request=DirectImageInputPreflightRequest(
+            query="Nhin anh nay",
+            state=state,
+            ctx={"images": [{"type": "base64", "data": "abc"}]},
+            response_present=False,
+            has_uploaded_document_context=False,
+        ),
+        dependencies=DirectImageInputPreflightDependencies(
+            record_thinking_snapshot_fn=lambda *_args, **_kwargs: None,
+        ),
     )
 
     assert result is not None

--- a/maritime-ai-service/tests/unit/test_direct_node_pre_llm_pipeline.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_pre_llm_pipeline.py
@@ -68,8 +68,9 @@ async def test_pre_llm_pipeline_preserves_document_then_image_order():
 
     async def document_preview_preflight_fn(**kwargs):
         calls.append("document")
-        assert kwargs["response_present"] is False
-        assert kwargs["sanitize_preview_response"]("ok", []) == "clean:ok"
+        assert kwargs["request"].response_present is False
+        assert kwargs["request"].has_uploaded_document_context is True
+        assert kwargs["dependencies"].sanitize_preview_response("ok", []) == "clean:ok"
         return SimpleNamespace(
             response="Preview da gui.",
             response_type="document_preview_host_action",
@@ -77,7 +78,8 @@ async def test_pre_llm_pipeline_preserves_document_then_image_order():
 
     async def image_input_preflight_fn(**kwargs):
         calls.append("image")
-        assert kwargs["response_present"] is True
+        assert kwargs["request"].response_present is True
+        assert kwargs["dependencies"].record_thinking_snapshot_fn
         return None
 
     def fast_response_fn(**_kwargs):
@@ -134,9 +136,16 @@ async def test_pre_llm_pipeline_uses_fast_response_when_preflights_do_not_answer
             record_document_plan_fn=lambda **_kwargs: None,
             document_preview_preflight_fn=no_document_answer,
             image_input_preflight_fn=no_image_answer,
-            fast_response_fn=lambda **_kwargs: SimpleNamespace(
-                response="Fast answer.",
-                response_type="wiii_pipeline_meta",
+            fast_response_fn=lambda **kwargs: (
+                SimpleNamespace(
+                    response="Fast answer.",
+                    response_type="wiii_pipeline_meta",
+                )
+                if (
+                    kwargs["request"].query == "wiii pipeline la gi"
+                    and kwargs["dependencies"].normalize_for_intent("A") == "A"
+                )
+                else None
             ),
         ),
     )


### PR DESCRIPTION
## Summary

- Adds `DirectNodePreLlmStage` typed contracts for the deterministic document preview, image input, and fast-response stages.
- Routes `direct_node_pre_llm_pipeline.py` through explicit `request/dependencies` objects instead of loose keyword bags.
- Updates focused tests so the Direct Node lifecycle remains ordered: turn start -> document preview -> image preflight -> deterministic fast response -> provider pipeline.

Closes #609.

## Scope

In scope:
- Backend Direct Node pre-LLM lifecycle contracts.
- Uploaded document preview host-action preflight handoff.
- Image-input preflight handoff.
- Deterministic fast-response handoff.

Out of scope:
- Provider/model routing behavior changes.
- LMS apply behavior or approval token flow changes.
- Frontend iframe/visual harness changes.

## Verification

Local:

```bash
cd maritime-ai-service
uv run --python 3.12 --extra dev pytest tests/unit/test_direct_node_pre_llm_pipeline.py tests/unit/test_direct_node_image_input_preflight.py tests/unit/test_direct_node_fast_response_runtime.py tests/unit/test_direct_node_provider_errors.py tests/unit/test_direct_node_llm_pipeline.py -q --tb=short
# 46 passed

uv run --python 3.12 --extra dev ruff check app/engine/multi_agent/direct_node_pre_llm_stage_contract.py app/engine/multi_agent/direct_node_document_preflight.py app/engine/multi_agent/direct_node_image_input_preflight.py app/engine/multi_agent/direct_node_fast_response_runtime.py app/engine/multi_agent/direct_node_pre_llm_pipeline.py tests/unit/test_direct_node_pre_llm_pipeline.py tests/unit/test_direct_node_image_input_preflight.py tests/unit/test_direct_node_fast_response_runtime.py
# All checks passed!

cd ..
git diff --check
# pass
```

## Risk And Rollback

Risk: medium. This preserves behavior but touches Direct Node pre-LLM routing, including LMS document preview preflight and image-input deterministic responses.

Safety notes:
- No LMS mutation path is added or widened.
- Uploaded document preview still only emits preview host action and remains separate from apply/approval_token.
- Provider fallback and LLM execution remain out of scope.

Rollback: revert this PR. No migrations or persisted data shape changes.

## Reviewer Focus

- Confirm request/dependency objects preserve previous kwargs semantics.
- Confirm document preview still runs before image preflight and before fast response.
- Confirm image turns with uploaded document context still clear ambiguous image payloads instead of bypassing document grounding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal pre-LLM processing pipeline to use standardized request and dependency patterns, improving code maintainability and consistency across document preview, image input, and response handling stages.
  * Updated unit tests to reflect the new internal structure while maintaining existing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->