### PR TITLE
refactor(backend): type code studio node preflight

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/code_studio_node_preflight.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_node_preflight.py
@@ -1,0 +1,123 @@
+"""Typed preflight lifecycle for the Code Studio node."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from app.engine.multi_agent.state import AgentState
+
+
+@dataclass(frozen=True, slots=True)
+class CodeStudioNodePreflightRequest:
+    """Per-turn state available before Code Studio binds tools or calls a provider."""
+
+    query: str
+    state: AgentState
+    default_domain: str
+    push_event: Callable[[dict[str, Any]], Awaitable[None]]
+    tracer: Any
+
+
+@dataclass(frozen=True, slots=True)
+class CodeStudioNodePreflightDependencies:
+    """Injected contracts used to resolve Code Studio preflight behavior."""
+
+    looks_like_ambiguous_simulation_request: Callable[[str, AgentState], bool]
+    ground_simulation_query_from_visual_context: Callable[[str, AgentState], str]
+    last_inline_visual_title: Callable[[AgentState], str]
+    build_ambiguous_simulation_clarifier: Callable[[AgentState], str]
+
+
+@dataclass(frozen=True, slots=True)
+class CodeStudioNodePreflightResult:
+    """Resolved pre-provider state for a Code Studio turn."""
+
+    effective_query: str
+    response: str
+    domain_name_vi: str
+
+    @property
+    def has_response(self) -> bool:
+        return bool(self.response)
+
+
+def resolve_code_studio_domain_name_vi(
+    *,
+    state: AgentState,
+    default_domain: str,
+) -> str:
+    """Resolve the Vietnamese domain label without leaking graph details."""
+
+    domain_config = state.get("domain_config", {})
+    domain_name_vi = (
+        domain_config.get("name_vi", "") if isinstance(domain_config, dict) else ""
+    )
+    if domain_name_vi:
+        return str(domain_name_vi)
+
+    domain_id = state.get("domain_id", default_domain)
+    return {
+        "maritime": "Hang hai",
+        "traffic_law": "Luat Giao thong",
+    }.get(domain_id, str(domain_id))
+
+
+async def execute_code_studio_node_preflight(
+    *,
+    request: CodeStudioNodePreflightRequest,
+    dependencies: CodeStudioNodePreflightDependencies,
+) -> CodeStudioNodePreflightResult:
+    """Resolve deterministic Code Studio preflight before tool/provider execution."""
+
+    query = request.query
+    state = request.state
+    effective_query = query
+    response = ""
+    domain_name_vi = resolve_code_studio_domain_name_vi(
+        state=state,
+        default_domain=request.default_domain,
+    )
+
+    if dependencies.looks_like_ambiguous_simulation_request(query, state):
+        grounded_query = dependencies.ground_simulation_query_from_visual_context(
+            query,
+            state,
+        )
+        if grounded_query:
+            effective_query = grounded_query
+            state["thinking_content"] = (
+                "Mình đang bám theo visual hiện tại để tiếp tục mô phỏng, "
+                "vì turn này tuy ngắn nhưng đã có đủ ngữ cảnh để không cần hỏi lại."
+            )
+            await request.push_event({
+                "type": "status",
+                "content": (
+                    "Mình đang nối mô phỏng vào chủ đề hiện tại: "
+                    f"`{dependencies.last_inline_visual_title(state)}`..."
+                ),
+                "step": "code_generation",
+                "node": "code_studio_agent",
+                "details": {"visibility": "status_only"},
+            })
+        else:
+            response = dependencies.build_ambiguous_simulation_clarifier(state)
+            state["thinking_content"] = (
+                "Mình cần chốt rõ chủ đề mô phỏng trước khi mở canvas, "
+                "để khỏi dựng sai hiện tượng hoặc tạo một app lệch mục tiêu."
+            )
+            request.tracer.end_step(
+                result="Code studio clarification before build",
+                confidence=0.9,
+                details={
+                    "response_type": "clarify",
+                    "reason": "ambiguous_simulation_request",
+                },
+            )
+
+    return CodeStudioNodePreflightResult(
+        effective_query=effective_query,
+        response=response,
+        domain_name_vi=domain_name_vi,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
@@ -7,6 +7,11 @@ from app.engine.multi_agent.code_studio_provider_execution import (
     CodeStudioProviderExecutionRequest,
     execute_code_studio_provider_execution,
 )
+from app.engine.multi_agent.code_studio_node_preflight import (
+    CodeStudioNodePreflightDependencies,
+    CodeStudioNodePreflightRequest,
+    execute_code_studio_node_preflight,
+)
 from app.engine.multi_agent.code_studio_scaffold_fallback_policy import (
     resolve_code_studio_scaffold_fallback,
 )
@@ -72,48 +77,36 @@ async def code_studio_node_impl(
     tracer = get_or_create_tracer(state)
     tracer.start_step(step_names.DIRECT_RESPONSE, "Che tac dau ra ky thuat")
 
-    domain_config = state.get("domain_config", {})
-    domain_name_vi = domain_config.get("name_vi", "")
-    if not domain_name_vi:
-        domain_id = state.get("domain_id", settings_obj.default_domain)
-        domain_name_vi = {
-            "maritime": "Hang hai",
-            "traffic_law": "Luat Giao thong",
-        }.get(domain_id, domain_id)
-
     try:
         _ctx = state.get("context", {})
         explicit_provider = get_effective_provider(state)
-        response = ""
+        preflight = await execute_code_studio_node_preflight(
+            request=CodeStudioNodePreflightRequest(
+                query=query,
+                state=state,
+                default_domain=settings_obj.default_domain,
+                push_event=_push_event,
+                tracer=tracer,
+            ),
+            dependencies=CodeStudioNodePreflightDependencies(
+                looks_like_ambiguous_simulation_request=(
+                    looks_like_ambiguous_simulation_request
+                ),
+                ground_simulation_query_from_visual_context=(
+                    ground_simulation_query_from_visual_context
+                ),
+                last_inline_visual_title=last_inline_visual_title,
+                build_ambiguous_simulation_clarifier=(
+                    build_ambiguous_simulation_clarifier
+                ),
+            ),
+        )
+        effective_query = preflight.effective_query
+        response = preflight.response
+        domain_name_vi = preflight.domain_name_vi
         tools: list = []
         force_tools = False
         runtime_context_base = None
-        if looks_like_ambiguous_simulation_request(query, state):
-            grounded_query = ground_simulation_query_from_visual_context(query, state)
-            if grounded_query:
-                effective_query = grounded_query
-                state["thinking_content"] = (
-                    "Mình đang bám theo visual hiện tại để tiếp tục mô phỏng, "
-                    "vì turn này tuy ngắn nhưng đã có đủ ngữ cảnh để không cần hỏi lại."
-                )
-                await _push_event({
-                    "type": "status",
-                    "content": f"Mình đang nối mô phỏng vào chủ đề hiện tại: `{last_inline_visual_title(state)}`...",
-                    "step": "code_generation",
-                    "node": "code_studio_agent",
-                    "details": {"visibility": "status_only"},
-                })
-            else:
-                response = build_ambiguous_simulation_clarifier(state)
-                state["thinking_content"] = (
-                    "Mình cần chốt rõ chủ đề mô phỏng trước khi mở canvas, "
-                    "để khỏi dựng sai hiện tượng hoặc tạo một app lệch mục tiêu."
-                )
-                tracer.end_step(
-                    result="Code studio clarification before build",
-                    confidence=0.9,
-                    details={"response_type": "clarify", "reason": "ambiguous_simulation_request"},
-                )
         if not response:
             tool_setup = prepare_code_studio_tool_setup(
                 effective_query=effective_query,

--- a/maritime-ai-service/tests/unit/test_code_studio_node_preflight.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_node_preflight.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.engine.multi_agent.code_studio_node_preflight import (
+    CodeStudioNodePreflightDependencies,
+    CodeStudioNodePreflightRequest,
+    execute_code_studio_node_preflight,
+    resolve_code_studio_domain_name_vi,
+)
+
+
+def _dependencies(**overrides):
+    values = {
+        "looks_like_ambiguous_simulation_request": lambda _query, _state: False,
+        "ground_simulation_query_from_visual_context": lambda _query, _state: "",
+        "last_inline_visual_title": lambda _state: "Visual hiện tại",
+        "build_ambiguous_simulation_clarifier": lambda _state: "Bạn muốn mô phỏng gì?",
+    }
+    values.update(overrides)
+    return CodeStudioNodePreflightDependencies(**values)
+
+
+def test_code_studio_domain_name_prefers_domain_config() -> None:
+    assert (
+        resolve_code_studio_domain_name_vi(
+            state={"domain_config": {"name_vi": "Hàng hải"}},
+            default_domain="maritime",
+        )
+        == "Hàng hải"
+    )
+
+
+@pytest.mark.asyncio
+async def test_code_studio_preflight_grounds_ambiguous_simulation_followup() -> None:
+    pushed: list[dict] = []
+    state = {"domain_id": "maritime"}
+
+    async def push_event(event: dict) -> None:
+        pushed.append(event)
+
+    result = await execute_code_studio_node_preflight(
+        request=CodeStudioNodePreflightRequest(
+            query="mô phỏng tiếp đi",
+            state=state,
+            default_domain="maritime",
+            push_event=push_event,
+            tracer=MagicMock(),
+        ),
+        dependencies=_dependencies(
+            looks_like_ambiguous_simulation_request=lambda _query, _state: True,
+            ground_simulation_query_from_visual_context=(
+                lambda _query, _state: "mô phỏng dao động con lắc"
+            ),
+            last_inline_visual_title=lambda _state: "Con lắc đơn",
+        ),
+    )
+
+    assert result.effective_query == "mô phỏng dao động con lắc"
+    assert result.response == ""
+    assert result.domain_name_vi == "Hang hai"
+    assert state["thinking_content"].startswith("Mình đang bám theo visual")
+    assert pushed == [
+        {
+            "type": "status",
+            "content": "Mình đang nối mô phỏng vào chủ đề hiện tại: `Con lắc đơn`...",
+            "step": "code_generation",
+            "node": "code_studio_agent",
+            "details": {"visibility": "status_only"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_code_studio_preflight_clarifies_ambiguous_simulation_without_context() -> None:
+    tracer = MagicMock()
+
+    result = await execute_code_studio_node_preflight(
+        request=CodeStudioNodePreflightRequest(
+            query="mô phỏng đi",
+            state={},
+            default_domain="traffic_law",
+            push_event=lambda _event: SimpleNamespace(),
+            tracer=tracer,
+        ),
+        dependencies=_dependencies(
+            looks_like_ambiguous_simulation_request=lambda _query, _state: True,
+            build_ambiguous_simulation_clarifier=lambda _state: (
+                "Cậu muốn mô phỏng hiện tượng nào?"
+            ),
+        ),
+    )
+
+    assert result.has_response is True
+    assert result.response == "Cậu muốn mô phỏng hiện tượng nào?"
+    assert result.effective_query == "mô phỏng đi"
+    assert result.domain_name_vi == "Luat Giao thong"
+    tracer.end_step.assert_called_once()
+    assert tracer.end_step.call_args.kwargs["details"] == {
+        "response_type": "clarify",
+        "reason": "ambiguous_simulation_request",
+    }


### PR DESCRIPTION
## Summary

- Extracts Code Studio domain resolution and ambiguous simulation preflight into `code_studio_node_preflight.py` with typed request/dependency/result contracts.
- Keeps grounded ambiguous simulation follow-ups and clarifier behavior unchanged.
- Adds focused unit tests for domain resolution, grounded follow-up status events, and clarification path.

Closes #615.

## Scope

In scope:
- Code Studio node pre-provider lifecycle.
- Ambiguous simulation continuation/clarifier behavior.
- Domain label resolution for provider prompt context.

Out of scope:
- Provider execution/tool loop behavior.
- Scaffold renderer/fallback policy changes.
- Frontend visual frame changes.

## Verification

Local:

```bash
cd maritime-ai-service
uv run --python 3.12 --extra dev pytest tests/unit/test_code_studio_node_preflight.py tests/unit/test_code_studio_provider_execution.py tests/unit/test_code_studio_fast_paths.py tests/unit/test_code_studio_tool_setup.py -q --tb=short
# 13 passed

uv run --python 3.12 --extra dev pytest tests/unit/test_graph_routing.py::TestSimulationClarifier::test_code_studio_node_grounds_ambiguous_simulation_followup_from_visual_context -q --tb=short
# 1 passed

uv run --python 3.12 --extra dev ruff check app/engine/multi_agent/code_studio_node_preflight.py app/engine/multi_agent/code_studio_node_runtime.py tests/unit/test_code_studio_node_preflight.py
# All checks passed!

cd ..
git diff --check
# pass
```

## Risk And Rollback

Risk: medium. This moves preflight logic that decides whether Code Studio should ask a clarifying question or proceed using existing visual context.

Safety notes:
- Provider/tool execution remains untouched.
- The same status event payload is emitted for grounded follow-ups.
- Clarifier still ends the tracer step before skipping build.

Rollback: revert this PR. No migrations or persisted data changes.

## Reviewer Focus

- Confirm grounded ambiguous simulation behavior is preserved.
- Confirm domain label behavior matches the old inline logic.
- Confirm the Code Studio runtime now delegates only preflight, not provider execution.