### PR TITLE
feat(chat): add runtime flow ledger metadata

### DIFF
--- a/maritime-ai-service/app/api/v1/chat_stream_presenter.py
+++ b/maritime-ai-service/app/api/v1/chat_stream_presenter.py
@@ -3,7 +3,7 @@
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Mapping
 
 from app.engine.llm_providers.wiii_chat_model import _ViSpaceInjector
 
@@ -305,6 +305,7 @@ def emit_blocked_sse_events(
     session_id: str,
     processing_time: float,
     event_counter: int,
+    extra_metadata: Mapping[str, Any] | None = None,
 ) -> tuple[list[str], int]:
     """Emit the standard blocked-response SSE sequence."""
     chunks = []
@@ -324,6 +325,7 @@ def emit_blocked_sse_events(
             {
                 **(blocked_response.metadata or {}),
                 "session_id": session_id,
+                **dict(extra_metadata or {}),
             },
             event_id=event_counter,
         )

--- a/maritime-ai-service/app/engine/multi_agent/runtime_flow_ledger.py
+++ b/maritime-ai-service/app/engine/multi_agent/runtime_flow_ledger.py
@@ -1,0 +1,458 @@
+"""Privacy-safe runtime flow ledger for Wiii chat turns."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+RUNTIME_FLOW_LEDGER_SCHEMA_VERSION = "wiii.runtime_flow_ledger.v1"
+_MAX_TOKEN_LENGTH = 96
+_MAX_SEQUENCE_ITEMS = 24
+
+
+def _hash_identifier(value: Any) -> str | None:
+    token = str(value or "").strip()
+    if not token:
+        return None
+    digest = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+    return f"sha256:{digest}"
+
+
+def _safe_token(value: Any, *, max_length: int = _MAX_TOKEN_LENGTH) -> str | None:
+    if value is None:
+        return None
+    token = str(value).strip()
+    if not token:
+        return None
+    token = " ".join(token.split())
+    if len(token) > max_length:
+        return token[: max_length - 1] + "..."
+    return token
+
+
+def _safe_token_list(values: Any) -> list[str]:
+    if not isinstance(values, (list, tuple, set)):
+        return []
+    tokens: list[str] = []
+    for value in values:
+        token = _safe_token(value)
+        if token and token not in tokens:
+            tokens.append(token)
+        if len(tokens) >= _MAX_SEQUENCE_ITEMS:
+            break
+    return tokens
+
+
+def _plain_mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    if hasattr(value, "model_dump"):
+        model_value = value.model_dump()
+        return model_value if isinstance(model_value, Mapping) else {}
+    if hasattr(value, "dict"):
+        dict_value = value.dict()
+        return dict_value if isinstance(dict_value, Mapping) else {}
+    return {}
+
+
+def _context_value(source: Any, key: str) -> Any:
+    if isinstance(source, Mapping):
+        return source.get(key)
+    return getattr(source, key, None)
+
+
+def _host_context_from_request(chat_request: Any) -> Mapping[str, Any]:
+    user_context = _context_value(chat_request, "user_context")
+    host_context = _context_value(user_context, "host_context")
+    return _plain_mapping(host_context)
+
+
+def _document_context_from_request(chat_request: Any) -> Mapping[str, Any]:
+    user_context = _context_value(chat_request, "user_context")
+    document_context = _context_value(user_context, "document_context")
+    return _plain_mapping(document_context)
+
+
+def _uploaded_document_count(chat_request: Any) -> int:
+    document_context = _document_context_from_request(chat_request)
+    attachments = document_context.get("attachments")
+    if not isinstance(attachments, list):
+        return 0
+    return sum(
+        1
+        for item in attachments
+        if isinstance(item, Mapping) and bool(str(item.get("markdown") or "").strip())
+    )
+
+
+def _host_surface(host_context: Mapping[str, Any]) -> str:
+    for key in ("surface", "host_surface", "app_surface", "client", "source"):
+        token = _safe_token(host_context.get(key))
+        if token:
+            return token
+    return "unknown"
+
+
+def _host_capabilities(host_context: Mapping[str, Any]) -> list[str]:
+    capabilities = _safe_token_list(host_context.get("capabilities"))
+    if capabilities:
+        return capabilities
+    if not host_context:
+        return []
+    safe_keys = {
+        "lms",
+        "document_preview",
+        "host_action",
+        "pointy",
+        "visual",
+        "code_studio",
+    }
+    return sorted(key for key in safe_keys if bool(host_context.get(key)))
+
+
+def _source_count(value: Any) -> int:
+    if isinstance(value, (list, tuple)):
+        return len(value)
+    if isinstance(value, Mapping):
+        sources = value.get("sources") or value.get("source_refs")
+        if isinstance(sources, (list, tuple)):
+            return len(sources)
+    return 0
+
+
+def _event_tool_name(event_type: str, content: Any) -> str | None:
+    if event_type in {
+        "visual",
+        "visual_open",
+        "visual_patch",
+        "visual_commit",
+        "visual_dispose",
+    }:
+        return "visual_runtime"
+    if event_type in {"code_open", "code_delta", "code_complete"}:
+        return "code_studio"
+    if event_type == "preview":
+        return "preview"
+    if not isinstance(content, Mapping):
+        if event_type in {"tool_call", "tool_result", "host_action", "pointy_action"}:
+            return event_type
+        return None
+    for key in ("tool_name", "name", "tool", "action", "type"):
+        token = _safe_token(content.get(key))
+        if token:
+            return token
+    if event_type in {"tool_call", "tool_result", "host_action", "pointy_action"}:
+        return event_type
+    return None
+
+
+@dataclass
+class RuntimeFlowLedger:
+    """Mutable recorder that serializes to a stable, privacy-safe payload."""
+
+    request_id: str | None
+    provider_requested: str | None = None
+    model_requested: str | None = None
+    session_id: str | None = None
+    user_id_hash: str | None = None
+    organization_id_hash: str | None = None
+    domain_id: str | None = None
+    host_surface: str = "unknown"
+    host_capabilities: list[str] = field(default_factory=list)
+    document_context_present: bool = False
+    uploaded_document_count: int = 0
+    route_lane: str = "preparing"
+    route_reason: str | None = None
+    selected_agent: str | None = None
+    final_agent: str | None = None
+    provider: str | None = None
+    model: str | None = None
+    runtime_authoritative: bool | None = None
+    fallback_used: bool = False
+    fallback_reason: str | None = None
+    failover_used: bool = False
+    observed_tools: list[str] = field(default_factory=list)
+    suppressed_tools: list[str] = field(default_factory=list)
+    event_counts: dict[str, int] = field(default_factory=dict)
+    event_sequence_tail: list[str] = field(default_factory=list)
+    metadata_seen: bool = False
+    done_seen: bool = False
+    source_ref_count: int = 0
+    memory_context_count: int | None = None
+    preview_required: bool = False
+    preview_emitted: bool = False
+    approval_token_present: bool = False
+    approval_token_hash: str | None = None
+    apply_attempted: bool = False
+    mutation_blocked_reason: str | None = None
+    finalization_status: str = "pending"
+    finalization_error_type: str | None = None
+    save_response_immediately: bool | None = None
+
+    @classmethod
+    def from_chat_request(
+        cls,
+        *,
+        chat_request: Any,
+        request_id: str | None,
+    ) -> "RuntimeFlowLedger":
+        host_context = _host_context_from_request(chat_request)
+        uploaded_count = _uploaded_document_count(chat_request)
+        host_capabilities = _host_capabilities(host_context)
+        return cls(
+            request_id=_safe_token(request_id),
+            provider_requested=_safe_token(_context_value(chat_request, "provider")),
+            model_requested=_safe_token(_context_value(chat_request, "model")),
+            user_id_hash=_hash_identifier(_context_value(chat_request, "user_id")),
+            host_surface=_host_surface(host_context),
+            host_capabilities=host_capabilities,
+            document_context_present=uploaded_count > 0,
+            uploaded_document_count=uploaded_count,
+            preview_required=uploaded_count > 0 and "lms" in host_capabilities,
+        )
+
+    def mark_prepared_turn(
+        self,
+        *,
+        session_id: Any,
+        organization_id: Any,
+        domain_id: Any,
+    ) -> None:
+        self.session_id = _safe_token(session_id)
+        self.organization_id_hash = _hash_identifier(organization_id)
+        self.domain_id = _safe_token(domain_id)
+
+    def mark_route(
+        self,
+        lane: str,
+        *,
+        reason: str | None = None,
+        fallback_used: bool | None = None,
+        fallback_reason: str | None = None,
+    ) -> None:
+        self.route_lane = _safe_token(lane) or "unknown"
+        self.route_reason = _safe_token(reason)
+        if fallback_used is not None:
+            self.fallback_used = fallback_used
+        if fallback_reason:
+            self.fallback_reason = _safe_token(fallback_reason)
+
+    def mark_execution_input(self, execution_input: Any) -> None:
+        self.provider = self.provider or _safe_token(
+            _context_value(execution_input, "provider")
+        )
+        self.model = self.model or _safe_token(
+            _context_value(execution_input, "model")
+        )
+        context = _plain_mapping(_context_value(execution_input, "context"))
+        source_refs = context.get("source_refs") or context.get("sources")
+        self.source_ref_count = max(self.source_ref_count, _source_count(source_refs))
+        memories = context.get("memories") or context.get("semantic_memories")
+        if isinstance(memories, (list, tuple)):
+            self.memory_context_count = len(memories)
+
+    def record_event(self, event: Any) -> None:
+        event_type = _safe_token(getattr(event, "type", None)) or "unknown"
+        content = getattr(event, "content", None)
+        self.event_counts[event_type] = self.event_counts.get(event_type, 0) + 1
+        self.event_sequence_tail.append(event_type)
+        if len(self.event_sequence_tail) > _MAX_SEQUENCE_ITEMS:
+            self.event_sequence_tail = self.event_sequence_tail[-_MAX_SEQUENCE_ITEMS:]
+        if event_type == "metadata":
+            self.metadata_seen = True
+        elif event_type == "done":
+            self.done_seen = True
+        elif event_type == "sources":
+            self.source_ref_count = max(self.source_ref_count, _source_count(content))
+        elif event_type in {
+            "tool_call",
+            "tool_result",
+            "host_action",
+            "pointy_action",
+            "preview",
+            "visual",
+            "visual_open",
+            "visual_patch",
+            "visual_commit",
+            "visual_dispose",
+            "code_open",
+            "code_delta",
+            "code_complete",
+        }:
+            self._record_tool_event(event_type, content)
+
+    def record_wire_event(self, event_type: str) -> None:
+        event_type = _safe_token(event_type) or "unknown"
+        self.event_counts[event_type] = self.event_counts.get(event_type, 0) + 1
+        self.event_sequence_tail.append(event_type)
+        if len(self.event_sequence_tail) > _MAX_SEQUENCE_ITEMS:
+            self.event_sequence_tail = self.event_sequence_tail[-_MAX_SEQUENCE_ITEMS:]
+        if event_type == "metadata":
+            self.metadata_seen = True
+        elif event_type == "done":
+            self.done_seen = True
+
+    def observe_metadata(self, metadata: Mapping[str, Any]) -> None:
+        self.metadata_seen = True
+        self.provider = self.provider or _safe_token(metadata.get("provider"))
+        self.model = self.model or _safe_token(metadata.get("model"))
+        runtime_authoritative = metadata.get("runtime_authoritative")
+        if isinstance(runtime_authoritative, bool):
+            self.runtime_authoritative = runtime_authoritative
+        self.selected_agent = self.selected_agent or _safe_token(metadata.get("agent_type"))
+
+        routing_metadata = metadata.get("routing_metadata")
+        if isinstance(routing_metadata, Mapping):
+            self.selected_agent = self.selected_agent or _safe_token(
+                routing_metadata.get("selected_agent")
+                or routing_metadata.get("target_agent")
+            )
+            self.final_agent = self.final_agent or _safe_token(
+                routing_metadata.get("final_agent")
+            )
+            if not self.route_reason:
+                self.route_reason = _safe_token(
+                    routing_metadata.get("method") or routing_metadata.get("intent")
+                )
+
+        failover = metadata.get("failover")
+        if isinstance(failover, Mapping):
+            switched = failover.get("switched")
+            self.failover_used = bool(switched)
+            self.fallback_reason = self.fallback_reason or _safe_token(
+                failover.get("last_reason_code") or failover.get("last_reason_category")
+            )
+
+        token = metadata.get("approval_token")
+        token_hash = metadata.get("approval_token_hash")
+        if token:
+            self.approval_token_present = True
+            self.approval_token_hash = _hash_identifier(token)
+        elif token_hash:
+            self.approval_token_present = True
+            self.approval_token_hash = _safe_token(token_hash)
+
+    def mark_finalization(
+        self,
+        status: str,
+        *,
+        error: Exception | None = None,
+        save_response_immediately: bool | None = None,
+    ) -> None:
+        self.finalization_status = _safe_token(status) or "unknown"
+        self.finalization_error_type = type(error).__name__ if error else None
+        self.save_response_immediately = save_response_immediately
+
+    def _record_tool_event(self, event_type: str, content: Any) -> None:
+        tool_name = _event_tool_name(event_type, content)
+        if tool_name and tool_name not in self.observed_tools:
+            self.observed_tools.append(tool_name)
+        if event_type == "preview":
+            self.preview_emitted = True
+        if isinstance(content, Mapping):
+            action = _safe_token(
+                content.get("action") or content.get("type") or content.get("name")
+            )
+            if action and "preview" in action.lower():
+                self.preview_emitted = True
+            if action and "apply" in action.lower():
+                self.apply_attempted = True
+            token = content.get("approval_token")
+            token_hash = content.get("approval_token_hash")
+            if token:
+                self.approval_token_present = True
+                self.approval_token_hash = _hash_identifier(token)
+            elif token_hash:
+                self.approval_token_present = True
+                self.approval_token_hash = _safe_token(token_hash)
+
+    def to_payload(self) -> dict[str, Any]:
+        self._refresh_suppressed_tools()
+        return {
+            "schema_version": RUNTIME_FLOW_LEDGER_SCHEMA_VERSION,
+            "request": {
+                "request_id": self.request_id,
+                "session_id": self.session_id,
+                "user_id_hash": self.user_id_hash,
+                "organization_id_hash": self.organization_id_hash,
+                "domain_id": self.domain_id,
+                "host_surface": self.host_surface,
+                "host_capabilities": list(self.host_capabilities),
+            },
+            "context": {
+                "document_context_present": self.document_context_present,
+                "uploaded_document_count": self.uploaded_document_count,
+                "source_ref_count": self.source_ref_count,
+                "memory_context_count": self.memory_context_count,
+            },
+            "route": {
+                "lane": self.route_lane,
+                "reason": self.route_reason,
+                "selected_agent": self.selected_agent,
+                "final_agent": self.final_agent,
+            },
+            "runtime": {
+                "requested_provider": self.provider_requested,
+                "requested_model": self.model_requested,
+                "provider": self.provider,
+                "model": self.model,
+                "runtime_authoritative": self.runtime_authoritative,
+                "fallback_used": self.fallback_used,
+                "fallback_reason": self.fallback_reason,
+                "failover_used": self.failover_used,
+            },
+            "tools": {
+                "observed": list(self.observed_tools),
+                "suppressed": list(self.suppressed_tools),
+            },
+            "stream": {
+                "transport": "sse_v3",
+                "event_counts": dict(self.event_counts),
+                "event_sequence_tail": list(self.event_sequence_tail),
+                "metadata_seen": self.metadata_seen,
+                "done_seen": self.done_seen,
+            },
+            "host_actions": {
+                "preview_required": self.preview_required,
+                "preview_emitted": self.preview_emitted,
+                "approval_token_present": self.approval_token_present,
+                "approval_token_hash": self.approval_token_hash,
+                "apply_attempted": self.apply_attempted,
+                "mutation_blocked_reason": self.mutation_blocked_reason,
+            },
+            "finalization": {
+                "status": self.finalization_status,
+                "error_type": self.finalization_error_type,
+                "save_response_immediately": self.save_response_immediately,
+            },
+        }
+
+    def _refresh_suppressed_tools(self) -> None:
+        suppressed: list[str] = []
+        if "host_action" not in self.host_capabilities and not self.event_counts.get(
+            "host_action"
+        ):
+            suppressed.append("host_action")
+        if "pointy" not in self.host_capabilities and not self.event_counts.get(
+            "pointy_action"
+        ):
+            suppressed.append("pointy_action")
+        if (
+            self.route_lane not in {"visual_fast_path", "native_turn"}
+            and "visual_runtime" not in self.observed_tools
+        ):
+            suppressed.append("visual_runtime")
+        if (
+            "code_studio" not in self.host_capabilities
+            and "code_studio" not in self.observed_tools
+        ):
+            suppressed.append("code_studio")
+        self.suppressed_tools = suppressed
+
+
+__all__ = [
+    "RUNTIME_FLOW_LEDGER_SCHEMA_VERSION",
+    "RuntimeFlowLedger",
+]

--- a/maritime-ai-service/app/services/chat_stream_coordinator.py
+++ b/maritime-ai-service/app/services/chat_stream_coordinator.py
@@ -11,6 +11,7 @@ from typing import Any, AsyncGenerator, Awaitable, Mapping
 from app.core.config import settings
 from app.core.exceptions import ProviderUnavailableError
 from app.engine.llm_runtime_metadata import resolve_runtime_llm_metadata
+from app.engine.multi_agent.runtime_flow_ledger import RuntimeFlowLedger
 from app.services.llm_runtime_audit_service import record_llm_runtime_observation
 from app.services.chat_orchestrator_runtime import build_wiii_turn_request
 from app.services.model_switch_prompt_service import (
@@ -364,7 +365,12 @@ async def _stream_with_idle_heartbeats(
         yield event
 
 
-def _with_latency_metadata(event, tracker: _StreamLatencyTracker):
+def _with_runtime_flow_metadata(
+    event,
+    tracker: _StreamLatencyTracker,
+    flow_ledger: RuntimeFlowLedger,
+):
+    flow_ledger.record_event(event)
     if getattr(event, "type", None) != "metadata":
         return event
     content = getattr(event, "content", None)
@@ -375,6 +381,8 @@ def _with_latency_metadata(event, tracker: _StreamLatencyTracker):
 
     metadata = dict(content)
     metadata.setdefault("stream_latency", tracker.to_payload())
+    flow_ledger.observe_metadata(metadata)
+    metadata.setdefault("runtime_flow_ledger", flow_ledger.to_payload())
     return StreamEvent(
         type="metadata",
         content=metadata,
@@ -453,8 +461,13 @@ async def generate_stream_v3_events(
         or request_headers.get("x-request-id")
         or ""
     ).strip() or None
+    flow_ledger = RuntimeFlowLedger.from_chat_request(
+        chat_request=chat_request,
+        request_id=request_id,
+    )
 
     event_counter += 1
+    flow_ledger.record_wire_event("status")
     yield format_sse(
         "status",
         {
@@ -533,8 +546,13 @@ async def generate_stream_v3_events(
             node="system",
         ):
             if update.kind == "status":
+                update_event = _with_runtime_flow_metadata(
+                    update.value,
+                    latency_tracker,
+                    flow_ledger,
+                )
                 chunks, event_counter, should_stop = serialize_stream_event(
-                    event=update.value,
+                    event=update_event,
                     event_counter=event_counter,
                     enable_artifacts=settings.enable_artifacts,
                     presentation_state=presentation_state,
@@ -551,14 +569,25 @@ async def generate_stream_v3_events(
         resolved_domain_id = prepared_turn.request_scope.domain_id
         effective_session_id = prepared_turn.session_id
         effective_session_id_str = str(effective_session_id)
+        flow_ledger.mark_prepared_turn(
+            session_id=effective_session_id_str,
+            organization_id=resolved_org_id,
+            domain_id=resolved_domain_id,
+        )
 
         if prepared_turn.validation.blocked:
+            flow_ledger.mark_route("blocked", reason="prepared_turn_validation")
+            flow_ledger.record_wire_event("answer")
+            flow_ledger.record_wire_event("metadata")
             blocked_chunks, event_counter = (
                 emit_blocked_sse_events(
                     blocked_response=prepared_turn.validation.blocked_response,
                     session_id=effective_session_id_str,
                     processing_time=time.time() - start_time,
                     event_counter=event_counter,
+                    extra_metadata={
+                        "runtime_flow_ledger": flow_ledger.to_payload(),
+                    },
                 )
             )
             for chunk in blocked_chunks:
@@ -585,6 +614,10 @@ async def generate_stream_v3_events(
             visual_fast_path = None
 
         if visual_fast_path is not None:
+            flow_ledger.mark_route(
+                "visual_fast_path",
+                reason="structured_visual_fast_path",
+            )
             visual_started_ms = latency_tracker.elapsed_ms()
             visual_events = [
                 await create_thinking_start_event(
@@ -630,6 +663,11 @@ async def generate_stream_v3_events(
             ]
 
             for event in visual_events:
+                event = _with_runtime_flow_metadata(
+                    event,
+                    latency_tracker,
+                    flow_ledger,
+                )
                 chunks, event_counter, should_stop = serialize_stream_event(
                     event=event,
                     event_counter=event_counter,
@@ -658,7 +696,16 @@ async def generate_stream_v3_events(
                     continuity_channel="web",
                     transport_type="stream",
                 )
+                flow_ledger.mark_finalization(
+                    "saved",
+                    save_response_immediately=False,
+                )
             except Exception as finalize_err:
+                flow_ledger.mark_finalization(
+                    "failed",
+                    error=finalize_err,
+                    save_response_immediately=False,
+                )
                 logger.warning(
                     "[STREAM-V3] Visual fast-path finalization failed: %s",
                     finalize_err,
@@ -685,6 +732,10 @@ async def generate_stream_v3_events(
             else ""
         )
         if pointy_fast_path_action == pointy_highlight_action_name:
+            flow_ledger.mark_route(
+                "pointy_fast_path",
+                reason="pointy_prepared_fast_path",
+            )
             pointy_answer = _pointy_action_answer(pointy_fast_path)
             pointy_thinking = _pointy_action_thinking(pointy_fast_path)
             pointy_label = _pointy_action_label(pointy_fast_path)
@@ -749,6 +800,11 @@ async def generate_stream_v3_events(
             ]
 
             for event in pointy_events:
+                event = _with_runtime_flow_metadata(
+                    event,
+                    latency_tracker,
+                    flow_ledger,
+                )
                 chunks, event_counter, should_stop = serialize_stream_event(
                     event=event,
                     event_counter=event_counter,
@@ -777,7 +833,16 @@ async def generate_stream_v3_events(
                     continuity_channel="web",
                     transport_type="stream",
                 )
+                flow_ledger.mark_finalization(
+                    "saved",
+                    save_response_immediately=False,
+                )
             except Exception as finalize_err:
+                flow_ledger.mark_finalization(
+                    "failed",
+                    error=finalize_err,
+                    save_response_immediately=False,
+                )
                 logger.warning(
                     "[STREAM-V3] Pointy fast-path finalization failed: %s",
                     finalize_err,
@@ -790,6 +855,12 @@ async def generate_stream_v3_events(
 
         if not use_multi_agent:
             logger.warning("[STREAM-V3] Multi-Agent disabled, using sync fallback path")
+            flow_ledger.mark_route(
+                "fallback",
+                reason="multi_agent_disabled",
+                fallback_used=True,
+                fallback_reason="multi_agent_disabled",
+            )
             fallback_status = await create_status_event(
                 "Wiii đang mở đường trả lời nhanh...",
                 node="direct",
@@ -798,6 +869,11 @@ async def generate_stream_v3_events(
                     "subtype": "heartbeat",
                     "visibility": "status_only",
                 },
+            )
+            fallback_status = _with_runtime_flow_metadata(
+                fallback_status,
+                latency_tracker,
+                flow_ledger,
             )
             chunks, event_counter, should_stop = serialize_stream_event(
                 event=fallback_status,
@@ -898,6 +974,11 @@ async def generate_stream_v3_events(
             )
 
             for event in fallback_events:
+                event = _with_runtime_flow_metadata(
+                    event,
+                    latency_tracker,
+                    flow_ledger,
+                )
                 chunks, event_counter, should_stop = serialize_stream_event(
                     event=event,
                     event_counter=event_counter,
@@ -926,7 +1007,16 @@ async def generate_stream_v3_events(
                     continuity_channel="web",
                     transport_type="stream",
                 )
+                flow_ledger.mark_finalization(
+                    "saved",
+                    save_response_immediately=True,
+                )
             except Exception as finalize_err:
+                flow_ledger.mark_finalization(
+                    "failed",
+                    error=finalize_err,
+                    save_response_immediately=True,
+                )
                 logger.warning(
                     "[STREAM-V3] Fallback post-response finalization failed: %s",
                     finalize_err,
@@ -934,6 +1024,7 @@ async def generate_stream_v3_events(
             return
 
         _provider = requested_provider
+        flow_ledger.mark_route("native_turn", reason="multi_agent_stream")
         context_status = await create_status_event(
             "Wiii đang gom ngữ cảnh và trí nhớ...",
             node="context",
@@ -944,6 +1035,11 @@ async def generate_stream_v3_events(
                     request_id=request_id,
                 ),
             },
+        )
+        context_status = _with_runtime_flow_metadata(
+            context_status,
+            latency_tracker,
+            flow_ledger,
         )
         chunks, event_counter, should_stop = serialize_stream_event(
             event=context_status,
@@ -979,8 +1075,13 @@ async def generate_stream_v3_events(
                 node="context",
             ):
                 if update.kind == "status":
+                    update_event = _with_runtime_flow_metadata(
+                        update.value,
+                        latency_tracker,
+                        flow_ledger,
+                    )
                     chunks, event_counter, should_stop = serialize_stream_event(
-                        event=update.value,
+                        event=update_event,
                         event_counter=event_counter,
                         enable_artifacts=settings.enable_artifacts,
                         presentation_state=presentation_state,
@@ -995,6 +1096,7 @@ async def generate_stream_v3_events(
                 raise RuntimeError(
                     "build_multi_agent_execution_input did not return context"
                 )
+            flow_ledger.mark_execution_input(execution_input)
         except Exception as ctx_err:
             logger.warning(
                 "[STREAM-V3] Full context build failed, using minimal: %s",
@@ -1015,6 +1117,13 @@ async def generate_stream_v3_events(
                         request_id=request_id,
                     )
                 )
+                flow_ledger.mark_route(
+                    "native_turn",
+                    reason="minimal_context_after_build_failure",
+                    fallback_used=True,
+                    fallback_reason="context_build_failed",
+                )
+                flow_ledger.mark_execution_input(execution_input)
             except Exception:
                 latency_tracker.finish("minimal_execution_input", status="error")
                 raise
@@ -1058,6 +1167,11 @@ async def generate_stream_v3_events(
                 ),
             ]
             for early_event in early_thinking_events:
+                early_event = _with_runtime_flow_metadata(
+                    early_event,
+                    latency_tracker,
+                    flow_ledger,
+                )
                 chunks, event_counter, should_stop = serialize_stream_event(
                     event=early_event,
                     event_counter=event_counter,
@@ -1091,7 +1205,42 @@ async def generate_stream_v3_events(
                 request_id=request_id,
                 create_status_event=create_status_event,
             ):
-                event = _with_latency_metadata(event, latency_tracker)
+                if event.type == "done" and not flow_ledger.metadata_seen:
+                    metadata_event = await create_metadata_event(
+                        reasoning_trace={
+                            "method": "runtime_flow_ledger",
+                            "steps": ["runtime_completed_without_metadata"],
+                        },
+                        processing_time=time.time() - start_time,
+                        confidence=0,
+                        session_id=effective_session_id_str,
+                        request_id=request_id,
+                        routing_metadata={
+                            "method": "runtime_flow_ledger",
+                            "intent": "observability",
+                        },
+                        stream_latency=latency_tracker.to_payload(),
+                        streaming_version="v3-runtime_flow",
+                    )
+                    metadata_event = _with_runtime_flow_metadata(
+                        metadata_event,
+                        latency_tracker,
+                        flow_ledger,
+                    )
+                    metadata_chunks, event_counter, _ = serialize_stream_event(
+                        event=metadata_event,
+                        event_counter=event_counter,
+                        enable_artifacts=settings.enable_artifacts,
+                        presentation_state=presentation_state,
+                    )
+                    for chunk in metadata_chunks:
+                        yield chunk
+
+                event = _with_runtime_flow_metadata(
+                    event,
+                    latency_tracker,
+                    flow_ledger,
+                )
                 stream_current_agent = _stream_agent_for_finalization(
                     event,
                     stream_current_agent,
@@ -1173,7 +1322,16 @@ async def generate_stream_v3_events(
                 continuity_channel="web",
                 transport_type="stream",
             )
+            flow_ledger.mark_finalization(
+                "saved",
+                save_response_immediately=bool(early_stop_reason),
+            )
         except Exception as finalize_err:
+            flow_ledger.mark_finalization(
+                "failed",
+                error=finalize_err,
+                save_response_immediately=bool(early_stop_reason),
+            )
             logger.warning(
                 "[STREAM-V3] Post-response finalization failed: %s",
                 finalize_err,
@@ -1185,7 +1343,42 @@ async def generate_stream_v3_events(
             processing_time,
         )
         if not saw_done_event:
+            if not flow_ledger.metadata_seen:
+                metadata_event = await create_metadata_event(
+                    reasoning_trace={
+                        "method": "runtime_flow_ledger",
+                        "steps": ["runtime_ended_without_done_or_metadata"],
+                    },
+                    processing_time=processing_time,
+                    confidence=0,
+                    session_id=effective_session_id_str,
+                    request_id=request_id,
+                    routing_metadata={
+                        "method": "runtime_flow_ledger",
+                        "intent": "observability",
+                    },
+                    stream_latency=latency_tracker.to_payload(),
+                    streaming_version="v3-runtime_flow",
+                )
+                metadata_event = _with_runtime_flow_metadata(
+                    metadata_event,
+                    latency_tracker,
+                    flow_ledger,
+                )
+                metadata_chunks, event_counter, _ = serialize_stream_event(
+                    event=metadata_event,
+                    event_counter=event_counter,
+                    enable_artifacts=settings.enable_artifacts,
+                    presentation_state=presentation_state,
+                )
+                for chunk in metadata_chunks:
+                    yield chunk
             done_event = await create_done_event(processing_time)
+            done_event = _with_runtime_flow_metadata(
+                done_event,
+                latency_tracker,
+                flow_ledger,
+            )
             done_chunks, event_counter, _ = serialize_stream_event(
                 event=done_event,
                 event_counter=event_counter,
@@ -1196,6 +1389,10 @@ async def generate_stream_v3_events(
                 yield chunk
 
     except ProviderUnavailableError as exc:
+        flow_ledger.mark_route(
+            "provider_unavailable",
+            reason=exc.reason_code or "provider_unavailable",
+        )
         logger.warning(
             "[STREAM-V3] Requested provider unavailable: provider=%s reason=%s",
             exc.provider,
@@ -1223,6 +1420,11 @@ async def generate_stream_v3_events(
                 reason_code=exc.reason_code,
             )
         )
+        error_event = _with_runtime_flow_metadata(
+            error_event,
+            latency_tracker,
+            flow_ledger,
+        )
         error_chunks, event_counter, _ = serialize_stream_event(
             event=error_event,
             event_counter=event_counter,
@@ -1231,10 +1433,46 @@ async def generate_stream_v3_events(
         )
         for chunk in error_chunks:
             yield chunk
+        metadata_event = await create_metadata_event(
+            reasoning_trace={
+                "method": "provider_unavailable",
+                "steps": ["provider_selectability_rejected_request"],
+            },
+            processing_time=time.time() - start_time,
+            confidence=0,
+            model=None,
+            provider=exc.provider,
+            session_id=flow_ledger.session_id,
+            request_id=request_id,
+            routing_metadata={
+                "method": "provider_unavailable",
+                "reason_code": exc.reason_code,
+            },
+            stream_latency=latency_tracker.to_payload(),
+            streaming_version="v3-provider_unavailable",
+        )
+        metadata_event = _with_runtime_flow_metadata(
+            metadata_event,
+            latency_tracker,
+            flow_ledger,
+        )
+        metadata_chunks, event_counter, _ = serialize_stream_event(
+            event=metadata_event,
+            event_counter=event_counter,
+            enable_artifacts=settings.enable_artifacts,
+            presentation_state=presentation_state,
+        )
+        for chunk in metadata_chunks:
+            yield chunk
         done_event = await create_done_event(time.time() - start_time)
+        done_event = _with_runtime_flow_metadata(
+            done_event,
+            latency_tracker,
+            flow_ledger,
+        )
         done_chunks, _, _ = serialize_stream_event(
             event=done_event,
-            event_counter=event_counter + 1,
+            event_counter=event_counter,
             enable_artifacts=settings.enable_artifacts,
             presentation_state=presentation_state,
         )

--- a/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
@@ -1,3 +1,4 @@
+import json
 import asyncio
 import time
 from types import SimpleNamespace
@@ -7,6 +8,7 @@ import pytest
 
 from app.models.schemas import UserRole
 from app.core.exceptions import ProviderUnavailableError
+from app.engine.multi_agent.runtime_flow_ledger import RUNTIME_FLOW_LEDGER_SCHEMA_VERSION
 from app.engine.multi_agent.runtime_contracts import WiiiStreamEvent, WiiiTurnRequest
 from app.services.chat_orchestrator import AgentType
 from app.services.chat_orchestrator import RequestScope
@@ -26,6 +28,27 @@ def _make_request(**overrides):
     }
     base.update(overrides)
     return SimpleNamespace(**base)
+
+
+def _event_payloads(chunks, event_name):
+    payloads = []
+    marker = f"event: {event_name}"
+    for chunk in chunks:
+        if marker not in chunk:
+            continue
+        for line in chunk.splitlines():
+            if line.startswith("data: "):
+                payloads.append(json.loads(line.removeprefix("data: ")))
+                break
+    return payloads
+
+
+def _runtime_flow_ledgers(chunks):
+    return [
+        payload["runtime_flow_ledger"]
+        for payload in _event_payloads(chunks, "metadata")
+        if isinstance(payload, dict) and "runtime_flow_ledger" in payload
+    ]
 
 
 @pytest.mark.asyncio
@@ -61,6 +84,10 @@ async def test_generate_stream_v3_events_emits_blocked_sequence():
     assert "event: answer" in chunks[2]
     assert "event: metadata" in chunks[3]
     assert "event: done" in chunks[4]
+    ledgers = _runtime_flow_ledgers(chunks)
+    assert ledgers
+    assert ledgers[0]["schema_version"] == RUNTIME_FLOW_LEDGER_SCHEMA_VERSION
+    assert ledgers[0]["route"]["lane"] == "blocked"
 
 
 @pytest.mark.asyncio
@@ -130,6 +157,122 @@ async def test_generate_stream_v3_events_finalizes_answer_after_stream():
 
 
 @pytest.mark.asyncio
+async def test_generate_stream_v3_events_emits_flow_ledger_when_runtime_omits_metadata():
+    orchestrator = MagicMock()
+    prepared_turn = SimpleNamespace(
+        request_scope=RequestScope("org-1", "maritime"),
+        session_id="session-1",
+        validation=SimpleNamespace(blocked=False),
+        chat_context=SimpleNamespace(user_name="Minh"),
+    )
+    orchestrator.prepare_turn = AsyncMock(return_value=prepared_turn)
+    orchestrator.build_multi_agent_execution_input = AsyncMock(
+        return_value=SimpleNamespace(
+            query="Explain Rule 5",
+            user_id="user-1",
+            session_id="session-1",
+            context={"conversation_history": ""},
+            domain_id="maritime",
+            thinking_effort=None,
+            provider="nvidia",
+            model="deepseek-ai/deepseek-v4-flash",
+        )
+    )
+
+    async def fake_stream_fn(**_kwargs):
+        yield SimpleNamespace(type="answer", content="Hello")
+        yield SimpleNamespace(type="done", content={"processing_time": 0.1})
+
+    chunks = []
+    async for chunk in generate_stream_v3_events(
+        chat_request=_make_request(),
+        request_headers={"X-Request-ID": "req-ledger-native"},
+        background_save=MagicMock(),
+        start_time=time.time(),
+        orchestrator=orchestrator,
+        stream_fn=fake_stream_fn,
+    ):
+        chunks.append(chunk)
+
+    ledgers = _runtime_flow_ledgers(chunks)
+    assert ledgers
+    ledger = ledgers[0]
+    assert ledger["schema_version"] == RUNTIME_FLOW_LEDGER_SCHEMA_VERSION
+    assert ledger["request"]["request_id"] == "req-ledger-native"
+    assert ledger["request"]["session_id"] == "session-1"
+    assert ledger["request"]["user_id_hash"].startswith("sha256:")
+    assert ledger["route"]["lane"] == "native_turn"
+    assert ledger["runtime"]["provider"] == "nvidia"
+    assert ledger["runtime"]["model"] == "deepseek-ai/deepseek-v4-flash"
+    assert ledger["stream"]["event_counts"]["answer"] == 1
+    assert ledger["stream"]["metadata_seen"] is True
+    assert "Explain Rule 5" not in json.dumps(ledger, ensure_ascii=False)
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_v3_events_flow_ledger_omits_uploaded_document_body():
+    orchestrator = MagicMock()
+    prepared_turn = SimpleNamespace(
+        request_scope=RequestScope("org-1", "maritime"),
+        session_id="session-1",
+        validation=SimpleNamespace(blocked=False),
+        chat_context=SimpleNamespace(user_name="Minh"),
+    )
+    orchestrator.prepare_turn = AsyncMock(return_value=prepared_turn)
+    orchestrator.build_multi_agent_execution_input = AsyncMock(
+        return_value=SimpleNamespace(
+            query="Create a lesson",
+            user_id="user-1",
+            session_id="session-1",
+            context={"conversation_history": ""},
+            domain_id="maritime",
+            thinking_effort=None,
+            provider=None,
+            model=None,
+        )
+    )
+
+    async def fake_stream_fn(**_kwargs):
+        yield SimpleNamespace(type="answer", content="Lesson draft preview")
+        yield SimpleNamespace(type="done", content={"processing_time": 0.1})
+
+    chunks = []
+    async for chunk in generate_stream_v3_events(
+        chat_request=_make_request(
+            message="Tao cho minh bai hoc",
+            user_context={
+                "host_context": {
+                    "surface": "lms_course_editor",
+                    "capabilities": ["lms", "host_action"],
+                },
+                "document_context": {
+                    "attachments": [
+                        {
+                            "name": "private.docx",
+                            "markdown": "SECRET DOCUMENT BODY ABOUT RULE 5",
+                        }
+                    ]
+                },
+            },
+        ),
+        request_headers={"X-Request-ID": "req-ledger-doc"},
+        background_save=MagicMock(),
+        start_time=time.time(),
+        orchestrator=orchestrator,
+        stream_fn=fake_stream_fn,
+    ):
+        chunks.append(chunk)
+
+    ledger = _runtime_flow_ledgers(chunks)[0]
+    assert ledger["context"]["document_context_present"] is True
+    assert ledger["context"]["uploaded_document_count"] == 1
+    assert ledger["host_actions"]["preview_required"] is True
+    ledger_json = json.dumps(ledger, ensure_ascii=False)
+    assert "SECRET DOCUMENT BODY" not in ledger_json
+    assert "Tao cho minh bai hoc" not in ledger_json
+
+
+@pytest.mark.asyncio
 async def test_generate_stream_v3_events_bypasses_context_build_for_pointy_highlight():
     orchestrator = MagicMock()
     prepared_turn = SimpleNamespace(
@@ -181,6 +324,10 @@ async def test_generate_stream_v3_events_bypasses_context_build_for_pointy_highl
     assert any("event: answer" in chunk for chunk in chunks)
     assert any("event: done" in chunk for chunk in chunks)
     assert any("v3-pointy_fast_path" in chunk for chunk in chunks)
+    ledgers = _runtime_flow_ledgers(chunks)
+    assert ledgers
+    assert ledgers[0]["route"]["lane"] == "pointy_fast_path"
+    assert "ui.highlight" in ledgers[0]["tools"]["observed"]
     orchestrator.build_multi_agent_execution_input.assert_not_called()
     orchestrator.finalize_response_turn.assert_called_once()
     assert (
@@ -231,6 +378,10 @@ async def test_generate_stream_v3_events_bypasses_provider_for_visual_fast_path(
     assert any("event: visual_open" in chunk for chunk in chunks)
     assert any("event: visual_commit" in chunk for chunk in chunks)
     assert any("v3-visual_fast_path" in chunk for chunk in chunks)
+    ledgers = _runtime_flow_ledgers(chunks)
+    assert ledgers
+    assert ledgers[0]["route"]["lane"] == "visual_fast_path"
+    assert "visual_runtime" in ledgers[0]["tools"]["observed"]
     orchestrator.build_multi_agent_execution_input.assert_not_called()
     orchestrator.finalize_response_turn.assert_called_once()
     assert (
@@ -829,6 +980,11 @@ async def test_generate_stream_v3_events_includes_request_id_and_routing_metadat
     assert '"request_id": "req-fast-social"' in metadata_chunk
     assert '"routing_metadata": {' in metadata_chunk
     assert '"fallback_direct_path"' in metadata_chunk
+    ledgers = _runtime_flow_ledgers(chunks)
+    assert ledgers
+    assert ledgers[0]["route"]["lane"] == "fallback"
+    assert ledgers[0]["runtime"]["fallback_used"] is True
+    assert ledgers[0]["runtime"]["model"] == "glm-5"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #644

## Summary
- Adds a typed, privacy-safe `runtime_flow_ledger` contract for backend chat stream metadata.
- Attaches the ledger to blocked, deterministic visual/Pointy, fallback, provider-unavailable, and native SSE metadata paths.
- Emits a synthetic metadata event before `done` when the native runtime omits metadata, so every completed active chat path has a flow ledger.

## Scope
- Backend SSE V3 chat stream metadata only.
- Privacy-safe observability fields: request/session/org/user hash, route lane, provider/model summary, tool/action names, source/memory counts, event counts/order, preview/approval-token flags, finalization status.
- Focused unit coverage in `tests/unit/test_chat_stream_coordinator.py`.

## Non-scope
- No database persistence, dashboard, production deploy, frontend UI changes, or LMS mutation behavior changes.
- Does not change uploaded-document preview/apply approval semantics.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_chat_stream_coordinator.py -q --tb=short` -> 22 passed
- `cd maritime-ai-service; python -m ruff check app/services app/engine/multi_agent tests/unit/test_chat_stream_coordinator.py --select=E9,F63,F7` -> passed
- `cd maritime-ai-service; python -m ruff check app/ --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
- Low-to-medium: metadata payloads become larger and native streams that previously ended with answer/done only now include a metadata event before done.
- Privacy risk is bounded by hashing user/org/approval token values and tests proving prompt/document body text is not serialized into the ledger.

## Rollback
- Revert this PR to remove the ledger module, metadata enrichment, and synthetic native metadata emission.