### PR TITLE
test(desktop): add browser chat-baseline acceptance harness

### DIFF
--- a/docs/operations/WIII_LOCAL_E2E_HARNESS.md
+++ b/docs/operations/WIII_LOCAL_E2E_HARNESS.md
@@ -4,14 +4,15 @@ Status: Active
 
 Owner: Project leadership
 
-Last updated: 2026-05-24
+Last updated: 2026-05-26
 
 ## Purpose
 
 The local E2E harness exists to prove that Wiii can enter the real chat UI on
-localhost before longer visual, Code Studio, LMS, or voice scenarios run. A
-test failure should say whether auth/bootstrap is broken or whether the product
-runtime under test is broken.
+localhost and complete a deterministic browser chat baseline before longer
+visual, Code Studio, LMS, or voice scenarios run. A test failure should say
+whether auth/bootstrap, browser stream assembly, or the product runtime under
+test is broken.
 
 ## Contract
 
@@ -45,6 +46,32 @@ $env:WIII_PLAYWRIGHT_BASE_URL="http://127.0.0.1:1430"
 npx playwright test -c playwright.visual.config.ts playwright/local-chat-harness.spec.ts
 ```
 
+## Chat Baseline Acceptance Command
+
+```bash
+cd wiii-desktop
+npx playwright test -c playwright.visual.config.ts playwright/chat-baseline-acceptance.spec.ts
+```
+
+This test uses the real browser UI, dev-login bootstrap, chat composer,
+frontend SSE parser, stream buffers, Markdown renderer, and chat persistence.
+It mocks only the `/api/v1/chat/stream/v3` SSE response at the Playwright
+network boundary so the acceptance signal is deterministic and does not require
+provider keys, production, or full Docker.
+
+The required evidence is:
+
+- ordinary Vietnamese prompts are submitted through `[data-wiii-id="chat-textarea"]`
+- final assistant answers render in `[data-message-role="assistant"]`
+- Markdown code renders as a chat code block, not Code Studio
+- stream events include `status`, `answer`, `metadata`, and terminal `done`
+- terminal `runtime_flow_ledger` says `host_surface=desktop_chat`,
+  `route.lane=native_turn`, no observed tools, host/Pointy/visual/Code Studio
+  suppressed, and `finalization.status=saved`
+- visible and persisted answers contain no raw provider/tool payload markers
+- no host action preview, Pointy spotlight/action surface, visual block, or
+  Code Studio surface appears
+
 ## Visual Runtime Command
 
 ```bash
