### PR TITLE
test(harness): add Understand-Anything flow map wrapper

### DIFF
--- a/.github/workflows/wiii-self-harness.yml
+++ b/.github/workflows/wiii-self-harness.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'tools/wiii_self_harness/**'
+      - 'tools/wiii_understand_harness/**'
       - 'docs/operations/WIII_SELF_HARNESS.md'
       - 'docs/operations/WIII_SYSTEM_CONTROL_PLANE.md'
       - 'docs/operations/WIII_REFERENCE_SYSTEMS_AUDIT_2026-05-25.md'
@@ -43,6 +44,7 @@ on:
     branches: [main]
     paths:
       - 'tools/wiii_self_harness/**'
+      - 'tools/wiii_understand_harness/**'
       - 'docs/operations/WIII_SELF_HARNESS.md'
       - 'docs/operations/WIII_SYSTEM_CONTROL_PLANE.md'
       - 'docs/operations/WIII_REFERENCE_SYSTEMS_AUDIT_2026-05-25.md'
@@ -104,3 +106,6 @@ jobs:
 
       - name: Run harness unit tests
         run: python -m unittest discover -s tools/wiii_self_harness -p "test_*.py"
+
+      - name: Run Understand-Anything wrapper unit tests
+        run: python -m unittest discover -s tools/wiii_understand_harness -p "test_*.py"

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ test_*.txt
 !/tools/wiii_self_harness/
 !/tools/wiii_self_harness/**
 tools/wiii_self_harness/__pycache__/
+!/tools/wiii_understand_harness/
+!/tools/wiii_understand_harness/**
+tools/wiii_understand_harness/__pycache__/
 
 # === pip install artifacts ===
 maritime-ai-service/=*

--- a/docs/operations/WIII_SELF_HARNESS.md
+++ b/docs/operations/WIII_SELF_HARNESS.md
@@ -40,7 +40,8 @@ The first scenario set covers the active product risk surface:
   describes the active flow-monitoring ladder.
 - `system-comprehension-reference-harness`: Understand-Anything remains a
   guarded, local-only comprehension reference with generated graph output
-  ignored.
+  ignored, and the repo-owned flow-map wrapper stays available for scoped
+  audits.
 - `memory-context-provenance-ledger`: Runtime Flow Ledger embeds privacy-safe
   context provenance for conversation, document, memory, and host sources.
 - `chat-baseline-acceptance-harness`: ordinary Vietnamese chat remains on the
@@ -63,6 +64,7 @@ From the repository root:
 ```powershell
 python tools/wiii_self_harness/run_wiii_self_harness.py
 python -m unittest discover -s tools/wiii_self_harness -p "test_*.py"
+python -m unittest discover -s tools/wiii_understand_harness -p "test_*.py"
 ```
 
 To list scenarios:
@@ -93,8 +95,9 @@ It fails closed when a scenario is malformed, a file disappears, or a required
 contract token no longer exists in the evidence file.
 
 The comprehension-reference scenario is intentionally static. It validates the
-adoption decision, ignore rules, and workflow triggers; it does not require
-generated `.understand-anything/` output to exist.
+adoption decision, ignore rules, wrapper files, wrapper unit tests, and workflow
+triggers; it does not require generated `.understand-anything/` output to
+exist.
 
 ## Extension Rules
 
@@ -115,10 +118,10 @@ specific contract, not merely show that a subsystem exists.
 
 ## CI
 
-`.github/workflows/wiii-self-harness.yml` runs the manifest validator and its
-unit tests when harness files, workflow files, or the covered product contracts
-change. The workflow uses only Python and does not install backend or desktop
-dependencies.
+`.github/workflows/wiii-self-harness.yml` runs the manifest validator,
+Self-Harness unit tests, and Understand-Anything wrapper unit tests when
+harness files, workflow files, or the covered product contracts change. The
+workflow uses only Python and does not install backend or desktop dependencies.
 
 ## Non-Goals
 

--- a/docs/operations/WIII_SYSTEM_CONTROL_PLANE.md
+++ b/docs/operations/WIII_SYSTEM_CONTROL_PLANE.md
@@ -61,6 +61,9 @@ As of 2026-05-25:
   supporting system-comprehension harness: `2433` tracked files, `3241`
   internal import edges, and `123` semantic batches. Generated output stays in
   ignored `.understand-anything/`.
+- `tools/wiii_understand_harness/run_wiii_understand_flow_map.py` provides
+  repo-owned scoped flow maps for chat baseline, LMS document preview,
+  visual/Code Studio, and harness governance audits.
 
 ## Control Plane Model
 
@@ -73,7 +76,7 @@ Wiii should be operated through five product layers and one governance layer:
 | Wiii Host | desktop, embed, LMS, Pointy, visual/code frames | preview missing, Pointy wrong action, visual clipped | `wiii-desktop/src/**`, LMS/host bridge modules |
 | Wiii Org | auth, membership, tenant boundaries, permissions | wrong user/org, auth loop, cross-tenant risk | `app/auth/**`, org middleware, repositories |
 | Wiii Data | PostgreSQL, pgvector, MinIO, Valkey, migrations | missing history, citations, uploads, memory, or source refs | repositories, migrations, document context paths |
-| Governance | issue/branch/PR/release/harness controls | risky or unreviewable changes keep landing | `.github/**`, `docs/operations/**`, `tools/wiii_self_harness/**` |
+| Governance | issue/branch/PR/release/harness controls | risky or unreviewable changes keep landing | `.github/**`, `docs/operations/**`, `tools/wiii_self_harness/**`, `tools/wiii_understand_harness/**` |
 
 Do not start with a code edit until the failing symptom is mapped to one of
 these layers and one active runtime flow.
@@ -136,12 +139,13 @@ The expected loop is:
 
 ## Harness Relationship
 
-Wiii currently has three harness levels:
+Wiii currently has four harness levels:
 
 | Harness | Purpose | What it proves | What it does not prove |
 |---|---|---|---|
 | Wiii Self-Harness | static contract manifest | critical evidence files and tokens still exist | runtime behavior works |
 | Understand-Anything Trial | source inventory and dependency graph | codebase size, dependency hubs, semantic batches, and scan pollution | runtime behavior, LMS safety, or product acceptance |
+| Understand-Anything Flow Map Wrapper | scoped deterministic scan/import-map profiles | selected flow files, support files, import-map stats, and dependency hotspots | runtime behavior, LMS safety, or product acceptance |
 | Local E2E Harness | browser/bootstrap smoke | local app can authenticate and reach chat UI | LMS production acceptance works |
 | Production Smoke | deployed release smoke | public health, embed, Pointy, structured visual SSE | deep document/LMS apply flow works |
 

--- a/docs/operations/WIII_UNDERSTAND_ANYTHING_REFERENCE_AUDIT_2026-05-25.md
+++ b/docs/operations/WIII_UNDERSTAND_ANYTHING_REFERENCE_AUDIT_2026-05-25.md
@@ -163,6 +163,35 @@ The highest inbound hubs match the places Wiii already feels risky:
 Future refactors touching these hubs need focused tests and an explicit
 rollback note because a small edit can affect many active flows.
 
+## Repo-Owned Wrapper
+
+Wiii now keeps a small wrapper around the deterministic Understand-Anything
+scanner and import-map extractor:
+
+```text
+tools/wiii_understand_harness/run_wiii_understand_flow_map.py
+```
+
+The wrapper exposes named flow profiles instead of asking each maintainer to
+reconstruct path lists by hand:
+
+- `chat-baseline`
+- `lms-document-preview`
+- `visual-code-studio`
+- `self-harness`
+
+Example:
+
+```powershell
+python tools/wiii_understand_harness/run_wiii_understand_flow_map.py --profile lms-document-preview
+```
+
+The wrapper writes generated scan, import input, import-map, and summary files
+under ignored `.understand-anything/tmp/`. The summary records selected files,
+support files, language/category counts, import-map stats, and top inbound and
+outbound dependency hubs. It does not run the full LLM graph workflow, does not
+enable auto-update hooks, and does not prove runtime safety.
+
 ## Adoption Decision
 
 Adopt Understand-Anything as a supporting system-comprehension harness for Wiii
@@ -198,14 +227,17 @@ Do not use it for:
   authoritative.
 - Re-run deterministic scan/import-map when a future audit touches a large
   dependency hub.
+- Keep repo-owned flow profiles in
+  `tools/wiii_understand_harness/run_wiii_understand_flow_map.py` focused on
+  active Wiii flows, not broad directory dumps.
 
 ## Follow-Up Issues
 
 Open separate issues before expanding this slice:
 
-1. Add a small repo-owned wrapper that runs the deterministic scan/import-map
-   into ignored output and prints the Wiii hotspot summary.
-   Owner: Project leadership. Target: 2026-06-05.
+1. Keep the repo-owned deterministic scan/import-map wrapper current as Wiii
+   flow ownership changes.
+   Owner: Project leadership. Target: ongoing.
 2. Decide whether a generated knowledge graph should ever be versioned, and if
    so, define size limits, privacy policy, update cadence, and review rules.
    Owner: Project leadership. Target: 2026-06-12.

--- a/tools/wiii_self_harness/wiii_self_harness_scenarios.json
+++ b/tools/wiii_self_harness/wiii_self_harness_scenarios.json
@@ -103,9 +103,11 @@
       "invariants": [
         "Understand-Anything remains a supporting comprehension reference, not a runtime dependency or test replacement.",
         "The focused audit records the inspected commit, bounded Wiii trial, dependency hubs, and adoption decision.",
+        "The repo-owned wrapper exposes scoped flow profiles for chat, LMS document preview, visual/Code Studio, and harness governance maps.",
+        "The wrapper writes generated scan, import-map, and hotspot summary output only under ignored `.understand-anything/tmp/`.",
         "Generated `.understand-anything/` graph and intermediate output stay ignored.",
         "A tracked `.understandignore` excludes generated output, local agent scratch, logs, secrets, binary assets, and build artifacts.",
-        "The Self-Harness workflow re-runs when the comprehension audit or scan guardrail changes."
+        "The Self-Harness workflow re-runs when the comprehension audit, wrapper, or scan guardrail changes."
       ],
       "evidence": [
         {
@@ -118,6 +120,36 @@
             "Dependency hubs found by import-map",
             "Windows Domain Scan Needs Guardrails",
             "Adoption Decision"
+          ]
+        },
+        {
+          "kind": "docs",
+          "path": "tools/wiii_understand_harness/README.md",
+          "must_contain": [
+            "Wiii Understand-Anything Flow Map",
+            "--profile lms-document-preview",
+            ".understand-anything/tmp/",
+            "navigation aid, not proof of runtime behavior"
+          ]
+        },
+        {
+          "kind": "runtime",
+          "path": "tools/wiii_understand_harness/run_wiii_understand_flow_map.py",
+          "must_contain": [
+            "FLOW_PROFILES",
+            "chat-baseline",
+            "lms-document-preview",
+            "visual-code-studio",
+            "llm_graph_workflow"
+          ]
+        },
+        {
+          "kind": "test",
+          "path": "tools/wiii_understand_harness/test_run_wiii_understand_flow_map.py",
+          "must_contain": [
+            "test_run_flow_map_reuses_scan_input_and_writes_ignored_outputs",
+            "test_select_profile_files_keeps_primary_and_support_separate",
+            "test_list_profiles_cli_does_not_require_reference_clone"
           ]
         },
         {
@@ -156,16 +188,19 @@
           "path": ".gitignore",
           "must_contain": [
             ".understand-anything/",
-            "**/.understand-anything/"
+            "**/.understand-anything/",
+            "tools/wiii_understand_harness"
           ]
         },
         {
           "kind": "ci",
           "path": ".github/workflows/wiii-self-harness.yml",
           "must_contain": [
+            "tools/wiii_understand_harness/**",
             "docs/operations/WIII_UNDERSTAND_ANYTHING_REFERENCE_AUDIT_*.md",
             ".understandignore",
-            "Validate scenario manifest"
+            "Validate scenario manifest",
+            "Run Understand-Anything wrapper unit tests"
           ]
         }
       ],
