### PR TITLE
fix(desktop): harden visual frame UX harness

### DIFF
--- a/wiii-desktop/src/__tests__/inline-visual-frame-rendering.test.tsx
+++ b/wiii-desktop/src/__tests__/inline-visual-frame-rendering.test.tsx
@@ -32,6 +32,8 @@ describe("InlineVisualFrame rendering contract", () => {
     await waitFor(() => expect(iframe.getAttribute("src")).toBe("blob:wiii-visual-frame"));
 
     expect(iframe.parentElement?.getAttribute("data-inline-visual-sizing")).toBe("viewport");
+    expect(iframe.parentElement?.getAttribute("data-inline-visual-ready")).toBe("false");
+    expect(iframe.parentElement?.getAttribute("aria-busy")).toBe("true");
     expect(iframe.parentElement?.style.height).toBe("100%");
     expect(iframe.parentElement?.style.minHeight).toBe("0px");
     expect((iframe as HTMLIFrameElement).style.height).toBe("100%");
@@ -67,11 +69,13 @@ describe("InlineVisualFrame rendering contract", () => {
           sessionId: "vs_bridge",
           frameKind: "app",
           shellVariant: "immersive",
+          sizingMode: "viewport",
           runtimeManifest: { ui_runtime: "iframe", storage: true },
         },
       },
       "*",
     );
+    expect(iframe.parentElement?.getAttribute("data-inline-visual-ready")).toBe("true");
   });
 
   it("keeps normal inline app visuals content-sized", async () => {

--- a/wiii-desktop/src/__tests__/inline-visual-frame.test.ts
+++ b/wiii-desktop/src/__tests__/inline-visual-frame.test.ts
@@ -54,12 +54,15 @@ describe("InlineVisualFrame host shell", () => {
       sessionId: "vs-tall",
       shellVariant: "immersive",
       frameKind: "app",
+      sizingMode: "viewport",
       showFrameIntro: false,
       hostShellMode: "force",
     });
 
     expect(wrapped).toContain("overflow: auto;");
     expect(wrapped).toContain("overscroll-behavior: contain;");
+    expect(wrapped).toContain('data-wiii-sizing-mode="viewport"');
+    expect(wrapped).toContain("state.parentState.sizingMode");
     expect(wrapped).toContain("function measureHeight()");
     expect(wrapped).toContain("resizeObserver.observe(document.documentElement)");
   });

--- a/wiii-desktop/src/__tests__/visual-frame-contract.test.ts
+++ b/wiii-desktop/src/__tests__/visual-frame-contract.test.ts
@@ -65,6 +65,7 @@ describe("visual frame contract", () => {
       sessionId: "vs_1",
       frameKind: "app",
       shellVariant: "immersive",
+      sizingMode: "viewport",
       runtimeManifest: { storage: "ephemeral" },
     })).toEqual({
       type: "wiii-visual-sync",
@@ -72,6 +73,7 @@ describe("visual frame contract", () => {
         sessionId: "vs_1",
         frameKind: "app",
         shellVariant: "immersive",
+        sizingMode: "viewport",
         runtimeManifest: { storage: "ephemeral" },
       },
     });

--- a/wiii-desktop/src/components/common/InlineVisualFrame.tsx
+++ b/wiii-desktop/src/components/common/InlineVisualFrame.tsx
@@ -63,6 +63,7 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
   );
   const [height, setHeight] = useState(heightProfile.initialHeight);
   const [error, setError] = useState<string | null>(null);
+  const [frameReady, setFrameReady] = useState(false);
   const [tweaksAvailable, setTweaksAvailable] = useState(false);
   const [tweaksActive, setTweaksActive] = useState(false);
 
@@ -78,6 +79,7 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
         sessionId,
         shellVariant,
         frameKind,
+        sizingMode,
         showFrameIntro,
         hostShellMode,
         hostThemeOverrides: readHostThemeOverrides(),
@@ -88,6 +90,7 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
       html,
       sessionId,
       shellVariant,
+      sizingMode,
       showFrameIntro,
       summary,
       title,
