### PR TITLE
fix(backend): fast path structured visual streams

### DIFF
--- a/maritime-ai-service/app/services/chat_stream_coordinator.py
+++ b/maritime-ai-service/app/services/chat_stream_coordinator.py
@@ -571,6 +571,100 @@ async def generate_stream_v3_events(
             "_use_multi_agent",
             getattr(settings, "use_multi_agent", True),
         )
+        try:
+            from app.services.chat_stream_visual_fast_path import (
+                build_visual_fast_path_result,
+            )
+
+            visual_fast_path = await build_visual_fast_path_result(chat_request)
+        except Exception as visual_fast_path_err:
+            logger.debug(
+                "[STREAM-V3] Structured visual fast-path skipped: %s",
+                visual_fast_path_err,
+            )
+            visual_fast_path = None
+
+        if visual_fast_path is not None:
+            visual_started_ms = latency_tracker.elapsed_ms()
+            visual_events = [
+                await create_thinking_start_event(
+                    "Wiii đang dựng minh họa",
+                    "visual_fast_path",
+                    summary=visual_fast_path.thinking,
+                ),
+                await create_thinking_delta_event(
+                    visual_fast_path.thinking,
+                    node="visual_fast_path",
+                ),
+                await create_thinking_end_event(
+                    "visual_fast_path",
+                    duration_ms=max(1, latency_tracker.elapsed_ms() - visual_started_ms),
+                ),
+                *visual_fast_path.events,
+                await create_answer_event(visual_fast_path.answer),
+                await create_metadata_event(
+                    reasoning_trace={
+                        "method": "structured_visual_fast_path",
+                        "steps": [
+                            "prepared_turn_validated",
+                            "matched_explicit_visual_creation",
+                            "emitted_structured_visual_lifecycle",
+                        ],
+                    },
+                    processing_time=time.time() - start_time,
+                    confidence=1.0,
+                    model=None,
+                    provider="deterministic",
+                    runtime_authoritative=True,
+                    doc_count=0,
+                    thinking=visual_fast_path.thinking,
+                    thinking_content=visual_fast_path.thinking,
+                    agent_type="visual_fast_path",
+                    session_id=effective_session_id_str,
+                    request_id=request_id,
+                    routing_metadata=visual_fast_path.routing_metadata,
+                    stream_latency=latency_tracker.to_payload(),
+                    streaming_version="v3-visual_fast_path",
+                ),
+                await create_done_event(time.time() - start_time),
+            ]
+
+            for event in visual_events:
+                chunks, event_counter, should_stop = serialize_stream_event(
+                    event=event,
+                    event_counter=event_counter,
+                    enable_artifacts=settings.enable_artifacts,
+                    presentation_state=presentation_state,
+                )
+                for chunk in chunks:
+                    yield chunk
+                if should_stop:
+                    return
+
+            try:
+                orchestrator.finalize_response_turn(
+                    session_id=effective_session_id,
+                    user_id=str(chat_request.user_id),
+                    user_role=chat_request.role,
+                    message=chat_request.message,
+                    response_text=visual_fast_path.answer,
+                    context=finalization_context,
+                    domain_id=resolved_domain_id,
+                    organization_id=resolved_org_id,
+                    current_agent="visual_fast_path",
+                    background_save=background_save,
+                    save_response_immediately=False,
+                    include_lms_insights=False,
+                    continuity_channel="web",
+                    transport_type="stream",
+                )
+            except Exception as finalize_err:
+                logger.warning(
+                    "[STREAM-V3] Visual fast-path finalization failed: %s",
+                    finalize_err,
+                )
+            return
+
         pointy_highlight_action_name = "ui.highlight"
         try:
             from app.engine.context.pointy_actions import POINTY_ACTION_HIGHLIGHT

