### PR TITLE
refactor(backend): add typed turn path governor

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_intent.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_intent.py
@@ -118,6 +118,24 @@ _LEGAL_INTENT_KEYWORDS: list[str] = [
     "nghi quyet", "quyet dinh so", "van ban quy pham",
 ]
 
+_MARITIME_INTENT_KEYWORDS: tuple[str, ...] = (
+    "colreg",
+    "colregs",
+    "solas",
+    "marpol",
+    "imo",
+    "hang hai",
+    "tau bien",
+    "tau thuyen",
+    "cang bien",
+    "vinamarine",
+    "cuc hang hai",
+    "quy tac tranh va",
+    "den hang hai",
+    "phao tieu",
+    "luong hang hai",
+)
+
 _ANALYSIS_INTENT_KEYWORDS: list[str] = [
     "python",
     "code python",
@@ -357,6 +375,14 @@ def _needs_legal_search(query: str) -> bool:
     """Detect if query needs legal search (Sprint 102)."""
     normalized = _normalize_for_intent(query)
     return any(kw in normalized for kw in _LEGAL_INTENT_KEYWORDS)
+
+
+def _needs_maritime_search(query: str) -> bool:
+    """Detect if query should expose the maritime-specific search path."""
+    normalized = _normalize_for_intent(query)
+    if not normalized:
+        return False
+    return any(kw in normalized for kw in _MARITIME_INTENT_KEYWORDS)
 
 
 def _needs_analysis_tool(query: str) -> bool:

--- a/maritime-ai-service/app/engine/multi_agent/tool_collection.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_collection.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from importlib import import_module
 import logging
+from types import SimpleNamespace
 from typing import Any, Optional
 
 from app.core.config import settings
@@ -17,6 +18,12 @@ from app.engine.multi_agent.document_preview_contract import (
     looks_uploaded_document_lesson_preview_request as _contract_looks_uploaded_document_lesson_preview_request,
 )
 from app.engine.multi_agent.state import AgentState
+from app.engine.multi_agent.turn_path_governor import (
+    TurnPathDecision,
+    TurnPathSignals,
+    filter_tools_for_turn_path,
+    resolve_turn_path_decision,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +59,10 @@ def _needs_news_search(query: str) -> bool:
 
 def _needs_legal_search(query: str) -> bool:
     return _load_attr("app.engine.multi_agent.direct_intent", "_needs_legal_search")(query)
+
+
+def _needs_maritime_search(query: str) -> bool:
+    return _load_attr("app.engine.multi_agent.direct_intent", "_needs_maritime_search")(query)
 
 
 def _needs_pointy(query: str) -> bool:
@@ -287,6 +298,11 @@ _POINTY_OUTPUT_REQUEST_CUES: tuple[str, ...] = (
     "tao app",
     "tao widget",
     "tao artifact",
+    "tao bai hoc",
+    "tao bai giang",
+    "tao khoa hoc",
+    "tao course",
+    "tao lesson",
     "create code",
     "write code",
     "run code",
@@ -297,6 +313,11 @@ _POINTY_OUTPUT_REQUEST_CUES: tuple[str, ...] = (
     "build app",
     "build widget",
     "create artifact",
+    "create lesson",
+    "generate lesson",
+    "create course",
+    "generate course",
+    "course draft",
 )
 
 
@@ -307,6 +328,25 @@ def _should_suppress_pointy_for_output_request(query: str) -> bool:
     if not normalized:
         return False
     return any(cue in normalized for cue in _POINTY_OUTPUT_REQUEST_CUES)
+
+
+def _prefers_code_execution_lane_from_normalized(normalized_query: str) -> bool:
+    return any(
+        token in normalized_query
+        for token in (
+            "python",
+            "code python",
+            "chay python",
+            "chay code",
+            "viet code",
+            "doan code",
+            "sandbox",
+            "pandas",
+            "xlsx",
+            "excel bang python",
+            "matplotlib",
+        )
+    )
 
 
 def _is_host_ui_navigation_route(state: Optional[AgentState]) -> bool:
@@ -427,6 +467,126 @@ def _safe_document_preview_capability_tools(
     ]
 
 
+def _safe_intent_flag(fn, query: str, *, default: bool = False) -> bool:
+    try:
+        return bool(fn(query))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[DIRECT] Turn-path signal failed for %s: %s", getattr(fn, "__name__", fn), exc)
+        return default
+
+
+def _default_visual_decision() -> Any:
+    return SimpleNamespace(
+        force_tool=False,
+        mode="text",
+        visual_type=None,
+        preferred_tool=None,
+        presentation_intent="text",
+    )
+
+
+def _safe_resolve_visual_decision(query: str) -> Any:
+    try:
+        return resolve_visual_intent(query)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[DIRECT] Visual intent unavailable for turn path: %s", exc)
+        return _default_visual_decision()
+
+
+def _safe_build_visual_requirement(
+    visual_decision: Any,
+    *,
+    structured_visuals_enabled: bool,
+) -> Any:
+    try:
+        return build_visual_tool_requirement(
+            visual_decision,
+            structured_visuals_enabled=structured_visuals_enabled,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[DIRECT] Visual tool requirement unavailable for turn path: %s", exc)
+        return SimpleNamespace(
+            force_tool=False,
+            mode=str(getattr(visual_decision, "mode", "text") or "text"),
+            presentation_intent=str(
+                getattr(visual_decision, "presentation_intent", "text") or "text"
+            ),
+            required_tool_names=(),
+        )
+
+
+def _resolve_direct_turn_path_decision(
+    *,
+    query: str,
+    state: Optional[AgentState],
+    visual_decision: Any,
+    visual_requirement: Any,
+    thinking_mode: str,
+    force_skills: set[str],
+) -> TurnPathDecision:
+    normalized_query = ""
+    try:
+        normalized_query = _normalize_for_intent(query)
+    except Exception:  # noqa: BLE001
+        normalized_query = str(query or "").lower().strip()
+
+    host_ui_navigation = _is_host_ui_navigation_route(state)
+    pointy_forced = "wiii-pointy" in force_skills
+    pointy_requested = (
+        pointy_forced
+        or host_ui_navigation
+        or _safe_intent_flag(_needs_pointy, query)
+    )
+    signals = TurnPathSignals(
+        normalized_query=normalized_query,
+        routing_intent=_routing_intent(state),
+        thinking_mode=thinking_mode,
+        force_skills=frozenset(force_skills),
+        web_search_forced="web-search" in force_skills,
+        pointy_forced=pointy_forced,
+        host_ui_navigation=host_ui_navigation,
+        looks_document_preview=_looks_like_document_preview_request(query, state),
+        looks_reasoning_safety_meta=_looks_reasoning_safety_meta_turn(query),
+        needs_web_search=_safe_intent_flag(_needs_web_search, query),
+        needs_datetime=_safe_intent_flag(_needs_datetime, query),
+        needs_news_search=_safe_intent_flag(_needs_news_search, query),
+        needs_legal_search=_safe_intent_flag(_needs_legal_search, query),
+        needs_lms_query=_safe_intent_flag(_needs_lms_query, query),
+        needs_direct_knowledge_search=_safe_intent_flag(
+            _needs_direct_knowledge_search,
+            query,
+        ),
+        needs_analysis_tool=_safe_intent_flag(_needs_analysis_tool, query),
+        prefers_code_execution_lane=_prefers_code_execution_lane_from_normalized(
+            normalized_query
+        ),
+        needs_maritime_search=_safe_intent_flag(_needs_maritime_search, query),
+        pointy_requested=pointy_requested,
+        suppress_pointy_for_output=_should_suppress_pointy_for_output_request(query),
+        visual_force_tool=bool(getattr(visual_requirement, "force_tool", False)),
+        visual_mode=str(
+            getattr(visual_requirement, "mode", None)
+            or getattr(visual_decision, "mode", "")
+            or ""
+        ),
+        visual_presentation_intent=str(
+            getattr(visual_requirement, "presentation_intent", "") or ""
+        ),
+        visual_required_tool_names=tuple(
+            getattr(visual_requirement, "required_tool_names", ()) or ()
+        ),
+    )
+    return resolve_turn_path_decision(signals)
+
+
+def _record_turn_path_decision(
+    state: Optional[AgentState],
+    decision: TurnPathDecision,
+) -> None:
+    if isinstance(state, dict):
+        state["_turn_path_decision"] = decision.to_metadata()
+
+
 def _should_use_no_tools_for_direct_prose(
     *,
     query: str,
@@ -484,6 +644,30 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
             - tools_list: List of available tools
             - force_tools: Whether to force tool calling (intent detected)
     """
+    force_skills = _force_skills_from_state(state)
+    structured_visuals_enabled = getattr(settings, "enable_structured_visuals", False)
+    visual_decision = _safe_resolve_visual_decision(query)
+    visual_requirement = _safe_build_visual_requirement(
+        visual_decision,
+        structured_visuals_enabled=structured_visuals_enabled,
+    )
+    try:
+        thinking_mode = _infer_direct_thinking_mode(query, state, [])
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[DIRECT] Thinking mode unavailable for turn path: %s", exc)
+        thinking_mode = ""
+    turn_path_decision = _resolve_direct_turn_path_decision(
+        query=query,
+        state=state,
+        visual_decision=visual_decision,
+        visual_requirement=visual_requirement,
+        thinking_mode=thinking_mode,
+        force_skills=force_skills,
+    )
+    _record_turn_path_decision(state, turn_path_decision)
+    if not turn_path_decision.bind_tools:
+        return [], False
+
     _direct_tools = []
     try:
         if settings.enable_character_tools:
@@ -531,7 +715,7 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
         _direct_tools = [*_direct_tools, tool_current_datetime,
                          tool_web_search, tool_fetch_url]
         # v2.8: force-bind via @web-search mention overrides news/legal gates.
-        web_search_forced = "web-search" in _force_skills_from_state(state)
+        web_search_forced = "web-search" in force_skills
         if _needs_news_search(query) or web_search_forced:
             _direct_tools.append(tool_search_news)
         if _needs_legal_search(query) or web_search_forced:
@@ -540,7 +724,6 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
         # intent (`_needs_pointy`) HOẶC explicit `@wiii-pointy` mention
         # (force_skills override, v2.8). Force-bind bypasses keyword
         # gates → user controls invocation explicitly.
-        force_skills = _force_skills_from_state(state)
         pointy_forced = "wiii-pointy" in force_skills
         host_ui_navigation = _is_host_ui_navigation_route(state)
         pointy_requested = pointy_forced or host_ui_navigation or _needs_pointy(query)
@@ -591,15 +774,10 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
         # Maritime is the default domain — bind tool only when query mentions
         # maritime/COLREGs/SOLAS/ship terminology so generic queries stay light.
         try:
-            _needs_maritime = _load_attr(
-                "app.engine.multi_agent.direct_intent",
-                "_needs_maritime_search",
-            )
-            if _needs_maritime(query):
+            if _needs_maritime_search(query):
                 _direct_tools.append(tool_search_maritime)
         except Exception:  # noqa: BLE001
-            # If helper missing, default to including maritime (safe for domain).
-            _direct_tools.append(tool_search_maritime)
+            logger.debug("[DIRECT] Maritime search intent unavailable")
     except Exception as _e:
         logger.debug("[DIRECT] Utility/web search tools unavailable: %s", _e)
 
@@ -621,7 +799,10 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
         str(getattr(t, "name", "") or getattr(t, "__name__", ""))
         for t in _direct_tools
     }
-    if "tool_knowledge_search" not in _bound_tool_names:
+    if (
+        turn_path_decision.allow_rag_delegation
+        and "tool_knowledge_search" not in _bound_tool_names
+    ):
         try:
             tool_rag_knowledge = _load_attr(
                 "app.engine.tools.agent_tools",
@@ -700,7 +881,6 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
     }:
         return [], False
 
-    force_skills = _force_skills_from_state(state)
     web_search_forced = "web-search" in force_skills
 
     # Structured visuals re-enable lightweight inline diagram/chart tools for direct,
@@ -729,29 +909,9 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
     except Exception as _e:
         logger.debug("[DIRECT] Visual tools unavailable: %s", _e)
 
-    visual_decision = resolve_visual_intent(query)
-    structured_visuals_enabled = getattr(settings, "enable_structured_visuals", False)
-    visual_requirement = build_visual_tool_requirement(
-        visual_decision,
-        structured_visuals_enabled=structured_visuals_enabled,
-    )
-    thinking_mode = _infer_direct_thinking_mode(query, state, [])
     normalized_query = _normalize_for_intent(query)
-    _prefers_code_execution_lane = any(
-        token in normalized_query
-        for token in (
-            "python",
-            "code python",
-            "chay python",
-            "chay code",
-            "viet code",
-            "doan code",
-            "sandbox",
-            "pandas",
-            "xlsx",
-            "excel bang python",
-            "matplotlib",
-        )
+    _prefers_code_execution_lane = _prefers_code_execution_lane_from_normalized(
+        normalized_query
     )
     _direct_tools = filter_tools_for_role(_direct_tools, user_role)
     _direct_tools = filter_tools_for_visual_intent(
@@ -772,6 +932,11 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
         thinking_mode=thinking_mode,
     ):
         _direct_tools = _strip_visual_tool_capabilities(_direct_tools)
+    _direct_tools = filter_tools_for_turn_path(
+        _direct_tools,
+        turn_path_decision,
+        tool_name=_tool_name,
+    )
     # Clear inline article/chart requests should stay tightly on the visual lane.
     # If there is no competing web/legal/news/datetime/LMS intent, bind only the
     # preferred visual tool so the first tool call is deterministic and the
@@ -811,6 +976,8 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
             query=query[:180],
         )
     force_tools = bool(_direct_tools) and (
+        turn_path_decision.force_tools
+        or
         web_search_forced
         or _needs_web_search(query) or _needs_datetime(query)
         or _needs_news_search(query) or _needs_legal_search(query)
@@ -826,7 +993,11 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
         return [], False
 
     # Agent handoff tool (Phase 3)
-    if getattr(settings, "enable_agent_handoffs", True) and not force_tools:
+    if (
+        turn_path_decision.allow_agent_handoff
+        and getattr(settings, "enable_agent_handoffs", True)
+        and not force_tools
+    ):
         try:
             from app.engine.multi_agent.handoff_tools import handoff_to_agent
             _direct_tools.append(handoff_to_agent)
@@ -995,6 +1166,8 @@ def _direct_required_tool_names(query: str, user_role: str = "student") -> list[
             required.append("tool_web_search")
     if _needs_direct_knowledge_search(query):
         required.append("tool_knowledge_search")
+    if _needs_maritime_search(query):
+        required.append("tool_search_maritime")
     # WAVE-001: browser_snapshot and execute_python removed from direct.
     # These capabilities now live exclusively in code_studio_agent.
 

--- a/maritime-ai-service/app/engine/multi_agent/turn_path_governor.py
+++ b/maritime-ai-service/app/engine/multi_agent/turn_path_governor.py
@@ -1,0 +1,392 @@
+"""Typed turn-path decisions for chat tool binding.
+
+The governor is intentionally pure: callers collect runtime signals, then this
+module chooses the path and the tool-binding policy for that path. Tool
+collection can then bind from the decision instead of mixing routing and
+capability exposure in the same block.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Literal
+
+
+TurnPathName = Literal[
+    "casual_chat",
+    "reasoning_safety",
+    "host_ui_navigation",
+    "pointy_guidance",
+    "lms_document_preview",
+    "web_search",
+    "datetime_lookup",
+    "lms_query",
+    "knowledge_search",
+    "maritime_search",
+    "visual_generation",
+    "code_execution",
+    "analytical_text",
+    "direct_prose",
+]
+
+
+POINTY_TOOL_PREFIXES: tuple[str, ...] = ("tool_pointy_",)
+HOST_ACTION_TOOL_PREFIXES: tuple[str, ...] = ("host_action__",)
+LMS_DOCUMENT_PREVIEW_TOOL_NAMES = frozenset(
+    {
+        "host_action__authoring__generate_course_from_document",
+        "host_action__authoring__preview_lesson_patch",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TurnPathSignals:
+    """Normalized input signals consumed by the turn path governor."""
+
+    normalized_query: str = ""
+    routing_intent: str = ""
+    thinking_mode: str = ""
+    force_skills: frozenset[str] = frozenset()
+    web_search_forced: bool = False
+    pointy_forced: bool = False
+    host_ui_navigation: bool = False
+    looks_document_preview: bool = False
+    looks_reasoning_safety_meta: bool = False
+    needs_web_search: bool = False
+    needs_datetime: bool = False
+    needs_news_search: bool = False
+    needs_legal_search: bool = False
+    needs_lms_query: bool = False
+    needs_direct_knowledge_search: bool = False
+    needs_analysis_tool: bool = False
+    prefers_code_execution_lane: bool = False
+    needs_maritime_search: bool = False
+    pointy_requested: bool = False
+    suppress_pointy_for_output: bool = False
+    visual_force_tool: bool = False
+    visual_mode: str = "text"
+    visual_presentation_intent: str = "text"
+    visual_required_tool_names: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class TurnPathDecision:
+    """Authoritative path and tool policy for one chat turn."""
+
+    path: TurnPathName
+    reason: str
+    bind_tools: bool = True
+    force_tools: bool = False
+    allow_all_tools: bool = True
+    allowed_tool_names: frozenset[str] = frozenset()
+    allowed_tool_prefixes: tuple[str, ...] = ()
+    forbidden_tool_names: frozenset[str] = frozenset()
+    forbidden_tool_prefixes: tuple[str, ...] = ()
+    allow_agent_handoff: bool = True
+    allow_rag_delegation: bool = False
+
+    def should_keep_tool_name(self, tool_name: str) -> bool:
+        name = str(tool_name or "").strip()
+        if not name or not self.bind_tools:
+            return False
+        if name in self.forbidden_tool_names:
+            return False
+        if any(name.startswith(prefix) for prefix in self.forbidden_tool_prefixes):
+            return False
+        if self.allow_all_tools:
+            return True
+        if name in self.allowed_tool_names:
+            return True
+        return any(name.startswith(prefix) for prefix in self.allowed_tool_prefixes)
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "reason": self.reason,
+            "bind_tools": self.bind_tools,
+            "force_tools": self.force_tools,
+            "allow_all_tools": self.allow_all_tools,
+            "allowed_tool_names": sorted(self.allowed_tool_names),
+            "allowed_tool_prefixes": list(self.allowed_tool_prefixes),
+            "forbidden_tool_names": sorted(self.forbidden_tool_names),
+            "forbidden_tool_prefixes": list(self.forbidden_tool_prefixes),
+            "allow_agent_handoff": self.allow_agent_handoff,
+            "allow_rag_delegation": self.allow_rag_delegation,
+        }
+
+
+def filter_tools_for_turn_path(
+    tools: list[Any],
+    decision: TurnPathDecision,
+    *,
+    tool_name: Callable[[Any], str],
+) -> list[Any]:
+    """Apply a turn-path binding policy to an already available tool pool."""
+
+    if not decision.bind_tools:
+        return []
+    return [
+        tool
+        for tool in tools
+        if decision.should_keep_tool_name(tool_name(tool))
+    ]
+
+
+def resolve_turn_path_decision(signals: TurnPathSignals) -> TurnPathDecision:
+    """Choose the active turn path before binding tools."""
+
+    if signals.looks_reasoning_safety_meta:
+        return TurnPathDecision(
+            path="reasoning_safety",
+            reason="reasoning_safety_meta_turn",
+            bind_tools=False,
+            allow_all_tools=False,
+            allow_agent_handoff=False,
+        )
+
+    if signals.looks_document_preview:
+        return TurnPathDecision(
+            path="lms_document_preview",
+            reason="uploaded_document_preview_request",
+            force_tools=True,
+            allow_all_tools=False,
+            allowed_tool_names=LMS_DOCUMENT_PREVIEW_TOOL_NAMES,
+            allow_agent_handoff=False,
+        )
+
+    if signals.host_ui_navigation:
+        return TurnPathDecision(
+            path="host_ui_navigation",
+            reason="routing_intent_host_ui_navigation",
+            force_tools=True,
+            allow_all_tools=False,
+            allowed_tool_prefixes=HOST_ACTION_TOOL_PREFIXES + POINTY_TOOL_PREFIXES,
+            allow_agent_handoff=False,
+        )
+
+    if _looks_casual_chat(signals):
+        return TurnPathDecision(
+            path="casual_chat",
+            reason="plain_casual_chat",
+            bind_tools=False,
+            allow_all_tools=False,
+            allow_agent_handoff=False,
+        )
+
+    if signals.web_search_forced or signals.needs_web_search or signals.needs_news_search or signals.needs_legal_search:
+        return TurnPathDecision(
+            path="web_search",
+            reason="explicit_or_detected_web_search",
+            force_tools=True,
+            forbidden_tool_prefixes=POINTY_TOOL_PREFIXES
+            if signals.suppress_pointy_for_output
+            else (),
+            allow_agent_handoff=False,
+        )
+
+    if signals.needs_datetime:
+        return TurnPathDecision(
+            path="datetime_lookup",
+            reason="datetime_request",
+            force_tools=True,
+            forbidden_tool_prefixes=POINTY_TOOL_PREFIXES,
+            allow_agent_handoff=False,
+        )
+
+    if signals.needs_lms_query:
+        return TurnPathDecision(
+            path="lms_query",
+            reason="lms_query_intent",
+            force_tools=True,
+            forbidden_tool_prefixes=POINTY_TOOL_PREFIXES
+            if signals.suppress_pointy_for_output
+            else (),
+            allow_agent_handoff=False,
+        )
+
+    if signals.needs_direct_knowledge_search:
+        return TurnPathDecision(
+            path="knowledge_search",
+            reason="explicit_internal_knowledge_lookup",
+            force_tools=True,
+            allow_rag_delegation=True,
+            forbidden_tool_prefixes=POINTY_TOOL_PREFIXES,
+            allow_agent_handoff=False,
+        )
+
+    if signals.needs_maritime_search:
+        return TurnPathDecision(
+            path="maritime_search",
+            reason="maritime_domain_lookup",
+            force_tools=True,
+            allow_rag_delegation=True,
+            forbidden_tool_prefixes=POINTY_TOOL_PREFIXES,
+            allow_agent_handoff=False,
+        )
+
+    if signals.prefers_code_execution_lane:
+        return TurnPathDecision(
+            path="code_execution",
+            reason="code_or_analysis_belongs_to_code_studio",
+            bind_tools=False,
+            allow_all_tools=False,
+            allow_agent_handoff=False,
+        )
+
+    if signals.visual_force_tool:
+        allowed_tool_names = frozenset(signals.visual_required_tool_names)
+        strict_visual_lane = (
+            signals.visual_presentation_intent
+            in {"article_figure", "chart_runtime", "code_studio_app", "artifact"}
+            and bool(allowed_tool_names)
+        )
+        return TurnPathDecision(
+            path="visual_generation",
+            reason=f"visual_intent_{signals.visual_presentation_intent or 'unknown'}",
+            force_tools=True,
+            allow_all_tools=not strict_visual_lane,
+            allowed_tool_names=allowed_tool_names,
+            forbidden_tool_prefixes=POINTY_TOOL_PREFIXES,
+            allow_agent_handoff=False,
+        )
+
+    if signals.suppress_pointy_for_output:
+        return TurnPathDecision(
+            path="direct_prose",
+            reason="output_request_without_tool_lane",
+            bind_tools=False,
+            allow_all_tools=False,
+            allow_agent_handoff=False,
+        )
+
+    if signals.pointy_requested and not signals.suppress_pointy_for_output:
+        return TurnPathDecision(
+            path="pointy_guidance",
+            reason="pointy_requested",
+            force_tools=True,
+            allow_all_tools=False,
+            allowed_tool_prefixes=POINTY_TOOL_PREFIXES,
+            allow_agent_handoff=False,
+        )
+
+    if str(signals.thinking_mode or "").strip().lower().startswith("analytical_"):
+        return TurnPathDecision(
+            path="analytical_text",
+            reason="analytical_text_mode",
+            allow_rag_delegation=False,
+        )
+
+    if signals.routing_intent in {
+        "general",
+        "off_topic",
+        "social",
+        "personal",
+        "emotional",
+        "identity",
+        "selfhood",
+    }:
+        return TurnPathDecision(
+            path="casual_chat",
+            reason=f"routing_intent_{signals.routing_intent}",
+            bind_tools=False,
+            allow_all_tools=False,
+            allow_agent_handoff=False,
+        )
+
+    return TurnPathDecision(
+        path="direct_prose",
+        reason="default_direct_prose",
+        allow_rag_delegation=False,
+    )
+
+
+def _looks_casual_chat(signals: TurnPathSignals) -> bool:
+    normalized = str(signals.normalized_query or "").strip()
+    if not normalized:
+        return True
+
+    tokens = [token for token in normalized.split() if token]
+    if len(tokens) > 12:
+        return False
+
+    exact_short_turns = {
+        "hi",
+        "hello",
+        "hey",
+        "xin chao",
+        "chao",
+        "chao ban",
+        "chao wiii",
+        "xin chao wiii",
+        "cam on",
+        "cam on ban",
+        "ok",
+        "oke",
+        "uh",
+        "uhm",
+    }
+    if normalized in exact_short_turns:
+        return True
+
+    casual_cues = (
+        "hom nay minh an",
+        "hom nay toi an",
+        "minh an com",
+        "an com roi",
+        "trua nay an",
+        "toi an",
+        "moi an",
+        "dang an",
+        "minh vua",
+        "toi vua",
+        "hom qua minh",
+        "hom qua toi",
+    )
+    if any(cue in normalized for cue in casual_cues):
+        return True
+
+    if _has_tool_or_output_signal(signals):
+        return False
+
+    greeting_prefixes = ("xin chao", "chao", "hello", "hi ")
+    action_cues = (
+        "tim",
+        "tra cuu",
+        "search",
+        "tao",
+        "viet",
+        "ve",
+        "mo phong",
+        "phan tich",
+        "giai thich",
+        "huong dan",
+        "chi vao",
+        "click",
+    )
+    return normalized.startswith(greeting_prefixes) and not any(
+        cue in normalized for cue in action_cues
+    )
+
+
+def _has_tool_or_output_signal(signals: TurnPathSignals) -> bool:
+    return any(
+        (
+            signals.web_search_forced,
+            signals.pointy_forced,
+            signals.host_ui_navigation,
+            signals.looks_document_preview,
+            signals.looks_reasoning_safety_meta,
+            signals.needs_web_search,
+            signals.needs_datetime,
+            signals.needs_news_search,
+            signals.needs_legal_search,
+            signals.needs_lms_query,
+            signals.needs_direct_knowledge_search,
+            signals.needs_analysis_tool,
+            signals.prefers_code_execution_lane,
+            signals.needs_maritime_search,
+            signals.pointy_requested,
+            signals.visual_force_tool,
+        )
+    )

--- a/maritime-ai-service/tests/unit/test_tool_collection_visual_requirements.py
+++ b/maritime-ai-service/tests/unit/test_tool_collection_visual_requirements.py
@@ -180,6 +180,25 @@ def test_collect_direct_tools_suppresses_forced_pointy_for_simulation_output_req
     assert "tool_pointy_show" not in names
     assert "tool_pointy_clear" not in names
     assert "tool_pointy_inventory" not in names
+    assert names == ["tool_create_visual_code"]
+
+
+def test_collect_direct_tools_suppresses_forced_pointy_for_lesson_output_request(monkeypatch):
+    from app.engine.multi_agent import tool_collection as module
+
+    _patch_visual_collection_modules(monkeypatch, module)
+
+    tools, force_tools = module._collect_direct_tools(
+        "@wiii-pointy tao bai hoc ngan ve ky nang hoc tap",
+        user_role="teacher",
+        state={
+            "routing_metadata": {"intent": "general"},
+            "context": {"force_skills": ["wiii-pointy"]},
+        },
+    )
+
+    assert tools == []
+    assert force_tools is False
 
 
 def test_collect_code_studio_tools_uses_visual_requirement_for_simulation(monkeypatch):

--- a/maritime-ai-service/tests/unit/test_turn_path_governor.py
+++ b/maritime-ai-service/tests/unit/test_turn_path_governor.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+
+
+def test_turn_path_governor_marks_plain_greeting_as_no_tool_chat():
+    from app.engine.multi_agent.turn_path_governor import (
+        TurnPathSignals,
+        resolve_turn_path_decision,
+    )
+
+    decision = resolve_turn_path_decision(
+        TurnPathSignals(normalized_query="xin chao wiii")
+    )
+
+    assert decision.path == "casual_chat"
+    assert decision.bind_tools is False
+    assert decision.force_tools is False
+
+
+def test_turn_path_governor_narrows_visual_app_to_required_tool():
+    from app.engine.multi_agent.turn_path_governor import (
+        TurnPathSignals,
+        resolve_turn_path_decision,
+    )
+
+    decision = resolve_turn_path_decision(
+        TurnPathSignals(
+            normalized_query="mo phong vat ly con lac",
+            visual_force_tool=True,
+            visual_mode="app",
+            visual_presentation_intent="code_studio_app",
+            visual_required_tool_names=("tool_create_visual_code",),
+            pointy_requested=True,
+            suppress_pointy_for_output=True,
+        )
+    )
+
+    assert decision.path == "visual_generation"
+    assert decision.force_tools is True
+    assert decision.allow_all_tools is False
+    assert decision.should_keep_tool_name("tool_create_visual_code") is True
+    assert decision.should_keep_tool_name("tool_generate_visual") is False
+    assert decision.should_keep_tool_name("tool_pointy_show") is False
+
+
+def test_turn_path_filter_keeps_only_lms_document_preview_tools():
+    from app.engine.multi_agent.turn_path_governor import (
+        TurnPathSignals,
+        filter_tools_for_turn_path,
+        resolve_turn_path_decision,
+    )
+
+    decision = resolve_turn_path_decision(
+        TurnPathSignals(
+            normalized_query="tao cho minh bai hoc",
+            looks_document_preview=True,
+        )
+    )
+    tools = [
+        SimpleNamespace(name="host_action__authoring__preview_lesson_patch"),
+        SimpleNamespace(name="host_action__authoring__apply_lesson_patch"),
+        SimpleNamespace(name="tool_web_search"),
+    ]
+
+    filtered = filter_tools_for_turn_path(
+        tools,
+        decision,
+        tool_name=lambda tool: tool.name,
+    )
+
+    assert decision.path == "lms_document_preview"
+    assert [tool.name for tool in filtered] == [
+        "host_action__authoring__preview_lesson_patch"
+    ]
+
+
+def test_collect_direct_tools_uses_governor_for_plain_greeting():
+    from app.engine.multi_agent import tool_collection as module
+
+    state = {"context": {}}
+    tools, force_tools = module._collect_direct_tools(
+        "Xin chào Wiii",
+        user_role="student",
+        state=state,
+    )
+
+    assert tools == []
+    assert force_tools is False
+    assert state["_turn_path_decision"]["path"] == "casual_chat"
+
+
+def test_collect_direct_tools_keeps_daily_status_off_search_path():
+    from app.engine.multi_agent import tool_collection as module
+
+    state = {"context": {}}
+    tools, force_tools = module._collect_direct_tools(
+        "Hôm nay mình ăn cơm rồi",
+        user_role="student",
+        state=state,
+    )
+
+    assert tools == []
+    assert force_tools is False
+    assert state["_turn_path_decision"]["path"] == "casual_chat"


### PR DESCRIPTION
## Summary
- Adds a pure typed `TurnPathDecision` governor for direct chat tool binding.
- Routes casual chat/status turns to no-tools before binding, so greetings do not drift into RAG/search.
- Narrows visual/app requests to the required visual tool, gates Pointy out of output-generation turns, and stops broad RAG delegation from being bound by default.
- Adds explicit maritime-search intent detection instead of falling back to maritime search when the helper is missing.

## Linked Issue
Closes #682

## Scope
- Backend direct tool binding and intent/tool policy only.
- Focused tests for governor decisions, casual chat, visual app narrowing, Pointy suppression, LMS preview filtering, and graph routing.

## Non-Scope
- Frontend UX changes.
- Provider/model routing changes.
- Production deploy changes.
- LMS document upload/apply E2E execution.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_turn_path_governor.py tests/unit/test_tool_collection_visual_requirements.py tests/unit/test_tool_collection_host_ui.py tests/unit/test_tool_collection_analytical.py tests/unit/test_sprint214_org_knowledge_retrieval.py tests/unit/test_sprint154_tech_debt.py::TestDirectAnalysisTools::test_force_tools_for_python_query tests/unit/test_direct_node_tool_selection.py tests/unit/test_chat_baseline_acceptance_harness.py tests/unit/test_graph_routing.py -q --tb=short` -> 125 passed
- `cd maritime-ai-service; python -m ruff check app/engine/multi_agent/turn_path_governor.py app/engine/multi_agent/tool_collection.py app/engine/multi_agent/direct_intent.py tests/unit/test_turn_path_governor.py tests/unit/test_tool_collection_visual_requirements.py --select=E9,F63,F7` -> All checks passed
- `git diff --check` -> passed

## Risk
- Backend runtime/tool exposure risk: a legitimate turn could lose a tool if the new path decision is too strict.
- Highest-risk areas are direct RAG delegation, Pointy host guidance, and visual app generation. Focused regression tests cover these paths.
- LMS mutation safety is preserved: document preview still binds only preview host actions and apply remains outside this path unless host approval rules allow it.

## Rollback
- Revert this PR to restore previous direct tool binding behavior.
- No migrations or durable data changes are included.

## Reviewer Focus
- Turn-path priority order in `turn_path_governor.py`.
- Whether direct prose should continue exposing utility tools while RAG delegation is opt-in.
- Pointy suppression for output-generation requests.
- LMS document preview action filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added maritime-specific query detection for improved domain-focused search routing.
  * Enhanced visual generation requirements handling with intelligent tool filtering based on query context.

* **Improvements**
  * Refined tool selection logic to better match queries to appropriate tools and execution paths across multiple domains.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->