### PR TITLE
fix(backend): emit tutor visual lifecycle

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/agents/tutor_request_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/agents/tutor_request_runtime.py
@@ -203,11 +203,13 @@ def prepare_tutor_request(
         logger_obj.debug("[TUTOR_AGENT] Runtime tool selection skipped: %s", exc)
 
     llm_with_tools_for_request = None
-    routing_intent = str((state.get("routing_metadata") or {}).get("intent", "")).strip().lower()
     if llm_for_request:
-        if visual_decision.force_tool and routing_intent not in ("learning", "lookup"):
+        if visual_decision.force_tool:
+            required_visual_names = set(required_visual_tool_names_fn(visual_decision))
             visual_tools_only = [
-                tool for tool in active_tools if getattr(tool, "name", "") == "tool_generate_visual"
+                tool
+                for tool in active_tools
+                if getattr(tool, "name", "") in required_visual_names
             ]
             if visual_tools_only:
                 forced_choice = resolve_tool_choice_fn(True, visual_tools_only, provider_override)
@@ -219,8 +221,9 @@ def prepare_tutor_request(
                     ),
                 )
                 logger_obj.info(
-                    "[TUTOR_AGENT] Visual intent -> force tool_choice=%r for tool_generate_visual",
+                    "[TUTOR_AGENT] Visual intent -> force tool_choice=%r for %s",
                     forced_choice,
+                    sorted(required_visual_names),
                 )
             else:
                 llm_with_tools_for_request = _copy_runtime_metadata(

--- a/maritime-ai-service/app/engine/multi_agent/agents/tutor_tool_dispatch_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/agents/tutor_tool_dispatch_runtime.py
@@ -4,6 +4,11 @@ from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Sequence
 
 from app.engine.messages import Message, ToolCall
+from app.engine.multi_agent.visual_events import (
+    _emit_visual_commit_events,
+    _maybe_emit_visual_event,
+    _summarize_tool_result_for_stream,
+)
 
 
 def _tool_call_dict_to_native(tool_call: dict[str, Any]) -> ToolCall:
@@ -16,6 +21,11 @@ def _tool_call_dict_to_native(tool_call: dict[str, Any]) -> ToolCall:
         name=str(tool_call.get("name") or ""),
         arguments=raw_args,
     )
+
+
+def _is_visual_result_tool(tool_name: str) -> bool:
+    lowered_tool_name = str(tool_name or "").lower()
+    return "visual" in lowered_tool_name or "chart" in lowered_tool_name
 
 
 @dataclass(slots=True)
@@ -85,6 +95,39 @@ async def _emit_tool_result(
             "node": "tutor_agent",
         }
     )
