### PR TITLE
test(frontend): guard visual copy against mojibake

### DIFF
--- a/wiii-desktop/src/__tests__/visual-code-studio-copy.test.ts
+++ b/wiii-desktop/src/__tests__/visual-code-studio-copy.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const visualUiFiles = [
+  "src/components/layout/CodeStudioPanel.tsx",
+  "src/components/chat/VisualBlock.tsx",
+  "src/components/common/InlineVisualFrame.tsx",
+];
+
+const mojibakeMarkers = [
+  { label: "UTF-8 C3 decoded as Latin-1", value: "\u00c3" },
+  { label: "UTF-8 C4 decoded as Latin-1", value: "\u00c4" },
+  { label: "Vietnamese tone marker decoded as Latin-1", value: "\u00e1\u00ba" },
+  { label: "Vietnamese vowel marker decoded as Latin-1", value: "\u00c6" },
+  { label: "middle dot decoded as Latin-1", value: "\u00c2\u00b7" },
+  { label: "em dash decoded as Latin-1", value: "\u00e2\u0080\u0094" },
+  { label: "em dash decoded as Windows-1252", value: "\u00e2\u20ac\u201d" },
+  { label: "arrow decoded as Latin-1", value: "\u00e2\u0086\u0092" },
+];
+
+describe("visual and Code Studio copy", () => {
+  it.each(visualUiFiles)(
+    "keeps %s free of common mojibake markers",
+    (file) => {
+      const content = readFileSync(join(process.cwd(), file), "utf8");
+
+      for (const marker of mojibakeMarkers) {
+        expect(content, marker.label).not.toContain(marker.value);
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #650

## Summary
- Adds a focused Vitest guard for visual and Code Studio UTF-8 copy surfaces.
- Checks active visual/Code Studio files for common Latin-1 and Windows-1252 mojibake markers.

## Scope
- New test only: wiii-desktop/src/__tests__/visual-code-studio-copy.test.ts.
- Covered surfaces: CodeStudioPanel, VisualBlock, InlineVisualFrame.

## Non-scope
- No runtime behavior changes.
- No UI layout or visual rendering changes.
- No LMS preview/apply mutation and no production deployment.

## Verification
- cd wiii-desktop; npm ci
- cd wiii-desktop; npx vitest run src/__tests__/visual-code-studio-copy.test.ts
- cd wiii-desktop; npx tsc --noEmit
- git diff --check

## Visual evidence
- Screenshot not captured because this PR is a source-level regression guard only and does not change rendered UI, layout, or copy content.

## Risk
- Low. The test can fail only if one of the guarded files contains known mojibake marker sequences; legitimate Vietnamese copy should not use these marker sequences.

## Rollback
- Revert commit f09281b3 to remove the guard test.