### PR TITLE
Fix fallback greeting routing

### DIFF
--- a/maritime-ai-service/app/services/chat_orchestrator.py
+++ b/maritime-ai-service/app/services/chat_orchestrator.py
@@ -11,7 +11,6 @@ Authoritative request flow:
 see app/services/REQUEST_FLOW_CONTRACT.md
 """
 
-import json
 import logging
 from dataclasses import dataclass
 from enum import Enum
@@ -37,6 +36,7 @@ from .chat_orchestrator_support import (
     persist_pronoun_style_impl,
 )
 from .chat_orchestrator_fallback_runtime import (
+    build_fast_chatter_result_impl,
     persist_chat_message_impl,
     process_with_direct_llm_impl,
     process_without_multi_agent_impl,
@@ -93,56 +93,6 @@ _AGENT_TYPE_MAP = {
     "direct": AgentType.DIRECT,
     "code_studio_agent": AgentType.CODE_STUDIO,
 }
-
-
-def _has_sync_fast_path_blocking_context(context: ChatContext | None) -> bool:
-    """Keep deterministic sync replies away from tool/file/action turns."""
-    if context is None:
-        return True
-    return any(
-        bool(getattr(context, field_name, None))
-        for field_name in (
-            "images",
-            "image_input_error",
-            "document_context",
-            "force_skills",
-            "pointy_mode",
-            "host_action_feedback",
-        )
-    )
-
-
-def _build_sync_social_chatter_answer(message: str, shape: str) -> tuple[str, str]:
-    from app.engine.multi_agent.supervisor_hint_runtime import (
-        _normalize_router_text_impl,
-    )
-
-    normalized = _normalize_router_text_impl(message)
-    if shape == "reaction":
-        return (
-            "Mình nghe thấy rồi. Nếu cậu muốn, cứ ném phần tiếp theo qua đây, mình bắt nhịp cùng cậu.",
-            "Đây chỉ là một phản ứng ngắn, không phải lượt cần tra cứu hay dùng tool. Mình nên đáp lại có mặt, gọn, và mở đường để cậu nói tiếp.",
-        )
-    if any(marker in normalized for marker in ("cam on", "thanks", "thank you", "thank")):
-        return (
-            "Không có gì đâu, mình ở đây mà. Cần mình phụ tiếp đoạn nào thì cứ nói nhé.",
-            "Cậu đang cảm ơn, nên câu trả lời tốt nhất là ấm, ngắn, không kéo pipeline LLM chỉ để tạo thêm chữ.",
-        )
-    if any(marker in normalized for marker in ("tam biet", "bye", "goodbye", "hen gap lai")):
-        return (
-            "Ừ, mình tạm gác ở đây nha. Khi cậu quay lại, mình tiếp tục cùng cậu từ mạch đang làm.",
-            "Đây là lượt kết thúc nhẹ, nên Wiii nên giữ cảm giác liên tục thay vì route sang RAG hoặc tool.",
-        )
-    if "alo" in normalized:
-        return (
-            "Mình nghe đây. Cậu cần mình phụ phần nào trước?",
-            "Câu này là tín hiệu gọi Wiii, không có yêu cầu tri thức hay hành động. Mình đáp nhanh để cuộc trò chuyện không bị khựng.",
-        )
-    return (
-        "Chào cậu, mình đây. Cậu muốn mình cùng xử lý phần nào trước?",
-        "Đây là lời chào rất rõ, không cần RAG, web hay tool. Mình nên phản hồi ngay để tạo nhịp tự nhiên rồi chờ yêu cầu thật sự của cậu.",
-    )
-
 
 @dataclass(frozen=True)
 class RequestScope:
@@ -295,57 +245,12 @@ class ChatOrchestrator:
         context: ChatContext | None,
     ) -> ProcessingResult | None:
         """Return a deterministic result for obvious sync-only chatter."""
-        if _has_sync_fast_path_blocking_context(context):
-            return None
-
-        message = getattr(context, "message", "") or ""
-        from app.engine.multi_agent.supervisor_hint_runtime import (
-            classify_fast_chatter_turn_impl,
-        )
-
-        classification = classify_fast_chatter_turn_impl(message)
-        if not classification:
-            return None
-
-        intent, shape = classification
-        if intent != "social":
-            return None
-
-        if shape == "hunger_chatter":
-            from app.engine.multi_agent.direct_node_chatter_runtime import (
-                _build_hunger_chatter_answer,
-                _build_hunger_chatter_thinking,
-            )
-
-            answer = _build_hunger_chatter_answer(message)
-            thinking = _build_hunger_chatter_thinking(message)
-        elif shape in {"social", "reaction"}:
-            answer, thinking = _build_sync_social_chatter_answer(message, shape)
-        else:
-            return None
-
-        return ProcessingResult(
-            message=answer,
-            agent_type=AgentType.DIRECT,
-            sources=None,
-            metadata={
-                "multi_agent": False,
-                "provider": "deterministic",
-                "model": "wiii-sync-fast-chatter-v1",
-                "runtime_authoritative": True,
-                "current_agent": "direct",
-                "tools_used": [],
-                "reasoning_trace": None,
-                "thinking": thinking,
-                "thinking_content": thinking,
-                "routing_metadata": {
-                    "method": "sync_fast_chatter",
-                    "intent": intent,
-                    "shape": shape,
-                    "reason": "obvious_short_social_turn_without_tool_context",
-                },
-            },
-            thinking=thinking,
+        return build_fast_chatter_result_impl(
+            context=context,
+            processing_result_cls=ProcessingResult,
+            agent_type_direct=AgentType.DIRECT,
+            routing_method="sync_fast_chatter",
+            model_name="wiii-sync-fast-chatter-v1",
         )
 
     def finalize_response_turn(
@@ -726,6 +631,7 @@ class ChatOrchestrator:
             resolve_runtime_llm_metadata_fn=resolve_runtime_llm_metadata,
             processing_result_cls=ProcessingResult,
             agent_type_rag=AgentType.RAG,
+            agent_type_direct=AgentType.DIRECT,
         )
 
     async def _process_with_direct_llm(self, context: ChatContext) -> ProcessingResult:

--- a/maritime-ai-service/app/services/chat_orchestrator_fallback_runtime.py
+++ b/maritime-ai-service/app/services/chat_orchestrator_fallback_runtime.py
@@ -76,6 +76,118 @@ def should_use_local_direct_llm_fallback_impl(*, settings_obj) -> bool:
     return provider == "ollama" and not settings_obj.google_api_key
 
 
+def _has_fast_chatter_blocking_context(context) -> bool:
+    """Keep deterministic replies away from file, host-action, and tool turns."""
+    if context is None:
+        return True
+    return any(
+        bool(getattr(context, field_name, None))
+        for field_name in (
+            "images",
+            "image_input_error",
+            "document_context",
+            "force_skills",
+            "pointy_mode",
+            "host_action_feedback",
+        )
+    )
+
+
+def _build_social_chatter_answer(message: str, shape: str) -> tuple[str, str]:
+    from app.engine.multi_agent.supervisor_hint_runtime import (
+        _normalize_router_text_impl,
+    )
+
+    normalized = _normalize_router_text_impl(message)
+    if shape == "reaction":
+        return (
+            "Mình nghe thấy rồi. Nếu cậu muốn, cứ ném phần tiếp theo qua đây, mình bắt nhịp cùng cậu.",
+            "Đây chỉ là một phản ứng ngắn, không phải lượt cần tra cứu hay dùng tool. Mình nên đáp lại có mặt, gọn, và mở đường để cậu nói tiếp.",
+        )
+    if any(marker in normalized for marker in ("cam on", "thanks", "thank you", "thank")):
+        return (
+            "Không có gì đâu, mình ở đây mà. Cần mình phụ tiếp đoạn nào thì cứ nói nhé.",
+            "Cậu đang cảm ơn, nên câu trả lời tốt nhất là ấm, ngắn, không kéo pipeline LLM chỉ để tạo thêm chữ.",
+        )
+    if any(marker in normalized for marker in ("tam biet", "bye", "goodbye", "hen gap lai")):
+        return (
+            "Ừ, mình tạm gác ở đây nha. Khi cậu quay lại, mình tiếp tục cùng cậu từ mạch đang làm.",
+            "Đây là lượt kết thúc nhẹ, nên Wiii nên giữ cảm giác liên tục thay vì route sang RAG hoặc tool.",
+        )
+    if "alo" in normalized:
+        return (
+            "Mình nghe đây. Cậu cần mình phụ phần nào trước?",
+            "Câu này là tín hiệu gọi Wiii, không có yêu cầu tri thức hay hành động. Mình đáp nhanh để cuộc trò chuyện không bị khựng.",
+        )
+    return (
+        "Chào cậu, mình đây. Cậu muốn mình cùng xử lý phần nào trước?",
+        "Đây là lời chào rất rõ, không cần RAG, web hay tool. Mình nên phản hồi ngay để tạo nhịp tự nhiên rồi chờ yêu cầu thật sự của cậu.",
+    )
+
+
+def build_fast_chatter_result_impl(
+    *,
+    context,
+    processing_result_cls,
+    agent_type_direct,
+    routing_method: str = "fast_chatter",
+    model_name: str = "wiii-fast-chatter-v1",
+):
+    """Return deterministic direct output for obvious short social turns."""
+    if _has_fast_chatter_blocking_context(context):
+        return None
+
+    message = getattr(context, "message", "") or ""
+    from app.engine.multi_agent.supervisor_hint_runtime import (
+        classify_fast_chatter_turn_impl,
+    )
+
+    classification = classify_fast_chatter_turn_impl(message)
+    if not classification:
+        return None
+
+    intent, shape = classification
+    if intent != "social":
+        return None
+
+    if shape == "hunger_chatter":
+        from app.engine.multi_agent.direct_node_chatter_runtime import (
+            _build_hunger_chatter_answer,
+            _build_hunger_chatter_thinking,
+        )
+
+        answer = _build_hunger_chatter_answer(message)
+        thinking = _build_hunger_chatter_thinking(message)
+    elif shape in {"social", "reaction"}:
+        answer, thinking = _build_social_chatter_answer(message, shape)
+    else:
+        return None
+
+    return processing_result_cls(
+        message=answer,
+        agent_type=agent_type_direct,
+        sources=None,
+        metadata={
+            "multi_agent": False,
+            "provider": "deterministic",
+            "model": model_name,
+            "runtime_authoritative": True,
+            "current_agent": "direct",
+            "tools_used": [],
+            "reasoning_trace": None,
+            "thinking": thinking,
+            "thinking_content": thinking,
+            "routing_metadata": {
+                "method": routing_method,
+                "intent": intent,
+                "shape": shape,
+                "reason": "obvious_short_social_turn_without_tool_context",
+            },
+        },
+        thinking=thinking,
+    )
+
+
 def _runtime_text(value) -> str | None:
     if not isinstance(value, str):
         return None
@@ -145,8 +257,18 @@ async def process_without_multi_agent_impl(
     resolve_runtime_llm_metadata_fn,
     processing_result_cls,
     agent_type_rag,
+    agent_type_direct="direct",
 ):
     """Run the authoritative non-multi-agent fallback used by sync and stream."""
+    fast_result = build_fast_chatter_result_impl(
+        context=context,
+        processing_result_cls=processing_result_cls,
+        agent_type_direct=agent_type_direct,
+    )
+    if fast_result is not None:
+        logger_obj.warning("[FALLBACK] Multi-Agent unavailable, using deterministic chatter")
+        return fast_result
+
     if should_use_local_direct_llm_fallback:
         logger_obj.warning("[FALLBACK] Multi-Agent unavailable, using local direct LLM")
         return await process_with_direct_llm_fn(context)

--- a/maritime-ai-service/tests/unit/test_chat_orchestrator_fallback_runtime.py
+++ b/maritime-ai-service/tests/unit/test_chat_orchestrator_fallback_runtime.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.services.chat_orchestrator_fallback_runtime import (
+    build_fast_chatter_result_impl,
     persist_chat_message_impl,
     process_with_direct_llm_impl,
     process_without_multi_agent_impl,
@@ -284,10 +285,66 @@ class TestProcessWithDirectLlmImpl:
 
 
 class TestProcessWithoutMultiAgentImpl:
+    def test_fast_chatter_result_handles_plain_greeting_without_rag(self):
+        context = SimpleNamespace(message="Xin chào Wiii")
+
+        result = build_fast_chatter_result_impl(
+            context=context,
+            processing_result_cls=FakeProcessingResult,
+            agent_type_direct="direct",
+        )
+
+        assert result is not None
+        assert result.agent_type == "direct"
+        assert "Chào" in result.message
+        assert result.metadata["provider"] == "deterministic"
+        assert result.metadata["routing_metadata"]["method"] == "fast_chatter"
+
+    def test_fast_chatter_result_does_not_bypass_document_context(self):
+        context = SimpleNamespace(
+            message="Xin chào Wiii",
+            document_context={"document_ids": ["doc-1"]},
+        )
+
+        result = build_fast_chatter_result_impl(
+            context=context,
+            processing_result_cls=FakeProcessingResult,
+            agent_type_direct="direct",
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_fallback_uses_fast_chatter_for_greeting_before_rag(self):
+        logger_obj = MagicMock()
+        rag_agent = MagicMock()
+        rag_agent.query = AsyncMock()
+
+        result = await process_without_multi_agent_impl(
+            context=SimpleNamespace(message="Xin chào Wiii"),
+            rag_agent=rag_agent,
+            output_processor=MagicMock(),
+            logger_obj=logger_obj,
+            should_use_local_direct_llm_fallback=False,
+            process_with_direct_llm_fn=AsyncMock(),
+            resolve_runtime_llm_metadata_fn=MagicMock(return_value={}),
+            processing_result_cls=FakeProcessingResult,
+            agent_type_rag="rag",
+            agent_type_direct="direct",
+        )
+
+        assert result.agent_type == "direct"
+        assert result.metadata["provider"] == "deterministic"
+        assert "searched for information" not in result.message.lower()
+        rag_agent.query.assert_not_awaited()
+
     @pytest.mark.asyncio
     async def test_uses_direct_llm_path_when_flag_enabled(self):
         logger_obj = MagicMock()
-        context = SimpleNamespace(message="Hi", user_role=SimpleNamespace(value="student"))
+        context = SimpleNamespace(
+            message="Explain COLREG Rule 5",
+            user_role=SimpleNamespace(value="student"),
+        )
         process_with_direct_llm_fn = AsyncMock(return_value=FakeProcessingResult("hello", "direct"))
 
         result = await process_without_multi_agent_impl(
@@ -320,7 +377,10 @@ class TestProcessWithoutMultiAgentImpl:
         )
 
         result = await process_without_multi_agent_impl(
-            context=SimpleNamespace(message="Hi", user_role=SimpleNamespace(value="student")),
+            context=SimpleNamespace(
+                message="Explain COLREG Rule 5",
+                user_role=SimpleNamespace(value="student"),
+            ),
             rag_agent=rag_agent,
             output_processor=output_processor,
             logger_obj=logger_obj,
@@ -352,7 +412,10 @@ class TestProcessWithoutMultiAgentImpl:
     async def test_raises_when_no_agent_available(self):
         with pytest.raises(RuntimeError, match="No processing agent available"):
             await process_without_multi_agent_impl(
-                context=SimpleNamespace(message="Hi", user_role=SimpleNamespace(value="student")),
+                context=SimpleNamespace(
+                    message="Explain COLREG Rule 5",
+                    user_role=SimpleNamespace(value="student"),
+                ),
                 rag_agent=None,
                 output_processor=MagicMock(),
                 logger_obj=MagicMock(),


### PR DESCRIPTION
Closes #675

## Summary
- Move deterministic fast-chatter handling into the shared fallback runtime.
- Reuse it from sync chat and from the non-multi-agent fallback path before RAG.
- Add regression coverage so Xin chào Wiii cannot fall into RAG/no-results fallback when multi-agent is disabled.

## Scope
- Backend chat routing/fallback only.
- No LMS mutation, document apply, auth, migration, provider secret, or frontend changes.

## Non-Scope
- Does not change production provider secrets or committed .env templates.
- Does not remove the RAG fallback itself.

## Verification
- python -m pytest tests/unit/test_chat_orchestrator_fallback_runtime.py tests/unit/test_chat_request_flow.py -q --tb=short -> 44 passed
- python -m ruff check app/services/chat_orchestrator.py app/services/chat_orchestrator_fallback_runtime.py tests/unit/test_chat_orchestrator_fallback_runtime.py tests/unit/test_chat_request_flow.py --select=E9,F63,F7,F401,F821 -> passed
- git diff --check -> passed
- Local stack config smoke after env correction: NVIDIA Qwen instruct full smoke 10 passed, 0 failed
- Manual stream check: Xin chào Wiii -> route direct, provider nvidia, model qwen/qwen3-next-80b-a3b-instruct

## Risk
Low-medium: touches shared chat fallback routing. The guard is narrow and skips deterministic replies when images, document context, forced skills, Pointy mode, or host-action feedback are present.

## Rollback
Revert this PR to restore previous fallback behavior; active multi-agent path remains controlled by USE_MULTI_AGENT=true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal chat service to handle simple greetings and social interactions with faster deterministic responses, bypassing more resource-intensive processing for these common cases.

* **Tests**
  * Added new test coverage for fast-path greeting handling and verified that document context prevents early response termination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->