### PR TITLE
fix(backend): keep host action audit route available

### DIFF
--- a/maritime-ai-service/app/api/v1/__init__.py
+++ b/maritime-ai-service/app/api/v1/__init__.py
@@ -65,6 +65,7 @@ def _build_router() -> APIRouter:
         ("app.api.v1.generated_files.router", "Generated Files"),
         ("app.api.v1.llm_status.router", "LLM Status"),
         ("app.api.v1.document_context.router", "Document Context"),
+        ("app.api.v1.host_actions.router", "Host Action Audit"),
         ("app.api.v1.voice.router", "Voice"),
         ("app.api.v1.soul_bridge.router", "Soul Bridge"),
         ("app.api.v1.living_agent.router", "Living Agent"),
@@ -88,7 +89,6 @@ def _build_router() -> APIRouter:
         ),
         ("enable_magic_link_auth", "app.auth.magic_link_router.router", "Magic Link Auth"),
         ("enable_dev_login", "app.auth.dev_login_router.router", "Dev Login"),
-        ("enable_host_actions", "app.api.v1.host_actions.router", "Host Actions"),
     ]
     for flag_name, import_path, label in optional_router_specs:
         _register_optional_router(router, flag_name, import_path, label)

--- a/maritime-ai-service/tests/unit/test_host_action_audit.py
+++ b/maritime-ai-service/tests/unit/test_host_action_audit.py
@@ -2,6 +2,36 @@ import pytest
 from starlette.requests import Request
 
 
+def test_host_action_audit_route_registered_when_host_actions_disabled(monkeypatch):
+    import app.api.v1 as api_v1
+    from app.core.config import settings
+
+    registered: list[tuple[str, str]] = []
+    optional_registered: list[tuple[str, str, str]] = []
+
+    monkeypatch.setattr(
+        api_v1,
+        "_register_router",
+        lambda _router, import_path, label: registered.append((import_path, label)),
+    )
+    monkeypatch.setattr(
+        api_v1,
+        "_register_optional_router",
+        lambda _router, flag_name, import_path, label: optional_registered.append(
+            (flag_name, import_path, label)
+        ),
+    )
+    monkeypatch.setattr(settings, "enable_host_actions", False, raising=False)
+
+    api_v1._build_router()
+
+    assert ("app.api.v1.host_actions.router", "Host Action Audit") in registered
+    assert all(
+        import_path != "app.api.v1.host_actions.router"
+        for _flag_name, import_path, _label in optional_registered
+    )
+
+
 def _make_request() -> Request:
     scope = {
         "type": "http",


### PR DESCRIPTION
Closes #631.

## Summary
- register the host action audit router in the core v1 API surface so /api/v1/host-actions/audit is available even when enable_host_actions is false
- keep host action tool binding and mutating action capability gating unchanged
- add focused registration coverage for the flag-off safe preview fallback case

## Scope
- backend v1 router registration
- host action audit unit coverage

## Non-scope
- no LMS mutation behavior change
- no broad enablement of host action tools
- no frontend UI changes
- no provider/runtime routing changes

## Verification
- uv run --python 3.12 --extra dev pytest tests/unit/test_host_action_audit.py -q --tb=short -> 3 passed
- uv run --python 3.12 --extra dev ruff check app/api/v1/__init__.py app/api/v1/host_actions.py tests/unit/test_host_action_audit.py -> All checks passed
- git diff --check -> passed

## Risk
Medium operational risk because this touches a host/LMS API route. The route is auth-protected and rate-limited, and this PR does not change host action tool binding or approval requirements.

## Rollback
Revert this PR to restore the previous feature-gated audit endpoint registration.

## Reviewer Focus
- confirm audit endpoint availability does not imply arbitrary host action tool availability
- confirm safe preview/apply flows can submit audit without requiring the broader host action feature flag