### PR TITLE
fix(desktop): harden visual frame host sync

### DIFF
--- a/wiii-desktop/src/__tests__/inline-visual-frame-rendering.test.tsx
+++ b/wiii-desktop/src/__tests__/inline-visual-frame-rendering.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { InlineVisualFrame } from "@/components/common/InlineVisualFrame";
 
 const originalCreateObjectUrl = URL.createObjectURL;
@@ -36,6 +36,42 @@ describe("InlineVisualFrame rendering contract", () => {
     expect(iframe.parentElement?.style.minHeight).toBe("0px");
     expect((iframe as HTMLIFrameElement).style.height).toBe("100%");
     expect((iframe as HTMLIFrameElement).style.minHeight).toBe("0px");
+  });
+
+  it("syncs host visual state when a sandbox frame finishes loading", async () => {
+    render(
+      <InlineVisualFrame
+        html="<main>Bridge app</main>"
+        title="Bridge app"
+        sessionId="vs_bridge"
+        frameKind="app"
+        sizingMode="viewport"
+        shellVariant="immersive"
+        runtimeManifest={{ ui_runtime: "iframe", storage: true }}
+      />,
+    );
+
+    const iframe = await screen.findByTitle("Bridge app");
+    const postMessage = vi.fn();
+    Object.defineProperty(iframe, "contentWindow", {
+      configurable: true,
+      value: { postMessage },
+    });
+
+    fireEvent.load(iframe);
+
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: "wiii-visual-sync",
+        payload: {
+          sessionId: "vs_bridge",
+          frameKind: "app",
+          shellVariant: "immersive",
+          runtimeManifest: { ui_runtime: "iframe", storage: true },
+        },
+      },
+      "*",
+    );
   });
 
   it("keeps normal inline app visuals content-sized", async () => {

--- a/wiii-desktop/src/components/common/InlineVisualFrame.tsx
+++ b/wiii-desktop/src/components/common/InlineVisualFrame.tsx
@@ -119,6 +119,20 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
     setHeight(heightProfile.initialHeight);
   }, [heightProfile.initialHeight, html, sizingMode]);
 
+  const postHostSync = useCallback(() => {
+    const target = iframeRef.current?.contentWindow;
+    if (!target) return;
+    target.postMessage(
+      buildVisualFrameHostSyncMessage({
+        sessionId,
+        frameKind,
+        shellVariant,
+        runtimeManifest: runtimeManifest || null,
+      }),
+      "*",
+    );
+  }, [frameKind, runtimeManifest, sessionId, shellVariant]);
+
   useEffect(() => {
     const handler = (event: MessageEvent) => {
       if (iframeRef.current && event.source !== iframeRef.current.contentWindow)
@@ -154,16 +168,8 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
         }
         return;
       }
-      if (message.kind === "ready" && iframeRef.current?.contentWindow) {
-        iframeRef.current.contentWindow.postMessage(
-          buildVisualFrameHostSyncMessage({
-            sessionId,
-            frameKind,
-            shellVariant,
-            runtimeManifest: runtimeManifest || null,
-          }),
-          "*",
-        );
+      if (message.kind === "ready") {
+        postHostSync();
         return;
       }
       if (message.kind === "bridge") {
@@ -175,7 +181,7 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
-  }, [frameKind, heightProfile, onBridgeEvent, runtimeManifest, sessionId, shellVariant]);
+  }, [heightProfile, onBridgeEvent, postHostSync]);
 
   // Tweaks toggle: send activate/deactivate to iframe
   const handleTweaksToggle = useCallback(() => {
@@ -237,6 +243,7 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
         sandbox="allow-scripts"
         // @ts-expect-error allowtransparency is a legacy but widely supported iframe attribute
         allowtransparency="true"
+        onLoad={postHostSync}
         style={{
           width: "100%",
           height: iframeHeight,


### PR DESCRIPTION
## Summary

- Sends `wiii-visual-sync` from the host when the sandbox iframe loads, in addition to the existing `wiii-frame-ready` path.
- Keeps Code Studio app previews on viewport sizing while preserving content sizing for inline app visuals.
- Adds a focused render harness assertion that iframe load posts the typed sync payload.

Closes #611.

## Scope

In scope:
- `InlineVisualFrame` host/iframe handshake reliability.
- Visual frame render tests for Code Studio preview sizing and host sync.

Out of scope:
- Backend Code Studio scaffold behavior.
- Generated visual app code templates.
- LMS preview/apply flow.

## Verification

Local:

```bash
cd wiii-desktop
npx vitest run src/__tests__/inline-visual-frame-rendering.test.tsx src/__tests__/visual-frame-contract.test.ts src/__tests__/inline-visual-frame.test.ts src/__tests__/code-studio-panel.test.tsx --pool forks --maxWorkers=1
# 4 files passed, 17 tests passed

npx tsc --noEmit
# pass

cd ..
git diff --check
# pass
```

Browser smoke:

```bash
# Playwright against http://127.0.0.1:1420/
# title: Wiii — Trợ lý AI thông minh cho học tập và nghiên cứu
# consoleErrors: []
# pageErrors: []
```

## Visual Evidence

Local browser smoke loaded the Wiii login shell on `http://127.0.0.1:1420/` with Vietnamese UI text and no console/page errors. The changed iframe sync path is covered by component-level harness because it depends on sandboxed `contentWindow.postMessage` rather than a visible static layout.

## Risk And Rollback

Risk: low-to-medium. This touches the iframe host handshake used by Code Studio previews and inline visual frames.

Safety notes:
- Sandbox policy remains `allow-scripts`; no new permissions are added.
- Host sync payload is the existing typed `wiii-visual-sync` message.
- No persisted state, LMS apply path, or generated artifact output changes.

Rollback: revert this PR. No migrations or generated assets.

## Reviewer Focus

- Confirm `postHostSync` does not widen iframe permissions.
- Confirm `ready` and `load` both send the same typed sync payload.
- Confirm viewport sizing remains limited to Code Studio/app preview lanes.