### PR TITLE
fix(backend): honor turn path force policy

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_tool_selection.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_tool_selection.py
@@ -25,6 +25,59 @@ class DirectNodeToolSelection:
     force_tools: bool
 
 
+def _turn_path_decision_metadata(state: AgentState) -> dict[str, Any]:
+    if not isinstance(state, dict):
+        return {}
+    metadata = state.get("_turn_path_decision")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _turn_path_allows_tool_name(state: AgentState, tool_name: str) -> bool:
+    decision = _turn_path_decision_metadata(state)
+    if not decision:
+        return True
+    if not bool(decision.get("bind_tools", True)):
+        return False
+
+    name = str(tool_name or "").strip()
+    if not name:
+        return False
+
+    forbidden_names = {
+        str(item or "").strip()
+        for item in decision.get("forbidden_tool_names", []) or []
+        if str(item or "").strip()
+    }
+    if name in forbidden_names:
+        return False
+
+    forbidden_prefixes = tuple(
+        str(item or "").strip()
+        for item in decision.get("forbidden_tool_prefixes", []) or []
+        if str(item or "").strip()
+    )
+    if any(name.startswith(prefix) for prefix in forbidden_prefixes):
+        return False
+
+    if bool(decision.get("allow_all_tools", True)):
+        return True
+
+    allowed_names = {
+        str(item or "").strip()
+        for item in decision.get("allowed_tool_names", []) or []
+        if str(item or "").strip()
+    }
+    if name in allowed_names:
+        return True
+
+    allowed_prefixes = tuple(
+        str(item or "").strip()
+        for item in decision.get("allowed_tool_prefixes", []) or []
+        if str(item or "").strip()
+    )
+    return any(name.startswith(prefix) for prefix in allowed_prefixes)
+
+
 def select_direct_node_tools(
     *,
     query: str,
@@ -61,9 +114,15 @@ def select_direct_node_tools(
 
     force_required_tools: list[str] = []
     if "wiii-pointy" in force_skills:
-        force_required_tools.extend(["tool_pointy_show", "tool_pointy_inventory"])
+        pointy_required = ["tool_pointy_show", "tool_pointy_inventory"]
+        force_required_tools.extend(
+            tool_name
+            for tool_name in pointy_required
+            if _turn_path_allows_tool_name(state, tool_name)
+        )
     if "web-search" in force_skills:
-        force_required_tools.append("tool_web_search")
+        if _turn_path_allows_tool_name(state, "tool_web_search"):
+            force_required_tools.append("tool_web_search")
     if force_required_tools:
         force_tools = True
         logger_obj.info("[DIRECT] Force-bound via @-mention: required=%s", force_required_tools)
@@ -109,5 +168,8 @@ def select_direct_node_tools(
         )
         if isinstance(state.get("routing_metadata"), dict):
             state["routing_metadata"]["doc_preview_runtime"] = doc_preview_debug
+
+    if not tools:
+        force_tools = False
 
     return DirectNodeToolSelection(tools=tools, force_tools=force_tools)

--- a/maritime-ai-service/tests/unit/test_direct_node_tool_selection.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_tool_selection.py
@@ -91,3 +91,111 @@ def test_select_direct_node_tools_forces_web_search_and_must_include(monkeypatch
     assert ctx["force_skills"] == ["web-search"]
     assert "tool_web_search" in captured["must_include"]
     assert captured["user_role"] == "teacher"
+
+
+def test_select_direct_node_tools_respects_governor_when_pointy_is_suppressed(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_select_runtime_tools(
+        tools: list[Any],
+        *,
+        query: str,
+        intent: str | None,
+        user_role: str,
+        max_tools: int,
+        must_include: list[str],
+    ) -> list[Any]:
+        captured["must_include"] = must_include
+        return tools
+
+    monkeypatch.setattr(
+        "app.engine.skills.skill_recommender.select_runtime_tools",
+        fake_select_runtime_tools,
+    )
+
+    state: dict[str, Any] = {
+        "_turn_path_decision": {
+            "path": "direct_prose",
+            "bind_tools": False,
+            "allow_all_tools": False,
+            "forbidden_tool_prefixes": ["tool_pointy_"],
+        },
+        "context": {"force_skills": ["wiii-pointy"]},
+        "routing_metadata": {"intent": "general"},
+    }
+
+    result = select_direct_node_tools(
+        query="@wiii-pointy tao bai hoc ngan ve ky nang hoc tap",
+        state=state,
+        ctx={"user_role": "teacher"},
+        routing_intent="general",
+        is_short_house_chatter=False,
+        is_identity_turn=False,
+        is_emotional_support_turn=False,
+        is_codebase_source_turn=False,
+        explicit_web_search_turn=False,
+        has_uploaded_document_context=False,
+        needs_web_search=lambda _query: False,
+        collect_direct_tools=lambda *_args, **_kwargs: ([], False),
+        direct_required_tool_names=lambda _query, _role: [],
+        logger_obj=logging.getLogger(__name__),
+    )
+
+    assert result.tools == []
+    assert result.force_tools is False
+    assert captured["must_include"] == []
+
+
+def test_select_direct_node_tools_force_binds_pointy_when_governor_allows_it(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_select_runtime_tools(
+        tools: list[Any],
+        *,
+        query: str,
+        intent: str | None,
+        user_role: str,
+        max_tools: int,
+        must_include: list[str],
+    ) -> list[Any]:
+        captured["must_include"] = must_include
+        return tools
+
+    monkeypatch.setattr(
+        "app.engine.skills.skill_recommender.select_runtime_tools",
+        fake_select_runtime_tools,
+    )
+
+    tools = [_Tool("tool_pointy_show"), _Tool("tool_pointy_inventory")]
+    state: dict[str, Any] = {
+        "_turn_path_decision": {
+            "path": "pointy_guidance",
+            "bind_tools": True,
+            "allow_all_tools": False,
+            "allowed_tool_prefixes": ["tool_pointy_"],
+        },
+        "context": {"force_skills": ["wiii-pointy"]},
+        "routing_metadata": {"intent": "host_ui_navigation"},
+    }
+
+    result = select_direct_node_tools(
+        query="@wiii-pointy chi vao nut gui",
+        state=state,
+        ctx={"user_role": "student"},
+        routing_intent="host_ui_navigation",
+        is_short_house_chatter=False,
+        is_identity_turn=False,
+        is_emotional_support_turn=False,
+        is_codebase_source_turn=False,
+        explicit_web_search_turn=False,
+        has_uploaded_document_context=False,
+        needs_web_search=lambda _query: False,
+        collect_direct_tools=lambda *_args, **_kwargs: (tools, False),
+        direct_required_tool_names=lambda _query, _role: [],
+        logger_obj=logging.getLogger(__name__),
+    )
+
+    assert result.tools == tools
+    assert result.force_tools is True
+    assert "tool_pointy_show" in captured["must_include"]
+    assert "tool_pointy_inventory" in captured["must_include"]


### PR DESCRIPTION
## Summary
- Makes downstream direct-node tool selection honor the `_turn_path_decision` written by the path governor.
- Prevents suppressed `@wiii-pointy` output requests from re-forcing Pointy after tool collection.
- Keeps legitimate Pointy guidance force-binding when the governor allows `tool_pointy_*` tools.
- Normalizes `force_tools` to false when no tools remain.

## Linked Issue
Closes #684

## Scope
- Backend direct-node tool selection only.
- Focused regression coverage for suppressed and allowed Pointy force skills.

## Non-Scope
- New path names or frontend behavior.
- Provider/model routing changes.
- LMS mutation behavior.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_direct_node_tool_selection.py tests/unit/test_direct_node_provider_errors.py::test_direct_response_node_uses_pointy_fast_path_without_llm tests/unit/test_direct_node_provider_errors.py::test_direct_response_node_uses_pointy_fast_path_even_if_router_mislabels_turn tests/unit/test_tool_collection_visual_requirements.py tests/unit/test_turn_path_governor.py tests/unit/test_tool_collection_host_ui.py -q --tb=short` -> 32 passed
- `cd maritime-ai-service; python -m ruff check app/engine/multi_agent/direct_node_tool_selection.py tests/unit/test_direct_node_tool_selection.py --select=E9,F63,F7` -> All checks passed
- `git diff --check` -> passed

## Risk
- Backend direct runtime tool forcing risk. A mistaken policy read could suppress intended force-bound tools.
- Regression tests cover both sides: suppressed Pointy output request and allowed Pointy guidance.

## Rollback
- Revert this PR to restore previous force-skill behavior.
- No migrations or durable data changes are included.

## Reviewer Focus
- `_turn_path_allows_tool_name` metadata interpretation.
- Pointy force-skill behavior when `bind_tools=false` or `allowed_tool_prefixes=[tool_pointy_]`.