### PR TITLE
fix(backend): suppress undeliverable Code Studio scaffolds

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_node_runtime.py
@@ -211,6 +211,7 @@ async def code_studio_node_impl(
             query=query,
             state=state,
             reason=f"node_outer_{type(e).__name__}",
+            allow_scaffold_delivery=False,
         )
         response = fallback_decision.response
         try:

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_fallback_policy.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_scaffold_fallback_policy.py
@@ -164,6 +164,14 @@ def _safe_failure_response(
     )
 
 
+def _scaffold_delivery_unavailable_response() -> str:
+    return (
+        "Mình đã giữ đúng lane Code Studio, nhưng lỗi xảy ra trước khi runtime "
+        "có thể gọi công cụ để mở preview thật. Mình dừng ở trạng thái an toàn "
+        "thay vì nói rằng đã tạo artifact."
+    )
+
+
 def _resolution_failure_decision(
     *,
     query: str,
@@ -195,6 +203,7 @@ def resolve_code_studio_scaffold_fallback(
     query: str,
     state: Any | None = None,
     reason: str = "unknown",
+    allow_scaffold_delivery: bool = True,
     resolve_visual_intent_fn: VisualIntentResolver = resolve_visual_intent,
     resolve_contract_fn: RuntimeContractResolver = resolve_visual_code_runtime_contract,
     build_caption_fn: CaptionBuilder = build_scaffold_visible_caption,
@@ -205,6 +214,9 @@ def resolve_code_studio_scaffold_fallback(
     Generic app/simulation fallbacks are intentionally suppressed: if the
     tool path cannot produce a real app preview, Wiii should fail visibly and
     safely instead of shipping a broad topic template.
+
+    ``allow_scaffold_delivery`` must be false for callsites that can only return
+    text and cannot dispatch ``tool_create_visual_code`` to open a real preview.
     """
     del state  # Reserved for future session-aware policy without changing call sites.
 
@@ -278,6 +290,17 @@ def resolve_code_studio_scaffold_fallback(
             metric_kind=metric_kind,
             callsite_reason=reason,
             policy_reason="app_requires_tool_generated_preview",
+            response_type="code_studio_scaffold_suppressed",
+            **intent.decision_fields(),
+        )
+
+    if not allow_scaffold_delivery:
+        return CodeStudioScaffoldFallbackDecision(
+            engage_scaffold=False,
+            response=_scaffold_delivery_unavailable_response(),
+            metric_kind=metric_kind,
+            callsite_reason=reason,
+            policy_reason="scaffold_delivery_unavailable",
             response_type="code_studio_scaffold_suppressed",
             **intent.decision_fields(),
         )

--- a/maritime-ai-service/tests/unit/test_code_studio_scaffold_fallback_policy.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_scaffold_fallback_policy.py
@@ -130,6 +130,30 @@ def test_allows_artifact_scaffold_fallback_with_contract_metadata() -> None:
     assert decision.metric_labels()["kind"] == "default"
 
 
+def test_suppresses_artifact_scaffold_when_callsite_cannot_deliver_preview() -> None:
+    decision = resolve_code_studio_scaffold_fallback(
+        query="Tạo một mini app HTML để nhúng LMS",
+        reason="node_outer_RuntimeError",
+        allow_scaffold_delivery=False,
+        resolve_visual_intent_fn=lambda _query: _visual_decision(
+            presentation_intent="artifact",
+            studio_lane="artifact",
+            visual_type=None,
+            quality_profile="premium",
+        ),
+        build_caption_fn=lambda _query: "caption should not be shown",
+        detect_kind_fn=lambda _query: "default",
+    )
+
+    assert decision.engage_scaffold is False
+    assert decision.policy_reason == "scaffold_delivery_unavailable"
+    assert decision.response_type == "code_studio_scaffold_suppressed"
+    assert decision.presentation_intent == "artifact"
+    assert decision.studio_lane == "artifact"
+    assert "preview thật" in decision.response
+    assert "caption should not be shown" not in decision.response
+
+
 def test_resolution_failure_suppresses_scaffold() -> None:
     def broken_resolver(_query: str):
         raise RuntimeError("resolver unavailable")


### PR DESCRIPTION
## Summary

- Adds an explicit Code Studio scaffold-delivery guard so fallback policy can distinguish "contract allows scaffold" from "this callsite can actually dispatch a preview tool call".
- Keeps outer `code_studio_node` exceptions from claiming an artifact/scaffold preview when that catch path can only return text.
- Adds regression coverage for artifact fallback suppression when preview delivery is unavailable.

## Linked Issue

Closes #664

## Scope

In scope:
- Backend Code Studio scaffold fallback policy.
- Backend Code Studio outer exception fallback callsite.
- Focused unit coverage for the new delivery guard.

Out of scope:
- Frontend Code Studio/VisualBlock UX.
- LMS preview/apply mutation flows.
- Provider routing, deployment, or generated Code Studio artifacts.

## Owner / Agents / Paths

- Owner: Codex
- Agents involved: Codex
- Owned paths: `maritime-ai-service/app/engine/multi_agent/code_studio_*`, `maritime-ai-service/tests/unit/test_code_studio_scaffold_fallback_policy.py`
- Conflict risk: Low; narrow backend runtime-policy slice.

## Verification

- `cd maritime-ai-service; $env:PYTHONIOENCODING='utf-8'; python -m pytest tests/unit/test_code_studio_scaffold_fallback_policy.py tests/unit/test_code_studio_tool_setup.py tests/unit/test_code_studio_provider_execution.py tests/unit/test_visual_code_runtime_contract.py -q --tb=short` -> 23 passed
- `python tools\wiii_self_harness\run_wiii_self_harness.py` -> PASS, scenarios=9, evidence files=40, checks passed=493
- `cd maritime-ai-service; python -m ruff check app/ tests/unit/test_code_studio_scaffold_fallback_policy.py --select=E9,F63,F7` -> All checks passed
- `git diff --check` -> passed

## Risk

Medium. This touches Code Studio fallback behavior in a high-risk visual/tool output path. The change is intentionally fail-closed: if a callsite cannot dispatch `tool_create_visual_code`, it now returns a safe text stop instead of implying a preview exists.

## Rollback

Revert this PR. Rollback restores previous behavior where outer Code Studio exceptions could reuse artifact scaffold captions without dispatching a preview tool call.

## Reviewer Focus

- Confirm only tool-round callsites can still create scaffold tool calls.
- Confirm outer exception fallback cannot claim a preview it did not open.
- Confirm artifact fallback remains allowed in the actual tool-round path.
