### PR TITLE
Fix Code Studio visual session mapping

### DIFF
--- a/wiii-desktop/src/__tests__/code-studio-store.test.ts
+++ b/wiii-desktop/src/__tests__/code-studio-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import {
   buildCodeStudioActiveSessionContext,
+  resolveCodeStudioSessionIdForVisualSession,
   useCodeStudioStore,
 } from "@/stores/code-studio-store";
 
@@ -139,6 +140,32 @@ describe("code-studio-store", () => {
       expect(session.activeVersion).toBe(2);
     });
 
+  });
+
+  describe("resolveCodeStudioSessionIdForVisualSession", () => {
+    it("resolves both direct session ids and mapped visual session ids", () => {
+      const store = useCodeStudioStore.getState();
+      store.openSession("cs_mapped", "Mapped App", "html", 1);
+      store.completeSession(
+        "cs_mapped",
+        "<main />",
+        "html",
+        1,
+        undefined,
+        "vs_mapped",
+      );
+
+      const { sessions } = useCodeStudioStore.getState();
+      expect(
+        resolveCodeStudioSessionIdForVisualSession(sessions, "cs_mapped"),
+      ).toBe("cs_mapped");
+      expect(
+        resolveCodeStudioSessionIdForVisualSession(sessions, "vs_mapped"),
+      ).toBe("cs_mapped");
+      expect(
+        resolveCodeStudioSessionIdForVisualSession(sessions, "missing"),
+      ).toBeNull();
+    });
   });
 
   describe("switchVersion", () => {

--- a/wiii-desktop/src/__tests__/interleaved-block-sequence.test.tsx
+++ b/wiii-desktop/src/__tests__/interleaved-block-sequence.test.tsx
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import type { ContentBlock } from "@/api/types";
 import { InterleavedBlockSequence } from "@/components/chat/InterleavedBlockSequence";
+import { useCodeStudioStore } from "@/stores/code-studio-store";
 
 vi.mock("@/components/common/MarkdownRenderer", () => ({
   MarkdownRenderer: ({ content }: { content: string }) => <div>{content}</div>,
@@ -161,6 +162,13 @@ function createVisual(
 }
 
 describe("InterleavedBlockSequence", () => {
+  beforeEach(() => {
+    useCodeStudioStore.setState({
+      activeSessionId: null,
+      sessions: {},
+    });
+  });
+
   it("dedupes action bridges that repeat adjacent thinking text", () => {
     const blocks: ContentBlock[] = [
       createThinking("Dang soi lai du lieu can bam.", {
@@ -316,6 +324,53 @@ describe("InterleavedBlockSequence", () => {
     expect(screen.queryByTestId("reasoning-interval")).toBeNull();
     expect(screen.getByTestId("tool-strip").textContent || "").toContain("tool_generate_visual");
     expect(screen.getByTestId("visual-block")).toBeTruthy();
+  });
+
+  it("keeps Code Studio-owned visual blocks as transcript anchors", () => {
+    const store = useCodeStudioStore.getState();
+    store.openSession("cs-code-visual", "Pendulum App", "html", 1, {
+      studioLane: "app",
+    });
+    store.completeSession(
+      "cs-code-visual",
+      "<main>Pendulum</main>",
+      "html",
+      1,
+      undefined,
+      "vs-code-visual",
+    );
+
+    const baseVisual = createVisual().visual;
+    const blocks: ContentBlock[] = [
+      createAnswer("Minh da dung mot app nho de minh hoa chuyen dong."),
+      createVisual({
+        id: "visual-code",
+        sessionId: "vs-code-visual",
+        visual: {
+          ...baseVisual,
+          id: "visual-code",
+          visual_session_id: "vs-code-visual",
+          title: "Pendulum App",
+          renderer_kind: "app",
+          shell_variant: "immersive",
+          patch_strategy: "app_state",
+          chrome_mode: "app",
+          runtime: "sandbox_html",
+          fallback_html: "<main>Pendulum</main>",
+        },
+      }),
+    ];
+
+    render(
+      <InterleavedBlockSequence
+        blocks={blocks}
+        showThinking
+        thinkingLevel="balanced"
+      />,
+    );
+
+    expect(screen.getByTestId("visual-block")).toBeTruthy();
+    expect(screen.getByText("Pendulum App")).toBeTruthy();
   });
 
   it("renders detailed trace in the main flow and still keeps the inspector available", () => {

--- a/wiii-desktop/src/__tests__/tool-execution-strip.test.tsx
+++ b/wiii-desktop/src/__tests__/tool-execution-strip.test.tsx
@@ -63,6 +63,42 @@ describe("ToolExecutionStrip", () => {
     expect(screen.getByText("Xem trước")).toBeTruthy();
   });
 
+  it("resolves CodeStudioCard through a mapped visual_session_id", () => {
+    const store = useCodeStudioStore.getState();
+    store.openSession("cs_mapped", "Mapped Pendulum App", "html", 1, {
+      studioLane: "app",
+    });
+    store.completeSession(
+      "cs_mapped",
+      "<div>app</div>",
+      "html",
+      1,
+      undefined,
+      "vs_mapped",
+    );
+
+    const block: ToolExecutionBlockData = {
+      type: "tool_execution",
+      id: "tool-code-mapped",
+      status: "completed",
+      tool: {
+        id: "tool-code-mapped",
+        name: "tool_create_visual_code",
+        args: {
+          title: "Mapped Pendulum App",
+        },
+        result: JSON.stringify({
+          visual_session_id: "vs_mapped",
+        }),
+      },
+    };
+
+    render(<ToolExecutionStrip block={block} />);
+
+    expect(screen.getByText("Mapped Pendulum App")).toBeTruthy();
+    expect(screen.getByText("Xem trước")).toBeTruthy();
+  });
+
   it("renders CodeStudioCard via _code_studio_session_id injected by SSE handler", () => {
     useCodeStudioStore.setState({
       activeSessionId: "cs_abc",

--- a/wiii-desktop/src/__tests__/visual-block-copy.test.tsx
+++ b/wiii-desktop/src/__tests__/visual-block-copy.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { VisualBlock } from "@/components/chat/VisualBlock";
 import type { VisualBlockData, VisualPayload } from "@/api/types";
@@ -82,5 +82,35 @@ describe("VisualBlock copy", () => {
     render(<VisualBlock block={block} onSuggestedQuestion={vi.fn()} />);
 
     expect(screen.getByRole("button", { name: "Mở thành Artifact" })).toBeTruthy();
+  });
+
+  it("delegates mapped Code Studio visuals to the owning panel session", () => {
+    const store = useCodeStudioStore.getState();
+    store.openSession("cs-owner", "Mapped simulation", "html", 1);
+    store.completeSession(
+      "cs-owner",
+      "<main>Mapped simulation</main>",
+      "html",
+      1,
+      undefined,
+      "vs-copy-1",
+    );
+    useUIStore.setState({
+      codeStudioPanelOpen: true,
+    });
+    store.setActiveSession("cs-owner");
+
+    const block: VisualBlockData = {
+      type: "visual",
+      id: "block-copy-2",
+      visual: makeVisual(),
+      status: "committed",
+    };
+
+    render(<VisualBlock block={block} onSuggestedQuestion={vi.fn()} />);
+
+    expect(screen.queryByTestId("inline-visual-frame")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Code Studio/ }));
+    expect(useCodeStudioStore.getState().activeSessionId).toBe("cs-owner");
   });
 });

--- a/wiii-desktop/src/components/chat/InterleavedBlockSequence.tsx
+++ b/wiii-desktop/src/components/chat/InterleavedBlockSequence.tsx
@@ -25,7 +25,6 @@ import { PreviewGroup } from "./PreviewGroup";
 import { ArtifactCard } from "./ArtifactCard";
 import { VisualBlock } from "./VisualBlock";
 import { ToolExecutionStrip } from "./ToolExecutionStrip";
-import { useCodeStudioStore } from "@/stores/code-studio-store";
 
 function BlockErrorFallback({
   blockType,
@@ -865,9 +864,6 @@ export function InterleavedBlockSequence({
   onSuggestedQuestion,
 }: InterleavedBlockSequenceProps) {
   const [inspectorIntervalId, setInspectorIntervalId] = useState<string | null>(null);
-  const codeStudioVisualIds = useCodeStudioStore((s) =>
-    new Set(Object.values(s.sessions).map((sess) => sess.visualSessionId).filter(Boolean)),
-  );
   const showReasoningRail = shouldRenderReasoningRail(blocks, showThinking, thinkingLevel);
   const groupedBlockIds = new Set<string>();
 
@@ -1031,9 +1027,6 @@ export function InterleavedBlockSequence({
         }
 
         if (block.type === "visual") {
-          // Skip visual blocks that belong to a CodeStudio session (rendered inside CodeStudioCard)
-          const vsId = (block as VisualBlockData).visual.visual_session_id;
-          if (vsId && codeStudioVisualIds.has(vsId)) return null;
           if (editorialComposition?.entryId === block.id) {
             return (
               <BlockErrorBoundary key={block.id} blockType="visual">

--- a/wiii-desktop/src/components/chat/ToolExecutionStrip.tsx
+++ b/wiii-desktop/src/components/chat/ToolExecutionStrip.tsx
@@ -16,7 +16,10 @@ import type { ToolExecutionBlockData } from "@/api/types";
 import { TOOL_LABELS } from "@/lib/reasoning-labels";
 import { VisualArtifactCard } from "./VisualArtifactCard";
 import { CodeStudioCard } from "./CodeStudioCard";
-import { useCodeStudioStore } from "@/stores/code-studio-store";
+import {
+  resolveCodeStudioSessionIdForVisualSession,
+  useCodeStudioStore,
+} from "@/stores/code-studio-store";
 
 interface ToolExecutionStripProps {
   block: ToolExecutionBlockData;
@@ -460,13 +463,13 @@ function VisualToolStrip({ block }: ToolExecutionStripProps) {
     block.tool.args.visual_session_id.trim()
       ? block.tool.args.visual_session_id.trim()
       : extractVisualSessionIdFromResult(block.tool.result);
-  const vsId = visual_session_id || csSessionId;
-  const hasCodeStudioSession = useCodeStudioStore((s) =>
-    vsId ? Boolean(s.sessions[vsId]) : false,
+  const codeStudioSessionId = useCodeStudioStore((s) =>
+    resolveCodeStudioSessionIdForVisualSession(s.sessions, visual_session_id)
+    || (csSessionId && s.sessions[csSessionId] ? csSessionId : null),
   );
 
-  if (hasCodeStudioSession) {
-    return <CodeStudioCard sessionId={vsId} />;
+  if (codeStudioSessionId) {
+    return <CodeStudioCard sessionId={codeStudioSessionId} />;
   }
   return <VisualArtifactCard block={block} />;
 }

--- a/wiii-desktop/src/components/chat/VisualBlock.tsx
+++ b/wiii-desktop/src/components/chat/VisualBlock.tsx
@@ -7,7 +7,10 @@ import type {
 import { motion, AnimatePresence } from "motion/react";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { useChatStore } from "@/stores/chat-store";
-import { useCodeStudioStore } from "@/stores/code-studio-store";
+import {
+  resolveCodeStudioSessionIdForVisualSession,
+  useCodeStudioStore,
+} from "@/stores/code-studio-store";
 import { useUIStore } from "@/stores/ui-store";
 import { trackVisualTelemetry } from "@/lib/visual-telemetry";
 import { staggerContainer } from "@/lib/animations";
@@ -146,10 +149,13 @@ export function VisualBlock({
   // Delegate to Code Studio panel when it's open for this visual — avoid duplicate display
   const codeStudioPanelOpen = useUIStore((s) => s.codeStudioPanelOpen);
   const codeStudioActiveSessionId = useCodeStudioStore((s) => s.activeSessionId);
-  const hasCodeStudioSessionForThis = useCodeStudioStore((s) => Boolean(s.sessions[sessionId]));
+  const codeStudioSessionIdForThis = useCodeStudioStore((s) =>
+    resolveCodeStudioSessionIdForVisualSession(s.sessions, sessionId),
+  );
+  const hasCodeStudioSessionForThis = Boolean(codeStudioSessionIdForThis);
   const delegateToCodeStudioPanel = codeStudioPanelOpen
     && hasCodeStudioSessionForThis
-    && codeStudioActiveSessionId === sessionId;
+    && codeStudioActiveSessionId === codeStudioSessionIdForThis;
 
   let renderError: string | null = null;
   let usedFallback = false;
@@ -385,7 +391,7 @@ export function VisualBlock({
           type="button"
           className="flex items-center gap-2.5 w-full rounded-xl border border-border/60 bg-surface-secondary/40 px-4 py-3 text-left text-sm text-text-secondary hover:bg-surface-secondary transition-colors"
           onClick={() => {
-            useCodeStudioStore.getState().setActiveSession(sessionId);
+            useCodeStudioStore.getState().setActiveSession(codeStudioSessionIdForThis || sessionId);
             useUIStore.getState().openCodeStudio();
           }}
         >
@@ -505,11 +511,15 @@ function VisualActionBar({
   artifactHandoffPrompt?: string;
   onSuggestedQuestion?: (prompt: string) => void;
 }) {
-  const hasCodeStudioSession = useCodeStudioStore((s) => Boolean(s.sessions[sessionId]));
+  const codeStudioSessionId = useCodeStudioStore((s) =>
+    resolveCodeStudioSessionIdForVisualSession(s.sessions, sessionId),
+  );
+  const hasCodeStudioSession = Boolean(codeStudioSessionId);
   const isStreaming = useChatStore((state) => state.isStreaming);
 
   const openInCodeStudio = () => {
-    useCodeStudioStore.getState().setActiveSession(sessionId);
+    if (!codeStudioSessionId) return;
+    useCodeStudioStore.getState().setActiveSession(codeStudioSessionId);
     useUIStore.getState().openCodeStudio();
   };
 

--- a/wiii-desktop/src/stores/code-studio-store.ts
+++ b/wiii-desktop/src/stores/code-studio-store.ts
@@ -86,6 +86,19 @@ export function buildCodeStudioActiveSessionContext(
   };
 }
 
+export function resolveCodeStudioSessionIdForVisualSession(
+  sessions: Record<string, CodeStudioSession>,
+  visualSessionId?: string | null,
+): string | null {
+  const normalized = visualSessionId?.trim();
+  if (!normalized) return null;
+  if (sessions[normalized]) return normalized;
+
+  return Object.values(sessions).find(
+    (session) => session.visualSessionId === normalized,
+  )?.sessionId ?? null;
+}
+
 interface CodeStudioState {
   activeSessionId: string | null;
   sessions: Record<string, CodeStudioSession>;


### PR DESCRIPTION
## Summary
- Add a typed Code Studio session resolver so frontend surfaces can map `visual_session_id` back to the owning code session.
- Keep Code Studio-owned visual blocks in the transcript as anchors instead of hiding them globally.
- Route VisualBlock and ToolExecutionStrip open/preview actions through the resolved code session id when backend `session_id` and `visual_session_id` differ.

## Scope
- Frontend chat display path only: `VisualBlock`, `ToolExecutionStrip`, `InterleavedBlockSequence`, and `code-studio-store`.
- Regression tests for mapped visual sessions, Code Studio card routing, and transcript anchor preservation.

## Non-Scope
- No backend SSE schema changes.
- No LMS mutation/apply flow changes.
- No generated `dist-embed` output committed.

## Verification
- `cd wiii-desktop; npx vitest run src/__tests__/code-studio-store.test.ts src/__tests__/visual-block-copy.test.tsx src/__tests__/tool-execution-strip.test.tsx src/__tests__/interleaved-block-sequence.test.tsx src/__tests__/code-studio-panel.test.tsx src/__tests__/inline-visual-frame-rendering.test.tsx src/__tests__/visual-code-studio-copy.test.ts` -> 7 files / 62 tests passed.
- `cd wiii-desktop; npx tsc --noEmit` -> passed.
- `cd wiii-desktop; npm run build:embed` -> passed; Vite reported existing large chunk / ineffective dynamic import warnings only.
- `cd wiii-desktop; npx vitest run` -> 133 files / 2506 tests passed; existing jsdom navigation log was emitted with exit code 0.
- `git diff --check` -> passed.

## Risk
- Low to medium frontend display risk. The change removes a broad hide condition and relies on VisualBlock's existing Code Studio delegation to avoid duplicate full previews when the panel is open.
- If a generated app is very large, closing the panel can show the app inline in chat; this is intentional so the transcript keeps a durable output anchor.

## Rollback
- Revert this PR to restore the previous direct session-id lookup and global Code Studio visual hiding behavior.

Closes #666