@@ -173,6 +208,10 @@
         {
           "command": "python tools/wiii_self_harness/run_wiii_self_harness.py",
           "purpose": "Prove the system-comprehension reference remains documented, ignored, and tied to workflow evidence."
+        },
+        {
+          "command": "python -m unittest discover -s tools/wiii_understand_harness -p \"test_*.py\"",
+          "purpose": "Prove the scoped Understand-Anything wrapper selects Wiii flow files and emits guarded summaries without requiring the reference clone in unit tests."
         }
       ]
     },

--- a/tools/wiii_understand_harness/README.md
+++ b/tools/wiii_understand_harness/README.md
@@ -1,0 +1,47 @@
+# Wiii Understand-Anything Flow Map
+
+This wrapper lets Wiii maintainers run the deterministic parts of
+Understand-Anything against a scoped Wiii flow without committing generated
+graphs or making Understand-Anything a runtime dependency.
+
+It uses the ignored local reference checkout by default:
+
+```text
+.Codex/external/reference-systems/understand-anything/understand-anything-plugin
+```
+
+Generated output is written to:
+
+```text
+.understand-anything/tmp/
+```
+
+## Commands
+
+List available flow profiles:
+
+```powershell
+python tools/wiii_understand_harness/run_wiii_understand_flow_map.py --list-profiles
+```
+
+Run the LMS document preview/apply profile:
+
+```powershell
+python tools/wiii_understand_harness/run_wiii_understand_flow_map.py --profile lms-document-preview
+```
+
+Run from an existing scan file when you only need to refresh the scoped import
+map:
+
+```powershell
+python tools/wiii_understand_harness/run_wiii_understand_flow_map.py --profile chat-baseline --scan-input .understand-anything/tmp/wiii-flow-map-chat-baseline-scan.json
+```
+
+## Guardrails
+
+- The wrapper does not run the full LLM graph workflow.
+- The wrapper does not enable Understand-Anything auto-update.
+- Output remains ignored under `.understand-anything/`.
+- The generated summary is a navigation aid, not proof of runtime behavior.
+- Runtime safety still comes from Wiii Self-Harness, focused tests, browser E2E,
+  and LMS preview/apply acceptance.