+
+
+async def _emit_visual_lifecycle_if_available(
+    *,
+    push: Callable[[dict[str, Any]], Awaitable[None]],
+    tool_name: str,
+    result: Any,
+    tool_id: str,
+    logger_obj: Any,
+) -> None:
+    """Forward structured visual payloads onto the same SSE lifecycle as direct."""
+    if not _is_visual_result_tool(tool_name):
+        return
+
+    visual_tool_call_events: list[dict[str, Any]] = []
+    try:
+        visual_session_ids, _disposed_session_ids = await _maybe_emit_visual_event(
+            push_event=push,
+            tool_name=tool_name,
+            tool_call_id=tool_id,
+            result=result,
+            node="tutor_agent",
+            tool_call_events=visual_tool_call_events,
+        )
+        if visual_session_ids:
+            await _emit_visual_commit_events(
+                push_event=push,
+                node="tutor_agent",
+                visual_session_ids=visual_session_ids,
+                tool_call_events=visual_tool_call_events,
+            )
+    except Exception as exc:
+        logger_obj.warning("[TUTOR_AGENT] Visual lifecycle emit skipped: %s", exc)
 
 
 async def _emit_tool_acknowledgment(
@@ -533,6 +576,13 @@ async def dispatch_tutor_tool_call(
             tool_call_id=tool_id,
             run_sync_in_thread=True,
         )
+        await _emit_visual_lifecycle_if_available(
+            push=push,
+            tool_name=tool_name,
+            result=result,
+            tool_id=tool_id,
+            logger_obj=logger_obj,
+        )
         _record_tool_use(
             tools_used=tools_used,
             tool_name=tool_name,
@@ -543,7 +593,11 @@ async def dispatch_tutor_tool_call(
         await _emit_tool_result(
             push=push,
             tool_name=tool_name,
-            result=result,
+            result=(
+                _summarize_tool_result_for_stream(tool_name, result)
+                if _is_visual_result_tool(tool_name)
+                else result
+            ),
             tool_id=tool_id,
         )
         await _emit_tool_acknowledgment(

--- a/maritime-ai-service/tests/unit/test_tutor_request_runtime.py
+++ b/maritime-ai-service/tests/unit/test_tutor_request_runtime.py
@@ -79,3 +79,53 @@ def test_prepare_tutor_request_copies_runtime_metadata_to_bound_llm():
 
     assert getattr(result.llm_with_tools_for_request, "_wiii_provider_name", None) == "zhipu"
     assert getattr(result.llm_with_tools_for_request, "_wiii_model_name", None) == "glm-5"
+
+
+def test_prepare_tutor_request_forces_visual_tool_for_learning_intent():
+    llm = MagicMock()
+    bound_llm = MagicMock()
+    llm.bind_tools = MagicMock(return_value=bound_llm)
+
+    tools = [
+        _Tool("tool_knowledge_search"),
+        _Tool("tool_generate_visual"),
+        _Tool("tool_report_progress"),
+    ]
+
+    visual_decision = SimpleNamespace(force_tool=True, presentation_intent="article_figure")
+
+    with patch(
+        "app.engine.multi_agent.agents.tutor_request_runtime.filter_tools_for_role",
+        side_effect=lambda runtime_tools, _role: list(runtime_tools),
+    ), patch(
+        "app.engine.multi_agent.agents.tutor_request_runtime.filter_tools_for_visual_intent",
+        side_effect=lambda runtime_tools, _visual_decision, structured_visuals_enabled=False: list(runtime_tools),
+    ), patch(
+        "app.engine.skills.skill_recommender.select_runtime_tools",
+        return_value=[
+            _Tool("tool_knowledge_search"),
+            _Tool("tool_generate_visual"),
+        ],
+    ):
+        result = prepare_tutor_request(
+            state={
+                "query": "Create a compact inline visual comparing soft attention and linear attention.",
+                "routing_metadata": {"intent": "learning"},
+            },
+            context={"user_role": "student"},
+            learning_context={},
+            default_llm=llm,
+            base_tools=tools,
+            settings_obj=SimpleNamespace(enable_structured_visuals=True),
+            logger_obj=MagicMock(),
+            resolve_visual_intent_fn=lambda _query: visual_decision,
+            required_visual_tool_names_fn=lambda _decision: ["tool_generate_visual"],
+            get_effective_provider_fn=lambda _state: None,
+            get_llm_fn=lambda *_args, **_kwargs: llm,
+            resolve_tool_choice_fn=lambda _force, selected_tools, _provider: selected_tools[0].name,
+        )
+
+    assert result.llm_with_tools_for_request is bound_llm
+    bind_args, bind_kwargs = llm.bind_tools.call_args
+    assert [tool.name for tool in bind_args[0]] == ["tool_generate_visual"]
+    assert bind_kwargs["tool_choice"] == "tool_generate_visual"

--- a/maritime-ai-service/tests/unit/test_tutor_tool_dispatch_runtime.py
+++ b/maritime-ai-service/tests/unit/test_tutor_tool_dispatch_runtime.py
@@ -1,0 +1,90 @@
+import json
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from app.engine.multi_agent.agents.tutor_tool_dispatch_runtime import (
+    dispatch_tutor_tool_call,
+)
+from app.engine.tools.visual_tools import tool_generate_visual
+
+
+def _tool_name(tool):
+    return getattr(tool, "name", getattr(tool, "__name__", ""))
+
+
+@pytest.mark.asyncio
+async def test_tutor_visual_tool_dispatch_emits_lifecycle_events():
+    events = []
+    tools_used = []
+    messages = []
+
+    async def push(event):
+        events.append(event)
+
+    async def invoke_tool_with_runtime(tool, tool_args, **_kwargs):
+        return tool.invoke(tool_args)
+
+    async def noop_thinking(_text):
+        return None
+
+    async def noop_acknowledgment(**_kwargs):
+        return ""
+
+    result = await dispatch_tutor_tool_call(
+        tool_call={
+            "name": "tool_generate_visual",
+            "args": {
+                "visual_type": "comparison",
+                "spec_json": json.dumps(
+                    {
+                        "left": {"title": "Softmax attention"},
+                        "right": {"title": "Linear attention"},
+                    }
+                ),
+                "title": "Softmax vs Linear",
+                "summary": "Quick comparison",
+            },
+            "id": "vis-1",
+        },
+        query="Create a compact inline visual comparing soft attention and linear attention.",
+        context={},
+        iteration=0,
+        tools_used=tools_used,
+        tools=[tool_generate_visual],
+        messages=messages,
+        runtime_context_base={},
+        push=push,
+        push_thinking_deltas=noop_thinking,
+        iteration_beat_fn=lambda **_kwargs: SimpleNamespace(
+            label="",
+            summary="",
+            phase="",
+            fragments=[],
+        ),
+        tool_acknowledgment_fn=noop_acknowledgment,
+        get_tool_by_name_fn=lambda runtime_tools, name: next(
+            (tool for tool in runtime_tools if _tool_name(tool) == name),
+            None,
+        ),
+        invoke_tool_with_runtime_fn=invoke_tool_with_runtime,
+        get_last_confidence_fn=lambda: (0.0, False),
+        knowledge_tool=None,
+        calculator_tool=None,
+        datetime_tool=None,
+        web_search_tool=None,
+        max_iterations=2,
+        max_phase_transitions=2,
+        phase_transition_count=0,
+        logger_obj=logging.getLogger(__name__),
+    )
+
+    event_types = [event["type"] for event in events]
+    assert "visual_open" in event_types
+    assert "visual_commit" in event_types
+    assert event_types.index("visual_open") < event_types.index("visual_commit")
+    assert event_types[-1] == "tool_result"
+    assert "VISUAL_PAYLOAD" not in events[-1]["content"]["result"]
+    assert tools_used[0]["name"] == "tool_generate_visual"
+    assert result.tool_result_text


### PR DESCRIPTION
## Summary
- Force the tutor visual tool when visual intent requires a structured visual, including learning turns.
- Forward tutor `tool_generate_visual` results through the same `visual_open`/`visual_commit` SSE lifecycle used by the direct lane.
- Summarize visual tool-result SSE payloads so the visual payload itself is not exposed through the tool strip.

## Scope
Backend tutor visual streaming only:
- `tutor_request_runtime.py`
- `tutor_tool_dispatch_runtime.py`
- focused unit tests

## Non-Scope
- No LMS mutation/apply behavior changes.
- No frontend rendering changes.
- No production env/secrets changes.

## Issue
Closes #635

## Verification
- `python -m pytest tests/unit/test_tutor_request_runtime.py tests/unit/test_tutor_tool_dispatch_runtime.py tests/unit/test_visual_intent_resolver.py -q --tb=short` -> 48 passed
- `python -m pytest tests/unit/test_tutor_request_runtime.py tests/unit/test_tutor_tool_dispatch_runtime.py tests/unit/test_chat_stream_presenter.py tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_tutor_agent_node.py -q --tb=short` -> 147 passed
- `python -m pytest tests/unit/test_tool_collection_visual_requirements.py tests/unit/test_graph_routing.py tests/unit/test_chat_stream_coordinator.py tests/unit/test_chat_request_flow.py -q --tb=short` -> 121 passed
- `python -m ruff check app/ tests/unit/ --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

Attempted full backend unit suite:
- `python -m pytest tests/unit/ -p no:capture --tb=short -q` -> timed out after 10 minutes in this local shell; focused production-smoke-related suites above passed.

## Risk
SSE event ordering is product-critical. The change is scoped to tutor visual tool output and reuses the existing direct-lane lifecycle helpers.

## Rollback
Revert this PR and redeploy the last accepted production image SHA if tutor visual lifecycle or frontend visual rendering regresses.

## Production Follow-Up
After merge and production image publication, redeploy a pinned SHA and rerun the production external smoke. The previous deploy run was https://github.com/meiiie/wiii/actions/runs/26371495004 and failed only the structured visual lifecycle checks after rollout.