### PR TITLE
refactor(backend): type code studio node lifecycle

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/code_studio_node_events.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_node_events.py
@@ -1,0 +1,58 @@
+"""Typed event sink contract for the Code Studio graph node."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from app.engine.multi_agent.state import AgentState
+
+
+@dataclass(frozen=True, slots=True)
+class CodeStudioNodeEventSinkRequest:
+    """Dependencies required to wire Code Studio status/tool events."""
+
+    state: AgentState
+    bus_id: str | None
+    get_event_queue: Callable[[str], Any]
+    capture_public_thinking_event: Callable[[AgentState, dict[str, Any]], Any]
+    logger: logging.Logger
+
+
+@dataclass(frozen=True, slots=True)
+class CodeStudioNodeEventSink:
+    """Bound event queue plus the async push function used by sub-stages."""
+
+    event_queue: Any | None
+    push_event: Callable[[dict[str, Any]], Any]
+
+    @property
+    def event_queue_present(self) -> bool:
+        return self.event_queue is not None
+
+
+def create_code_studio_node_event_sink(
+    request: CodeStudioNodeEventSinkRequest,
+) -> CodeStudioNodeEventSink:
+    """Create the Code Studio node event sink without hiding side effects."""
+
+    event_queue = request.get_event_queue(request.bus_id) if request.bus_id else None
+
+    async def push_event(event: dict[str, Any]) -> None:
+        request.capture_public_thinking_event(request.state, event)
+        if event_queue is None:
+            return
+        try:
+            event_queue.put_nowait(event)
+        except Exception as queue_error:  # noqa: BLE001 - event stream must not fail turn
+            request.logger.debug(
+                "[CODE_STUDIO] Event queue push failed: %s",
+                queue_error,
+            )
+
+    return CodeStudioNodeEventSink(
+        event_queue=event_queue,
+        push_event=push_event,
+    )

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_node_final_state.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_node_final_state.py
@@ -1,0 +1,66 @@
+"""Final state contract for the Code Studio graph node."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from app.engine.multi_agent.state import AgentState
+from app.engine.reasoning import (
+    record_thinking_snapshot,
+    resolve_visible_thinking_from_lifecycle,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CodeStudioNodeFinalStateRequest:
+    """Response and state needed to close a Code Studio node turn."""
+
+    state: AgentState
+    response: str
+    query: str
+
+
+@dataclass(frozen=True, slots=True)
+class CodeStudioNodeFinalStateDependencies:
+    """Injected helpers for thinking cleanup and final state mutation."""
+
+    build_code_studio_reasoning_summary: Callable[..., Any]
+    direct_tool_names: Callable[[list[Any]], list[str]]
+    resolve_visible_thinking_fn: Callable[..., str] = (
+        resolve_visible_thinking_from_lifecycle
+    )
+    record_thinking_snapshot_fn: Callable[..., Any] = record_thinking_snapshot
+
+
+async def apply_code_studio_node_final_state(
+    *,
+    request: CodeStudioNodeFinalStateRequest,
+    dependencies: CodeStudioNodeFinalStateDependencies,
+) -> AgentState:
+    """Apply final response fields and public thinking snapshot for Code Studio."""
+
+    state = request.state
+    if not state.get("thinking_content"):
+        state["thinking_content"] = dependencies.resolve_visible_thinking_fn(
+            state,
+            fallback=await dependencies.build_code_studio_reasoning_summary(
+                request.query,
+                state,
+                dependencies.direct_tool_names(state.get("tools_used", [])),
+            ),
+            default_node="code_studio_agent",
+        )
+    if state.get("thinking_content"):
+        dependencies.record_thinking_snapshot_fn(
+            state,
+            state.get("thinking_content"),
+            node="code_studio_agent",
+            provenance="final_snapshot",
+        )
+
+    state["final_response"] = request.response
+    state["agent_outputs"] = {"code_studio_agent": request.response}
+    state["current_agent"] = "code_studio_agent"
+    return state

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
@@ -12,6 +12,15 @@ from app.engine.multi_agent.code_studio_node_preflight import (
     CodeStudioNodePreflightRequest,
     execute_code_studio_node_preflight,
 )
+from app.engine.multi_agent.code_studio_node_events import (
+    CodeStudioNodeEventSinkRequest,
+    create_code_studio_node_event_sink,
+)
+from app.engine.multi_agent.code_studio_node_final_state import (
+    CodeStudioNodeFinalStateDependencies,
+    CodeStudioNodeFinalStateRequest,
+    apply_code_studio_node_final_state,
+)
 from app.engine.multi_agent.code_studio_scaffold_fallback_policy import (
     resolve_code_studio_scaffold_fallback,
 )
@@ -19,10 +28,6 @@ from app.engine.multi_agent.code_studio_tool_setup import (
     prepare_code_studio_tool_setup,
 )
 from app.engine.multi_agent.state import AgentState
-from app.engine.reasoning import (
-    record_thinking_snapshot,
-    resolve_visible_thinking_from_lifecycle,
-)
 from app.engine.runtime.runtime_metrics import inc_counter
 
 
@@ -61,18 +66,16 @@ async def code_studio_node_impl(
     query = state.get("query", "")
     effective_query = query
 
-    _event_queue = None
     _bus_id = state.get("_event_bus_id")
-    if _bus_id:
-        _event_queue = get_event_queue(_bus_id)
-
-    async def _push_event(event: dict):
-        capture_public_thinking_event(state, event)
-        if _event_queue:
-            try:
-                _event_queue.put_nowait(event)
-            except Exception as _qe:
-                logger.debug("[CODE_STUDIO] Event queue push failed: %s", _qe)
+    event_sink = create_code_studio_node_event_sink(
+        CodeStudioNodeEventSinkRequest(
+            state=state,
+            bus_id=_bus_id,
+            get_event_queue=get_event_queue,
+            capture_public_thinking_event=capture_public_thinking_event,
+            logger=logger,
+        )
+    )
 
     tracer = get_or_create_tracer(state)
     tracer.start_step(step_names.DIRECT_RESPONSE, "Che tac dau ra ky thuat")
@@ -85,7 +88,7 @@ async def code_studio_node_impl(
                 query=query,
                 state=state,
                 default_domain=settings_obj.default_domain,
-                push_event=_push_event,
+                push_event=event_sink.push_event,
                 tracer=tracer,
             ),
             dependencies=CodeStudioNodePreflightDependencies(
@@ -127,7 +130,7 @@ async def code_studio_node_impl(
                 state=state,
                 query=effective_query,
                 tools=tools,
-                push_event=_push_event,
+                push_event=event_sink.push_event,
                 runtime_context_base=runtime_context_base,
             )
 
@@ -157,8 +160,8 @@ async def code_studio_node_impl(
                         tools=tools,
                         force_tools=force_tools,
                         runtime_context_base=runtime_context_base,
-                        event_queue_present=bool(_event_queue),
-                        push_event=_push_event,
+                        event_queue_present=event_sink.event_queue_present,
+                        push_event=event_sink.push_event,
                         settings_obj=settings_obj,
                         requested_model=state.get("model"),
                     ),
@@ -231,27 +234,17 @@ async def code_studio_node_impl(
             },
         )
 
-    if not state.get("thinking_content"):
-        state["thinking_content"] = resolve_visible_thinking_from_lifecycle(
-            state,
-            fallback=await build_code_studio_reasoning_summary(
-                query,
-                state,
-                direct_tool_names(state.get("tools_used", [])),
-            ),
-            default_node="code_studio_agent",
-        )
-    if state.get("thinking_content"):
-        record_thinking_snapshot(
-            state,
-            state.get("thinking_content"),
-            node="code_studio_agent",
-            provenance="final_snapshot",
-        )
-
-    state["final_response"] = response
-    state["agent_outputs"] = {"code_studio_agent": response}
-    state["current_agent"] = "code_studio_agent"
+    await apply_code_studio_node_final_state(
+        request=CodeStudioNodeFinalStateRequest(
+            state=state,
+            response=response,
+            query=query,
+        ),
+        dependencies=CodeStudioNodeFinalStateDependencies(
+            build_code_studio_reasoning_summary=build_code_studio_reasoning_summary,
+            direct_tool_names=direct_tool_names,
+        ),
+    )
 
     logger.info("[CODE_STUDIO] Response prepared, tracer passed to synthesizer")
 

--- a/maritime-ai-service/tests/unit/test_code_studio_node_events.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_node_events.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.engine.multi_agent.code_studio_node_events import (
+    CodeStudioNodeEventSinkRequest,
+    create_code_studio_node_event_sink,
+)
+
+
+@pytest.mark.asyncio
+async def test_code_studio_node_event_sink_captures_public_event_without_bus():
+    state = {}
+    captured: list[dict] = []
+
+    sink = create_code_studio_node_event_sink(
+        CodeStudioNodeEventSinkRequest(
+            state=state,
+            bus_id=None,
+            get_event_queue=lambda _bus_id: None,
+            capture_public_thinking_event=lambda _state, event: captured.append(event),
+            logger=MagicMock(),
+        )
+    )
+
+    await sink.push_event({"type": "status", "content": "Dang tao preview"})
+
+    assert sink.event_queue_present is False
+    assert captured == [{"type": "status", "content": "Dang tao preview"}]
+
+
+@pytest.mark.asyncio
+async def test_code_studio_node_event_sink_logs_queue_push_failures():
+    state = {}
+    captured: list[dict] = []
+    logger = MagicMock()
+
+    class Queue:
+        def put_nowait(self, _event):
+            raise RuntimeError("queue full")
+
+    sink = create_code_studio_node_event_sink(
+        CodeStudioNodeEventSinkRequest(
+            state=state,
+            bus_id="bus-1",
+            get_event_queue=lambda _bus_id: Queue(),
+            capture_public_thinking_event=lambda _state, event: captured.append(event),
+            logger=logger,
+        )
+    )
+
+    await sink.push_event({"type": "status", "content": "Dang tao preview"})
+
+    assert sink.event_queue_present is True
+    assert captured == [{"type": "status", "content": "Dang tao preview"}]
+    logger.debug.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_code_studio_node_event_sink_pushes_to_queue_when_available():
+    state = {}
+    queue = SimpleNamespace(events=[])
+    queue.put_nowait = lambda event: queue.events.append(event)
+
+    sink = create_code_studio_node_event_sink(
+        CodeStudioNodeEventSinkRequest(
+            state=state,
+            bus_id="bus-1",
+            get_event_queue=lambda _bus_id: queue,
+            capture_public_thinking_event=lambda _state, _event: None,
+            logger=MagicMock(),
+        )
+    )
+
+    await sink.push_event({"type": "tool", "name": "tool_create_visual_code"})
+
+    assert queue.events == [{"type": "tool", "name": "tool_create_visual_code"}]

--- a/maritime-ai-service/tests/unit/test_code_studio_node_final_state.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_node_final_state.py
@@ -1,0 +1,87 @@
+import pytest
+
+from app.engine.multi_agent.code_studio_node_final_state import (
+    CodeStudioNodeFinalStateDependencies,
+    CodeStudioNodeFinalStateRequest,
+    apply_code_studio_node_final_state,
+)
+
+
+@pytest.mark.asyncio
+async def test_apply_code_studio_node_final_state_builds_missing_thinking():
+    state = {"tools_used": ["tool_create_visual_code"]}
+    snapshots: list[tuple[str, str, str]] = []
+
+    async def build_summary(query, _state, tool_names):
+        assert query == "Tao mo phong con lac"
+        assert tool_names == ["tool_create_visual_code"]
+        return "Minh dang giu preview that."
+
+    result = await apply_code_studio_node_final_state(
+        request=CodeStudioNodeFinalStateRequest(
+            state=state,
+            response="Da tao preview.",
+            query="Tao mo phong con lac",
+        ),
+        dependencies=CodeStudioNodeFinalStateDependencies(
+            build_code_studio_reasoning_summary=build_summary,
+            direct_tool_names=lambda tools: list(tools),
+            resolve_visible_thinking_fn=(
+                lambda _state, *, fallback, default_node: (
+                    f"{default_node}: {fallback}"
+                )
+            ),
+            record_thinking_snapshot_fn=(
+                lambda _state, content, *, node, provenance: snapshots.append(
+                    (node, provenance, content)
+                )
+            ),
+        ),
+    )
+
+    assert result is state
+    assert state["thinking_content"] == (
+        "code_studio_agent: Minh dang giu preview that."
+    )
+    assert snapshots == [
+        (
+            "code_studio_agent",
+            "final_snapshot",
+            "code_studio_agent: Minh dang giu preview that.",
+        )
+    ]
+    assert state["final_response"] == "Da tao preview."
+    assert state["agent_outputs"] == {"code_studio_agent": "Da tao preview."}
+    assert state["current_agent"] == "code_studio_agent"
+
+
+@pytest.mark.asyncio
+async def test_apply_code_studio_node_final_state_preserves_existing_thinking():
+    state = {"thinking_content": "Existing public thinking."}
+    summary_called = False
+    snapshots: list[str] = []
+
+    async def build_summary(*_args, **_kwargs):
+        nonlocal summary_called
+        summary_called = True
+        return "Should not be used"
+
+    await apply_code_studio_node_final_state(
+        request=CodeStudioNodeFinalStateRequest(
+            state=state,
+            response="Clarify simulation.",
+            query="mo phong di",
+        ),
+        dependencies=CodeStudioNodeFinalStateDependencies(
+            build_code_studio_reasoning_summary=build_summary,
+            direct_tool_names=lambda tools: list(tools),
+            record_thinking_snapshot_fn=(
+                lambda _state, content, **_kwargs: snapshots.append(content)
+            ),
+        ),
+    )
+
+    assert summary_called is False
+    assert snapshots == ["Existing public thinking."]
+    assert state["thinking_content"] == "Existing public thinking."
+    assert state["final_response"] == "Clarify simulation."


### PR DESCRIPTION
Closes #619.

## Summary
- Extract Code Studio node event sink wiring into code_studio_node_events.py with a typed request/result contract.
- Extract final response, gent_outputs, current agent, and public thinking snapshot mutation into code_studio_node_final_state.py.
- Keep code_studio_node_runtime.py focused on orchestration across preflight, tool setup, fast path, provider execution, and fallback policy.

## Scope / non-scope
- Backend Code Studio lifecycle refactor only.
- No provider routing behavior changes.
- No visual scaffold policy changes.
- No LMS approval/apply or frontend changes.

## Verification
- cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_code_studio_node_events.py tests/unit/test_code_studio_node_final_state.py tests/unit/test_code_studio_node_preflight.py tests/unit/test_code_studio_provider_execution.py tests/unit/test_code_studio_fast_paths.py tests/unit/test_code_studio_tool_setup.py -q --tb=short -> 18 passed.
- cd maritime-ai-service && uv run --python 3.12 --extra dev pytest tests/unit/test_graph_routing.py::TestSimulationClarifier::test_code_studio_node_grounds_ambiguous_simulation_followup_from_visual_context -q --tb=short -> 1 passed.
- cd maritime-ai-service && uv run --python 3.12 --extra dev ruff check app/engine/multi_agent/code_studio_node_events.py app/engine/multi_agent/code_studio_node_final_state.py app/engine/multi_agent/code_studio_node_runtime.py tests/unit/test_code_studio_node_events.py tests/unit/test_code_studio_node_final_state.py -> passed.
- git diff --check -> passed.

## Risk / rollback
Low backend refactor risk. Event delivery and final state side effects are preserved but now testable. Rollback is a revert of this PR; no migrations or persistent data changes.

## Reviewer focus
- Event sink still captures public thinking events even when queue push fails.
- Final state preserves existing thinking content and only builds a fallback summary when missing.
- Code Studio node behavior remains unchanged for ambiguous simulation follow-ups.