--- a/tools/wiii_understand_harness/run_wiii_understand_flow_map.py
+++ b/tools/wiii_understand_harness/run_wiii_understand_flow_map.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Run a scoped deterministic Understand-Anything flow map for Wiii.
+
+The script is intentionally a thin wrapper around the reference project's
+deterministic scanner and import-map extractor. It keeps generated output in
+ignored local scratch and produces a small JSON summary that points maintainers
+at import hubs before they edit a Wiii flow.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+import json
+from pathlib import Path, PurePosixPath
+import subprocess
+import sys
+from typing import Any, Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / ".understand-anything" / "tmp"
+DEFAULT_PLUGIN_ROOT = (
+    REPO_ROOT
+    / ".Codex"
+    / "external"
+    / "reference-systems"
+    / "understand-anything"
+    / "understand-anything-plugin"
+)
+DEFAULT_SUPPORT_PATTERNS = (
+    "package.json",
+    "pyproject.toml",
+    "maritime-ai-service/pyproject.toml",
+    "wiii-desktop/package.json",
+    "wiii-desktop/tsconfig.json",
+    "wiii-desktop/tsconfig.*.json",
+    "wiii-desktop/vite.config.ts",
+    "wiii-desktop/vitest.config.ts",
+)
+
+
+@dataclass(frozen=True)
+class FlowProfile:
+    description: str
+    include: tuple[str, ...]
+    support: tuple[str, ...] = DEFAULT_SUPPORT_PATTERNS
+
+
+@dataclass(frozen=True)
+class SelectedFiles:
+    primary: tuple[dict[str, Any], ...]
+    support: tuple[dict[str, Any], ...]
+
+    @property
+    def all(self) -> tuple[dict[str, Any], ...]:
+        return self.primary + self.support
+
+
+FLOW_PROFILES: dict[str, FlowProfile] = {
+    "chat-baseline": FlowProfile(
+        description="Ordinary chat stream, runtime ledger, frontend stream assembly, and no-tool baseline checks.",
+        include=(
+            "docs/operations/WIII_OPENCLAW_REFERENCE_AUDIT_2026-05-25.md",
+            "docs/operations/WIII_SYSTEM_CONTROL_PLANE.md",
+            "maritime-ai-service/app/api/v1/chat_stream_presenter.py",
+            "maritime-ai-service/app/services/chat_stream_coordinator.py",
+            "maritime-ai-service/app/services/llm_runtime_audit_service.py",
+            "maritime-ai-service/app/services/llm_selectability_service.py",
+            "maritime-ai-service/app/engine/multi_agent/runtime_flow_ledger.py",
+            "maritime-ai-service/tests/unit/test_chat_baseline_acceptance_harness.py",
+            "wiii-desktop/src/hooks/useSSEStream.ts",
+            "wiii-desktop/src/stores/chat-store.ts",
+            "wiii-desktop/src/components/chat/*.tsx",
+            "wiii-desktop/src/components/chat/**/*.tsx",
+        ),
+    ),
+    "lms-document-preview": FlowProfile(
+        description="Uploaded document to LMS lesson preview/apply contract, host actions, source refs, and approval token path.",
+        include=(
+            "docs/integration/WIII_LMS_DOC_TO_COURSE_CONTRACT.md",
+            "maritime-ai-service/app/api/v1/host_actions.py",
+            "maritime-ai-service/app/engine/context/host_action_audit.py",
+            "maritime-ai-service/app/engine/multi_agent/document_preview_contract.py",
+            "maritime-ai-service/app/engine/multi_agent/direct_document_*.py",
+            "maritime-ai-service/app/engine/multi_agent/direct_node_document_preview_runtime.py",
+            "maritime-ai-service/app/engine/multi_agent/direct_tool_rounds_runtime.py",
+            "maritime-ai-service/app/engine/multi_agent/document_course_*.py",
+            "maritime-ai-service/tests/unit/test_*document*preview*.py",
+            "maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py",
+            "maritime-ai-service/tests/unit/test_host_action_audit.py",
+            "maritime-ai-service/tests/unit/test_sprint222b_host_action_event.py",
+            "wiii-desktop/src/components/layout/PreviewPanel.tsx",
+            "wiii-desktop/src/hooks/useSSEStream.ts",
+            "wiii-desktop/src/__tests__/preview-panel-ui.test.tsx",
+            "wiii-desktop/src/__tests__/host-action-sse.test.ts",
+        ),
+    ),
+    "visual-code-studio": FlowProfile(
+        description="Visual intent, tool capability sync, Code Studio tool rounds, and frontend visual shell.",
+        include=(
+            "maritime-ai-service/app/engine/multi_agent/visual_intent_*.py",
+            "maritime-ai-service/app/engine/multi_agent/visual_runtime_metadata_contract.py",
+            "maritime-ai-service/app/engine/multi_agent/tool_collection.py",
+            "maritime-ai-service/app/engine/multi_agent/code_studio_*.py",
+            "maritime-ai-service/app/engine/tools/visual_*contract.py",
+            "maritime-ai-service/app/engine/tools/code_studio_app_intent_contract.py",
+            "maritime-ai-service/tests/unit/test_visual_intent*.py",
+            "maritime-ai-service/tests/unit/test_code_studio*.py",
+            "wiii-desktop/src/components/chat/VisualBlock.tsx",
+            "wiii-desktop/src/components/layout/CodeStudioPanel.tsx",
+            "wiii-desktop/src/components/common/InlineVisualFrame.tsx",
+            "wiii-desktop/src/lib/visual-frame-*.ts",
+            "wiii-desktop/src/__tests__/*visual*.test.tsx",
+            "wiii-desktop/src/__tests__/*code-studio*.test.tsx",
+        ),
+    ),
+    "self-harness": FlowProfile(
+        description="Wiii operating docs, Self-Harness manifest, workflow, and Understand-Anything guardrails.",
+        include=(
+            ".github/workflows/wiii-self-harness.yml",
+            ".gitignore",
+            ".understandignore",
+            "docs/operations/WIII_SELF_HARNESS.md",
+            "docs/operations/WIII_SYSTEM_CONTROL_PLANE.md",
+            "docs/operations/WIII_REFERENCE_SYSTEMS_AUDIT_2026-05-25.md",
+            "docs/operations/WIII_UNDERSTAND_ANYTHING_REFERENCE_AUDIT_2026-05-25.md",
+            "tools/wiii_self_harness/*.py",
+            "tools/wiii_self_harness/*.json",
+            "tools/wiii_understand_harness/*.py",
+            "tools/wiii_understand_harness/*.md",
+        ),
+    ),
+}
+
+
+def _to_posix(path: str | Path) -> str:
+    return str(path).replace("\\", "/")
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return _to_posix(resolved.relative_to(REPO_ROOT))
+    except ValueError:
+        return _to_posix(resolved)
+
+
+def _matches(path: str, patterns: Iterable[str]) -> bool:
+    posix = PurePosixPath(path)
+    return any(posix.match(pattern) for pattern in patterns)
+
+
+def _unique_by_path(files: Iterable[dict[str, Any]]) -> tuple[dict[str, Any], ...]:
+    seen: set[str] = set()
+    selected: list[dict[str, Any]] = []
+    for item in files:
+        path = str(item.get("path") or "")
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        selected.append(item)
+    return tuple(selected)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, ensure_ascii=False, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def select_profile_files(scan_result: dict[str, Any], profile: FlowProfile) -> SelectedFiles:
+    files = scan_result.get("files")
+    if not isinstance(files, list):
+        raise ValueError("scan result must contain a `files` list")
+
+    primary = _unique_by_path(
+        item
+        for item in files
+        if isinstance(item, dict) and _matches(str(item.get("path") or ""), profile.include)
+    )
+    if not primary:
+        raise ValueError("profile selected no primary files; check include patterns or scan input")
+
+    primary_paths = {str(item.get("path") or "") for item in primary}
+    support = _unique_by_path(
+        item
+        for item in files
+        if (
+            isinstance(item, dict)
+            and str(item.get("path") or "") not in primary_paths
+            and _matches(str(item.get("path") or ""), profile.support)
+        )
+    )
+    return SelectedFiles(primary=primary, support=support)
+
+
+def _counter_for(files: Iterable[dict[str, Any]], field: str) -> dict[str, int]:
+    counter: Counter[str] = Counter()
+    for item in files:
+        value = item.get(field)
+        if isinstance(value, str) and value:
+            counter[value] += 1
+    return dict(sorted(counter.items(), key=lambda pair: (-pair[1], pair[0])))
+
+
+def _top_outbound(import_map: dict[str, Any], limit: int) -> list[dict[str, Any]]:
+    rows = []
+    for source, targets in import_map.items():
+        if not isinstance(targets, list):
+            continue
+        rows.append({"path": source, "edge_count": len(targets)})
+    rows.sort(key=lambda row: (-int(row["edge_count"]), str(row["path"])))
+    return rows[:limit]
+
+
+def _top_inbound(import_map: dict[str, Any], limit: int) -> list[dict[str, Any]]:
+    inbound: defaultdict[str, set[str]] = defaultdict(set)
+    for source, targets in import_map.items():
+        if not isinstance(targets, list):
+            continue
+        for target in targets:
+            if isinstance(target, str) and target:
+                inbound[target].add(source)
+    rows = [{"path": path, "edge_count": len(sources)} for path, sources in inbound.items()]
+    rows.sort(key=lambda row: (-int(row["edge_count"]), str(row["path"])))
+    return rows[:limit]
+
+
+def build_import_input(repo_root: Path, selected: SelectedFiles) -> dict[str, Any]:
+    return {
+        "projectRoot": str(repo_root.resolve()),
+        "files": list(selected.all),
+    }
+
+
+def build_summary(
+    *,
+    profile_name: str,
+    profile: FlowProfile,
+    scan_result: dict[str, Any],
+    selected: SelectedFiles,
+    import_output: dict[str, Any],
+    scan_path: Path,
+    import_input_path: Path,
+    import_output_path: Path,
+) -> dict[str, Any]:
+    import_map_raw = import_output.get("importMap", {})
+    import_map = import_map_raw if isinstance(import_map_raw, dict) else {}
+    stats = scan_result.get("stats", {})
+    return {
+        "profile": profile_name,
+        "description": profile.description,
+        "guardrails": {
+            "runtime_dependency": False,
+            "llm_graph_workflow": False,
+            "output_directory": ".understand-anything/tmp",
+            "raw_uploaded_documents_included": False,
+        },
+        "scan": {
+            "path": _display_path(scan_path),
+            "total_files": scan_result.get("totalFiles"),
+            "estimated_complexity": scan_result.get("estimatedComplexity"),
+            "stats": stats if isinstance(stats, dict) else {},
+        },
+        "selection": {
+            "primary_file_count": len(selected.primary),
+            "support_file_count": len(selected.support),
+            "total_file_count": len(selected.all),
+            "by_language": _counter_for(selected.all, "language"),
+            "by_category": _counter_for(selected.all, "fileCategory"),
+            "primary_files": [str(item.get("path")) for item in selected.primary],
+            "support_files": [str(item.get("path")) for item in selected.support],
+        },
+        "import_map": {
+            "input_path": _display_path(import_input_path),
+            "output_path": _display_path(import_output_path),
+            "stats": import_output.get("stats", {}),
+            "top_outbound": _top_outbound(import_map, limit=10),
+            "top_inbound": _top_inbound(import_map, limit=10),
+        },
+    }
+
+
+def validate_plugin_root(plugin_root: Path) -> tuple[Path, Path]:
+    skill_dir = plugin_root / "skills" / "understand"
+    scan_script = skill_dir / "scan-project.mjs"
+    import_script = skill_dir / "extract-import-map.mjs"
+    missing = [str(path) for path in (scan_script, import_script) if not path.is_file()]
+    if missing:
+        joined = "\n  - ".join(missing)
+        raise FileNotFoundError(
+            "Understand-Anything deterministic scripts were not found. "
+            "Clone the reference project into .Codex/external/reference-systems "
+            "or pass --plugin-root.\nMissing:\n  - "
+            + joined
+        )
+    return scan_script, import_script
+
+
+def run_command(args: list[str], *, cwd: Path, verbose: bool) -> None:
+    result = subprocess.run(args, cwd=str(cwd), text=True, capture_output=True, check=False)
+    if verbose and result.stdout:
+        sys.stdout.write(result.stdout)
+    if verbose and result.stderr:
+        sys.stderr.write(result.stderr)
+    if result.returncode == 0:
+        return
+    stderr_tail = "\n".join(result.stderr.splitlines()[-20:])
+    raise RuntimeError(
+        "Command failed with exit code "
+        f"{result.returncode}: {' '.join(args)}\n{stderr_tail}"
+    )
+
+
+def run_flow_map(
+    *,
+    profile_name: str,
+    plugin_root: Path,
+    output_dir: Path,
+    scan_input: Path | None,
+    verbose: bool,
+) -> dict[str, Any]:
+    if profile_name not in FLOW_PROFILES:
+        raise ValueError(f"unknown profile {profile_name!r}")
+    profile = FLOW_PROFILES[profile_name]
+    scan_script, import_script = validate_plugin_root(plugin_root.resolve())
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    prefix = f"wiii-flow-map-{profile_name}"
+    scan_path = output_dir / f"{prefix}-scan.json"
+    import_input_path = output_dir / f"{prefix}-import-input.json"
+    import_output_path = output_dir / f"{prefix}-import-map.json"
+    summary_path = output_dir / f"{prefix}-summary.json"
+
+    if scan_input is None:
+        run_command(
+            ["node", str(scan_script), str(REPO_ROOT), str(scan_path)],
+            cwd=REPO_ROOT,
+            verbose=verbose,
+        )
+    else:
+        scan_path = scan_input.resolve()
+
+    scan_result = load_json(scan_path)
+    selected = select_profile_files(scan_result, profile)
+    write_json(import_input_path, build_import_input(REPO_ROOT, selected))
+    run_command(
+        ["node", str(import_script), str(import_input_path), str(import_output_path)],
+        cwd=REPO_ROOT,
+        verbose=verbose,
+    )
+    import_output = load_json(import_output_path)
+    summary = build_summary(
+        profile_name=profile_name,
+        profile=profile,
+        scan_result=scan_result,
+        selected=selected,
+        import_output=import_output,
+        scan_path=scan_path,
+        import_input_path=import_input_path,
+        import_output_path=import_output_path,
+    )
+    write_json(summary_path, summary)
+    summary["summary_path"] = _display_path(summary_path)
+    return summary
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile",
+        default="chat-baseline",
+        choices=sorted(FLOW_PROFILES),
+        help="Scoped Wiii flow profile to map.",
+    )
+    parser.add_argument(
+        "--plugin-root",
+        type=Path,
+        default=DEFAULT_PLUGIN_ROOT,
+        help="Path to understand-anything-plugin.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Ignored output directory for generated scan/import-map files.",
+    )
+    parser.add_argument(
+        "--scan-input",
+        type=Path,
+        help="Existing scan-project JSON to reuse instead of running a fresh scan.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print the summary JSON to stdout.")
+    parser.add_argument("--verbose", action="store_true", help="Print wrapped Node command output.")
+    parser.add_argument("--list-profiles", action="store_true", help="List flow profiles and exit.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.list_profiles:
+        for name, profile in sorted(FLOW_PROFILES.items()):
+            print(f"{name}: {profile.description}")
+        return 0
+
+    try:
+        summary = run_flow_map(
+            profile_name=args.profile,
+            plugin_root=args.plugin_root,
+            output_dir=args.output_dir,
+            scan_input=args.scan_input,
+            verbose=args.verbose,
+        )
+    except Exception as exc:  # pragma: no cover - CLI boundary.
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        selection = summary["selection"]
+        import_stats = summary["import_map"].get("stats") or {}
+        print(
+            "Wiii Understand-Anything flow map complete: "
+            f"profile={summary['profile']} "
+            f"files={selection['total_file_count']} "
+            f"edges={import_stats.get('totalEdges', 0)} "
+            f"summary={summary['summary_path']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/wiii_understand_harness/test_run_wiii_understand_flow_map.py
+++ b/tools/wiii_understand_harness/test_run_wiii_understand_flow_map.py
@@ -1,0 +1,139 @@
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+import run_wiii_understand_flow_map as flow_map
+
+
+def _file(path: str, language: str = "python", category: str = "code") -> dict:
+    return {"path": path, "language": language, "fileCategory": category, "sizeLines": 10}
+
+
+class WiiiUnderstandFlowMapTests(unittest.TestCase):
+    def test_select_profile_files_keeps_primary_and_support_separate(self) -> None:
+        scan = {
+            "files": [
+                _file("maritime-ai-service/app/services/chat_stream_coordinator.py"),
+                _file("wiii-desktop/tsconfig.json", "json", "config"),
+                _file("docs/operations/unrelated.md", "markdown", "docs"),
+            ]
+        }
+
+        selected = flow_map.select_profile_files(scan, flow_map.FLOW_PROFILES["chat-baseline"])
+
+        self.assertEqual(
+            ["maritime-ai-service/app/services/chat_stream_coordinator.py"],
+            [item["path"] for item in selected.primary],
+        )
+        self.assertEqual(["wiii-desktop/tsconfig.json"], [item["path"] for item in selected.support])
+
+    def test_select_profile_files_fails_when_profile_has_no_primary_match(self) -> None:
+        scan = {"files": [_file("docs/operations/unrelated.md", "markdown", "docs")]}
+
+        with self.assertRaisesRegex(ValueError, "selected no primary"):
+            flow_map.select_profile_files(scan, flow_map.FLOW_PROFILES["lms-document-preview"])
+
+    def test_build_summary_reports_guardrails_and_import_hubs(self) -> None:
+        scan = {
+            "totalFiles": 3,
+            "estimatedComplexity": "small",
+            "stats": {"filesScanned": 3},
+            "files": [
+                _file("a.py"),
+                _file("b.py"),
+                _file("pyproject.toml", "toml", "config"),
+            ],
+        }
+        selected = flow_map.SelectedFiles(
+            primary=(_file("a.py"), _file("b.py")),
+            support=(_file("pyproject.toml", "toml", "config"),),
+        )
+        import_output = {
+            "stats": {"filesScanned": 3, "filesWithImports": 2, "totalEdges": 2},
+            "importMap": {"a.py": ["b.py"], "b.py": ["a.py"]},
+        }
+
+        summary = flow_map.build_summary(
+            profile_name="sample",
+            profile=flow_map.FlowProfile(description="sample", include=("*.py",)),
+            scan_result=scan,
+            selected=selected,
+            import_output=import_output,
+            scan_path=flow_map.REPO_ROOT / ".understand-anything/tmp/scan.json",
+            import_input_path=flow_map.REPO_ROOT / ".understand-anything/tmp/input.json",
+            import_output_path=flow_map.REPO_ROOT / ".understand-anything/tmp/import.json",
+        )
+
+        self.assertFalse(summary["guardrails"]["runtime_dependency"])
+        self.assertFalse(summary["guardrails"]["llm_graph_workflow"])
+        self.assertEqual(3, summary["selection"]["total_file_count"])
+        self.assertEqual("a.py", summary["import_map"]["top_outbound"][0]["path"])
+        self.assertEqual(1, summary["import_map"]["top_inbound"][0]["edge_count"])
+
+    def test_run_flow_map_reuses_scan_input_and_writes_ignored_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = Path(temp_dir)
+            plugin_root = temp / "plugin"
+            skill_dir = plugin_root / "skills" / "understand"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "scan-project.mjs").write_text("// fake", encoding="utf-8")
+            (skill_dir / "extract-import-map.mjs").write_text("// fake", encoding="utf-8")
+            scan_input = temp / "scan.json"
+            scan_input.write_text(
+                json.dumps(
+                    {
+                        "totalFiles": 2,
+                        "estimatedComplexity": "small",
+                        "stats": {"filesScanned": 2},
+                        "files": [
+                            _file("maritime-ai-service/app/services/chat_stream_coordinator.py"),
+                            _file("wiii-desktop/tsconfig.json", "json", "config"),
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            def fake_run(args: list[str], *, cwd: Path, verbose: bool) -> None:
+                output_path = Path(args[-1])
+                output_path.write_text(
+                    json.dumps(
+                        {
+                            "scriptCompleted": True,
+                            "stats": {"filesScanned": 2, "filesWithImports": 1, "totalEdges": 1},
+                            "importMap": {
+                                "maritime-ai-service/app/services/chat_stream_coordinator.py": [
+                                    "wiii-desktop/tsconfig.json"
+                                ]
+                            },
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+
+            with mock.patch.object(flow_map, "run_command", side_effect=fake_run):
+                summary = flow_map.run_flow_map(
+                    profile_name="chat-baseline",
+                    plugin_root=plugin_root,
+                    output_dir=temp / "out",
+                    scan_input=scan_input,
+                    verbose=False,
+                )
+
+        self.assertEqual("chat-baseline", summary["profile"])
+        self.assertEqual(2, summary["selection"]["total_file_count"])
+        self.assertTrue(summary["summary_path"].endswith("wiii-flow-map-chat-baseline-summary.json"))
+
+    def test_list_profiles_cli_does_not_require_reference_clone(self) -> None:
+        with mock.patch("sys.stdout") as stdout:
+            result = flow_map.main(["--list-profiles"])
+
+        self.assertEqual(0, result)
+        written = "".join(call.args[0] for call in stdout.write.call_args_list if call.args)
+        self.assertIn("chat-baseline", written)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a repo-owned `tools/wiii_understand_harness` wrapper for deterministic Understand-Anything scan/import-map runs.
- Defines scoped Wiii flow profiles for `chat-baseline`, `lms-document-preview`, `visual-code-studio`, and `self-harness`.
- Wires the wrapper into Self-Harness evidence, docs, `.gitignore`, and the Self-Harness GitHub Actions workflow.

Refs #397.

## Scope
- Tooling/docs/harness only.
- Generated output remains under ignored `.understand-anything/tmp/`.
- Unit tests cover profile selection, summary guardrails, scan-input reuse, and clone-free profile listing.

## Non-Scope
- No Wiii runtime behavior changes.
- No LMS mutation or production deploy.
- No generated Understand-Anything graph or scan output committed.
- No vendoring of Understand-Anything source.

## Verification
- `python -m unittest discover -s tools\wiii_understand_harness -p test_*.py` -> 5 passed.
- `python tools\wiii_self_harness\run_wiii_self_harness.py` -> PASS, 9 scenarios, 46 evidence files, 547 checks.
- `python -m unittest discover -s tools\wiii_self_harness -p test_*.py` -> 5 passed.
- `python -m py_compile tools\wiii_understand_harness\run_wiii_understand_flow_map.py tools\wiii_understand_harness\test_run_wiii_understand_flow_map.py` -> passed.
- `python tools\wiii_understand_harness\run_wiii_understand_flow_map.py --profile lms-document-preview --verbose` -> profile complete, 31 files, 31 edges, scan filesScanned=2433.
- `python tools\wiii_understand_harness\run_wiii_understand_flow_map.py --profile chat-baseline --scan-input .understand-anything\tmp\wiii-flow-map-lms-document-preview-scan.json` -> 64 files, 56 edges.
- `python tools\wiii_understand_harness\run_wiii_understand_flow_map.py --profile visual-code-studio --scan-input .understand-anything\tmp\wiii-flow-map-lms-document-preview-scan.json` -> 61 files, 64 edges.
- `python tools\wiii_understand_harness\run_wiii_understand_flow_map.py --profile self-harness --scan-input .understand-anything\tmp\wiii-flow-map-lms-document-preview-scan.json` -> 18 files, 2 edges.
- `git diff --check` -> passed.

## Risk
- Low runtime risk: this is not imported by backend, desktop, or production paths.
- Main risk is governance/tooling drift if profile path patterns go stale; Self-Harness now checks the wrapper docs, script, tests, and workflow path.
- Generated `.understand-anything/` and `.Codex/` artifacts were verified ignored and not staged.

## Rollback
- Revert this PR. Runtime behavior and production deploy state are unaffected.

## Reviewer Focus
- Confirm the wrapper does not make Understand-Anything a runtime dependency.
- Confirm generated outputs stay ignored and profile summaries are framed as navigation aids, not acceptance evidence.
- Confirm workflow coverage is scoped and does not install backend/frontend dependencies.