@@ -52,17 +79,19 @@ cd wiii-desktop
 npx playwright test -c playwright.visual.config.ts
 ```
 
-This runs the lightweight auth harness first, then the visual runtime and Code
-Studio runtime specs.
+This runs the chat baseline acceptance, lightweight auth harness, visual
+runtime, and Code Studio runtime specs.
 
 ## Expected Evidence
 
 - `local-chat-harness.spec.ts` reaches `[data-wiii-id="chat-textarea"]`.
+- `chat-baseline-acceptance.spec.ts` sends real UI prompts and proves
+  prompt-to-answer browser assembly with a deterministic SSE baseline.
 - Login screen text is absent after bootstrap.
 - Backend `/api/v1/auth/dev-login/status` reports enabled for the local test
   server.
 - If a test stops at login, treat it as harness/auth failure before debugging
-  visual runtime.
+  chat, visual runtime, or Code Studio behavior.
 
 ## Rollback
 

--- a/wiii-desktop/playwright.visual.config.ts
+++ b/wiii-desktop/playwright.visual.config.ts
@@ -10,6 +10,7 @@ const backendURL =
 export default defineConfig({
   testDir: "./playwright",
   testMatch: [
+    "chat-baseline-acceptance.spec.ts",
     "local-chat-harness.spec.ts",
     "visual-runtime.spec.ts",
     "code-studio-runtime.spec.ts",

--- a/wiii-desktop/playwright/chat-baseline-acceptance.spec.ts
+++ b/wiii-desktop/playwright/chat-baseline-acceptance.spec.ts
@@ -1,0 +1,215 @@
+import { expect, test, type Page } from "@playwright/test";
+import {
+  assistantMessages,
+  bootstrapLocalChat,
+  expectNoBaselineToolSurfaces,
+  expectNoRawChatBaselinePayload,
+  installChatBaselineStreamMock,
+  lastAssistantMessage,
+  readPersistedAssistantMessages,
+  sendPrompt,
+  waitForObservedChatBaselineStream,
+  waitForGenerationToSettle,
+  type ChatBaselineScenario,
+  type ChatBaselineTurnCapture,
+  type ObservedChatBaselineStream,
+} from "./support/local-chat-harness";
+
+const CHAT_BASELINE_SCENARIOS: ChatBaselineScenario[] = [
+  {
+    id: "vietnamese-greeting",
+    prompt: "xin chào Wiii, hôm nay bạn thế nào?",
+    answerChunks: [
+      "Chào bạn, mình vẫn ở đây ",
+      "và sẵn sàng cùng bạn làm tiếp.",
+    ],
+    expectedText: "Chào bạn, mình vẫn ở đây",
+  },
+  {
+    id: "simple-factual-chat",
+    prompt: "giải thích ngắn gọn sự khác nhau giữa API và SDK",
+    answerChunks: [
+      "API là giao diện để phần mềm gọi nhau; ",
+      "SDK là bộ công cụ giúp lập trình viên dùng API đó dễ hơn.",
+    ],
+    expectedText: "API là giao diện để phần mềm gọi nhau",
+  },
+  {
+    id: "inline-code-explanation",
+    prompt: "cho mình ví dụ nhỏ về Promise trong JavaScript",
+    answerChunks: [
+      "Ví dụ nhỏ:\n\n```javascript\n",
+      "Promise.resolve('x').then(console.log);\n",
+      "```\n\nPromise giữ kết quả bất đồng bộ và gọi `.then` khi hoàn tất.",
+    ],
+    expectedText: "Promise.resolve",
+    expectCodeBlock: true,
+  },
+];
+
+const DISALLOWED_BASELINE_EVENTS = [
+  "host_action",
+  "pointy_action",
+  "visual",
+  "visual_open",
+  "visual_patch",
+  "visual_commit",
+  "code_open",
+  "code_delta",
+  "code_complete",
+  "tool_call",
+  "tool_result",
+];
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? value as Record<string, unknown> : {};
+}
+
+function nestedRecord(
+  value: Record<string, unknown> | undefined,
+  key: string,
+): Record<string, unknown> {
+  return asRecord(value?.[key]);
+}
+
+function eventTypes(stream: ObservedChatBaselineStream): string[] {
+  return stream.events.map((event) => event.type);
+}
+
+function expectSafeRequestShape(capture: ChatBaselineTurnCapture, scenario: ChatBaselineScenario) {
+  expect(capture.request.message).toBe(scenario.prompt);
+  expect(capture.request.pointy_mode).toBe(false);
+  expect(capture.request.force_skills).toBeUndefined();
+  expect(capture.request.images).toBeUndefined();
+
+  const userContext = asRecord(capture.request.user_context);
+  expect(userContext.document_context).toBeUndefined();
+  expect(userContext.host_action_feedback).toBeUndefined();
+  expect(userContext.visual_context).toBeUndefined();
+  expect(userContext.code_studio_context).toBeUndefined();
+}
+
+function expectSafeLedger(ledger: Record<string, unknown> | undefined) {
+  expect(ledger).toBeTruthy();
+
+  const request = nestedRecord(ledger, "request");
+  expect(request.host_surface).toBe("desktop_chat");
+  expect(request.host_capabilities).toEqual([]);
+
+  const context = nestedRecord(ledger, "context");
+  expect(context.document_context_present).toBe(false);
+  expect(context.uploaded_document_count).toBe(0);
+  expect(context.source_ref_count).toBe(0);
+
+  const route = nestedRecord(ledger, "route");
+  expect(route.lane).toBe("native_turn");
+
+  const tools = nestedRecord(ledger, "tools");
+  expect(tools.observed).toEqual([]);
+  expect(tools.suppressed).toEqual(expect.arrayContaining([
+    "host_action",
+    "pointy_action",
+    "visual_runtime",
+    "code_studio",
+  ]));
+
+  const hostActions = nestedRecord(ledger, "host_actions");
+  expect(hostActions.preview_required).toBe(false);
+  expect(hostActions.preview_emitted).toBe(false);
+  expect(hostActions.approval_token_present).toBe(false);
+  expect(hostActions.apply_attempted).toBe(false);
+}
+
+function expectTerminalLedger(ledger: Record<string, unknown> | undefined) {
+  expectSafeLedger(ledger);
+  const stream = nestedRecord(ledger, "stream");
+  expect(stream.metadata_seen).toBe(true);
+  expect(stream.done_seen).toBe(true);
+  expect(stream.event_sequence_tail).toEqual(expect.arrayContaining(["metadata", "done"]));
+
+  const finalization = nestedRecord(ledger, "finalization");
+  expect(finalization.status).toBe("saved");
+  expect(finalization.save_response_immediately).toBe(false);
+}
+
+function terminalLedgerFrom(stream: ObservedChatBaselineStream): Record<string, unknown> | undefined {
+  const ledger = stream.events.find((event) => event.type === "done")?.data?.runtime_flow_ledger;
+  return ledger && typeof ledger === "object" ? ledger as Record<string, unknown> : undefined;
+}
+
+async function latestPersistedAssistant(
+  page: Page,
+  userId: string,
+  minimumCount: number,
+) {
+  await expect
+    .poll(
+      async () => (await readPersistedAssistantMessages(page, userId)).length,
+      { timeout: 30_000, intervals: [250, 500, 1_000] },
+    )
+    .toBeGreaterThanOrEqual(minimumCount);
+
+  const messages = await readPersistedAssistantMessages(page, userId);
+  return messages[messages.length - 1];
+}
+
+test.describe("browser chat-baseline acceptance", () => {
+  test("sends ordinary Vietnamese prompts through the UI and keeps the no-tool chat lane", async ({ page }) => {
+    const streamMock = await installChatBaselineStreamMock(page, CHAT_BASELINE_SCENARIOS);
+    const bootstrap = await bootstrapLocalChat(page, {
+      userId: `browser-chat-baseline-${Date.now()}`,
+      displayName: "Browser Chat Baseline",
+    });
+
+    expect(bootstrap.authenticatedBy).toBe("dev-login-api");
+    await expect(assistantMessages(page)).toHaveCount(0);
+
+    for (let index = 0; index < CHAT_BASELINE_SCENARIOS.length; index += 1) {
+      const scenario = CHAT_BASELINE_SCENARIOS[index];
+      const previousCaptureCount = streamMock.captures.length;
+
+      await sendPrompt(page, scenario.prompt);
+      await expect
+        .poll(() => streamMock.captures.length, {
+          timeout: 30_000,
+          intervals: [250, 500, 1_000],
+        })
+        .toBe(previousCaptureCount + 1);
+      await waitForGenerationToSettle(page);
+
+      const capture = streamMock.captures[streamMock.captures.length - 1];
+      expect(capture.scenarioId).toBe(scenario.id);
+      expectSafeRequestShape(capture, scenario);
+
+      const observedStream = await waitForObservedChatBaselineStream(page, index);
+      expect(observedStream.status).toBe(200);
+
+      const observedEvents = eventTypes(observedStream);
+      expect(observedEvents).toEqual(expect.arrayContaining(["status", "answer", "metadata", "done"]));
+      expect(observedEvents[observedEvents.length - 1]).toBe("done");
+      for (const eventType of DISALLOWED_BASELINE_EVENTS) {
+        expect(observedEvents).not.toContain(eventType);
+      }
+
+      const assistant = lastAssistantMessage(page);
+      await expect(assistant).toContainText(scenario.expectedText, { timeout: 30_000 });
+      if (scenario.expectCodeBlock) {
+        await expect(assistant.locator("pre code").first()).toContainText("Promise.resolve", {
+          timeout: 30_000,
+        });
+      }
+
+      const visibleText = await assistant.innerText();
+      expectNoRawChatBaselinePayload(visibleText);
+      await expectNoBaselineToolSurfaces(page);
+
+      const terminalLedger = terminalLedgerFrom(observedStream);
+      expectTerminalLedger(terminalLedger);
+
+      const persisted = await latestPersistedAssistant(page, bootstrap.userId, index + 1);
+      expect(persisted.content).toContain(scenario.expectedText);
+      expectNoRawChatBaselinePayload(persisted.content || "");
+      expectSafeLedger(asRecord(persisted.metadata?.runtime_flow_ledger));
+    }
+  });
+});