@@ -102,6 +105,7 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
       blobUrlRef.current = url;
       setBlobUrl(url);
       setError(null);
+      setFrameReady(false);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Không thể tạo visual frame",
@@ -127,11 +131,12 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
         sessionId,
         frameKind,
         shellVariant,
+        sizingMode,
         runtimeManifest: runtimeManifest || null,
       }),
       "*",
     );
-  }, [frameKind, runtimeManifest, sessionId, shellVariant]);
+  }, [frameKind, runtimeManifest, sessionId, shellVariant, sizingMode]);
 
   useEffect(() => {
     const handler = (event: MessageEvent) => {
@@ -169,6 +174,7 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
         return;
       }
       if (message.kind === "ready") {
+        setFrameReady(true);
         postHostSync();
         return;
       }
@@ -231,6 +237,8 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
       data-inline-visual-frame={frameKind}
       data-inline-visual-shell={shellVariant}
       data-inline-visual-sizing={sizingMode}
+      data-inline-visual-ready={frameReady ? "true" : "false"}
+      aria-busy={frameReady ? undefined : true}
       style={{
         position: "relative",
         ...(sizingMode === "viewport" ? { height: "100%", minHeight: "0px" } : {}),
@@ -243,7 +251,10 @@ export const InlineVisualFrame = memo(function InlineVisualFrame({
         sandbox="allow-scripts"
         // @ts-expect-error allowtransparency is a legacy but widely supported iframe attribute
         allowtransparency="true"
-        onLoad={postHostSync}
+        onLoad={() => {
+          setFrameReady(true);
+          postHostSync();
+        }}
         style={{
           width: "100%",
           height: iframeHeight,

--- a/wiii-desktop/src/lib/visual-frame-contract.ts
+++ b/wiii-desktop/src/lib/visual-frame-contract.ts
@@ -5,6 +5,7 @@ export interface VisualFrameHostSyncPayload {
   sessionId: string;
   frameKind: VisualFrameKind;
   shellVariant: string;
+  sizingMode: VisualFrameSizingMode;
   runtimeManifest: unknown | null;
 }
 

--- a/wiii-desktop/src/lib/visual-frame-document.ts
+++ b/wiii-desktop/src/lib/visual-frame-document.ts
@@ -1,5 +1,8 @@
 import type { VisualShellVariant } from "@/api/types";
-import type { VisualFrameKind } from "@/lib/visual-frame-contract";
+import type {
+  VisualFrameKind,
+  VisualFrameSizingMode,
+} from "@/lib/visual-frame-contract";
 
 export type VisualFrameHostShellMode = "auto" | "force";
 
@@ -9,6 +12,7 @@ export interface VisualFrameDocumentOptions {
   sessionId?: string;
   shellVariant?: VisualShellVariant;
   frameKind?: VisualFrameKind;
+  sizingMode?: VisualFrameSizingMode;
   showFrameIntro?: boolean;
   hostShellMode?: VisualFrameHostShellMode;
   hostThemeOverrides?: Record<string, string>;
@@ -255,6 +259,7 @@ export function buildVisualFrameDocument(
     sessionId = "",
     shellVariant = "editorial",
     frameKind = "inline_html",
+    sizingMode = "content",
     showFrameIntro = false,
     hostShellMode = frameKind === "legacy" ? "auto" : "force",
     hostThemeOverrides = undefined,
@@ -272,8 +277,20 @@ export function buildVisualFrameDocument(
         summary: ${JSON.stringify(summary)},
         shellVariant: ${JSON.stringify(shellVariant)},
         frameKind: ${JSON.stringify(frameKind)},
+        sizingMode: ${JSON.stringify(sizingMode)},
         reducedMotion: reducedMotion
       };
+
+      function applyRuntimeDataset() {
+        document.documentElement.dataset.wiiiFrameKind = state.frameKind;
+        document.documentElement.dataset.wiiiShellVariant = state.shellVariant;
+        document.documentElement.dataset.wiiiSizingMode = state.sizingMode;
+        if (document.body) {
+          document.body.dataset.wiiiFrameKind = state.frameKind;
+          document.body.dataset.wiiiShellVariant = state.shellVariant;
+          document.body.dataset.wiiiSizingMode = state.sizingMode;
+        }
+      }
 
       function post(type, payload) {
         parent.postMessage({ type: type, payload: payload || {} }, '*');
@@ -337,12 +354,16 @@ export function buildVisualFrameDocument(
         if (!data || typeof data !== 'object') return;
         if (data.type === 'wiii-visual-sync') {
           state.parentState = data.payload || {};
-          document.documentElement.dataset.wiiiShellVariant = state.shellVariant;
+          if (state.parentState && typeof state.parentState.sizingMode === 'string') {
+            state.sizingMode = state.parentState.sizingMode;
+          }
+          applyRuntimeDataset();
           notifyResize();
         }
       });
 
       window.addEventListener('load', function () {
+        applyRuntimeDataset();
         notifyResize();
         if (window.ResizeObserver) {
           var resizeObserver = new ResizeObserver(function () { queueResize(); });
@@ -351,7 +372,7 @@ export function buildVisualFrameDocument(
         }
         setTimeout(notifyResize, 120);
         setTimeout(notifyResize, 500);
-        post('wiii-frame-ready', { sessionId: state.sessionId, frameKind: state.frameKind, shellVariant: state.shellVariant });
+        post('wiii-frame-ready', { sessionId: state.sessionId, frameKind: state.frameKind, shellVariant: state.shellVariant, sizingMode: state.sizingMode });
       });
     })();
   </script>`;
@@ -498,6 +519,15 @@ export function buildVisualFrameDocument(
     .wiii-frame-content {
       padding: ${contentPadding};
     }
+    body[data-wiii-sizing-mode="viewport"] {
+      min-height: 100vh;
+    }
+    body[data-wiii-sizing-mode="viewport"] .wiii-frame-shell {
+      min-height: calc(100vh - 8px);
+    }
+    body[data-wiii-sizing-mode="viewport"] .wiii-frame-content {
+      min-height: 0;
+    }
     canvas, svg, table, img { max-width: 100%; height: auto; }
     /* Sprint V5: Lighter form defaults — transparent, thin border */
     button, select, input:not([type="range"]), textarea {
@@ -584,7 +614,7 @@ export function buildVisualFrameDocument(
             attrs,
             "wiii-host-shell-active",
           );
-          return `<body${mergedAttrs} data-wiii-host-shell="true" data-wiii-has-intro="${hasIntro ? "true" : "false"}">
+          return `<body${mergedAttrs} data-wiii-host-shell="true" data-wiii-has-intro="${hasIntro ? "true" : "false"}" data-wiii-frame-kind="${escapeHtml(frameKind)}" data-wiii-shell-variant="${escapeHtml(shellVariant)}" data-wiii-sizing-mode="${escapeHtml(sizingMode)}">
   <div class="wiii-frame-shell" data-wiii-frame-kind="${escapeHtml(frameKind)}" data-wiii-shell-variant="${escapeHtml(shellVariant)}">
     ${intro}
     <div class="wiii-frame-content">${bodyContent}</div>
@@ -597,13 +627,17 @@ export function buildVisualFrameDocument(
     }
 
     const bodyDecorated = headInjected.replace(
-      /<body([^>]*>)/i,
+      /<body([^>]*)>/i,
       (_match, attrs: string) => {
         const mergedAttrs = mergeBodyClassAttribute(
           attrs,
           hostShellMode === "force" ? "wiii-host-shell-active" : "",
         );
-        return `<body${mergedAttrs}${hostShellMode === "force" ? ` data-wiii-host-shell="true" data-wiii-has-intro="${hasIntro ? "true" : "false"}"` : ""}>`;
+        const hostAttrs =
+          hostShellMode === "force"
+            ? ` data-wiii-host-shell="true" data-wiii-has-intro="${hasIntro ? "true" : "false"}"`
+            : "";
+        return `<body${mergedAttrs}${hostAttrs} data-wiii-frame-kind="${escapeHtml(frameKind)}" data-wiii-shell-variant="${escapeHtml(shellVariant)}" data-wiii-sizing-mode="${escapeHtml(sizingMode)}">`;
       },
     );
 
@@ -616,14 +650,14 @@ export function buildVisualFrameDocument(
   }
 
   return `<!DOCTYPE html>
-<html lang="vi">
+<html lang="vi" data-wiii-frame-kind="${escapeHtml(frameKind)}" data-wiii-shell-variant="${escapeHtml(shellVariant)}" data-wiii-sizing-mode="${escapeHtml(sizingMode)}">
 <head>
   <meta charset="utf-8">
   ${FRAME_CSP}
   ${STORAGE_SHIM}
   ${shellStyle}${themeOverrideBlock}
 </head>
-<body class="${hostShellMode === "force" ? "wiii-host-shell-active" : ""}" data-wiii-host-shell="${hostShellMode === "force" ? "true" : "false"}" data-wiii-has-intro="${hasIntro ? "true" : "false"}">
+<body class="${hostShellMode === "force" ? "wiii-host-shell-active" : ""}" data-wiii-host-shell="${hostShellMode === "force" ? "true" : "false"}" data-wiii-has-intro="${hasIntro ? "true" : "false"}" data-wiii-frame-kind="${escapeHtml(frameKind)}" data-wiii-shell-variant="${escapeHtml(shellVariant)}" data-wiii-sizing-mode="${escapeHtml(sizingMode)}">
   <div class="wiii-frame-shell" data-wiii-frame-kind="${escapeHtml(frameKind)}" data-wiii-shell-variant="${escapeHtml(shellVariant)}">
     ${intro}
     <div class="wiii-frame-content">${sanitizedContent}</div>


### PR DESCRIPTION
Closes #617.

## Summary
- Include sizingMode in the typed wiii-visual-sync host contract so Code Studio viewport previews and content-sized inline apps are explicit.
- Stamp iframe documents with runtime dataset attributes for frame kind, shell variant, and sizing mode; iframe code can now adapt without guessing layout.
- Add host-side ready/busy state for sandbox frames and focused tests for viewport previews, tall app frames, and host sync payloads.

## Scope / non-scope
- Desktop visual runtime and focused tests only.
- No backend provider/tool routing changes.
- No LMS preview/apply mutation behavior changes.
- No generated dist assets committed.

## Verification
- cd wiii-desktop && npx vitest run src/__tests__/inline-visual-frame-rendering.test.tsx src/__tests__/visual-frame-contract.test.ts src/__tests__/inline-visual-frame.test.ts src/__tests__/code-studio-panel.test.tsx --pool forks --maxWorkers=1 -> 4 files passed, 17 tests passed.
- cd wiii-desktop && npx tsc --noEmit -> passed.
- cd wiii-desktop && npm run build:embed -> passed; existing Vite chunk/dynamic-import warnings only.
- git diff --check -> passed.
- Browser smoke via Playwright against http://127.0.0.1:1420/ -> HTTP 200, title Wiii — Trợ lý AI thông minh cho học tập và nghiên cứu, no console/page errors. Authenticated visual screenshot was not available in this local shell, so visual evidence is covered by component tests plus localhost shell smoke.

## Risk / rollback
Medium-low frontend runtime risk. This changes iframe sync metadata and host ready state only, with backward-compatible app message handling. Rollback is a revert of this PR; no migrations or persistent data changes.

## Reviewer focus
- sizingMode contract remains backward-compatible for iframe apps.
- Viewport Code Studio previews stay full-height while inline app visuals remain content-sized by default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit frame readiness tracking with new accessibility attributes (`data-inline-visual-ready` to indicate iframe readiness, `aria-busy` for loading state).
  * Introduced viewport sizing mode support for flexible iframe layout configuration.

* **Tests**
  * Enhanced test coverage to validate frame readiness states, accessibility attributes, and sizing mode synchronization across iframe lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->