### PR TITLE
fix(code-studio): normalize context copy

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/code_studio_context.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_context.py
@@ -132,7 +132,7 @@ def _format_code_studio_progress_message(message: str, elapsed_seconds: float) -
     if elapsed_seconds <= 0:
         return message
     elapsed = int(max(1, round(elapsed_seconds)))
-    return f"{message} (da {elapsed}s)"
+    return f"{message} (đã {elapsed}s)"
 
 
 def _build_code_studio_retry_status(
@@ -261,19 +261,19 @@ def _build_code_studio_terminal_failure_response(
 
     if artifact_names:
         return (
-            f"Mình đã bắt đầu chuẩn bị `{artifact_names[0]}`, nhưng sandbox đang gặp lỗi kết nối (ket noi) nên chưa thể "
+            f"Mình đã bắt đầu chuẩn bị `{artifact_names[0]}`, nhưng sandbox đang gặp lỗi kết nối nên chưa thể "
             "hoàn tất artifact này ở turn hiện tại. Khi kênh thực thi ổn định trở lại, mình có thể chạy lại và "
             "gửi kết quả ngay."
         )
 
     if is_chart_request:
         return (
-            "Mình chưa thể tạo file PNG thật lúc này vì sandbox đang gặp lỗi kết nối (ket noi). "
+            "Mình chưa thể tạo file PNG thật lúc này vì sandbox đang gặp lỗi kết nối. "
             "Khi kênh thực thi ổn định trở lại, mình có thể chạy lại và gửi cho cậu artifact biểu đồ ngay."
         )
 
     return (
-        "Mình đã đến bước thực thi, nhưng sandbox đang gặp lỗi kết nối (ket noi) nên chưa thể tạo kết quả thật ngay lúc này. "
+        "Mình đã đến bước thực thi, nhưng sandbox đang gặp lỗi kết nối nên chưa thể tạo kết quả thật ngay lúc này. "
         "Khi kênh này ổn định trở lại, mình có thể chạy lại và giao artifact hoàn chỉnh cho cậu."
     )
 
@@ -363,7 +363,7 @@ def _infer_pendulum_fast_path_title(query: str, state: Optional[AgentState] = No
         return active_title
     normalized_query = _normalize_for_intent(query)
     if "con lac" in normalized_query:
-        return "Mo phong con lac"
+        return "Mô phỏng con lắc"
     return "Mini Pendulum Physics App"
 
 

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_fast_paths.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_fast_paths.py
@@ -388,14 +388,14 @@ _COLREG_RULE15_FAST_PATH_HTML = """
 
 _ARTIFACT_FAST_PATH_HTML = """
 <section style="font-family:system-ui,sans-serif;padding:24px;border:1px solid #e2e8f0;border-radius:18px;background:#fff8f1;max-width:520px">
-  <span style="display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border-radius:999px;background:#ffedd5;color:#9a3412;font-weight:600">Artifact scaffold</span>
-  <h2 style="margin:14px 0 10px;font-size:24px;color:#7c2d12">Mini HTML app ready</h2>
+  <span style="display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border-radius:999px;background:#ffedd5;color:#9a3412;font-weight:600">Khung Artifact</span>
+  <h2 style="margin:14px 0 10px;font-size:24px;color:#7c2d12">Mini HTML app đã sẵn sàng</h2>
   <p style="margin:0;color:#78350f;line-height:1.6">Đây là bộ khung embeddable gọn nhẹ để bạn preview ngay và patch tiếp trong Code Studio hoặc Artifact lane.</p>
   <button id="cta" type="button">Thử tương tác</button>
-  <p id="state" aria-live="polite" style="margin:12px 0 0">Ready to embed</p>
+  <p id="state" aria-live="polite" style="margin:12px 0 0">Sẵn sàng nhúng</p>
 </section>
 <script>
-const state=document.getElementById('state');document.getElementById('cta')?.addEventListener('click',()=>{state.textContent='Clicked once - artifact scaffold is alive';window.WiiiVisualBridge?.reportResult?.('artifact',{clicked:true},'Mini HTML app ready','completed')});
+const state=document.getElementById('state');document.getElementById('cta')?.addEventListener('click',()=>{state.textContent='Đã nhấn một lần - khung artifact đang hoạt động';window.WiiiVisualBridge?.reportResult?.('artifact',{clicked:true},'Mini HTML app đã sẵn sàng','completed')});
 </script>
 """.strip()
 

--- a/maritime-ai-service/tests/unit/test_code_studio_context_copy.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_context_copy.py
@@ -1,0 +1,32 @@
+from app.engine.multi_agent.code_studio_context import (
+    _build_code_studio_terminal_failure_response,
+    _format_code_studio_progress_message,
+    _infer_pendulum_fast_path_title,
+)
+from app.engine.multi_agent.code_studio_fast_paths import _ARTIFACT_FAST_PATH_HTML
+
+
+def test_code_studio_elapsed_status_uses_accented_vietnamese() -> None:
+    assert _format_code_studio_progress_message("Đang dựng preview...", 12) == (
+        "Đang dựng preview... (đã 12s)"
+    )
+
+
+def test_code_studio_pendulum_title_uses_accented_vietnamese() -> None:
+    assert _infer_pendulum_fast_path_title("mô phỏng con lắc", {}) == "Mô phỏng con lắc"
+
+
+def test_code_studio_terminal_failure_copy_does_not_include_ascii_parenthetical() -> None:
+    message = _build_code_studio_terminal_failure_response("tạo artifact html")
+
+    assert "kết nối" in message
+    assert "ket noi" not in message.lower()
+
+
+def test_artifact_fast_path_scaffold_copy_is_vietnamese_first() -> None:
+    assert "Khung Artifact" in _ARTIFACT_FAST_PATH_HTML
+    assert "Mini HTML app đã sẵn sàng" in _ARTIFACT_FAST_PATH_HTML
+    assert "Sẵn sàng nhúng" in _ARTIFACT_FAST_PATH_HTML
+    assert "Đã nhấn một lần - khung artifact đang hoạt động" in _ARTIFACT_FAST_PATH_HTML
+    assert "Ready to embed" not in _ARTIFACT_FAST_PATH_HTML
+    assert "Clicked once" not in _ARTIFACT_FAST_PATH_HTML

--- a/maritime-ai-service/tests/unit/test_graph_routing.py
+++ b/maritime-ai-service/tests/unit/test_graph_routing.py
@@ -1479,7 +1479,7 @@ class TestCodeStudioProgressHeartbeat:
 
     def test_progress_message_includes_elapsed_seconds(self):
         formatted = _format_code_studio_progress_message("Minh dang dung canvas loop...", 42.1)
-        assert "(da 42s)" in formatted
+        assert "(đã 42s)" in formatted
 
     def test_retry_status_is_honest_about_long_running_simulation(self):
         retry = _build_code_studio_retry_status(
@@ -1488,7 +1488,7 @@ class TestCodeStudioProgressHeartbeat:
             elapsed_seconds=240,
         )
         assert "preview thật" in retry
-        assert "(da 240s)" in retry
+        assert "(đã 240s)" in retry
 
     @pytest.mark.asyncio
     async def test_stream_answer_suppresses_raw_code_dump_for_code_studio_lane(self):

--- a/maritime-ai-service/tests/unit/test_sprint154_tech_debt.py
+++ b/maritime-ai-service/tests/unit/test_sprint154_tech_debt.py
@@ -470,7 +470,7 @@ class TestCodeStudioTerminalFailures:
 
         assert "PNG" in message or "png" in message
         assert "sandbox" in message.lower()
-        assert "ket noi" in message.lower()
+        assert "lỗi kết nối" in message.lower()
 
 
 class TestCodeStudioWave002:


### PR DESCRIPTION
Closes #654

## Summary
- Restores accented Vietnamese in Code Studio context status and terminal failure copy.
- Localizes artifact fast-path scaffold UI text to Vietnamese-first copy.
- Adds focused unit coverage for the affected copy contract and updates existing elapsed/terminal-failure expectations.

## Scope
- maritime-ai-service/app/engine/multi_agent/code_studio_context.py
- maritime-ai-service/app/engine/multi_agent/code_studio_fast_paths.py
- maritime-ai-service/tests/unit/test_code_studio_context_copy.py
- maritime-ai-service/tests/unit/test_graph_routing.py
- maritime-ai-service/tests/unit/test_sprint154_tech_debt.py

## Non-scope
- No routing, tool-loop, scaffold policy, or visual runtime contract changes.
- No LMS preview/apply mutation and no production deployment.
- No broad rewrite of simulation/dashboard fast-path HTML.

## Verification
- cd maritime-ai-service; python -m pytest tests/unit/test_code_studio_context_copy.py tests/unit/test_code_studio_tool_rounds_copy.py tests/unit/test_graph_routing.py::TestCodeStudioProgressHeartbeat::test_progress_message_includes_elapsed_seconds tests/unit/test_graph_routing.py::TestCodeStudioProgressHeartbeat::test_retry_status_is_honest_about_long_running_simulation tests/unit/test_sprint154_tech_debt.py::TestCodeStudioTerminalFailures::test_builds_chart_specific_terminal_failure_response -q --tb=short
- cd maritime-ai-service; python -m ruff check app/engine/multi_agent/code_studio_context.py app/engine/multi_agent/code_studio_fast_paths.py tests/unit/test_code_studio_context_copy.py tests/unit/test_graph_routing.py tests/unit/test_sprint154_tech_debt.py --select=E9,F63,F7
- git diff --check

## Risk
- Low. Copy-only change in Code Studio status/fallback and artifact scaffold text. No tool invocation behavior changed.

## Rollback
- Revert commit 4f1d6077 to restore previous copy and remove the guard test.