--- a/wiii-desktop/playwright/support/local-chat-harness.ts
+++ b/wiii-desktop/playwright/support/local-chat-harness.ts
@@ -13,6 +13,59 @@ type BootstrapResult = {
   authenticatedBy: "dev-login-api";
 };
 
+export type ChatBaselineScenario = {
+  id: string;
+  prompt: string;
+  answerChunks: string[];
+  expectedText: string;
+  expectCodeBlock?: boolean;
+};
+
+export type ChatBaselineTurnCapture = {
+  scenarioId: string;
+  request: Record<string, unknown>;
+};
+
+export type ObservedChatBaselineEvent = {
+  id: string | null;
+  type: string;
+  data: Record<string, unknown> | null;
+  rawData: string;
+};
+
+export type ObservedChatBaselineStream = {
+  url: string;
+  status: number;
+  events: ObservedChatBaselineEvent[];
+  done: boolean;
+  error?: string;
+};
+
+type PersistedAssistantMessage = {
+  role?: string;
+  content?: string;
+  metadata?: Record<string, unknown>;
+};
+
+const CHAT_BASELINE_SUPPRESSED_TOOLS = [
+  "host_action",
+  "pointy_action",
+  "visual_runtime",
+  "code_studio",
+];
+
+const RAW_CHAT_BASELINE_MARKERS = [
+  '"tool_calls"',
+  '"function_call"',
+  '"host_action"',
+  '"pointy_action"',
+  '"visual_open"',
+  '"code_open"',
+  "<wiii-widget",
+  "[POINT:",
+  "runtime_flow_ledger",
+];
+
 function defaultServerUrl(): string {
   return process.env.WIII_PLAYWRIGHT_SERVER_URL || "http://127.0.0.1:8000";
 }
