### PR TITLE
fix(code-studio): restore Vietnamese tool-round copy

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/code_studio_tool_rounds.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_tool_rounds.py
@@ -655,8 +655,8 @@ async def execute_code_studio_tool_rounds_impl(
                 phase=round_phase,
                 cue=round_cue,
                 tool_names=round_tool_names,
-                next_action="Mo cong cu can thiet roi xac minh output co the dung that.",
-                observations=[f"Sap goi {len(round_tool_names)} cong cu trong vong nay."],
+                next_action="Mở công cụ cần thiết rồi xác minh đầu ra có thể dùng thật.",
+                observations=[f"Sắp gọi {len(round_tool_names)} công cụ trong vòng này."],
                 style_tags=["code-studio", "tooling"],
             )
         except Exception as rr_err:
@@ -885,8 +885,8 @@ async def execute_code_studio_tool_rounds_impl(
                 phase="act",
                 cue=round_cue,
                 tool_names=round_tool_names,
-                next_action="Rut gon thanh mot buoc thuc hien tiep theo roi moi chot.",
-                observations=["Da co them ket qua moi va dang can khau lai."],
+                next_action="Rút gọn thành một bước thực hiện tiếp theo rồi mới chốt.",
+                observations=["Đã có thêm kết quả mới và đang cần khâu lại."],
                 style_tags=["code-studio", "transition"],
             )
             await push_event(
@@ -908,7 +908,7 @@ async def execute_code_studio_tool_rounds_impl(
         phase="synthesize",
         cue=synthesis_cue,
         tool_names=synthesis_tool_names,
-        next_action="Noi ro da tao xong san pham nao, no dung de lam gi, va nguoi dung co the mo artifact ay ngay luc nay.",
+        next_action="Nói rõ đã tạo xong sản phẩm nào, nó dùng để làm gì, và người dùng có thể mở artifact đó ngay lúc này.",
         observations=synthesis_observations,
         style_tags=["code-studio", "synthesis"],
     )

--- a/maritime-ai-service/tests/unit/test_code_studio_tool_rounds_copy.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_tool_rounds_copy.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+
+CODE_STUDIO_TOOL_ROUNDS = (
+    Path(__file__).resolve().parents[2]
+    / "app"
+    / "engine"
+    / "multi_agent"
+    / "code_studio_tool_rounds.py"
+).read_text(encoding="utf-8")
+
+
+def test_code_studio_tool_round_copy_uses_accented_vietnamese() -> None:
+    old_accentless_phrases = [
+        "Mo cong cu can thiet roi xac minh output co the dung that.",
+        "Sap goi",
+        "Rut gon thanh mot buoc thuc hien tiep theo roi moi chot.",
+        "Da co them ket qua moi va dang can khau lai.",
+        "Noi ro da tao xong san pham nao",
+    ]
+    expected_accented_phrases = [
+        "Mở công cụ cần thiết rồi xác minh đầu ra có thể dùng thật.",
+        "Sắp gọi",
+        "Rút gọn thành một bước thực hiện tiếp theo rồi mới chốt.",
+        "Đã có thêm kết quả mới và đang cần khâu lại.",
+        "Nói rõ đã tạo xong sản phẩm nào",
+    ]
+
+    for phrase in old_accentless_phrases:
+        assert phrase not in CODE_STUDIO_TOOL_ROUNDS
+
+    for phrase in expected_accented_phrases:
+        assert phrase in CODE_STUDIO_TOOL_ROUNDS


### PR DESCRIPTION
Closes #652

## Summary
- Replaces the remaining accentless Vietnamese reasoning/status copy in the Code Studio tool-round path.
- Adds a focused backend unit guard for the corrected copy.

## Scope
- maritime-ai-service/app/engine/multi_agent/code_studio_tool_rounds.py
- maritime-ai-service/tests/unit/test_code_studio_tool_rounds_copy.py

## Non-scope
- No tool-loop behavior change.
- No visual runtime contract change.
- No LMS preview/apply mutation and no production deployment.

## Verification
- cd maritime-ai-service; python -m pytest tests/unit/test_code_studio_tool_rounds_copy.py tests/unit/test_code_studio_scaffold_fallback_policy.py -q --tb=short
- cd maritime-ai-service; python -m ruff check app/engine/multi_agent/code_studio_tool_rounds.py tests/unit/test_code_studio_tool_rounds_copy.py --select=E9,F63,F7
- git diff --check

## Risk
- Low. Copy-only change in reasoning/status text; no tool invocation, fallback, or streaming behavior changes.

## Rollback
- Revert commit 65b03aeb to restore the previous copy and remove the guard test.