### PR TITLE
fix(backend): fast-path short social follow-ups

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_chatter_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_chatter_runtime.py
@@ -18,18 +18,28 @@ _HUNGER_CHATTER_MARKERS = (
 )
 
 _HUNGER_CHATTER_TASK_BLOCKERS = (
+    "audit",
     "bao nhieu",
+    "bat ",
     "canvas",
     "chart",
+    "chay",
     "code",
     "css",
+    "deploy",
+    "docker",
     "excel",
     "file",
+    "fix",
     "giai thich",
     "html",
     "huong dan",
     "javascript",
+    "kiem tra",
     "la gi",
+    "log",
+    "luong",
+    "model",
     "mo phong",
     "pdf",
     "phan tich",
@@ -38,6 +48,9 @@ _HUNGER_CHATTER_TASK_BLOCKERS = (
     "react",
     "search",
     "so sanh",
+    "sua",
+    "tat ",
+    "test",
     "tao anh",
     "the nao",
     "thay doi",
@@ -49,6 +62,31 @@ _HUNGER_CHATTER_TASK_BLOCKERS = (
     "word",
 )
 
+_CHATTER_FALSE_POSITIVE_BLOCKERS = (
+    "du an",
+    "do an",
+    "phuong an",
+    "vu an",
+    "ban an",
+)
+
+_SOCIAL_STATUS_CHATTER_MARKERS = (
+    "an com roi",
+    "an roi",
+    "da an",
+    "moi an",
+    "vua an",
+    "no roi",
+    "trua nay an",
+    "toi nay an",
+    "sang nay an",
+    "uong nuoc roi",
+    "moi uong nuoc",
+    "vua uong nuoc",
+    "di ngu roi",
+    "ngu roi",
+)
+
 
 def _looks_hunger_chatter_turn(normalized_query: str) -> bool:
     folded = _fold_direct_text(normalized_query)
@@ -56,12 +94,30 @@ def _looks_hunger_chatter_turn(normalized_query: str) -> bool:
         return False
     if any(marker in folded for marker in ("hay nho", "ghi nho", "nho rang", "luu lai")):
         return False
+    if any(marker in folded for marker in _CHATTER_FALSE_POSITIVE_BLOCKERS):
+        return False
     if any(marker in folded for marker in _HUNGER_CHATTER_TASK_BLOCKERS):
         return False
     tokens = [token for token in folded.split() if token]
     if len(tokens) > 40:
         return False
     return any(marker in folded for marker in _HUNGER_CHATTER_MARKERS)
+
+
+def _looks_social_status_chatter_turn(normalized_query: str) -> bool:
+    folded = _fold_direct_text(normalized_query)
+    if not folded:
+        return False
+    if any(marker in folded for marker in ("hay nho", "ghi nho", "nho rang", "luu lai")):
+        return False
+    if any(marker in folded for marker in _CHATTER_FALSE_POSITIVE_BLOCKERS):
+        return False
+    if any(marker in folded for marker in _HUNGER_CHATTER_TASK_BLOCKERS):
+        return False
+    tokens = [token for token in folded.split() if token]
+    if len(tokens) > 12:
+        return False
+    return any(marker in folded for marker in _SOCIAL_STATUS_CHATTER_MARKERS)
 
 
 def _build_hunger_chatter_answer(_query: str) -> str:
@@ -88,4 +144,26 @@ def _build_hunger_chatter_thinking(_query: str) -> str:
     return (
         "Cậu nói rất ngắn, nhưng mình nghe được một nhu cầu rất thật: bụng đói thì mọi thứ cũng tụt pin theo. "
         "Mình không cần làm màu ở đây; chỉ cần kéo cậu về một việc nhỏ có ích ngay, rồi ở lại cùng cậu tính tiếp."
+    )
+
+
+def _build_social_status_chatter_answer(_query: str) -> str:
+    folded = _fold_direct_text(_query)
+    if any(marker in folded for marker in ("ngu roi", "di ngu roi")):
+        return (
+            "Ổn rồi, vậy mình giữ nhịp nhẹ thôi. Khi cậu quay lại, mình sẽ tiếp tục từ đúng đoạn đang làm."
+        )
+    if any(marker in folded for marker in ("uong nuoc", "moi uong", "vua uong")):
+        return (
+            "Tốt rồi, có nước vào người thì đỡ hụt năng lượng hơn. Mình ở đây; cậu muốn mình tiếp tục phần nào?"
+        )
+    return (
+        "Ổn rồi, vậy là có sức hơn chút. Mình ở đây; cậu muốn nói tiếp vài câu hay quay lại phần đang làm của Wiii?"
+    )
+
+
+def _build_social_status_chatter_thinking(_query: str) -> str:
+    return (
+        "Đây là một cập nhật xã giao ngắn, không có yêu cầu tra cứu, công cụ, visual, code hay tài liệu. "
+        "Wiii đáp trực tiếp để tránh gọi provider chậm và tránh tạo câu trả lời cụt không có ích."
     )

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_fast_response_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_fast_response_runtime.py
@@ -7,7 +7,10 @@ from typing import Any, Callable
 from app.engine.multi_agent.direct_node_chatter_runtime import (
     _build_hunger_chatter_answer,
     _build_hunger_chatter_thinking,
+    _build_social_status_chatter_answer,
+    _build_social_status_chatter_thinking,
     _looks_hunger_chatter_turn,
+    _looks_social_status_chatter_turn,
 )
 from app.engine.multi_agent.direct_node_meta_fast_paths import (
     _build_reasoning_safety_meta_answer,
@@ -268,6 +271,21 @@ def resolve_direct_node_fast_response(
                 record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
             )
             return DirectNodeFastResponse(response, "hunger_chatter")
+        elif (
+            not request.has_uploaded_document_context
+            and _looks_social_status_chatter_turn(normalized_for_fast)
+            and not _looks_session_memory_write_turn(normalized_for_fast)
+            and not dependencies.needs_web_search(query)
+            and not dependencies.needs_datetime(query)
+        ):
+            response = _build_social_status_chatter_answer(query)
+            _record_fast_thinking(
+                state=state,
+                thinking=_build_social_status_chatter_thinking(query),
+                provenance="deterministic_social_status_chatter",
+                record_thinking_snapshot_fn=dependencies.record_thinking_snapshot_fn,
+            )
+            return DirectNodeFastResponse(response, "social_status_chatter")
     except Exception as exc:  # noqa: BLE001
         if dependencies.logger_obj is not None:
             dependencies.logger_obj.debug(

--- a/maritime-ai-service/app/engine/multi_agent/supervisor_hint_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/supervisor_hint_runtime.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import re
 
+from app.engine.multi_agent.direct_node_chatter_runtime import (
+    _looks_social_status_chatter_turn,
+)
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.direct_intent import _looks_selfhood_followup_turn
 from app.engine.multi_agent.visual_intent_resolver import resolve_visual_intent
@@ -319,6 +322,8 @@ def classify_fast_chatter_turn_impl(query: str) -> tuple[str, str] | None:
         return None
     if _looks_hunger_chatter_impl(normalized):
         return ("social", "hunger_chatter")
+    if _looks_social_status_chatter_turn(normalized):
+        return ("social", "social_status")
     if _looks_clear_social_impl(normalized):
         return ("social", "social")
     tokens = [token for token in re.sub(r"[^\w\s]", " ", normalized).split() if token]

--- a/maritime-ai-service/tests/unit/test_conservative_evolution.py
+++ b/maritime-ai-service/tests/unit/test_conservative_evolution.py
@@ -780,6 +780,28 @@ class TestConservativeFastRouting:
         assert "COLREG" not in _build_hunger_chatter_answer(query)
         assert "bao cao" in _fold_direct_text(_build_hunger_chatter_answer(query))
 
+    def test_short_social_status_routes_to_fast_social_without_task_bleed(self):
+        from app.engine.multi_agent.direct_node_chatter_runtime import (
+            _build_social_status_chatter_answer,
+            _looks_social_status_chatter_turn,
+        )
+        from app.engine.multi_agent.supervisor_hint_runtime import (
+            classify_fast_chatter_turn_impl,
+        )
+
+        assert classify_fast_chatter_turn_impl("trưa nay ăn cơm rồi") == (
+            "social",
+            "social_status",
+        )
+        assert _looks_social_status_chatter_turn("trua nay an com roi") is True
+        assert _looks_social_status_chatter_turn("du an roi") is False
+        assert (
+            _looks_social_status_chatter_turn("trua nay an com roi, kiem tra log")
+            is False
+        )
+        assert _looks_social_status_chatter_turn("tao code mo phong luc an com") is False
+        assert "Wiii" in _build_social_status_chatter_answer("trưa nay ăn cơm rồi")
+
     def test_reasoning_safety_meta_turn_is_detected(self):
         from app.engine.multi_agent.supervisor_runtime_support import (
             _looks_reasoning_safety_meta_turn,

--- a/maritime-ai-service/tests/unit/test_direct_node_provider_errors.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_provider_errors.py
@@ -741,6 +741,36 @@ async def test_direct_response_node_uses_hunger_chatter_fast_path_without_llm():
 
 
 @pytest.mark.asyncio
+async def test_direct_response_node_uses_social_status_fast_path_without_llm():
+    state = _base_state()
+    state.update(
+        {
+            "query": "trưa nay ăn cơm rồi",
+            "routing_metadata": {
+                "method": "structured",
+                "intent": "social",
+            },
+        }
+    )
+
+    kwargs = _base_direct_kwargs()
+    kwargs["looks_identity_selfhood_turn"] = lambda *_args, **_kwargs: False
+
+    with patch(
+        "app.engine.multi_agent.agent_config.AgentConfigRegistry.get_llm",
+        side_effect=AssertionError("social status fast path should not call an LLM"),
+    ):
+        result = await direct_response_node_impl(
+            state,
+            **kwargs,
+        )
+
+    assert "có sức hơn chút" in result["final_response"]
+    assert "provider chậm" in result["thinking_content"]
+    assert "(๑" not in result["final_response"]
+
+
+@pytest.mark.asyncio
 async def test_direct_response_node_uses_self_feeling_probe_without_llm():
     state = _base_state()
     state.update(

--- a/maritime-ai-service/tests/unit/test_supervisor_agent.py
+++ b/maritime-ai-service/tests/unit/test_supervisor_agent.py
@@ -122,7 +122,11 @@ class TestSupervisorRoute:
             "domain_config": {},
         }
 
-        with patch.object(sup, "_route_structured", new=AsyncMock(return_value="direct")) as mock_route:
+        with patch.object(
+            sup,
+            "_route_structured",
+            new=AsyncMock(return_value="direct"),
+        ) as mock_route:
             result = await sup.route(state)
 
         assert result == "direct"
@@ -151,6 +155,27 @@ class TestSupervisorRoute:
             "kind": "fast_chatter",
             "intent": "social",
             "shape": "social",
+        }
+        assert state["routing_metadata"]["method"] == "conservative_fast_path"
+        mock_route.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_route_short_social_status_uses_fast_path(self, mock_llm):
+        sup = _make_supervisor(mock_llm)
+        state = {
+            "query": "trưa nay ăn cơm rồi",
+            "context": {},
+            "domain_config": {},
+        }
+
+        with patch.object(sup, "_route_structured", new=AsyncMock(return_value="direct")) as mock_route:
+            result = await sup.route(state)
+
+        assert result == "direct"
+        assert state["_routing_hint"] == {
+            "kind": "fast_chatter",
+            "intent": "social",
+            "shape": "social_status",
         }
         assert state["routing_metadata"]["method"] == "conservative_fast_path"
         mock_route.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Adds a deterministic fast-path for short social/status follow-ups such as `trưa nay ăn cơm rồi`.
- Shares the status-chatter detector between supervisor routing hints and direct-node pre-LLM response selection.
- Keeps task-like turns out via blockers for code/visual/web/log/model/deploy/test and false positives such as `dự án`.

## Linked Issue
Closes #677

## Scope
- Backend multi-agent supervisor hint classification.
- Direct node deterministic pre-LLM social/status response.
- Focused unit coverage for supervisor, direct-node, and conservative routing.

## Non-Scope
- No provider/model selection changes.
- No frontend rendering changes.
- No LMS host action or mutation path changes.
- No OpenHuman code changes.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_direct_node_provider_errors.py tests/unit/test_supervisor_agent.py tests/unit/test_conservative_evolution.py tests/unit/test_chat_request_flow.py tests/unit/test_chat_stream_coordinator.py::test_generate_stream_v3_events_social_turn_invokes_native_llm_stream -q --tb=short` -> 186 passed
- `cd maritime-ai-service; python -m ruff check app/engine/multi_agent/direct_node_chatter_runtime.py app/engine/multi_agent/direct_node_fast_response_runtime.py app/engine/multi_agent/supervisor_hint_runtime.py tests/unit/test_direct_node_provider_errors.py tests/unit/test_supervisor_agent.py tests/unit/test_conservative_evolution.py --select=E9,F63,F7` -> All checks passed
- `git diff --check` -> clean

## Risk
- Backend chat routing/runtime behavior. The main risk is over-broad classification hiding a real task request. This is mitigated by blockers and tests for `kiểm tra log`, code/visual prompts, and `dự án` false positives.

## Rollback
- Revert commit `bc66ad2f` or revert this PR to restore the previous supervisor/direct-node behavior.

## Reviewer Focus
- Confirm the social/status markers are narrow enough for active chat.
- Confirm uploaded document/tool/web/code requests cannot be swallowed by this fast path.