### PR TITLE
fix(backend): skip supervisor LLM for social status follow-ups

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/supervisor.py
+++ b/maritime-ai-service/app/engine/multi_agent/supervisor.py
@@ -318,6 +318,29 @@ class SupervisorAgent:
 
         routing_hint = state.get("_routing_hint") or {}
         if (
+            isinstance(routing_hint, dict)
+            and routing_hint.get("kind") == "fast_chatter"
+            and routing_hint.get("shape") == "social_status"
+        ):
+            agent = AgentType.DIRECT.value
+            intent = str(routing_hint.get("intent") or "social")
+            method = "always_on_social_status_fast_path"
+            state["routing_metadata"] = {
+                "intent": intent,
+                "confidence": 1.0,
+                "reasoning": _finalize_routing_reasoning(
+                    raw_reasoning="obvious short social status update",
+                    method=method,
+                    chosen_agent=agent,
+                    intent=intent,
+                    query=query,
+                ),
+                "llm_reasoning": "",
+                "method": method,
+                "final_agent": agent,
+            }
+            return agent
+        if (
             settings.enable_conservative_fast_routing
             and (not routing_hint or routing_hint.get("kind") == "fast_chatter")
         ):

--- a/maritime-ai-service/app/engine/multi_agent/supervisor_surface.py
+++ b/maritime-ai-service/app/engine/multi_agent/supervisor_surface.py
@@ -228,6 +228,12 @@ def _finalize_routing_reasoning_impl(
     if normalized_method == "always_on_social_fast_path":
         return "Đây là một nhịp xã giao rất rõ, nên mình đáp ngay để giữ cuộc trò chuyện tự nhiên."
 
+    if normalized_method == "always_on_social_status_fast_path":
+        return (
+            "Đây là một cập nhật sinh hoạt rất ngắn, không có yêu cầu tra cứu hay công cụ, "
+            "nên Wiii đáp trực tiếp."
+        )
+
     if normalized_method == "always_on_chatter_fast_path":
         return "Đây là một nhịp trò chuyện rất ngắn và ít thông tin, nên mình giữ nó ở lane đáp trực tiếp."
 

--- a/maritime-ai-service/tests/unit/test_supervisor_agent.py
+++ b/maritime-ai-service/tests/unit/test_supervisor_agent.py
@@ -160,7 +160,19 @@ class TestSupervisorRoute:
         mock_route.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_route_short_social_status_uses_fast_path(self, mock_llm):
+    async def test_route_short_social_status_uses_fast_path_without_feature_flag(
+        self,
+        mock_llm,
+        monkeypatch,
+    ):
+        from app.core.config import settings
+
+        monkeypatch.setattr(
+            settings,
+            "enable_conservative_fast_routing",
+            False,
+            raising=False,
+        )
         sup = _make_supervisor(mock_llm)
         state = {
             "query": "trưa nay ăn cơm rồi",
@@ -177,7 +189,7 @@ class TestSupervisorRoute:
             "intent": "social",
             "shape": "social_status",
         }
-        assert state["routing_metadata"]["method"] == "conservative_fast_path"
+        assert state["routing_metadata"]["method"] == "always_on_social_status_fast_path"
         mock_route.assert_not_awaited()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds a narrow always-on supervisor route for `social_status` fast-chatter hints.
- Keeps broad conservative fast routing behind `ENABLE_CONSERVATIVE_FAST_ROUTING`; this only bypasses the supervisor LLM for obvious short status updates already classified by the shared detector.
- Adds routing coverage proving the path works when the conservative feature flag is disabled.

## Linked Issue
Closes #677

## Scope
- Backend supervisor routing only.
- Public routing reasoning text for the new method.
- Focused supervisor unit coverage.

## Non-Scope
- No provider/model selection changes.
- No frontend changes.
- No LMS/document/tool mutation changes.
- No broad enablement of conservative fast routing.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_direct_node_provider_errors.py tests/unit/test_supervisor_agent.py tests/unit/test_conservative_evolution.py tests/unit/test_chat_request_flow.py tests/unit/test_chat_stream_coordinator.py::test_generate_stream_v3_events_social_turn_invokes_native_llm_stream -q --tb=short` -> 186 passed
- `cd maritime-ai-service; python -m ruff check app/engine/multi_agent/direct_node_chatter_runtime.py app/engine/multi_agent/direct_node_fast_response_runtime.py app/engine/multi_agent/supervisor_hint_runtime.py app/engine/multi_agent/supervisor.py app/engine/multi_agent/supervisor_surface.py tests/unit/test_direct_node_provider_errors.py tests/unit/test_supervisor_agent.py tests/unit/test_conservative_evolution.py --select=E9,F63,F7` -> All checks passed
- `git diff --check` -> clean

## Risk
- Backend routing behavior. Risk is over-bypass of real tasks, but the route only activates when the shared fast-chatter detector produced `shape=social_status`, which already blocks web/code/visual/log/model/deploy/test and `dự án` false positives.

## Rollback
- Revert this PR to restore feature-flag-gated supervisor routing; PR #678 will still prevent provider use inside direct-node for this status shape.

## Reviewer Focus
- Confirm this is narrower than enabling `enable_conservative_fast_routing` globally.
- Confirm real task requests still reach structured routing or deterministic source/tool guards.