### PR TITLE
test(frontend): harden chat baseline path harness

### DIFF
--- a/docs/operations/WIII_LOCAL_E2E_HARNESS.md
+++ b/docs/operations/WIII_LOCAL_E2E_HARNESS.md
@@ -62,12 +62,15 @@ provider keys, production, or full Docker.
 The required evidence is:
 
 - ordinary Vietnamese prompts are submitted through `[data-wiii-id="chat-textarea"]`
+- a daily-status prompt containing "hôm nay" stays on chat instead of web search
 - final assistant answers render in `[data-message-role="assistant"]`
 - Markdown code renders as a chat code block, not Code Studio
 - stream events include `status`, `answer`, `metadata`, and terminal `done`
 - terminal `runtime_flow_ledger` says `host_surface=desktop_chat`,
   `route.lane=native_turn`, no observed tools, host/Pointy/visual/Code Studio
   suppressed, and `finalization.status=saved`
+- turn-path metadata is preserved in the stream/persisted message and reports
+  `casual_chat`, `bind_tools=false`, and `force_tools=false`
 - visible and persisted answers contain no raw provider/tool payload markers
 - no host action preview, Pointy spotlight/action surface, visual block, or
   Code Studio surface appears

--- a/wiii-desktop/playwright/chat-baseline-acceptance.spec.ts
+++ b/wiii-desktop/playwright/chat-baseline-acceptance.spec.ts
@@ -24,6 +24,17 @@ const CHAT_BASELINE_SCENARIOS: ChatBaselineScenario[] = [
       "và sẵn sàng cùng bạn làm tiếp.",
     ],
     expectedText: "Chào bạn, mình vẫn ở đây",
+    expectedTurnPath: "casual_chat",
+  },
+  {
+    id: "daily-status-no-search",
+    prompt: "hôm nay mình ăn cơm rồi",
+    answerChunks: [
+      "Vậy ổn rồi. Mình sẽ giữ nhịp trò chuyện nhẹ nhàng ",
+      "và không kéo câu này sang tìm kiếm hay công cụ.",
+    ],
+    expectedText: "không kéo câu này sang tìm kiếm hay công cụ",
+    expectedTurnPath: "casual_chat",
   },
   {
     id: "simple-factual-chat",
@@ -33,6 +44,7 @@ const CHAT_BASELINE_SCENARIOS: ChatBaselineScenario[] = [
       "SDK là bộ công cụ giúp lập trình viên dùng API đó dễ hơn.",
     ],
     expectedText: "API là giao diện để phần mềm gọi nhau",
+    expectedTurnPath: "casual_chat",
   },
   {
     id: "inline-code-explanation",
@@ -43,6 +55,7 @@ const CHAT_BASELINE_SCENARIOS: ChatBaselineScenario[] = [
       "```\n\nPromise giữ kết quả bất đồng bộ và gọi `.then` khi hoàn tất.",
     ],
     expectedText: "Promise.resolve",
+    expectedTurnPath: "casual_chat",
     expectCodeBlock: true,
   },
 ];
@@ -89,7 +102,10 @@ function expectSafeRequestShape(capture: ChatBaselineTurnCapture, scenario: Chat
   expect(userContext.code_studio_context).toBeUndefined();
 }
 
