### PR TITLE
fix(code-studio): preserve required file tools

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/tool_collection.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_collection.py
@@ -245,10 +245,28 @@ def _strip_visual_tool_capabilities(
 
 
 def _tools_matching_visual_requirement(tools: list[Any], visual_requirement: Any) -> list[Any]:
-    required_names = set(getattr(visual_requirement, "required_tool_names", ()) or ())
+    return _tools_matching_names(
+        tools,
+        getattr(visual_requirement, "required_tool_names", ()) or (),
+    )
+
+
+def _tools_matching_names(tools: list[Any], tool_names: list[str] | tuple[str, ...]) -> list[Any]:
+    required_names = [
+        str(name or "").strip()
+        for name in tool_names
+        if str(name or "").strip()
+    ]
     if not required_names:
         return []
-    return [tool for tool in tools if _tool_name(tool) in required_names]
+
+    tools_by_name: dict[str, Any] = {}
+    for tool in tools:
+        name = _tool_name(tool)
+        if name and name not in tools_by_name:
+            tools_by_name[name] = tool
+
+    return [tools_by_name[name] for name in required_names if name in tools_by_name]
 
 
 _POINTY_OUTPUT_REQUEST_CUES: tuple[str, ...] = (
@@ -879,6 +897,7 @@ def _collect_code_studio_tools(query: str, user_role: str = "student"):
         visual_decision,
         structured_visuals_enabled=structured_visuals_enabled,
     )
+    required_tool_names = _code_studio_required_tool_names(query, user_role)
     _tools = filter_tools_for_role(_tools, user_role)
     _tools = filter_tools_for_visual_intent(
         _tools,
@@ -896,8 +915,18 @@ def _collect_code_studio_tools(query: str, user_role: str = "student"):
         and visual_requirement.presentation_intent in {"code_studio_app", "artifact"}
     ):
         preferred_tools = _tools_matching_visual_requirement(_tools, visual_requirement)
-        if preferred_tools:
-            _tools = preferred_tools
+        required_tools = _tools_matching_names(_tools, required_tool_names)
+        narrowed_tools = [*required_tools]
+        seen_names = {_tool_name(tool) for tool in narrowed_tools}
+        for tool in preferred_tools:
+            tool_name = _tool_name(tool)
+            if tool_name in seen_names:
+                continue
+            narrowed_tools.append(tool)
+            if tool_name:
+                seen_names.add(tool_name)
+        if narrowed_tools:
+            _tools = narrowed_tools
 
     force_tools = bool(_tools)
     return _tools, force_tools

--- a/maritime-ai-service/tests/unit/test_tool_collection_visual_requirements.py
+++ b/maritime-ai-service/tests/unit/test_tool_collection_visual_requirements.py
@@ -194,3 +194,20 @@ def test_collect_code_studio_tools_uses_visual_requirement_for_simulation(monkey
 
     assert force_tools is True
     assert _tool_names(tools) == ["tool_create_visual_code"]
+
+
+def test_collect_code_studio_tools_keeps_required_html_file_tool(monkeypatch):
+    from app.engine.multi_agent import tool_collection as module
+
+    _patch_visual_collection_modules(monkeypatch, module)
+
+    tools, force_tools = module._collect_code_studio_tools(
+        "Tao landing page HTML cho san pham de nhung LMS",
+        user_role="student",
+    )
+
+    assert force_tools is True
+    assert _tool_names(tools) == [
+        "tool_generate_html_file",
+        "tool_create_visual_code",
+    ]


### PR DESCRIPTION
Closes #656

## Summary
- Keeps Code Studio collection aligned with `_code_studio_required_tool_names()` when visual intent narrows the tool bundle.
- Adds an ordered tool-name matcher so required file/output tools can survive artifact visual narrowing.
- Adds regression coverage proving landing page HTML requests bind both `tool_generate_html_file` and `tool_create_visual_code`, while existing simulation narrowing still stays single-tool.

## Scope
- maritime-ai-service/app/engine/multi_agent/tool_collection.py
- maritime-ai-service/tests/unit/test_tool_collection_visual_requirements.py

## Non-scope
- No visual intent classification changes.
- No LMS preview/apply mutation and no production deployment.
- No frontend changes.

## Verification
- cd maritime-ai-service; python -m pytest tests/unit/test_tool_collection_visual_requirements.py tests/unit/test_code_studio_tool_setup.py tests/unit/test_sprint154_tech_debt.py::TestCodeStudioWave002 tests/unit/test_graph_routing.py::TestCollectCodeStudioTools -q --tb=short
- cd maritime-ai-service; python -m ruff check app/engine/multi_agent/tool_collection.py tests/unit/test_tool_collection_visual_requirements.py tests/unit/test_code_studio_tool_setup.py tests/unit/test_sprint154_tech_debt.py tests/unit/test_graph_routing.py --select=E9,F63,F7
- git diff --check

## Risk
- Low to medium. This changes Code Studio tool binding for explicit file/artifact requests so required file tools are available alongside the visual app tool. Simulation-only requests remain narrowed to `tool_create_visual_code` by test.

## Rollback
- Revert commit 9d65a625 to restore previous visual-only narrowing behavior.