### PR TITLE
fix(code-studio): sanitize tool call stream args

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/code_studio_event_payloads.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_event_payloads.py
@@ -1,0 +1,78 @@
+"""Public event payload shaping for Code Studio tool calls."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Mapping
+
+
+_RAW_CODE_ARG_KEYS = {
+    "code",
+    "code_html",
+    "fallback_html",
+    "full_code",
+    "html",
+    "source",
+    "source_code",
+    "visual_payload",
+}
+_MAX_PUBLIC_ARG_KEYS = 16
+_MAX_PUBLIC_STRING_CHARS = 180
+
+
+def _hash_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+
+
+def _redacted_text_summary(value: Any) -> dict[str, Any]:
+    text = str(value or "")
+    return {
+        "redacted": True,
+        "chars": len(text),
+        "sha256": _hash_text(text) if text else None,
+    }
+
+
+def _summarize_public_value(key: str, value: Any) -> Any:
+    normalized_key = str(key or "").strip().lower()
+    if normalized_key in _RAW_CODE_ARG_KEYS:
+        return _redacted_text_summary(value)
+    if isinstance(value, str):
+        if len(value) <= _MAX_PUBLIC_STRING_CHARS:
+            return value
+        return {
+            "truncated": True,
+            "preview": value[:_MAX_PUBLIC_STRING_CHARS],
+            "chars": len(value),
+            "sha256": _hash_text(value),
+        }
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, Mapping):
+        keys = [str(item) for item in list(value.keys())[:_MAX_PUBLIC_ARG_KEYS]]
+        return {"type": "object", "keys": keys, "key_count": len(value)}
+    if isinstance(value, (list, tuple, set)):
+        return {"type": "array", "item_count": len(value)}
+    return {"type": type(value).__name__}
+
+
+def sanitize_code_studio_tool_call_args_for_stream(
+    tool_name: str,
+    args: Any,
+) -> dict[str, Any]:
+    """Return public-safe tool args for SSE without mutating internal args."""
+
+    if not isinstance(args, Mapping):
+        return {}
+    sanitized: dict[str, Any] = {}
+    for key, value in list(args.items())[:_MAX_PUBLIC_ARG_KEYS]:
+        sanitized[str(key)] = _summarize_public_value(str(key), value)
+    omitted_count = max(0, len(args) - _MAX_PUBLIC_ARG_KEYS)
+    if omitted_count:
+        sanitized["_omitted_arg_count"] = omitted_count
+    if str(tool_name or "").strip() == "tool_create_visual_code":
+        sanitized.setdefault("_public_contract", "code_studio_tool_call_args.v1")
+    return sanitized
+
+
+__all__ = ["sanitize_code_studio_tool_call_args_for_stream"]

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_fast_paths.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_fast_paths.py
@@ -16,6 +16,9 @@ from app.engine.multi_agent.code_studio_context import (
     _should_use_colreg_code_studio_fast_path,
     _should_use_pendulum_code_studio_fast_path,
 )
+from app.engine.multi_agent.code_studio_event_payloads import (
+    sanitize_code_studio_tool_call_args_for_stream,
+)
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.visual_events import (
     _collect_active_visual_session_ids,
@@ -514,7 +517,14 @@ async def execute_code_studio_fast_path(
 
     await push_event({
         "type": "tool_call",
-        "content": {"name": tool_name, "args": tool_args, "id": tool_call_id},
+        "content": {
+            "name": tool_name,
+            "args": sanitize_code_studio_tool_call_args_for_stream(
+                tool_name,
+                tool_args,
+            ),
+            "id": tool_call_id,
+        },
         "node": "code_studio_agent",
     })
     await push_event({

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_tool_rounds.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_tool_rounds.py
@@ -15,6 +15,9 @@ from app.engine.multi_agent.code_studio_scaffold_fallback_policy import (
     CodeStudioScaffoldFallbackDecision,
     resolve_code_studio_scaffold_fallback,
 )
+from app.engine.multi_agent.code_studio_event_payloads import (
+    sanitize_code_studio_tool_call_args_for_stream,
+)
 from app.engine.multi_agent.code_studio_template_scaffold import (
     build_code_studio_scaffold,
 )
@@ -703,7 +706,18 @@ async def execute_code_studio_tool_rounds_impl(
                 "[CODE_STUDIO] Invoking tool %s (id=%s, args_keys=%s)",
                 tc_name, tc_id, list(tc_args.keys()) if isinstance(tc_args, dict) else "?",
             )
-            await push_event({"type": "tool_call", "content": {"name": tc_name, "args": tc_args, "id": tc_id}, "node": "code_studio_agent"})
+            await push_event({
+                "type": "tool_call",
+                "content": {
+                    "name": tc_name,
+                    "args": sanitize_code_studio_tool_call_args_for_stream(
+                        tc_name,
+                        tc_args,
+                    ),
+                    "id": tc_id,
+                },
+                "node": "code_studio_agent",
+            })
             tool_call_events.append({"type": "call", "name": tc_name, "args": tc_args, "id": tc_id})
             matched = get_tool_by_name(tools, str(tc_name).strip())
             logger.info(

--- a/maritime-ai-service/tests/unit/test_code_studio_event_payloads.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_event_payloads.py
@@ -1,0 +1,43 @@
+import json
+
+from app.engine.multi_agent.code_studio_event_payloads import (
+    sanitize_code_studio_tool_call_args_for_stream,
+)
+
+
+def test_sanitize_code_studio_tool_call_args_redacts_code_html_without_mutation():
+    code_html = "<html><body>" + ("secret-code" * 80) + "</body></html>"
+    args = {
+        "code_html": code_html,
+        "title": "Pendulum simulation",
+        "subtitle": "Interactive canvas",
+    }
+
+    public_args = sanitize_code_studio_tool_call_args_for_stream(
+        "tool_create_visual_code",
+        args,
+    )
+
+    assert args["code_html"] == code_html
+    assert public_args["title"] == "Pendulum simulation"
+    assert public_args["code_html"]["redacted"] is True
+    assert public_args["code_html"]["chars"] == len(code_html)
+    assert public_args["_public_contract"] == "code_studio_tool_call_args.v1"
+    assert "secret-code" not in json.dumps(public_args, ensure_ascii=False)
+
+
+def test_sanitize_code_studio_tool_call_args_summarizes_large_nested_values():
+    public_args = sanitize_code_studio_tool_call_args_for_stream(
+        "tool_other",
+        {
+            "query": "short prompt",
+            "options": {"a": 1, "b": 2},
+            "items": [1, 2, 3],
+            "notes": "x" * 220,
+        },
+    )
+
+    assert public_args["query"] == "short prompt"
+    assert public_args["options"] == {"type": "object", "keys": ["a", "b"], "key_count": 2}
+    assert public_args["items"] == {"type": "array", "item_count": 3}
+    assert public_args["notes"]["truncated"] is True

--- a/maritime-ai-service/tests/unit/test_code_studio_fast_paths.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_fast_paths.py
@@ -70,7 +70,10 @@ def test_fast_path_recipe_contract_builds_tool_args() -> None:
 
 @pytest.mark.asyncio
 async def test_recipe_fast_path_returns_typed_result(monkeypatch) -> None:
+    invoked_args = {}
+
     async def fake_invoke_tool_with_runtime(*_args, **_kwargs):
+        invoked_args.update(_args[1])
         return '{"visual_session_id":"vs-fast","fallback_html":"<canvas></canvas>"}'
 
     async def fake_maybe_emit_visual_event(**_kwargs):
@@ -95,8 +98,10 @@ async def test_recipe_fast_path_returns_typed_result(monkeypatch) -> None:
         fake_emit_visual_commit_events,
     )
 
-    async def push_event(*_args, **_kwargs):
-        return None
+    pushed_events = []
+
+    async def push_event(event):
+        pushed_events.append(event)
 
     result = await code_studio_fast_paths.execute_code_studio_fast_path(
         state={"context": {}},
@@ -112,6 +117,12 @@ async def test_recipe_fast_path_returns_typed_result(monkeypatch) -> None:
     assert result.fast_path == "fast_colreg15"
     assert result.tools_used == [{"name": "tool_create_visual_code"}]
     assert result.tool_call_events[0]["type"] == "call"
+    assert result.tool_call_events[0]["args"]["code_html"] == _COLREG_RULE15_FAST_PATH_HTML
+    assert invoked_args["code_html"] == _COLREG_RULE15_FAST_PATH_HTML
+    tool_call_event = next(event for event in pushed_events if event["type"] == "tool_call")
+    public_args = tool_call_event["content"]["args"]
+    assert public_args["code_html"]["redacted"] is True
+    assert _COLREG_RULE15_FAST_PATH_HTML not in str(public_args)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #648

## Summary
- Adds a shared Code Studio public event arg sanitizer for `tool_call` SSE payloads.
- Uses it in both Code Studio tool rounds and recipe-backed fast paths so full `code_html`/raw code payloads are not streamed as tool-call args.
- Keeps raw args intact for internal tool invocation and backend `tool_call_events` provenance.

## Scope
- Backend Code Studio event payload shaping only.
- `tool_call` args public surface for `code_studio_tool_rounds.py` and `code_studio_fast_paths.py`.
- Focused tests for sanitizer behavior and fast-path raw-internal/public-redacted split.

## Non-scope
- No scaffold policy change.
- No frontend UI change.
- No tool result summarizer rewrite.
- No production deploy.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_code_studio_event_payloads.py tests/unit/test_code_studio_fast_paths.py tests/unit/test_code_studio_scaffold_fallback_policy.py -q --tb=short` -> 18 passed
- `cd maritime-ai-service; python -m ruff check app/engine/multi_agent/code_studio_event_payloads.py app/engine/multi_agent/code_studio_tool_rounds.py app/engine/multi_agent/code_studio_fast_paths.py tests/unit/test_code_studio_event_payloads.py tests/unit/test_code_studio_fast_paths.py tests/unit/test_code_studio_scaffold_fallback_policy.py --select=E9,F63,F7` -> passed
- `cd maritime-ai-service; python -m ruff check app/ --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
- Low: public `tool_call` events now show redacted summaries for large/raw code args. Backend invocation and provenance still receive the original args.
- Consumers that incorrectly depended on full `code_html` inside `tool_call.content.args` should instead use Code Studio `code_open`/`code_delta`/`code_complete` or visual events.

## Rollback
- Revert this PR to restore prior raw `tool_call` arg streaming.