### PR TITLE
Fix local direct chat prompt and Ollama selectability

### DIFF
--- a/maritime-ai-service/app/engine/llm_providers/wiii_chat_model.py
+++ b/maritime-ai-service/app/engine/llm_providers/wiii_chat_model.py
@@ -109,12 +109,15 @@ class StreamChunk:
 # ---------------------------------------------------------------------------
 
 
-def _coerce_to_openai_messages(messages: Iterable[Any]) -> list[dict]:
-    """Accept native ``Message``, plain dict, or LC ``BaseMessage`` and emit OpenAI dicts.
+def _coerce_to_openai_messages(messages: Iterable[Any] | str) -> list[dict]:
+    """Accept user text, native ``Message``, plain dict, or LC ``BaseMessage``.
 
     Phase 1 migrated SEND-side callers to dict; some history slices still pass
     raw LC objects through unchanged. Phase 9b will remove the latter.
     """
+    if isinstance(messages, str):
+        return [{"role": "user", "content": messages}]
+
     out: list[dict] = []
     for m in messages:
         if isinstance(m, dict):
@@ -419,12 +422,12 @@ class WiiiChatModel(BaseModel):
     # ------------------------------------------------------------------ #
     def _build_api_kwargs(
         self,
-        messages: Iterable[Any],
+        messages: Iterable[Any] | str,
         kwargs: dict[str, Any],
         *,
         stream: bool = False,
     ) -> dict[str, Any]:
-        oa_msgs = _coerce_to_openai_messages(list(messages))
+        oa_msgs = _coerce_to_openai_messages(messages)
 
         api_kwargs: dict[str, Any] = {
             "model": self.model,
@@ -458,7 +461,7 @@ class WiiiChatModel(BaseModel):
 
         return _strip_unsupported_params(api_kwargs, self.base_url)
 
-    async def ainvoke(self, messages: Iterable[Any], **kwargs: Any) -> Message:
+    async def ainvoke(self, messages: Iterable[Any] | str, **kwargs: Any) -> Message:
         """Async invoke. Returns a native ``Message`` with ``.content`` + ``.tool_calls``."""
         client = self._get_client()
         api_kwargs = self._build_api_kwargs(messages, kwargs, stream=False)
@@ -481,7 +484,7 @@ class WiiiChatModel(BaseModel):
 
         return from_openai_response(response.choices[0].message)
 
-    def invoke(self, messages: Iterable[Any], **kwargs: Any) -> Message:
+    def invoke(self, messages: Iterable[Any] | str, **kwargs: Any) -> Message:
         """Sync invoke — bridges to ``ainvoke`` via thread-pool when in async context."""
         try:
             loop = asyncio.get_running_loop()
@@ -501,7 +504,7 @@ class WiiiChatModel(BaseModel):
     # ------------------------------------------------------------------ #
     async def astream(
         self,
-        messages: Iterable[Any],
+        messages: Iterable[Any] | str,
         **kwargs: Any,
     ) -> AsyncIterator[StreamChunk]:
         """Async stream. Yields ``StreamChunk`` (with ``.content`` + ``.message`` shim)."""
@@ -596,7 +599,7 @@ class _StructuredOutputWrapper(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
 
-    def _build_messages_with_instruction(self, messages: Iterable[Any]) -> list[Any]:
+    def _build_messages_with_instruction(self, messages: Iterable[Any] | str) -> list[Any]:
         try:
             schema_text = json.dumps(
                 self.output_schema.model_json_schema(),
@@ -611,7 +614,11 @@ class _StructuredOutputWrapper(BaseModel):
         if schema_text:
             instruction = f"{instruction}\nSchema: {schema_text}"
 
-        as_list = list(messages)
+        as_list: list[Any]
+        if isinstance(messages, str):
+            as_list = [{"role": "user", "content": messages}]
+        else:
+            as_list = list(messages)
         if as_list and isinstance(as_list[0], dict) and as_list[0].get("role") == "system":
             head = dict(as_list[0])
             head["content"] = (head.get("content") or "") + "\n\n" + instruction
@@ -637,7 +644,7 @@ class _StructuredOutputWrapper(BaseModel):
                 text = text[4:].strip()
         return text.strip()
 
-    async def ainvoke(self, messages: Iterable[Any], **kwargs: Any) -> Any:
+    async def ainvoke(self, messages: Iterable[Any] | str, **kwargs: Any) -> Any:
         prepared = self._build_messages_with_instruction(messages)
         response = await self.llm.ainvoke(prepared, **kwargs)
 
@@ -661,7 +668,7 @@ class _StructuredOutputWrapper(BaseModel):
 
         return self.output_schema.model_validate(data)
 
-    def invoke(self, messages: Iterable[Any], **kwargs: Any) -> Any:
+    def invoke(self, messages: Iterable[Any] | str, **kwargs: Any) -> Any:
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:

--- a/maritime-ai-service/app/services/chat_orchestrator_fallback_runtime.py
+++ b/maritime-ai-service/app/services/chat_orchestrator_fallback_runtime.py
@@ -76,6 +76,35 @@ def should_use_local_direct_llm_fallback_impl(*, settings_obj) -> bool:
     return provider == "ollama" and not settings_obj.google_api_key
 
 
+def _runtime_text(value) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _authoritative_runtime_metadata(runtime_llm: dict | None, llm=None) -> dict:
+    metadata = dict(runtime_llm or {})
+    provider = _runtime_text(getattr(llm, "_wiii_provider_name", None)) or _runtime_text(
+        metadata.get("_execution_provider")
+    ) or _runtime_text(
+        metadata.get("provider")
+    )
+    model = _runtime_text(getattr(llm, "model", None)) or _runtime_text(
+        metadata.get("_execution_model")
+    ) or _runtime_text(metadata.get("model"))
+
+    if provider:
+        metadata["provider"] = provider
+        metadata["_execution_provider"] = provider
+    if model:
+        metadata["model"] = model
+        metadata["_execution_model"] = model
+    if provider and model:
+        metadata["runtime_authoritative"] = True
+    return metadata
+
+
 async def process_with_direct_llm_impl(
     *,
     context,
@@ -87,15 +116,19 @@ async def process_with_direct_llm_impl(
 ):
     """Generate a local-first response without RAG when cloud retrieval is unavailable."""
     llm = get_llm_light_fn()
-    response = await llm.ainvoke(context.message)
+    response = await llm.ainvoke([{"role": "user", "content": context.message}])
     message, thinking = extract_thinking_from_response_fn(response.content)
+    runtime_llm = _authoritative_runtime_metadata(
+        resolve_runtime_llm_metadata_fn(),
+        llm=llm,
+    )
 
     return processing_result_cls(
         message=message,
         agent_type=agent_type_direct,
         metadata={
             "mode": "local_direct_llm",
-            **resolve_runtime_llm_metadata_fn(),
+            **runtime_llm,
         },
         thinking=thinking,
     )
@@ -126,7 +159,7 @@ async def process_without_multi_agent_impl(
             user_role=context.user_role.value,
             limit=5,
         )
-        runtime_llm = resolve_runtime_llm_metadata_fn()
+        runtime_llm = _authoritative_runtime_metadata(resolve_runtime_llm_metadata_fn())
         return processing_result_cls(
             message=rag_result.content,
             agent_type=agent_type_rag,

--- a/maritime-ai-service/app/services/llm_runtime_audit_service.py
+++ b/maritime-ai-service/app/services/llm_runtime_audit_service.py
@@ -619,7 +619,9 @@ def record_llm_runtime_observation(
         )
 
     payload["audit_updated_at"] = now_iso
-    return persist_llm_runtime_audit_snapshot(payload)
+    record = persist_llm_runtime_audit_snapshot(payload)
+    bump_llm_selectability_cache_generation()
+    return record
 
 
 def record_runtime_discovery_snapshot(catalog: Mapping[str, Any]) -> Optional[LlmRuntimeAuditRecord]:

--- a/maritime-ai-service/app/services/llm_selectability_service.py
+++ b/maritime-ai-service/app/services/llm_selectability_service.py
@@ -221,10 +221,12 @@ def _parse_iso_datetime(value: Any) -> datetime | None:
 def _latest_runtime_observation_succeeded(state: dict[str, Any]) -> bool:
     observed_at = _parse_iso_datetime(state.get("last_runtime_observation_at"))
     success_at = _parse_iso_datetime(state.get("last_runtime_success_at"))
+    if observed_at is None:
+        return success_at is not None
+    if _is_preflight_provider_unavailable_observation(state):
+        return True
     if success_at is None:
         return False
-    if observed_at is None:
-        return True
     return success_at >= observed_at
 
 
@@ -248,6 +250,11 @@ def _probe_success_supersedes_observation(state: Mapping[str, Any]) -> bool:
 def _latest_runtime_observation_failed(state: Mapping[str, Any]) -> bool:
     observed_at = _parse_iso_datetime(state.get("last_runtime_observation_at"))
     if observed_at is None:
+        return False
+    if (
+        _is_preflight_provider_unavailable_observation(state)
+        and _live_streaming_probe_supersedes_host_down_signal(state)
+    ):
         return False
     if _probe_success_supersedes_observation(state):
         return False
@@ -315,6 +322,36 @@ def _collect_signal_texts(state: dict[str, Any]) -> str:
         if text:
             parts.append(text)
     return " | ".join(parts).lower()
+
+
+def _is_preflight_provider_unavailable_observation(state: Mapping[str, Any]) -> bool:
+    source = str(state.get("last_runtime_source") or "").strip().lower()
+    note = str(state.get("last_runtime_note") or "").strip().lower()
+    if source not in {"chat_stream:error", "chat_sync:error"}:
+        return False
+    return "requested provider" in note and "unavailable" in note
+
+
+def _live_streaming_probe_supersedes_host_down_signal(state: Mapping[str, Any]) -> bool:
+    """Treat a fresh successful streaming probe as authoritative for reachability."""
+    if state.get("streaming_supported") is not True:
+        return False
+    if str(state.get("streaming_source") or "").strip().lower() != "live_probe":
+        return False
+
+    probe_success_at = _parse_iso_datetime(state.get("last_live_probe_success_at"))
+    if probe_success_at is None:
+        return False
+
+    observed_at = _parse_iso_datetime(state.get("last_runtime_observation_at"))
+    if (
+        observed_at is not None
+        and probe_success_at < observed_at
+        and not _is_preflight_provider_unavailable_observation(state)
+    ):
+        return False
+
+    return True
 
 
 def _has_provider_audit_truth(state: dict[str, Any]) -> bool:
@@ -488,9 +525,6 @@ def _resolve_disabled_reason(
         else:
             return "busy"
 
-    if provider == "ollama" and any(marker in signal_text for marker in _HOST_DOWN_MARKERS):
-        return "host_down"
-
     capability_reason = _resolve_required_capability_reason(state, provider=provider)
     if capability_reason is not None:
         if (
@@ -501,8 +535,17 @@ def _resolve_disabled_reason(
             return None
         return capability_reason
 
-    if runtime_available and _latest_runtime_observation_succeeded(state):
+    if _latest_runtime_observation_succeeded(state):
         return None
+
+    if provider == "ollama" and any(marker in signal_text for marker in _HOST_DOWN_MARKERS):
+        if _live_streaming_probe_supersedes_host_down_signal(state):
+            logger.info(
+                "[LLM_SELECTABILITY] Ignoring Ollama host-down marker after "
+                "successful live streaming probe",
+            )
+        else:
+            return "host_down"
 
     if not runtime_available:
         if provider == "ollama":
@@ -602,7 +645,7 @@ def get_llm_selectability_snapshot(
                 )
                 if capability_reason is None and provider_state.get("selected_model_in_catalog", False):
                     reason_code = None
-            if reason_code is None and runtime_available:
+            if reason_code is None:
                 state = "selectable"
             else:
                 state = "disabled"
@@ -642,6 +685,14 @@ def get_llm_selectability_snapshot(
 def get_provider_selectability(provider: str) -> Optional[ProviderSelectability]:
     normalized = str(provider).strip().lower()
     for item in get_llm_selectability_snapshot():
+        if item.provider == normalized:
+            return item
+    return None
+
+
+def _refresh_provider_selectability(provider: str) -> Optional[ProviderSelectability]:
+    normalized = str(provider).strip().lower()
+    for item in get_llm_selectability_snapshot(force_refresh=True):
         if item.provider == normalized:
             return item
     return None
@@ -719,6 +770,16 @@ def ensure_provider_is_selectable(provider: str | None) -> ProviderSelectability
         return None
 
     item = get_provider_selectability(normalized)
+    if (
+        normalized == "ollama"
+        and item is not None
+        and item.state == "disabled"
+        and item.reason_code == "host_down"
+    ):
+        refreshed = _refresh_provider_selectability(normalized)
+        if refreshed is not None:
+            item = refreshed
+
     if item is not None and item.state == "selectable":
         return item
     # Explicit user pin: allow degraded-but-routable states (e.g.

--- a/maritime-ai-service/tests/unit/test_chat_orchestrator_fallback_runtime.py
+++ b/maritime-ai-service/tests/unit/test_chat_orchestrator_fallback_runtime.py
@@ -183,7 +183,9 @@ class TestProcessWithDirectLlmImpl:
         llm.ainvoke = AsyncMock(return_value=SimpleNamespace(content="assistant text"))
         get_llm_light_fn = MagicMock(return_value=llm)
         extract_thinking = MagicMock(return_value=("Hello there", "Thinking here"))
-        resolve_runtime = MagicMock(return_value={"provider": "google"})
+        resolve_runtime = MagicMock(
+            return_value={"provider": "google", "model": "gemini-test"}
+        )
         context = SimpleNamespace(message="Hi")
 
         result = await process_with_direct_llm_impl(
@@ -198,9 +200,87 @@ class TestProcessWithDirectLlmImpl:
         assert result == FakeProcessingResult(
             message="Hello there",
             agent_type="direct",
-            metadata={"mode": "local_direct_llm", "provider": "google"},
+            metadata={
+                "mode": "local_direct_llm",
+                "provider": "google",
+                "model": "gemini-test",
+                "_execution_provider": "google",
+                "_execution_model": "gemini-test",
+                "runtime_authoritative": True,
+            },
             thinking="Thinking here",
         )
+        llm.ainvoke.assert_awaited_once_with([{"role": "user", "content": "Hi"}])
+
+    @pytest.mark.asyncio
+    async def test_builds_processing_result_prefers_llm_authoritative_override(self):
+        llm = MagicMock()
+        llm._wiii_provider_name = "openai"
+        llm.model = "gpt-4o"
+        llm.ainvoke = AsyncMock(return_value=SimpleNamespace(content="assistant text"))
+        get_llm_light_fn = MagicMock(return_value=llm)
+        extract_thinking = MagicMock(return_value=("Hello there", None))
+        resolve_runtime = MagicMock(
+            return_value={
+                "provider": "google",
+                "model": "gemini-test",
+                "_execution_provider": "zhipu",
+                "_execution_model": "glm-4.5-air",
+            }
+        )
+        context = SimpleNamespace(message="Hi")
+
+        result = await process_with_direct_llm_impl(
+            context=context,
+            get_llm_light_fn=get_llm_light_fn,
+            extract_thinking_from_response_fn=extract_thinking,
+            resolve_runtime_llm_metadata_fn=resolve_runtime,
+            processing_result_cls=FakeProcessingResult,
+            agent_type_direct="direct",
+        )
+
+        assert result.metadata == {
+            "mode": "local_direct_llm",
+            "provider": "openai",
+            "model": "gpt-4o",
+            "_execution_provider": "openai",
+            "_execution_model": "gpt-4o",
+            "runtime_authoritative": True,
+        }
+        llm.ainvoke.assert_awaited_once_with([{"role": "user", "content": "Hi"}])
+
+    @pytest.mark.asyncio
+    async def test_builds_processing_result_from_execution_metadata_only(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(return_value=SimpleNamespace(content="assistant text"))
+        get_llm_light_fn = MagicMock(return_value=llm)
+        extract_thinking = MagicMock(return_value=("Hello there", None))
+        resolve_runtime = MagicMock(
+            return_value={
+                "_execution_provider": "zhipu",
+                "_execution_model": "glm-4.5-air",
+            }
+        )
+        context = SimpleNamespace(message="Hi")
+
+        result = await process_with_direct_llm_impl(
+            context=context,
+            get_llm_light_fn=get_llm_light_fn,
+            extract_thinking_from_response_fn=extract_thinking,
+            resolve_runtime_llm_metadata_fn=resolve_runtime,
+            processing_result_cls=FakeProcessingResult,
+            agent_type_direct="direct",
+        )
+
+        assert result.metadata == {
+            "mode": "local_direct_llm",
+            "provider": "zhipu",
+            "model": "glm-4.5-air",
+            "_execution_provider": "zhipu",
+            "_execution_model": "glm-4.5-air",
+            "runtime_authoritative": True,
+        }
+        llm.ainvoke.assert_awaited_once_with([{"role": "user", "content": "Hi"}])
 
 
 class TestProcessWithoutMultiAgentImpl:
@@ -246,7 +326,9 @@ class TestProcessWithoutMultiAgentImpl:
             logger_obj=logger_obj,
             should_use_local_direct_llm_fallback=False,
             process_with_direct_llm_fn=AsyncMock(),
-            resolve_runtime_llm_metadata_fn=MagicMock(return_value={"provider": "google"}),
+            resolve_runtime_llm_metadata_fn=MagicMock(
+                return_value={"provider": "google", "model": "gemini-test"}
+            ),
             processing_result_cls=FakeProcessingResult,
             agent_type_rag="rag",
         )
@@ -255,7 +337,14 @@ class TestProcessWithoutMultiAgentImpl:
             message="rag answer",
             agent_type="rag",
             sources=[{"title": "Doc"}],
-            metadata={"mode": "fallback_rag", "provider": "google"},
+            metadata={
+                "mode": "fallback_rag",
+                "provider": "google",
+                "model": "gemini-test",
+                "_execution_provider": "google",
+                "_execution_model": "gemini-test",
+                "runtime_authoritative": True,
+            },
             thinking="rag thinking",
         )
 

--- a/maritime-ai-service/tests/unit/test_llm_runtime_audit_service.py
+++ b/maritime-ai-service/tests/unit/test_llm_runtime_audit_service.py
@@ -293,7 +293,9 @@ def test_record_llm_runtime_observation_tracks_failover_route_and_success():
     with patch(
         "app.services.llm_runtime_audit_service.get_admin_runtime_settings_repository",
         return_value=repo,
-    ):
+    ), patch(
+        "app.services.llm_runtime_audit_service.bump_llm_selectability_cache_generation",
+    ) as bump_cache:
         record = record_llm_runtime_observation(
             provider="openrouter",
             success=True,
@@ -312,6 +314,7 @@ def test_record_llm_runtime_observation_tracks_failover_route_and_success():
         )
 
     assert record is not None
+    bump_cache.assert_called_once_with()
     google_state = persisted_payload["providers"]["google"]
     openrouter_state = persisted_payload["providers"]["openrouter"]
     assert google_state["last_runtime_error"] == "Provider vuot gioi han hoac dang bi quota/rate limit."

--- a/maritime-ai-service/tests/unit/test_llm_selectability_service.py
+++ b/maritime-ai-service/tests/unit/test_llm_selectability_service.py
@@ -320,6 +320,298 @@ def test_probe_failed_capability_does_not_disable_otherwise_healthy_provider(
     assert zhipu.reason_code is None
 
 
+@patch("app.services.llm_selectability_service.get_supported_provider_names")
+@patch("app.services.llm_selectability_service.settings")
+@patch("app.services.llm_selectability_service.LLMPool.get_provider_info")
+@patch("app.services.llm_selectability_service.LLMPool.get_stats")
+def test_ollama_partial_probe_timeout_does_not_override_streaming_success(
+    mock_stats,
+    mock_provider_info,
+    mock_settings,
+    mock_supported_providers,
+):
+    from app.services.llm_selectability_service import (
+        get_llm_selectability_snapshot,
+        invalidate_llm_selectability_cache,
+    )
+
+    invalidate_llm_selectability_cache()
+    mock_supported_providers.return_value = ("ollama",)
+    mock_settings.use_multi_agent = False
+    mock_settings.google_model = "gemini-3.1-flash-lite-preview"
+    mock_settings.zhipu_model = "glm-4.5-air"
+    mock_settings.ollama_model = "qwen3:4b"
+    mock_settings.llm_provider = "ollama"
+    mock_settings.openai_base_url = None
+    mock_settings.openai_model = "gpt-5-mini"
+    mock_stats.return_value = {
+        "request_selectable_providers": ["ollama"],
+        "active_provider": "ollama",
+        "fallback_provider": None,
+    }
+    mock_provider_info.return_value = _provider(configured=True, available=False)
+
+    record = LlmRuntimeAuditRecord(
+        payload={
+            "schema_version": 1,
+            "audit_updated_at": "2026-05-26T04:23:47+00:00",
+            "last_live_probe_at": "2026-05-26T04:23:26+00:00",
+            "providers": {
+                "ollama": {
+                    "provider": "ollama",
+                    "selected_model": "qwen3:4b",
+                    "selected_model_in_catalog": True,
+                    "model_count": 2,
+                    "last_discovery_attempt_at": "2026-05-26T04:23:26+00:00",
+                    "last_live_probe_attempt_at": "2026-05-26T04:23:26+00:00",
+                    "last_live_probe_success_at": "2026-05-26T04:23:26+00:00",
+                    "last_live_probe_error": "tool calling: timeout; structured output: timeout",
+                    "last_runtime_observation_at": "2026-05-26T04:30:12+00:00",
+                    "last_runtime_success_at": "2026-05-26T04:29:50+00:00",
+                    "last_runtime_error": "May chu local hien chua san sang.",
+                    "last_runtime_note": "chat_stream:error: requested provider ollama unavailable (host_down).",
+                    "last_runtime_source": "chat_stream:error",
+                    "tool_calling_supported": None,
+                    "tool_calling_source": "probe_failed",
+                    "structured_output_supported": None,
+                    "structured_output_source": "probe_failed",
+                    "streaming_supported": True,
+                    "streaming_source": "live_probe",
+                    "degraded_reasons": ["Live capability probe failed."],
+                },
+            },
+        },
+        updated_at=datetime(2026, 5, 26, 4, 23, tzinfo=timezone.utc),
+        persisted=True,
+    )
+
+    with patch(
+        "app.services.llm_selectability_service.get_persisted_llm_runtime_audit",
+        return_value=record,
+    ):
+        snapshot = get_llm_selectability_snapshot(force_refresh=True)
+
+    ollama = next(item for item in snapshot if item.provider == "ollama")
+    assert ollama.state == "selectable"
+    assert ollama.reason_code is None
+
+
+@patch("app.services.llm_selectability_service.get_supported_provider_names")
+@patch("app.services.llm_selectability_service.settings")
+@patch("app.services.llm_selectability_service.LLMPool.get_provider_info")
+@patch("app.services.llm_selectability_service.LLMPool.get_stats")
+def test_ollama_runtime_success_overrides_partial_probe_timeout(
+    mock_stats,
+    mock_provider_info,
+    mock_settings,
+    mock_supported_providers,
+):
+    from app.services.llm_selectability_service import (
+        get_llm_selectability_snapshot,
+        invalidate_llm_selectability_cache,
+    )
+
+    invalidate_llm_selectability_cache()
+    mock_supported_providers.return_value = ("ollama",)
+    mock_settings.use_multi_agent = False
+    mock_settings.ollama_model = "qwen3:4b"
+    mock_settings.llm_provider = "ollama"
+    mock_settings.google_model = "gemini-3.1-flash-lite-preview"
+    mock_settings.zhipu_model = "glm-4.5-air"
+    mock_settings.openai_base_url = None
+    mock_settings.openai_model = "gpt-5-mini"
+    mock_stats.return_value = {
+        "request_selectable_providers": ["ollama"],
+        "active_provider": "ollama",
+        "fallback_provider": None,
+    }
+    mock_provider_info.return_value = _provider(configured=True, available=True)
+
+    record = LlmRuntimeAuditRecord(
+        payload={
+            "schema_version": 1,
+            "audit_updated_at": "2026-05-26T04:49:08+00:00",
+            "providers": {
+                "ollama": {
+                    "provider": "ollama",
+                    "selected_model": "qwen3:4b",
+                    "selected_model_in_catalog": True,
+                    "model_count": 2,
+                    "last_live_probe_success_at": "2026-05-26T04:23:26+00:00",
+                    "last_live_probe_error": "tool calling: timeout; structured output: timeout",
+                    "last_runtime_observation_at": "2026-05-26T04:49:08+00:00",
+                    "last_runtime_success_at": "2026-05-26T04:49:08+00:00",
+                    "last_runtime_error": None,
+                    "last_runtime_note": "chat_sync: completed via ollama/qwen3:4b.",
+                    "last_runtime_source": "chat_sync",
+                    "tool_calling_supported": None,
+                    "tool_calling_source": "probe_failed",
+                    "structured_output_supported": None,
+                    "structured_output_source": "probe_failed",
+                    "streaming_supported": True,
+                    "streaming_source": "live_probe",
+                    "degraded_reasons": ["Live capability probe failed."],
+                },
+            },
+        },
+        updated_at=datetime(2026, 5, 26, 4, 49, tzinfo=timezone.utc),
+        persisted=True,
+    )
+
+    with patch(
+        "app.services.llm_selectability_service.get_persisted_llm_runtime_audit",
+        return_value=record,
+    ):
+        snapshot = get_llm_selectability_snapshot(force_refresh=True)
+
+    ollama = next(item for item in snapshot if item.provider == "ollama")
+    assert ollama.state == "selectable"
+    assert ollama.reason_code is None
+
+
+@patch("app.services.llm_selectability_service.get_supported_provider_names")
+@patch("app.services.llm_selectability_service.settings")
+@patch("app.services.llm_selectability_service.LLMPool.get_provider_info")
+@patch("app.services.llm_selectability_service.LLMPool.get_stats")
+def test_ollama_preflight_unavailable_does_not_override_streaming_success_without_runtime_success(
+    mock_stats,
+    mock_provider_info,
+    mock_settings,
+    mock_supported_providers,
+):
+    from app.services.llm_selectability_service import (
+        get_llm_selectability_snapshot,
+        invalidate_llm_selectability_cache,
+    )
+
+    invalidate_llm_selectability_cache()
+    mock_supported_providers.return_value = ("ollama",)
+    mock_settings.use_multi_agent = False
+    mock_settings.ollama_model = "qwen3:4b"
+    mock_settings.llm_provider = "ollama"
+    mock_settings.google_model = "gemini-3.1-flash-lite-preview"
+    mock_settings.zhipu_model = "glm-4.5-air"
+    mock_settings.openai_base_url = None
+    mock_settings.openai_model = "gpt-5-mini"
+    mock_stats.return_value = {
+        "request_selectable_providers": ["ollama"],
+        "active_provider": "ollama",
+        "fallback_provider": None,
+    }
+    mock_provider_info.return_value = _provider(configured=True, available=False)
+
+    record = LlmRuntimeAuditRecord(
+        payload={
+            "schema_version": 1,
+            "audit_updated_at": "2026-05-26T04:49:08+00:00",
+            "providers": {
+                "ollama": {
+                    "provider": "ollama",
+                    "selected_model": "qwen3:4b",
+                    "selected_model_in_catalog": True,
+                    "model_count": 2,
+                    "last_live_probe_attempt_at": "2026-05-26T04:23:26+00:00",
+                    "last_live_probe_success_at": "2026-05-26T04:23:26+00:00",
+                    "last_live_probe_error": "tool calling: timeout; structured output: timeout",
+                    "last_runtime_observation_at": "2026-05-26T04:49:08+00:00",
+                    "last_runtime_error": "May chu local hien chua san sang.",
+                    "last_runtime_note": "chat_stream:error: requested provider ollama unavailable (host_down).",
+                    "last_runtime_source": "chat_stream:error",
+                    "tool_calling_supported": None,
+                    "tool_calling_source": "probe_failed",
+                    "structured_output_supported": None,
+                    "structured_output_source": "probe_failed",
+                    "streaming_supported": True,
+                    "streaming_source": "live_probe",
+                    "degraded_reasons": ["Live capability probe failed."],
+                },
+            },
+        },
+        updated_at=datetime(2026, 5, 26, 4, 49, tzinfo=timezone.utc),
+        persisted=True,
+    )
+
+    with patch(
+        "app.services.llm_selectability_service.get_persisted_llm_runtime_audit",
+        return_value=record,
+    ):
+        snapshot = get_llm_selectability_snapshot(force_refresh=True)
+
+    ollama = next(item for item in snapshot if item.provider == "ollama")
+    assert ollama.state == "selectable"
+    assert ollama.reason_code is None
+
+
+@patch("app.services.llm_selectability_service.get_supported_provider_names")
+@patch("app.services.llm_selectability_service.settings")
+@patch("app.services.llm_selectability_service.LLMPool.get_provider_info")
+@patch("app.services.llm_selectability_service.LLMPool.get_stats")
+def test_runtime_success_does_not_bypass_required_capability_gating(
+    mock_stats,
+    mock_provider_info,
+    mock_settings,
+    mock_supported_providers,
+):
+    from app.services.llm_selectability_service import (
+        get_llm_selectability_snapshot,
+        invalidate_llm_selectability_cache,
+    )
+
+    invalidate_llm_selectability_cache()
+    mock_supported_providers.return_value = ("google",)
+    mock_settings.use_multi_agent = True
+    mock_settings.google_model = "gemini-3.1-flash-lite-preview"
+    mock_settings.zhipu_model = "glm-4.5-air"
+    mock_settings.ollama_model = "qwen3:8b"
+    mock_settings.llm_provider = "google"
+    mock_settings.openai_base_url = None
+    mock_settings.openai_model = "gpt-5-mini"
+    mock_stats.return_value = {
+        "request_selectable_providers": ["google"],
+        "active_provider": "google",
+        "fallback_provider": None,
+    }
+    mock_provider_info.return_value = _provider(configured=True, available=True)
+
+    record = LlmRuntimeAuditRecord(
+        payload={
+            "schema_version": 1,
+            "audit_updated_at": "2026-05-26T04:49:08+00:00",
+            "providers": {
+                "google": {
+                    "provider": "google",
+                    "selected_model": "gemini-3.1-flash-lite-preview",
+                    "selected_model_in_catalog": True,
+                    "model_count": 3,
+                    "last_runtime_observation_at": "2026-05-26T04:49:08+00:00",
+                    "last_runtime_success_at": "2026-05-26T04:49:08+00:00",
+                    "last_runtime_error": None,
+                    "last_runtime_note": "chat_sync: completed via google/gemini-3.1-flash-lite-preview.",
+                    "last_runtime_source": "chat_sync",
+                    "streaming_supported": True,
+                    "streaming_source": "live_probe",
+                    "structured_output_supported": False,
+                    "structured_output_source": "live_probe",
+                    "tool_calling_supported": True,
+                    "tool_calling_source": "live_probe",
+                },
+            },
+        },
+        updated_at=datetime(2026, 5, 26, 4, 49, tzinfo=timezone.utc),
+        persisted=True,
+    )
+
+    with patch(
+        "app.services.llm_selectability_service.get_persisted_llm_runtime_audit",
+        return_value=record,
+    ):
+        snapshot = get_llm_selectability_snapshot(force_refresh=True)
+
+    google = next(item for item in snapshot if item.provider == "google")
+    assert google.state == "disabled"
+    assert google.reason_code == "capability_missing"
+
+
 @patch("app.services.llm_selectability_service.settings")
 @patch("app.services.llm_selectability_service.LLMPool.get_provider_info")
 @patch("app.services.llm_selectability_service.LLMPool.get_stats")
@@ -946,6 +1238,55 @@ def test_ensure_provider_is_selectable_allows_capability_missing_for_explicit_pi
     ):
         result = ensure_provider_is_selectable("nvidia")
     assert result is pinned_capable
+
+
+def test_ensure_provider_is_selectable_refreshes_stale_ollama_host_down():
+    from app.services.llm_selectability_service import (
+        ensure_provider_is_selectable,
+        ProviderSelectability,
+    )
+
+    stale_host_down = ProviderSelectability(
+        provider="ollama",
+        display_name="Ollama",
+        state="disabled",
+        reason_code="host_down",
+        reason_label="May chu local hien chua san sang.",
+        selected_model="qwen3:4b",
+        strict_pin=True,
+        verified_at="2026-05-26T04:23:26+00:00",
+        available=False,
+        configured=True,
+        request_selectable=True,
+        is_primary=True,
+        is_fallback=False,
+    )
+    refreshed = ProviderSelectability(
+        provider="ollama",
+        display_name="Ollama",
+        state="selectable",
+        reason_code=None,
+        reason_label=None,
+        selected_model="qwen3:4b",
+        strict_pin=True,
+        verified_at="2026-05-26T04:41:20+00:00",
+        available=True,
+        configured=True,
+        request_selectable=True,
+        is_primary=True,
+        is_fallback=False,
+    )
+
+    with patch(
+        "app.services.llm_selectability_service.get_provider_selectability",
+        return_value=stale_host_down,
+    ), patch(
+        "app.services.llm_selectability_service._refresh_provider_selectability",
+        return_value=refreshed,
+    ):
+        result = ensure_provider_is_selectable("ollama")
+
+    assert result is refreshed
 
 
 def test_ensure_provider_is_selectable_still_rejects_hidden_provider():

--- a/maritime-ai-service/tests/unit/test_wiii_chat_model_message_coercion.py
+++ b/maritime-ai-service/tests/unit/test_wiii_chat_model_message_coercion.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from app.engine.llm_providers.wiii_chat_model import (
+    WiiiChatModel,
+    _StructuredOutputWrapper,
+)
+
+
+def _build_model() -> WiiiChatModel:
+    return WiiiChatModel(
+        model="test-model",
+        api_key="test-key",
+        base_url="https://example.test/v1",
+    )
+
+
+def test_build_api_kwargs_treats_plain_string_as_single_user_message():
+    model = _build_model()
+
+    kwargs = model._build_api_kwargs(
+        "Noi chinh xac: BACKEND_OK",
+        {},
+        stream=False,
+    )
+
+    assert kwargs["messages"] == [
+        {"role": "user", "content": "Noi chinh xac: BACKEND_OK"}
+    ]
+
+
+def test_build_api_kwargs_preserves_message_dict_list():
+    model = _build_model()
+    messages = [
+        {"role": "system", "content": "You are Wiii."},
+        {"role": "user", "content": "Hi"},
+    ]
+
+    kwargs = model._build_api_kwargs(messages, {}, stream=False)
+
+    assert kwargs["messages"] == messages
+
+
+class ProbeResult(BaseModel):
+    status: str
+    detail: str
+
+
+class RecordingLlm:
+    def __init__(self) -> None:
+        self.messages: list[Any] | None = None
+        self.kwargs: dict[str, Any] | None = None
+
+    async def ainvoke(self, messages: list[Any], **kwargs: Any) -> SimpleNamespace:
+        self.messages = messages
+        self.kwargs = kwargs
+        return SimpleNamespace(content='{"status":"ok","detail":"probe"}')
+
+
+@pytest.mark.asyncio
+async def test_structured_output_wrapper_treats_plain_string_as_user_message():
+    llm = RecordingLlm()
+    wrapper = _StructuredOutputWrapper(llm=llm, output_schema=ProbeResult)
+
+    result = await wrapper.ainvoke("Tra ve status ok.", temperature=0)
+
+    assert result.model_dump() == {"status": "ok", "detail": "probe"}
+    assert llm.messages is not None
+    assert llm.messages[0]["role"] == "system"
+    assert llm.messages[1] == {"role": "user", "content": "Tra ve status ok."}
+    assert llm.kwargs == {"temperature": 0}


### PR DESCRIPTION
Closes #673

## Summary
- Preserve plain-string prompts in `WiiiChatModel` and structured-output wrappers by coercing them to a single user message instead of iterating characters.
- Send local direct fallback prompts as typed chat messages and mark fallback runtime metadata authoritative for sync `/chat` parity.
- Harden Ollama selectability so successful streaming/runtime observations override stale preflight host-down loops, and invalidate selectability cache after runtime audit observations.

## Scope
- Backend local direct chat fallback
- OpenAI-compatible message coercion
- LLM runtime audit/selectability cache and Ollama host-down classification
- Focused unit coverage and local full-stack smoke

## Non-Scope
- No frontend UI changes
- No LMS mutation/apply flow changes
- No provider secret/config changes
- No model catalog or deployment workflow changes

## Verification
- `python -m pytest tests/unit/test_chat_orchestrator_fallback_runtime.py tests/unit/test_wiii_chat_model_message_coercion.py tests/unit/test_llm_selectability_service.py tests/unit/test_llm_runtime_audit_service.py -q --tb=short` -> 46 passed
- `python -m ruff check app/ --select=E9,F63,F7` -> passed
- `git diff --check` -> passed
- Full local stack smoke: `python scripts/local_demo_smoke.py --backend-url http://localhost:8000 --frontend-url http://127.0.0.1:1420 --provider ollama --model qwen3:4b --expect-provider ollama --expect-model qwen3:4b --timeout 20 --chat-timeout 180 --stream-timeout 240 --stream-idle-timeout 120 --max-first-event-seconds 20 --max-first-answer-seconds 200 --max-stream-total-seconds 240 --message "Noi ngan gon: BACKEND_OK_FULL."` -> 10 passed, 0 failed

## Risk
- Touches runtime provider selectability, so provider routing behavior is affected for explicit Ollama pins.
- The change is intentionally narrow: only stale Ollama `host_down` states are force-refreshed before rejection, and actual runtime success/streaming probe evidence must exist to override stale probe timeout text.

## Rollback
- Revert this PR to restore previous prompt coercion and selectability behavior.
- If local Ollama routing regresses before revert, switch provider to another selectable runtime or disable explicit Ollama pin in local smoke.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * LLM invocation now accepts plain string inputs directly, simplifying API usage without requiring message list wrapping.

* **Bug Fixes**
  * Enhanced provider availability detection to properly handle live streaming probes and fallback scenarios.
  * Improved cache invalidation for runtime metadata changes to ensure fresh provider state.

* **Tests**
  * Added comprehensive test coverage for message input handling and provider selectability edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->