--- a/maritime-ai-service/app/services/chat_stream_visual_fast_path.py
+++ b/maritime-ai-service/app/services/chat_stream_visual_fast_path.py
@@ -1,0 +1,244 @@
+"""Deterministic structured-visual fast path for streaming turns."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import re
+from typing import Any, Mapping
+
+from app.engine.multi_agent.stream_utils import StreamEvent
+from app.engine.multi_agent.visual_intent_resolver import (
+    detect_visual_patch_request,
+    resolve_visual_intent,
+)
+from app.engine.tools.visual_tools import parse_visual_payloads, tool_generate_visual
+
+
+_VISUAL_CREATE_CUES = (
+    "create",
+    "draw",
+    "make",
+    "build",
+    "dung",
+    "dựng",
+    "tao",
+    "tạo",
+    "ve ",
+    "vẽ",
+)
+_RETRIEVAL_CUES = (
+    "citation",
+    "citations",
+    "docx",
+    "document",
+    "file",
+    "pdf",
+    "source",
+    "sources",
+    "tai lieu",
+    "tài liệu",
+    "trich dan",
+    "trích dẫn",
+)
+_FRESH_OR_WEB_CUES = (
+    "current",
+    "gia hien tai",
+    "giá hiện tại",
+    "latest",
+    "news",
+    "search web",
+    "today",
+    "web search",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class VisualFastPathResult:
+    """Events and metadata for a deterministic visual-only stream."""
+
+    events: list[StreamEvent]
+    answer: str
+    thinking: str
+    routing_metadata: dict[str, Any]
+
+
+def _plain_context_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return dict(value)
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    if hasattr(value, "dict"):
+        return value.dict()
+    return value
+
+
+def _has_uploaded_document_context(chat_request: Any) -> bool:
+    user_context = getattr(chat_request, "user_context", None)
+    if isinstance(user_context, Mapping):
+        document_context = user_context.get("document_context")
+    else:
+        document_context = getattr(user_context, "document_context", None)
+    document_context = _plain_context_value(document_context)
+    if not isinstance(document_context, Mapping):
+        return False
+
+    attachments = document_context.get("attachments")
+    if not isinstance(attachments, list):
+        return False
+    return any(
+        isinstance(item, Mapping) and str(item.get("markdown") or "").strip()
+        for item in attachments
+    )
+
+
+def _has_image_input(chat_request: Any) -> bool:
+    images = getattr(chat_request, "images", None)
+    return isinstance(images, list) and any(images)
+
+
+def _contains_any(text: str, cues: tuple[str, ...]) -> bool:
+    return any(cue in text for cue in cues)
+
+
+def _clean_label(value: str) -> str:
+    cleaned = re.sub(r"\s+", " ", value).strip(" .,:;!?\"'")
+    return cleaned[:80] or "Item"
+
+
+def _comparison_spec(query: str) -> dict[str, Any]:
+    patterns = (
+        r"\bcompar(?:e|ing)\s+(.+?)\s+(?:and|vs\.?|versus|with)\s+(.+?)(?:[.!?]|$)",
+        r"\bso sanh\s+(.+?)\s+(?:voi|va|và|vs\.?)\s+(.+?)(?:[.!?]|$)",
+        r"\bso sánh\s+(.+?)\s+(?:với|và|vs\.?)\s+(.+?)(?:[.!?]|$)",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, query, flags=re.I)
+        if not match:
+            continue
+        left = _clean_label(match.group(1))
+        right = _clean_label(match.group(2))
+        if left and right:
+            return {
+                "left": {"title": left},
+                "right": {"title": right},
+            }
+    return {}
+
+
+def _title_from_query(query: str, visual_type: str, spec: dict[str, Any]) -> str:
+    if visual_type == "comparison" and spec.get("left") and spec.get("right"):
+        left = str((spec.get("left") or {}).get("title") or "Left").strip()
+        right = str((spec.get("right") or {}).get("title") or "Right").strip()
+        return f"{left} vs {right}"
+    first_sentence = re.split(r"[.!?]\s+", query.strip(), maxsplit=1)[0]
+    first_sentence = re.sub(
+        r"^(create|draw|make|build|dung|dựng|tao|tạo|ve|vẽ)\s+",
+        "",
+        first_sentence,
+        flags=re.I,
+    )
+    return _clean_label(first_sentence) or "Inline visual"
+
+
+def should_use_visual_fast_path(chat_request: Any) -> bool:
+    """Return True for explicit visual creation turns safe to handle locally."""
+
+    query = str(getattr(chat_request, "message", "") or "").strip()
+    if not query:
+        return False
+    normalized = query.lower()
+    if _has_uploaded_document_context(chat_request) or _has_image_input(chat_request):
+        return False
+    if detect_visual_patch_request(query):
+        return False
+    if _contains_any(normalized, _RETRIEVAL_CUES) or _contains_any(normalized, _FRESH_OR_WEB_CUES):
+        return False
+    if not (
+        _contains_any(normalized, _VISUAL_CREATE_CUES)
+        or "structured visual lifecycle" in normalized
+    ):
+        return False
+
+    decision = resolve_visual_intent(query)
+    return bool(
+        decision.force_tool
+        and decision.presentation_intent in {"article_figure", "chart_runtime"}
+    )
+
+
+async def build_visual_fast_path_result(
+    chat_request: Any,
+    *,
+    node: str = "visual_fast_path",
+) -> VisualFastPathResult | None:
+    """Build visual lifecycle events without waiting on provider tool-calling."""
+
+    if not should_use_visual_fast_path(chat_request):
+        return None
+
+    query = str(getattr(chat_request, "message", "") or "").strip()
+    decision = resolve_visual_intent(query)
+    visual_type = decision.visual_type or (
+        "chart" if decision.presentation_intent == "chart_runtime" else "concept"
+    )
+    spec = _comparison_spec(query) if visual_type == "comparison" else {}
+    title = _title_from_query(query, visual_type, spec)
+    summary = f"Minh họa ngắn cho yêu cầu: {query[:140]}"
+
+    result = tool_generate_visual.invoke(
+        {
+            "visual_type": visual_type,
+            "spec_json": json.dumps(spec, ensure_ascii=False),
+            "title": title,
+            "summary": summary,
+        }
+    )
+    payloads = parse_visual_payloads(result)
+    if not payloads:
+        return None
+
+    events: list[StreamEvent] = []
+    visual_session_ids: list[str] = []
+    for payload in sorted(payloads, key=lambda item: (item.figure_index, item.title)):
+        payload_dict = payload.model_dump(mode="json")
+        event_type = (
+            payload.lifecycle_event
+            if payload.lifecycle_event in {"visual_open", "visual_patch"}
+            else "visual_open"
+        )
+        events.append(StreamEvent(type=event_type, content=payload_dict, node=node))
+        if payload.visual_session_id and payload.visual_session_id not in visual_session_ids:
+            visual_session_ids.append(payload.visual_session_id)
+
+    for visual_session_id in visual_session_ids:
+        events.append(
+            StreamEvent(
+                type="visual_commit",
+                content={
+                    "visual_session_id": visual_session_id,
+                    "status": "committed",
+                },
+                node=node,
+            )
+        )
+
+    thinking = (
+        "Yêu cầu là một lượt tạo visual rõ ràng, không kèm tài liệu upload hay dữ liệu thời sự, "
+        "nên Wiii dựng nhanh phần nhìn trước khi gọi mô hình."
+    )
+    routing_metadata = {
+        "method": "structured_visual_fast_path",
+        "intent": "learning",
+        "final_agent": node,
+        "presentation_intent": decision.presentation_intent,
+        "visual_type": visual_type,
+    }
+    return VisualFastPathResult(
+        events=events,
+        answer="Mình đã dựng minh họa inline cho yêu cầu này.",
+        thinking=thinking,
+        routing_metadata=routing_metadata,
+    )

--- a/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
@@ -196,6 +196,56 @@ async def test_generate_stream_v3_events_bypasses_context_build_for_pointy_highl
 
 
 @pytest.mark.asyncio
+async def test_generate_stream_v3_events_bypasses_provider_for_visual_fast_path():
+    orchestrator = MagicMock()
+    prepared_turn = SimpleNamespace(
+        request_scope=RequestScope("org-1", "maritime"),
+        session_id="session-1",
+        validation=SimpleNamespace(blocked=False),
+        chat_context=SimpleNamespace(user_name="Minh"),
+    )
+    orchestrator.prepare_turn = AsyncMock(return_value=prepared_turn)
+    orchestrator.build_multi_agent_execution_input = AsyncMock(
+        side_effect=AssertionError("visual fast path should not build full context")
+    )
+    orchestrator.finalize_response_turn = MagicMock()
+
+    request = _make_request(
+        message=(
+            "Create a compact inline visual comparing soft attention and linear attention. "
+            "Use structured visual lifecycle."
+        ),
+        user_context=SimpleNamespace(document_context=None),
+    )
+
+    chunks = []
+    async for chunk in generate_stream_v3_events(
+        chat_request=request,
+        request_headers={},
+        background_save=MagicMock(),
+        start_time=time.time(),
+        orchestrator=orchestrator,
+    ):
+        chunks.append(chunk)
+
+    assert any("event: visual_open" in chunk for chunk in chunks)
+    assert any("event: visual_commit" in chunk for chunk in chunks)
+    assert any("v3-visual_fast_path" in chunk for chunk in chunks)
+    orchestrator.build_multi_agent_execution_input.assert_not_called()
+    orchestrator.finalize_response_turn.assert_called_once()
+    assert (
+        orchestrator.finalize_response_turn.call_args.kwargs["current_agent"]
+        == "visual_fast_path"
+    )
+    assert (
+        orchestrator.finalize_response_turn.call_args.kwargs[
+            "include_lms_insights"
+        ]
+        is False
+    )
+
+
+@pytest.mark.asyncio
 async def test_generate_stream_v3_events_forwards_metadata_agent_to_finalize():
     orchestrator = MagicMock()
     prepared_turn = SimpleNamespace(

--- a/maritime-ai-service/tests/unit/test_chat_stream_visual_fast_path.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_visual_fast_path.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.chat_stream_visual_fast_path import (
+    build_visual_fast_path_result,
+    should_use_visual_fast_path,
+)
+
+
+def _request(message: str, **overrides):
+    data = {
+        "message": message,
+        "user_context": None,
+        "images": [],
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+@pytest.mark.asyncio
+async def test_build_visual_fast_path_result_emits_lifecycle_for_creation_request():
+    request = _request(
+        "Create a compact inline visual comparing soft attention and linear attention. "
+        "Use structured visual lifecycle."
+    )
+
+    result = await build_visual_fast_path_result(request)
+
+    assert result is not None
+    event_types = [event.type for event in result.events]
+    assert "visual_open" in event_types
+    assert "visual_commit" in event_types
+    assert result.routing_metadata["method"] == "structured_visual_fast_path"
+
+
+def test_visual_fast_path_skips_uploaded_document_context():
+    request = _request(
+        "Create an inline visual from this document.",
+        user_context=SimpleNamespace(
+            document_context={
+                "attachments": [
+                    {
+                        "name": "lesson.docx",
+                        "markdown": "# Lesson\nSource-backed content",
+                    }
+                ]
+            }
+        ),
+    )
+
+    assert should_use_visual_fast_path(request) is False
+
+
+def test_visual_fast_path_skips_fresh_or_web_sensitive_visuals():
+    request = _request("Create a chart of latest shipping prices today.")
+
+    assert should_use_visual_fast_path(request) is False


### PR DESCRIPTION
## Summary
- Add a guarded deterministic fast path for explicit inline visual creation requests in `/chat/stream/v3`.
- Emit `visual_open` and `visual_commit` before provider execution when the request is safe to satisfy locally.
- Guard the fast path away from uploaded documents, image inputs, visual patches, retrieval/source/citation cues, and fresh/current/web-sensitive requests.

## Scope
Backend streaming only:
- `app/services/chat_stream_visual_fast_path.py`
- `app/services/chat_stream_coordinator.py`
- focused coordinator/fast-path tests

## Non-Scope
- No LMS mutation or Apply behavior changes.
- No frontend rendering changes.
- No production env/secrets changes.
- Does not hardcode a specific BanGioiThieu file or a single production smoke session.

## Issue
Refs #635

## Verification
- `python -m pytest tests/unit/test_chat_stream_visual_fast_path.py tests/unit/test_chat_stream_coordinator.py tests/unit/test_tutor_request_runtime.py tests/unit/test_tutor_tool_dispatch_runtime.py tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_visual_intent_resolver.py -q --tb=short` -> 152 passed
- `python -m pytest tests/unit/test_tool_collection_visual_requirements.py tests/unit/test_graph_routing.py tests/unit/test_chat_request_flow.py tests/unit/test_chat_stream_presenter.py -q --tb=short` -> 116 passed
- `python -m ruff check app/ tests/unit/ --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
The fast path intentionally bypasses provider/tool-call latency for a narrow visual-only class of requests. Main risk is over-triggering, mitigated by guards for uploaded documents, images, patch requests, retrieval/source/citation cues, and fresh/web-sensitive prompts.

## Rollback
Revert this PR and redeploy the previous accepted image SHA if the fast path incorrectly handles a user turn or visual SSE rendering regresses.

## Production Follow-Up
After merge and image publication, redeploy pinned SHA and rerun production external smoke. The latest deploy of PR #636 code rolled out but still failed only `Structured visual SSE opens/patches lifecycle` and `Structured visual SSE commits lifecycle`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual fast path for streaming visual responses including charts and concept visualizations, delivering precomputed answers along with detailed reasoning traces and comprehensive routing metadata.
  * Added intelligent request eligibility detection to ensure the visual fast path is applied only to appropriate requests, automatically filtering out those with document attachments, image inputs, or specialized content requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->