-function expectSafeLedger(ledger: Record<string, unknown> | undefined) {
+function expectSafeLedger(
+  ledger: Record<string, unknown> | undefined,
+  scenario: ChatBaselineScenario,
+) {
   expect(ledger).toBeTruthy();
 
   const request = nestedRecord(ledger, "request");
@@ -103,6 +119,10 @@ function expectSafeLedger(ledger: Record<string, unknown> | undefined) {
 
   const route = nestedRecord(ledger, "route");
   expect(route.lane).toBe("native_turn");
+  const turnPathDecision = nestedRecord(route, "turn_path_decision");
+  expect(turnPathDecision.path).toBe(scenario.expectedTurnPath);
+  expect(turnPathDecision.bind_tools).toBe(false);
+  expect(turnPathDecision.force_tools).toBe(false);
 
   const tools = nestedRecord(ledger, "tools");
   expect(tools.observed).toEqual([]);
@@ -120,8 +140,11 @@ function expectSafeLedger(ledger: Record<string, unknown> | undefined) {
   expect(hostActions.apply_attempted).toBe(false);
 }
 
-function expectTerminalLedger(ledger: Record<string, unknown> | undefined) {
-  expectSafeLedger(ledger);
+function expectTerminalLedger(
+  ledger: Record<string, unknown> | undefined,
+  scenario: ChatBaselineScenario,
+) {
+  expectSafeLedger(ledger, scenario);
   const stream = nestedRecord(ledger, "stream");
   expect(stream.metadata_seen).toBe(true);
   expect(stream.done_seen).toBe(true);
@@ -204,12 +227,16 @@ test.describe("browser chat-baseline acceptance", () => {
       await expectNoBaselineToolSurfaces(page);
 
       const terminalLedger = terminalLedgerFrom(observedStream);
-      expectTerminalLedger(terminalLedger);
+      expectTerminalLedger(terminalLedger, scenario);
 
       const persisted = await latestPersistedAssistant(page, bootstrap.userId, index + 1);
       expect(persisted.content).toContain(scenario.expectedText);
       expectNoRawChatBaselinePayload(persisted.content || "");
-      expectSafeLedger(asRecord(persisted.metadata?.runtime_flow_ledger));
+      const persistedTurnPath = asRecord(persisted.metadata?.turn_path_decision);
+      expect(persistedTurnPath.path).toBe(scenario.expectedTurnPath);
+      expect(persistedTurnPath.bind_tools).toBe(false);
+      expect(persistedTurnPath.force_tools).toBe(false);
+      expectSafeLedger(asRecord(persisted.metadata?.runtime_flow_ledger), scenario);
     }
   });
 });

--- a/wiii-desktop/playwright/support/local-chat-harness.ts
+++ b/wiii-desktop/playwright/support/local-chat-harness.ts
@@ -18,6 +18,7 @@ export type ChatBaselineScenario = {
   prompt: string;
   answerChunks: string[];
   expectedText: string;
+  expectedTurnPath: string;
   expectCodeBlock?: boolean;
 };
 
@@ -64,6 +65,7 @@ const RAW_CHAT_BASELINE_MARKERS = [
   "<wiii-widget",
   "[POINT:",
   "runtime_flow_ledger",
+  "turn_path_decision",
 ];
 
 function defaultServerUrl(): string {
@@ -167,6 +169,7 @@ function formatSseEvent(
 
 function createChatBaselineLedger(
   request: Record<string, unknown>,
+  scenario: ChatBaselineScenario,
   eventTypes: string[],
   finalizationStatus: "pending" | "saved",
 ) {
@@ -201,6 +204,12 @@ function createChatBaselineLedger(
       reason: "browser_chat_baseline_acceptance",
       selected_agent: "direct",
       final_agent: "direct",
+      turn_path_decision: {
+        path: scenario.expectedTurnPath,
+        reason: "browser_chat_baseline_mock",
+        bind_tools: false,
+        force_tools: false,
+      },
     },
     runtime: {
       requested_provider: typeof request.provider === "string" ? request.provider : null,
@@ -375,10 +384,11 @@ export async function installChatBaselineStreamMock(
     ];
     const metadataLedger = createChatBaselineLedger(
       request,
+      scenario,
       eventTypes.filter((type) => type !== "done"),
       "pending",
     );
-    const terminalLedger = createChatBaselineLedger(request, eventTypes, "saved");
+    const terminalLedger = createChatBaselineLedger(request, scenario, eventTypes, "saved");
     const sseEvents: Array<{ type: string; data: Record<string, unknown> }> = [
       {
         type: "status",
@@ -408,6 +418,12 @@ export async function installChatBaselineStreamMock(
           routing_metadata: {
             method: "browser_chat_baseline_acceptance",
             intent: "ordinary_chat",
+          },
+          turn_path_decision: {
+            path: scenario.expectedTurnPath,
+            reason: "browser_chat_baseline_mock",
+            bind_tools: false,
+            force_tools: false,
           },
           runtime_flow_ledger: metadataLedger,
         },


### PR DESCRIPTION
## Summary
- Hardens the browser chat-baseline acceptance harness for the new path-governor contract.
- Adds a daily-status prompt with `hôm nay` to prove ordinary life chatter stays out of web/tool paths.
- Carries `turn_path_decision` metadata through mocked SSE, runtime ledger, and persisted assistant metadata.
- Documents the expected local E2E evidence.

## Linked Issue
Closes #686

## Scope
- Playwright browser chat-baseline harness and local harness docs.
- Test-only deterministic SSE mock metadata and assertions.

## Non-Scope
- Product runtime behavior changes.
- Provider/model changes.
- Production deploy.
- LMS document upload/apply E2E.

## Verification
- `cd wiii-desktop; $env:WIII_PLAYWRIGHT_BACKEND_PORT='8031'; $env:WIII_PLAYWRIGHT_FRONTEND_PORT='1431'; $env:WIII_PLAYWRIGHT_SERVER_URL='http://127.0.0.1:8031'; $env:WIII_PLAYWRIGHT_BASE_URL='http://127.0.0.1:1431'; npx playwright test -c playwright.visual.config.ts playwright/chat-baseline-acceptance.spec.ts` -> 1 passed
- `cd wiii-desktop; npx tsc --noEmit` -> passed
- `cd maritime-ai-service; python -m pytest tests/unit/test_turn_path_governor.py -q --tb=short` -> 5 passed
- `git diff --check` -> passed

## Risk
- Test harness risk only. The SSE mock is deterministic and does not change product runtime behavior.
- The main risk is over-asserting mocked metadata shape; this is intentional for acceptance evidence that the UI preserves path-governor metadata without surfacing it to users.

## Rollback
- Revert this PR to restore the previous browser chat-baseline harness.
- No migrations, secrets, or durable runtime data changes are included.

## Reviewer Focus
- Whether the daily-status prompt covers the `hôm nay` no-search regression.
- Whether `turn_path_decision` metadata is asserted in both stream ledger and persisted assistant metadata.
- Whether raw metadata remains hidden from visible chat text.