### PR TITLE
fix(desktop): prevent code studio panel clipping

### DIFF
--- a/wiii-desktop/src/__tests__/code-studio-panel.test.tsx
+++ b/wiii-desktop/src/__tests__/code-studio-panel.test.tsx
@@ -142,6 +142,23 @@ describe("CodeStudioPanel", () => {
     );
   });
 
+  it("keeps the overlay shell mobile-safe before the sm breakpoint", async () => {
+    seedCompleteSession("code");
+
+    const { container } = render(<CodeStudioPanel />);
+
+    const shell = container.querySelector(".code-studio-panel");
+    expect(shell).toBeTruthy();
+    const classTokens = new Set((shell?.getAttribute("class") || "").split(/\s+/));
+
+    expect(classTokens.has("inset-x-0")).toBe(true);
+    expect(classTokens.has("w-full")).toBe(true);
+    expect(classTokens.has("max-w-full")).toBe(true);
+    expect(classTokens.has("min-w-0")).toBe(true);
+    expect(classTokens.has("min-w-[420px]")).toBe(false);
+    expect(classTokens.has("sm:min-w-[420px]")).toBe(true);
+  });
+
   it("uses Vietnamese-first labels in the Code Studio surface", async () => {
     seedCompleteSession("code");
 

--- a/wiii-desktop/src/components/layout/CodeStudioPanel.tsx
+++ b/wiii-desktop/src/components/layout/CodeStudioPanel.tsx
@@ -46,7 +46,7 @@ export const CodeStudioPanel = memo(function CodeStudioPanel({
         animate={{ x: 0, opacity: 1 }}
         exit={{ x: "100%", opacity: 0 }}
         transition={{ type: "spring", damping: 25, stiffness: 200 }}
-        className="fixed right-0 top-[var(--titlebar-height,32px)] bottom-[var(--statusbar-height,24px)] w-[52vw] max-w-[860px] min-w-[420px] border-l border-border z-40 flex flex-col shadow-xl code-studio-panel"
+        className="fixed inset-x-0 top-[var(--titlebar-height,32px)] bottom-[var(--statusbar-height,24px)] w-full max-w-full min-w-0 border-l border-border z-40 flex flex-col shadow-xl code-studio-panel sm:left-auto sm:right-0 sm:w-[52vw] sm:max-w-[860px] sm:min-w-[420px]"
       >
         <CodeStudioContent session={session} onClose={closeCodeStudio} />
       </motion.div>


### PR DESCRIPTION
Closes #629.

## Summary
- make the non-inline Code Studio overlay full-width on base/mobile viewports instead of enforcing a 420px minimum
- keep the existing 52vw / 420px desktop sizing from the sm breakpoint upward
- add a focused responsive shell contract test so the fixed min-width does not return to the base overlay class

## Scope
- CodeStudioPanel overlay shell classes
- focused Code Studio panel Vitest coverage

## Non-scope
- no backend routing changes
- no LMS preview/apply behavior changes
- no visual runtime iframe contract redesign
- inline split-panel Code Studio behavior is unchanged

## Verification
- 
px vitest run src/__tests__/code-studio-panel.test.tsx src/__tests__/inline-visual-frame-rendering.test.tsx --pool forks --maxWorkers=1 -> 2 files passed, 10 tests passed
- 
px tsc --noEmit -> passed
- Playwright narrow viewport smoke at http://127.0.0.1:1420/, viewport 390x720 -> overlay probe width 390, minWidth 0px, maxWidth 100%, no horizontal overflow, no console/page errors
- 
pm run build:embed -> passed; existing Vite chunk-size and ineffective dynamic import warnings only
- git diff --check -> passed

## Risk
Low UX risk. The change only relaxes the base/mobile overlay width and preserves desktop sizing at sm and above. Main risk is a subtle mobile visual difference for the overlay fallback.

## Rollback
Revert this PR to restore the previous fixed ight-0 w-[52vw] max-w-[860px] min-w-[420px] overlay sizing.

## Reviewer Focus
- confirm mobile/base overlay sizing no longer clips on narrow surfaces
- confirm desktop overlay sizing remains equivalent from sm upward