@@ -62,12 +115,389 @@ export function chatComposer(page: Page) {
   return page.locator('[data-wiii-id="chat-textarea"]').first();
 }
 
+export function assistantMessages(page: Page) {
+  return page.locator('[data-message-role="assistant"]');
+}
+
+export function lastAssistantMessage(page: Page) {
+  return assistantMessages(page).last();
+}
+
 export async function sendPrompt(page: Page, prompt: string): Promise<void> {
   const input = chatComposer(page);
   await input.waitFor({ state: "visible", timeout: 60_000 });
   await expect(input).toBeEnabled({ timeout: 60_000 });
   await input.fill(prompt);
   await input.press("Enter");
+}
+
+export async function waitForGenerationToSettle(page: Page): Promise<void> {
+  await expect
+    .poll(
+      async () => page.locator('[aria-label="Dừng tạo phản hồi"]').count(),
+      { timeout: 120_000, intervals: [500, 1_000, 1_500] },
+    )
+    .toBe(0);
+  await expect(chatComposer(page)).toBeEnabled({ timeout: 60_000 });
+}
+
+export async function expectNoBaselineToolSurfaces(page: Page): Promise<void> {
+  await expect(page.getByTestId("visual-block")).toHaveCount(0);
+  await expect(page.locator(".code-studio-card")).toHaveCount(0);
+  await expect(page.locator(".code-studio-panel")).toHaveCount(0);
+  await expect(page.locator('[aria-label^="Preview thao tác host"]')).toHaveCount(0);
+  await expect(page.locator(
+    '[data-wiii-pointy="overlay"], [data-wiii-pointy="target-ring"], [data-wiii-pointy="tooltip"]',
+  )).toHaveCount(0);
+}
+
+export function expectNoRawChatBaselinePayload(text: string): void {
+  for (const marker of RAW_CHAT_BASELINE_MARKERS) {
+    expect(text).not.toContain(marker);
+  }
+}
+
+function formatSseEvent(
+  id: number,
+  type: string,
+  data: Record<string, unknown>,
+): string {
+  return `id: ${id}\nevent: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function createChatBaselineLedger(
+  request: Record<string, unknown>,
+  eventTypes: string[],
+  finalizationStatus: "pending" | "saved",
+) {
+  const eventCounts = eventTypes.reduce<Record<string, number>>((counts, type) => {
+    counts[type] = (counts[type] || 0) + 1;
+    return counts;
+  }, {});
+  return {
+    schema_version: "wiii.runtime_flow_ledger.v1",
+    request: {
+      request_id: "browser-chat-baseline",
+      session_id: typeof request.session_id === "string" ? request.session_id : null,
+      user_id_hash: "browser-harness-user",
+      organization_id_hash: null,
+      domain_id: typeof request.domain_id === "string" ? request.domain_id : null,
+      host_surface: "desktop_chat",
+      host_capabilities: [],
+    },
+    context: {
+      document_context_present: false,
+      uploaded_document_count: 0,
+      source_ref_count: 0,
+      memory_context_count: 0,
+      context_provenance: {
+        uploaded_documents: 0,
+        source_references: 0,
+        memory_items: 0,
+      },
+    },
+    route: {
+      lane: "native_turn",
+      reason: "browser_chat_baseline_acceptance",
+      selected_agent: "direct",
+      final_agent: "direct",
+    },
+    runtime: {
+      requested_provider: typeof request.provider === "string" ? request.provider : null,
+      requested_model: typeof request.model === "string" ? request.model : null,
+      provider: "browser-harness",
+      model: "browser-chat-baseline-mock",
+      runtime_authoritative: true,
+      fallback_used: false,
+      fallback_reason: null,
+      failover_used: false,
+    },
+    tools: {
+      observed: [],
+      suppressed: CHAT_BASELINE_SUPPRESSED_TOOLS,
+    },
+    stream: {
+      transport: "sse_v3",
+      event_counts: eventCounts,
+      event_sequence_tail: eventTypes.slice(-12),
+      metadata_seen: eventTypes.includes("metadata"),
+      done_seen: eventTypes.includes("done"),
+    },
+    host_actions: {
+      preview_required: false,
+      preview_emitted: false,
+      approval_token_present: false,
+      approval_token_hash: null,
+      apply_attempted: false,
+      mutation_blocked_reason: null,
+    },
+    finalization: {
+      status: finalizationStatus,
+      error_type: null,
+      save_response_immediately: false,
+    },
+  };
+}
+
+function parseChatRequestBody(raw: string | null): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return { parse_error: "invalid_json" };
+  }
+}
+
+export async function installChatBaselineStreamMock(
+  page: Page,
+  scenarios: ChatBaselineScenario[],
+) {
+  const captures: ChatBaselineTurnCapture[] = [];
+  const byPrompt = new Map(scenarios.map((scenario) => [scenario.prompt, scenario]));
+
+  await page.addInitScript(() => {
+    type BrowserObservedEvent = {
+      id: string | null;
+      type: string;
+      data: Record<string, unknown> | null;
+      rawData: string;
+    };
+    type BrowserObservedStream = {
+      url: string;
+      status: number;
+      events: BrowserObservedEvent[];
+      done: boolean;
+      error?: string;
+    };
+    type BrowserWindow = typeof window & {
+      __wiiiChatBaselineFetchWrapped?: boolean;
+      __wiiiChatBaselineObservedStreams?: BrowserObservedStream[];
+    };
+
+    const browserWindow = window as BrowserWindow;
+    if (browserWindow.__wiiiChatBaselineFetchWrapped) return;
+
+    browserWindow.__wiiiChatBaselineFetchWrapped = true;
+    const originalFetch = window.fetch.bind(window);
+    const observedStreams: BrowserObservedStream[] = [];
+    browserWindow.__wiiiChatBaselineObservedStreams = observedStreams;
+
+    const parseSseText = (text: string): BrowserObservedEvent[] => text
+      .split(/\r?\n\r?\n/)
+      .map((block) => block.trim())
+      .filter(Boolean)
+      .map((block) => {
+        let id: string | null = null;
+        let type = "message";
+        const dataLines: string[] = [];
+
+        for (const line of block.split(/\r?\n/)) {
+          if (line.startsWith("id:")) {
+            id = line.slice(3).trim();
+          } else if (line.startsWith("event:")) {
+            type = line.slice(6).trim();
+          } else if (line.startsWith("data:")) {
+            dataLines.push(line.slice(5).trimStart());
+          }
+        }
+
+        const rawData = dataLines.join("\n");
+        let data: Record<string, unknown> | null = null;
+        if (rawData) {
+          try {
+            const parsed = JSON.parse(rawData);
+            data = parsed && typeof parsed === "object"
+              ? parsed as Record<string, unknown>
+              : { value: parsed };
+          } catch {
+            data = { parse_error: "invalid_json", raw: rawData };
+          }
+        }
+
+        return { id, type, data, rawData };
+      });
+
+    const requestUrl = (input: Parameters<typeof fetch>[0]): string => {
+      if (typeof input === "string") return input;
+      if (input instanceof URL) return input.toString();
+      return input.url;
+    };
+
+    window.fetch = async (
+      input: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1],
+    ): Promise<Response> => {
+      const response = await originalFetch(input, init);
+      const url = requestUrl(input);
+
+      if (url.includes("/api/v1/chat/stream/v3")) {
+        const record: BrowserObservedStream = {
+          url,
+          status: response.status,
+          events: [],
+          done: false,
+        };
+        observedStreams.push(record);
+        response.clone().text()
+          .then((text) => {
+            record.events = parseSseText(text);
+            record.done = record.events.some((event) => event.type === "done");
+          })
+          .catch((error: unknown) => {
+            record.error = error instanceof Error ? error.message : String(error);
+          });
+      }
+
+      return response;
+    };
+  });
+
+  await page.route("**/api/v1/chat/stream/v3", async (route) => {
+    const request = parseChatRequestBody(route.request().postData());
+    const prompt = typeof request.message === "string" ? request.message : "";
+    const scenario = byPrompt.get(prompt);
+
+    if (!scenario) {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: `Unexpected chat-baseline prompt: ${prompt}` }),
+      });
+      return;
+    }
+
+    const eventTypes = [
+      "status",
+      ...scenario.answerChunks.map(() => "answer"),
+      "metadata",
+      "done",
+    ];
+    const metadataLedger = createChatBaselineLedger(
+      request,
+      eventTypes.filter((type) => type !== "done"),
+      "pending",
+    );
+    const terminalLedger = createChatBaselineLedger(request, eventTypes, "saved");
+    const sseEvents: Array<{ type: string; data: Record<string, unknown> }> = [
+      {
+        type: "status",
+        data: {
+          content: "Đang kiểm tra baseline chat...",
+          step: "browser_chat_baseline",
+          node: "browser_harness",
+          details: {
+            subtype: "status_only",
+            visibility: "status_only",
+          },
+        },
+      },
+      ...scenario.answerChunks.map((content) => ({
+        type: "answer",
+        data: { content },
+      })),
+      {
+        type: "metadata",
+        data: {
+          session_id: typeof request.session_id === "string" ? request.session_id : "browser-session",
+          thread_id: `browser-thread-${scenario.id}`,
+          processing_time: 0.12,
+          confidence: 1,
+          model: "browser-chat-baseline-mock",
+          runtime_authoritative: true,
+          routing_metadata: {
+            method: "browser_chat_baseline_acceptance",
+            intent: "ordinary_chat",
+          },
+          runtime_flow_ledger: metadataLedger,
+        },
+      },
+      {
+        type: "done",
+        data: {
+          status: "complete",
+          processing_time: 0.12,
+          runtime_flow_ledger: terminalLedger,
+        },
+      },
+    ];
+
+    captures.push({ scenarioId: scenario.id, request });
+
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "text/event-stream; charset=utf-8",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      },
+      body: sseEvents.map((event, index) => formatSseEvent(index + 1, event.type, event.data)).join(""),
+    });
+  });
+
+  return { captures };
+}
+
+export async function readObservedChatBaselineStreams(
+  page: Page,
+): Promise<ObservedChatBaselineStream[]> {
+  return page.evaluate(() => {
+    type BrowserWindow = typeof window & {
+      __wiiiChatBaselineObservedStreams?: ObservedChatBaselineStream[];
+    };
+    return (window as BrowserWindow).__wiiiChatBaselineObservedStreams || [];
+  });
+}
+
+export async function waitForObservedChatBaselineStream(
+  page: Page,
+  index: number,
+): Promise<ObservedChatBaselineStream> {
+  await expect
+    .poll(
+      async () => {
+        const stream = (await readObservedChatBaselineStreams(page))[index];
+        if (!stream) return `missing:${index}`;
+        if (stream.error) return `error:${stream.error}`;
+        return stream.done ? "done" : `pending:${stream.events.length}`;
+      },
+      { timeout: 30_000, intervals: [250, 500, 1_000] },
+    )
+    .toBe("done");
+
+  const stream = (await readObservedChatBaselineStreams(page))[index];
+  if (!stream) {
+    throw new Error(`Browser did not observe chat-baseline stream ${index}.`);
+  }
+  if (stream.error) {
+    throw new Error(`Browser failed to observe chat-baseline stream ${index}: ${stream.error}`);
+  }
+  return stream;
+}
+
+export async function readPersistedAssistantMessages(
+  page: Page,
+  userId: string,
+): Promise<PersistedAssistantMessage[]> {
+  return page.evaluate((uid) => {
+    const raw = localStorage.getItem(`wiii:conversations_${uid}.json`);
+    if (!raw) return [];
+    try {
+      const parsed = JSON.parse(raw);
+      const conversations = parsed?.[`conversations_${uid}`];
+      if (!Array.isArray(conversations)) return [];
+      return conversations.flatMap((conversation: { messages?: unknown[] }) => {
+        const messages = Array.isArray(conversation.messages) ? conversation.messages : [];
+        return messages.filter((message: unknown) => (
+          Boolean(message)
+          && typeof message === "object"
+          && (message as { role?: unknown }).role === "assistant"
+        ));
+      });
+    } catch {
+      return [];
+    }
+  }, userId);
 }
 
 async function assertDevLoginEnabled(page: Page, serverUrl: string): Promise<void> {
@@ -84,7 +514,7 @@ async function assertDevLoginEnabled(page: Page, serverUrl: string): Promise<voi
   if (!data?.enabled) {
     throw new Error(
       "Local dev-login is disabled. The visual E2E harness requires " +
-        "ENABLE_DEV_LOGIN=true on the local backend.",
+        "ENABLE_DEV_LOGIN=true and ENVIRONMENT=development on the local backend.",
     );
   }
 }


### PR DESCRIPTION
## Summary
- Adds a real browser Chat-Baseline Acceptance Harness for ordinary Wiii chat.
- The new Playwright spec submits Vietnamese prompts through the real chat UI, uses a deterministic SSE baseline at the network boundary, and asserts visible/persisted answers, terminal ledger evidence, and no host/Pointy/visual/Code Studio lane leakage.
- Documents the new local command and expected evidence in the Local E2E Harness runbook.

Closes #671.

## Scope
- `wiii-desktop/playwright/chat-baseline-acceptance.spec.ts`
- `wiii-desktop/playwright/support/local-chat-harness.ts`
- `wiii-desktop/playwright.visual.config.ts`
- `docs/operations/WIII_LOCAL_E2E_HARNESS.md`

## Non-Scope
- No production deploy or VM restart.
- No LMS preview/apply mutation path.
- No provider/runtime implementation change.
- No committed screenshots, traces, logs, or generated Playwright output.

## Verification
- `cd wiii-desktop; $env:WIII_PLAYWRIGHT_BACKEND_PORT='8031'; $env:WIII_PLAYWRIGHT_FRONTEND_PORT='1431'; $env:WIII_PLAYWRIGHT_SERVER_URL='http://127.0.0.1:8031'; $env:WIII_PLAYWRIGHT_BASE_URL='http://127.0.0.1:1431'; npx playwright test -c playwright.visual.config.ts playwright/chat-baseline-acceptance.spec.ts` -> 1 passed
- `cd wiii-desktop; $env:WIII_PLAYWRIGHT_BACKEND_PORT='8033'; $env:WIII_PLAYWRIGHT_FRONTEND_PORT='1433'; $env:WIII_PLAYWRIGHT_SERVER_URL='http://127.0.0.1:8033'; $env:WIII_PLAYWRIGHT_BASE_URL='http://127.0.0.1:1433'; npx playwright test -c playwright.visual.config.ts playwright/chat-baseline-acceptance.spec.ts` -> 1 passed
- `cd wiii-desktop; $env:WIII_PLAYWRIGHT_BACKEND_PORT='8032'; $env:WIII_PLAYWRIGHT_FRONTEND_PORT='1432'; $env:WIII_PLAYWRIGHT_SERVER_URL='http://127.0.0.1:8032'; $env:WIII_PLAYWRIGHT_BASE_URL='http://127.0.0.1:1432'; npx playwright test -c playwright.visual.config.ts playwright/local-chat-harness.spec.ts` -> 1 passed
- `cd wiii-desktop; npx vitest run src/__tests__/sse.test.ts src/__tests__/streaming-blocks.test.ts src/__tests__/use-sse-stream-concurrency.test.ts --reporter=dot` -> 3 files passed, 46 tests passed
- `cd wiii-desktop; npx tsc --noEmit` -> passed
- `cd maritime-ai-service; python -m pytest tests/unit/test_chat_baseline_acceptance_harness.py -q --tb=short` -> 6 passed
- `git diff --check` -> passed

## Risk
- Low runtime risk: this is test/docs only and does not change product runtime code.
- The acceptance stream is deterministic and mocked at Playwright's network boundary; it proves browser UI/SSE/store behavior, not live provider quality.
- Pointy may render its default dock cursor; the harness asserts no Pointy action/spotlight/event leakage rather than banning the idle cursor.

## Rollback
- Revert this PR. It only adds/updates local harness files and documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new chat baseline acceptance tests to validate end-to-end chat functionality across multiple scenarios.
  * Enhanced test infrastructure with utilities for deterministic testing and result validation.
  * Updated test configuration and documentation to reflect new baseline acceptance test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->