### PR TITLE
feat(backend): add tool policy session guard

### DIFF
--- a/docs/operations/WIII_TOOL_POLICY_SESSION_STANDARD.md
+++ b/docs/operations/WIII_TOOL_POLICY_SESSION_STANDARD.md
@@ -1,0 +1,76 @@
+# Wiii Tool Policy Session Standard
+
+Status: Active
+
+Owner: Backend maintainers
+
+Last updated: 2026-05-26
+
+Applies to: Direct chat tool binding, runtime tool execution, host actions, LMS authoring, Pointy, web/search, weather, visual tools
+
+## Purpose
+
+Wiii must choose the active product path before exposing tools to a model. Tool
+policy is the contract that prevents a casual chat turn from drifting into web
+search, a weather turn from searching the wrong entity, Pointy from appearing in
+code/visual output turns, or LMS mutation tools from appearing without host
+connection and approval context.
+
+The canonical backend shape is:
+
+```text
+query/context -> TurnPathDecision -> ToolPolicySession -> bound tools -> execution guard
+```
+
+## Required Contract
+
+Every direct chat turn should have a `ToolPolicySession` in `AgentState` when
+tool selection is evaluated.
+
+The session records:
+
+- `path`: active path such as `casual_chat`, `weather_lookup`, `web_search`,
+  `maritime_search`, `lms_document_preview`, `pointy_guidance`, or
+  `visual_generation`.
+- `candidate_tool_names`: tools collected before final policy filtering.
+- `visible_tool_names`: final tools bound to the model after runtime pruning.
+- `allowed_tool_names` and `allowed_tool_prefixes`: positive allow rules for
+  narrow paths.
+- `forbidden_tool_names` and `forbidden_tool_prefixes`: explicit negative rules.
+- `connection_status`: fail-closed service status such as LMS authoring
+  connection, host capability presence, and weather provider availability.
+- `approval_required_tool_names`: tools that require preview/approval evidence.
+
+## Runtime Rules
+
+1. Path-specific tools must be exposed only through `ToolPolicySession`.
+2. A tool not visible in `visible_tool_names` must not execute, even if a model
+   emits a raw or stale tool call.
+3. LMS authoring tools require an active LMS host connection. Apply tools also
+   require host-issued approval evidence.
+4. Weather may expose a fail-closed status tool on `weather_lookup`, but it must
+   not fall back to generic web search unless the user explicitly requests web
+   search.
+5. Pointy must stay out of code, visual, simulation, artifact, and LMS output
+   creation paths unless the active path explicitly allows it.
+6. Denied tool calls should emit a visible tool result that explains the policy
+   denial instead of silently doing nothing.
+
+## Verification
+
+Policy changes should include focused tests for:
+
+- prompt/bind-time visibility;
+- execution-time denial;
+- narrow path dominance over broad fallback paths;
+- connection-gated host/LMS tools;
+- no raw internal tool names leaking into user-facing prose.
+
+Recommended commands:
+
+```powershell
+cd maritime-ai-service
+python -m pytest tests/unit/test_tool_policy_session.py tests/unit/test_turn_path_governor.py tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short
+python -m ruff check app/ tests/unit/ --select=E9,F63,F7
+git diff --check
+```

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_tool_selection.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_tool_selection.py
@@ -16,6 +16,10 @@ from app.engine.multi_agent.direct_node_uploaded_context import (
     _looks_uploaded_document_preview_request,
 )
 from app.engine.multi_agent.state import AgentState
+from app.engine.multi_agent.tool_policy_session import (
+    finalize_tool_policy_visible_tools,
+    tool_policy_session_from_state,
+)
 from app.engine.multi_agent.tool_collection import _force_skills_from_state
 
 
@@ -33,6 +37,10 @@ def _turn_path_decision_metadata(state: AgentState) -> dict[str, Any]:
 
 
 def _turn_path_allows_tool_name(state: AgentState, tool_name: str) -> bool:
+    policy_session = tool_policy_session_from_state(state)
+    if policy_session is not None:
+        return policy_session.should_expose_tool(tool_name)
+
     decision = _turn_path_decision_metadata(state)
     if not decision:
         return True
@@ -171,5 +179,11 @@ def select_direct_node_tools(
 
     if not tools:
         force_tools = False
+
+    finalize_tool_policy_visible_tools(
+        state,
+        tools,
+        tool_name=lambda tool: str(getattr(tool, "name", getattr(tool, "__name__", "")) or ""),
+    )
 
     return DirectNodeToolSelection(tools=tools, force_tools=force_tools)

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_dispatch_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_dispatch_runtime.py
@@ -6,6 +6,11 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
+from app.engine.multi_agent.tool_policy_session import (
+    tool_policy_denial_message,
+    tool_policy_session_from_state,
+)
+
 
 @dataclass(slots=True)
 class DirectToolDispatchResult:
@@ -37,6 +42,7 @@ async def dispatch_direct_tool_call(
     tool_round: int,
     tools: list[Any],
     query: str,
+    state: dict[str, Any] | None = None,
     push_event,
     tool_call_events: list[dict[str, Any]],
     get_tool_by_name,
@@ -54,6 +60,65 @@ async def dispatch_direct_tool_call(
     if not isinstance(tool_args, dict):
         tool_args = {"value": tool_args}
         tool_call["args"] = tool_args
+
+    policy_session = tool_policy_session_from_state(state)
+    if policy_session is not None:
+        policy_decision = policy_session.decision_for(tool_name.strip())
+        if not policy_decision.allowed:
+            result = tool_policy_denial_message(policy_decision)
+            logger_obj.warning(
+                "[DIRECT] Tool policy denied tool=%r path=%s reason=%s",
+                tool_name,
+                policy_decision.path,
+                policy_decision.reason,
+            )
+            await push_event(
+                {
+                    "type": "tool_call",
+                    "content": {
+                        "name": tool_name,
+                        "args": tool_args,
+                        "id": tool_call_id,
+                        "policy": {
+                            "allowed": False,
+                            "path": policy_decision.path,
+                            "reason": policy_decision.reason,
+                        },
+                    },
+                    "node": "direct",
+                }
+            )
+            tool_call_events.append(
+                {
+                    "type": "call",
+                    "name": tool_name,
+                    "args": tool_args,
+                    "id": tool_call_id,
+                    "policy": {
+                        "allowed": False,
+                        "path": policy_decision.path,
+                        "reason": policy_decision.reason,
+                    },
+                }
+            )
+            await push_event(
+                {
+                    "type": "tool_result",
+                    "content": {
+                        "name": tool_name,
+                        "result": summarize_tool_result_for_stream(tool_name, result),
+                        "id": tool_call_id,
+                    },
+                    "node": "direct",
+                }
+            )
+            return DirectToolDispatchResult(
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                tool_args=tool_args,
+                result=result,
+                matched=False,
+            )
 
     if is_search_tool_name(tool_name):
         tool_args = prefer_official_query_for_known_docs(tool_args, query)

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_round_execution_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_round_execution_runtime.py
@@ -81,6 +81,7 @@ async def execute_direct_tool_round(
             tool_round=tool_round,
             tools=tools,
             query=query,
+            state=state,
             push_event=push_event,
             tool_call_events=tool_call_events,
             get_tool_by_name=get_tool_by_name,

--- a/maritime-ai-service/app/engine/multi_agent/tool_collection.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_collection.py
@@ -21,8 +21,13 @@ from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.turn_path_governor import (
     TurnPathDecision,
     TurnPathSignals,
-    filter_tools_for_turn_path,
     resolve_turn_path_decision,
+)
+from app.engine.multi_agent.tool_policy_session import (
+    build_tool_policy_session,
+    filter_tools_for_policy_session,
+    finalize_tool_policy_visible_tools,
+    record_tool_policy_session,
 )
 
 logger = logging.getLogger(__name__)
@@ -592,6 +597,54 @@ def _record_turn_path_decision(
         state["_turn_path_decision"] = decision.to_metadata()
 
 
+def _record_empty_tool_policy_session(
+    *,
+    state: Optional[AgentState],
+    decision: TurnPathDecision,
+    query: str,
+    user_role: str,
+) -> None:
+    if not isinstance(state, dict):
+        return
+    record_tool_policy_session(
+        state,
+        build_tool_policy_session(
+            decision=decision,
+            state=state,
+            query=query,
+            user_role=user_role,
+            candidate_tool_names=(),
+        ),
+    )
+
+
+def _apply_tool_policy_session(
+    tools: list[Any],
+    *,
+    state: Optional[AgentState],
+    decision: TurnPathDecision,
+    query: str,
+    user_role: str,
+) -> list[Any]:
+    if not isinstance(state, dict):
+        return tools
+    session = build_tool_policy_session(
+        decision=decision,
+        state=state,
+        query=query,
+        user_role=user_role,
+        candidate_tool_names=[_tool_name(tool) for tool in tools],
+    )
+    record_tool_policy_session(state, session)
+    filtered = filter_tools_for_policy_session(
+        tools,
+        session,
+        tool_name=_tool_name,
+    )
+    finalize_tool_policy_visible_tools(state, filtered, tool_name=_tool_name)
+    return filtered
+
+
 def _should_use_no_tools_for_direct_prose(
     *,
     query: str,
@@ -671,6 +724,12 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
     )
     _record_turn_path_decision(state, turn_path_decision)
     if not turn_path_decision.bind_tools:
+        _record_empty_tool_policy_session(
+            state=state,
+            decision=turn_path_decision,
+            query=query,
+            user_role=user_role,
+        )
         return [], False
 
     _direct_tools = []
@@ -878,6 +937,13 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
 
     if _is_host_ui_navigation_route(state):
         scoped_host_tools = _host_action_tools(_direct_tools)
+        scoped_host_tools = _apply_tool_policy_session(
+            scoped_host_tools,
+            state=state,
+            decision=turn_path_decision,
+            query=query,
+            user_role=user_role,
+        )
         return scoped_host_tools, bool(scoped_host_tools)
 
     if _looks_like_document_preview_request(query, state):
@@ -885,6 +951,13 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
         if preview_tools:
             logger.info(
                 "[DIRECT] Forcing LMS document preview host action for uploaded document context"
+            )
+            preview_tools = _apply_tool_policy_session(
+                preview_tools[:1],
+                state=state,
+                decision=turn_path_decision,
+                query=query,
+                user_role=user_role,
             )
             return preview_tools[:1], True
 
@@ -894,6 +967,12 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
         "personal",
         "social",
     }:
+        _record_empty_tool_policy_session(
+            state=state,
+            decision=turn_path_decision,
+            query=query,
+            user_role=user_role,
+        )
         return [], False
 
     web_search_forced = "web-search" in force_skills
@@ -947,10 +1026,12 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
         thinking_mode=thinking_mode,
     ):
         _direct_tools = _strip_visual_tool_capabilities(_direct_tools)
-    _direct_tools = filter_tools_for_turn_path(
+    _direct_tools = _apply_tool_policy_session(
         _direct_tools,
-        turn_path_decision,
-        tool_name=_tool_name,
+        state=state,
+        decision=turn_path_decision,
+        query=query,
+        user_role=user_role,
     )
     # Clear inline article/chart requests should stay tightly on the visual lane.
     # If there is no competing web/legal/news/datetime/LMS intent, bind only the
@@ -1005,6 +1086,12 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
         visual_decision=visual_decision,
         force_tools=force_tools,
     ):
+        _record_empty_tool_policy_session(
+            state=state,
+            decision=turn_path_decision,
+            query=query,
+            user_role=user_role,
+        )
         return [], False
 
     # Agent handoff tool (Phase 3)
@@ -1019,6 +1106,7 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
         except Exception:
             pass
 
+    finalize_tool_policy_visible_tools(state, _direct_tools, tool_name=_tool_name)
     return _direct_tools, force_tools
 
 

--- a/maritime-ai-service/app/engine/multi_agent/tool_policy_session.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_policy_session.py
@@ -1,0 +1,373 @@
+"""Per-turn tool policy sessions for prompt visibility and execution guards."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Callable
+
+from app.core.config import settings
+from app.engine.multi_agent.document_preview_contract import (
+    LMS_AUTHORING_CAPABILITY_NAMES,
+    lms_authoring_connection_status,
+)
+from app.engine.multi_agent.turn_path_governor import TurnPathDecision
+
+
+TOOL_POLICY_SESSION_VERSION = "tool_policy_session.v1"
+TOOL_POLICY_STATE_KEY = "_tool_policy_session"
+
+HOST_ACTION_PREFIX = "host_action__"
+LMS_AUTHORING_PREFIX = "host_action__authoring__"
+POINTY_PREFIX = "tool_pointy_"
+WEATHER_TOOL_NAME = "tool_current_weather"
+
+
+@dataclass(frozen=True, slots=True)
+class ToolPolicyDecision:
+    """Decision for one tool under the active policy session."""
+
+    tool_name: str
+    allowed: bool
+    reason: str
+    path: str
+    visible: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ToolPolicySession:
+    """Immutable policy for tool visibility and execution in one turn."""
+
+    version: str
+    path: str
+    reason: str
+    bind_tools: bool
+    force_tools: bool
+    allow_all_tools: bool
+    allowed_tool_names: frozenset[str] = frozenset()
+    allowed_tool_prefixes: tuple[str, ...] = ()
+    forbidden_tool_names: frozenset[str] = frozenset()
+    forbidden_tool_prefixes: tuple[str, ...] = ()
+    candidate_tool_names: frozenset[str] = frozenset()
+    visible_tool_names: frozenset[str] = frozenset()
+    connection_status: dict[str, dict[str, Any]] | None = None
+    approval_required_tool_names: frozenset[str] = frozenset()
+    allow_agent_handoff: bool = True
+    allow_rag_delegation: bool = False
+
+    def should_expose_tool(self, tool_name: str) -> bool:
+        """Return whether a tool can be shown to the model for this turn."""
+
+        name = _normalize_tool_name(tool_name)
+        if not name or not self.bind_tools:
+            return False
+        if name in self.forbidden_tool_names:
+            return False
+        if any(name.startswith(prefix) for prefix in self.forbidden_tool_prefixes):
+            return False
+        if self._requires_inactive_connection(name):
+            return False
+        if self.allow_all_tools:
+            return True
+        if name in self.allowed_tool_names:
+            return True
+        return any(name.startswith(prefix) for prefix in self.allowed_tool_prefixes)
+
+    def decision_for(self, tool_name: str) -> ToolPolicyDecision:
+        """Return execution-time policy for a normalized tool call."""
+
+        name = _normalize_tool_name(tool_name)
+        if not name:
+            return ToolPolicyDecision(
+                tool_name=name,
+                allowed=False,
+                reason="missing_tool_name",
+                path=self.path,
+                visible=False,
+            )
+        if not self.should_expose_tool(name):
+            return ToolPolicyDecision(
+                tool_name=name,
+                allowed=False,
+                reason="not_allowed_by_path_policy",
+                path=self.path,
+                visible=False,
+            )
+        visible = name in self.visible_tool_names
+        if self.visible_tool_names and not visible:
+            return ToolPolicyDecision(
+                tool_name=name,
+                allowed=False,
+                reason="not_visible_in_bound_tool_set",
+                path=self.path,
+                visible=False,
+            )
+        return ToolPolicyDecision(
+            tool_name=name,
+            allowed=True,
+            reason="allowed",
+            path=self.path,
+            visible=visible,
+        )
+
+    def with_visible_tools(self, tool_names: list[str] | tuple[str, ...] | set[str]) -> "ToolPolicySession":
+        """Return a copy with final bound tool names recorded."""
+
+        visible = frozenset(_normalize_tool_name(name) for name in tool_names if _normalize_tool_name(name))
+        return replace(self, visible_tool_names=visible)
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Serialize to state-safe metadata."""
+
+        return {
+            "version": self.version,
+            "path": self.path,
+            "reason": self.reason,
+            "bind_tools": self.bind_tools,
+            "force_tools": self.force_tools,
+            "allow_all_tools": self.allow_all_tools,
+            "allowed_tool_names": sorted(self.allowed_tool_names),
+            "allowed_tool_prefixes": list(self.allowed_tool_prefixes),
+            "forbidden_tool_names": sorted(self.forbidden_tool_names),
+            "forbidden_tool_prefixes": list(self.forbidden_tool_prefixes),
+            "candidate_tool_names": sorted(self.candidate_tool_names),
+            "visible_tool_names": sorted(self.visible_tool_names),
+            "connection_status": dict(self.connection_status or {}),
+            "approval_required_tool_names": sorted(self.approval_required_tool_names),
+            "allow_agent_handoff": self.allow_agent_handoff,
+            "allow_rag_delegation": self.allow_rag_delegation,
+        }
+
+    @classmethod
+    def from_metadata(cls, metadata: dict[str, Any]) -> "ToolPolicySession":
+        """Rehydrate policy metadata stored in AgentState."""
+
+        return cls(
+            version=str(metadata.get("version") or TOOL_POLICY_SESSION_VERSION),
+            path=str(metadata.get("path") or "unknown"),
+            reason=str(metadata.get("reason") or ""),
+            bind_tools=bool(metadata.get("bind_tools", True)),
+            force_tools=bool(metadata.get("force_tools", False)),
+            allow_all_tools=bool(metadata.get("allow_all_tools", True)),
+            allowed_tool_names=_frozen_name_set(metadata.get("allowed_tool_names")),
+            allowed_tool_prefixes=_name_tuple(metadata.get("allowed_tool_prefixes")),
+            forbidden_tool_names=_frozen_name_set(metadata.get("forbidden_tool_names")),
+            forbidden_tool_prefixes=_name_tuple(metadata.get("forbidden_tool_prefixes")),
+            candidate_tool_names=_frozen_name_set(metadata.get("candidate_tool_names")),
+            visible_tool_names=_frozen_name_set(metadata.get("visible_tool_names")),
+            connection_status=_plain_connection_status(metadata.get("connection_status")),
+            approval_required_tool_names=_frozen_name_set(
+                metadata.get("approval_required_tool_names")
+            ),
+            allow_agent_handoff=bool(metadata.get("allow_agent_handoff", True)),
+            allow_rag_delegation=bool(metadata.get("allow_rag_delegation", False)),
+        )
+
+    def _requires_inactive_connection(self, tool_name: str) -> bool:
+        if _is_lms_authoring_tool(tool_name):
+            status = (self.connection_status or {}).get("lms_authoring") or {}
+            return not bool(status.get("active"))
+        return False
+
+
+def build_tool_policy_session(
+    *,
+    decision: TurnPathDecision,
+    state: dict[str, Any] | None,
+    query: str = "",
+    user_role: str = "student",
+    candidate_tool_names: list[str] | tuple[str, ...] | set[str] = (),
+) -> ToolPolicySession:
+    """Build the authoritative per-turn tool policy session."""
+
+    normalized_candidates = frozenset(
+        _normalize_tool_name(name) for name in candidate_tool_names if _normalize_tool_name(name)
+    )
+    connection_status = _connection_status_for_turn(state=state, query=query)
+    approval_required_names = frozenset(
+        name for name in normalized_candidates if _requires_approval_token(name)
+    )
+    return ToolPolicySession(
+        version=TOOL_POLICY_SESSION_VERSION,
+        path=decision.path,
+        reason=decision.reason,
+        bind_tools=decision.bind_tools,
+        force_tools=decision.force_tools,
+        allow_all_tools=decision.allow_all_tools,
+        allowed_tool_names=frozenset(decision.allowed_tool_names),
+        allowed_tool_prefixes=tuple(decision.allowed_tool_prefixes),
+        forbidden_tool_names=frozenset(decision.forbidden_tool_names),
+        forbidden_tool_prefixes=tuple(decision.forbidden_tool_prefixes),
+        candidate_tool_names=normalized_candidates,
+        connection_status=connection_status,
+        approval_required_tool_names=approval_required_names,
+        allow_agent_handoff=decision.allow_agent_handoff,
+        allow_rag_delegation=decision.allow_rag_delegation,
+    )
+
+
+def record_tool_policy_session(
+    state: dict[str, Any] | None,
+    session: ToolPolicySession,
+) -> None:
+    if isinstance(state, dict):
+        state[TOOL_POLICY_STATE_KEY] = session.to_metadata()
+
+
+def tool_policy_session_from_state(state: dict[str, Any] | None) -> ToolPolicySession | None:
+    """Read the active policy session from AgentState, if present."""
+
+    if not isinstance(state, dict):
+        return None
+    metadata = state.get(TOOL_POLICY_STATE_KEY)
+    if isinstance(metadata, dict):
+        return ToolPolicySession.from_metadata(metadata)
+
+    legacy_decision = state.get("_turn_path_decision")
+    if isinstance(legacy_decision, dict):
+        return ToolPolicySession.from_metadata(
+            {
+                "path": legacy_decision.get("path"),
+                "reason": legacy_decision.get("reason"),
+                "bind_tools": legacy_decision.get("bind_tools", True),
+                "force_tools": legacy_decision.get("force_tools", False),
+                "allow_all_tools": legacy_decision.get("allow_all_tools", True),
+                "allowed_tool_names": legacy_decision.get("allowed_tool_names") or [],
+                "allowed_tool_prefixes": legacy_decision.get("allowed_tool_prefixes") or [],
+                "forbidden_tool_names": legacy_decision.get("forbidden_tool_names") or [],
+                "forbidden_tool_prefixes": legacy_decision.get("forbidden_tool_prefixes") or [],
+                "allow_agent_handoff": legacy_decision.get("allow_agent_handoff", True),
+                "allow_rag_delegation": legacy_decision.get("allow_rag_delegation", False),
+            }
+        )
+    return None
+
+
+def filter_tools_for_policy_session(
+    tools: list[Any],
+    session: ToolPolicySession,
+    *,
+    tool_name: Callable[[Any], str],
+) -> list[Any]:
+    """Apply prompt-visibility policy to a candidate tool list."""
+
+    return [
+        tool
+        for tool in tools
+        if session.should_expose_tool(tool_name(tool))
+    ]
+
+
+def finalize_tool_policy_visible_tools(
+    state: dict[str, Any] | None,
+    tools: list[Any],
+    *,
+    tool_name: Callable[[Any], str],
+) -> ToolPolicySession | None:
+    """Record the final bound tool set after runtime pruning."""
+
+    session = tool_policy_session_from_state(state)
+    if session is None:
+        return None
+    visible_names = [tool_name(tool) for tool in tools]
+    updated = session.with_visible_tools(visible_names)
+    record_tool_policy_session(state, updated)
+    return updated
+
+
+def tool_policy_denial_message(decision: ToolPolicyDecision) -> str:
+    """User-visible tool result when execution is denied by policy."""
+
+    return (
+        "Tool bị chặn bởi chính sách lượt hiện tại: "
+        f"`{decision.tool_name}` không thuộc path `{decision.path}` "
+        f"({decision.reason})."
+    )
+
+
+def _connection_status_for_turn(
+    *,
+    state: dict[str, Any] | None,
+    query: str,
+) -> dict[str, dict[str, Any]]:
+    lms_status = lms_authoring_connection_status(
+        state,
+        (state or {}).get("context") if isinstance((state or {}).get("context"), dict) else {},
+    )
+    return {
+        "lms_authoring": lms_status,
+        "weather": _weather_connection_status(),
+        "host_actions": _host_action_connection_status(state),
+        "query": {
+            "active": bool(str(query or "").strip()),
+            "reason": "present" if str(query or "").strip() else "missing_query",
+        },
+    }
+
+
+def _weather_connection_status() -> dict[str, Any]:
+    enabled = bool(getattr(settings, "living_agent_enable_weather", False))
+    has_provider = bool(str(getattr(settings, "living_agent_weather_api_key", "") or "").strip())
+    active = enabled and has_provider
+    return {
+        "active": active,
+        "reason": "active" if active else "missing_weather_provider",
+        "fail_closed_tool": True,
+        "default_city": str(getattr(settings, "living_agent_weather_city", "") or "").strip() or None,
+    }
+
+
+def _host_action_connection_status(state: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(state, dict):
+        return {"active": False, "reason": "missing_state"}
+    host_capabilities = state.get("host_capabilities")
+    if not isinstance(host_capabilities, dict):
+        context = state.get("context")
+        if isinstance(context, dict):
+            host_capabilities = context.get("host_capabilities")
+    if not isinstance(host_capabilities, dict):
+        return {"active": False, "reason": "missing_host_capabilities"}
+    tools = host_capabilities.get("tools")
+    tool_count = len(tools) if isinstance(tools, list) else 0
+    return {
+        "active": tool_count > 0,
+        "reason": "active" if tool_count > 0 else "missing_host_tools",
+        "tool_count": tool_count,
+    }
+
+
+def _is_lms_authoring_tool(tool_name: str) -> bool:
+    if not tool_name.startswith(LMS_AUTHORING_PREFIX):
+        return False
+    action_name = tool_name.removeprefix(HOST_ACTION_PREFIX).replace("__", ".")
+    return action_name in LMS_AUTHORING_CAPABILITY_NAMES
+
+
+def _requires_approval_token(tool_name: str) -> bool:
+    normalized = tool_name.strip().lower()
+    return normalized.endswith("apply_lesson_patch") or normalized.endswith("apply_course_plan")
+
+
+def _normalize_tool_name(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _frozen_name_set(value: Any) -> frozenset[str]:
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return frozenset()
+    return frozenset(_normalize_tool_name(item) for item in value if _normalize_tool_name(item))
+
+
+def _name_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return ()
+    return tuple(_normalize_tool_name(item) for item in value if _normalize_tool_name(item))
+
+
+def _plain_connection_status(value: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(value, dict):
+        return {}
+    plain: dict[str, dict[str, Any]] = {}
+    for key, item in value.items():
+        if isinstance(item, dict):
+            plain[str(key)] = dict(item)
+    return plain

--- a/maritime-ai-service/tests/unit/test_tool_policy_session.py
+++ b/maritime-ai-service/tests/unit/test_tool_policy_session.py
@@ -1,0 +1,154 @@
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_tool_policy_session_records_visible_weather_tool_only():
+    from app.engine.multi_agent.tool_policy_session import (
+        build_tool_policy_session,
+        filter_tools_for_policy_session,
+        finalize_tool_policy_visible_tools,
+        record_tool_policy_session,
+        tool_policy_session_from_state,
+    )
+    from app.engine.multi_agent.turn_path_governor import (
+        TurnPathSignals,
+        resolve_turn_path_decision,
+    )
+
+    decision = resolve_turn_path_decision(
+        TurnPathSignals(
+            normalized_query="thoi tiet hom nay bao do",
+            needs_weather_lookup=True,
+            needs_web_search=True,
+        )
+    )
+    state = {"context": {}}
+    tools = [
+        SimpleNamespace(name="tool_current_weather"),
+        SimpleNamespace(name="tool_web_search"),
+        SimpleNamespace(name="tool_pointy_show"),
+    ]
+    session = build_tool_policy_session(
+        decision=decision,
+        state=state,
+        query="thời tiết hôm nay bao độ",
+        user_role="student",
+        candidate_tool_names=[tool.name for tool in tools],
+    )
+    record_tool_policy_session(state, session)
+
+    filtered = filter_tools_for_policy_session(
+        tools,
+        session,
+        tool_name=lambda tool: tool.name,
+    )
+    finalize_tool_policy_visible_tools(
+        state,
+        filtered,
+        tool_name=lambda tool: tool.name,
+    )
+    final_session = tool_policy_session_from_state(state)
+
+    assert [tool.name for tool in filtered] == ["tool_current_weather"]
+    assert final_session is not None
+    assert final_session.path == "weather_lookup"
+    assert final_session.visible_tool_names == frozenset({"tool_current_weather"})
+    assert final_session.decision_for("tool_current_weather").allowed is True
+    assert final_session.decision_for("tool_web_search").allowed is False
+
+
+def test_tool_policy_session_denies_lms_authoring_without_connection():
+    from app.engine.multi_agent.tool_policy_session import build_tool_policy_session
+    from app.engine.multi_agent.turn_path_governor import (
+        TurnPathSignals,
+        resolve_turn_path_decision,
+    )
+
+    decision = resolve_turn_path_decision(
+        TurnPathSignals(
+            normalized_query="tao bai hoc tu tai lieu",
+            looks_document_preview=True,
+        )
+    )
+    session = build_tool_policy_session(
+        decision=decision,
+        state={"context": {}},
+        query="tạo bài học từ tài liệu",
+        user_role="teacher",
+        candidate_tool_names=[
+            "host_action__authoring__preview_lesson_patch",
+            "host_action__authoring__apply_lesson_patch",
+        ],
+    )
+
+    assert session.connection_status is not None
+    assert session.connection_status["lms_authoring"]["active"] is False
+    assert session.should_expose_tool("host_action__authoring__preview_lesson_patch") is False
+    assert "host_action__authoring__apply_lesson_patch" in session.approval_required_tool_names
+
+
+@pytest.mark.asyncio
+async def test_dispatch_direct_tool_call_denies_tool_not_visible_in_policy():
+    from app.engine.multi_agent.direct_tool_dispatch_runtime import (
+        dispatch_direct_tool_call,
+    )
+
+    emitted: list[dict] = []
+    tool_events: list[dict] = []
+    invoked = False
+    state = {
+        "_tool_policy_session": {
+            "version": "tool_policy_session.v1",
+            "path": "weather_lookup",
+            "reason": "weather_current_conditions_request",
+            "bind_tools": True,
+            "force_tools": True,
+            "allow_all_tools": False,
+            "allowed_tool_names": ["tool_current_weather"],
+            "allowed_tool_prefixes": [],
+            "forbidden_tool_names": [],
+            "forbidden_tool_prefixes": ["tool_pointy_"],
+            "candidate_tool_names": ["tool_current_weather", "tool_web_search"],
+            "visible_tool_names": ["tool_current_weather"],
+            "connection_status": {},
+            "approval_required_tool_names": [],
+        }
+    }
+
+    async def push_event(event):
+        emitted.append(event)
+
+    async def invoke_tool_with_runtime(*_args, **_kwargs):
+        nonlocal invoked
+        invoked = True
+        raise AssertionError("denied tool must not be invoked")
+
+    result = await dispatch_direct_tool_call(
+        tool_call={
+            "id": "tc-denied",
+            "name": "tool_web_search",
+            "args": {"query": "weather today"},
+        },
+        tool_round=0,
+        tools=[SimpleNamespace(name="tool_web_search")],
+        query="thời tiết hôm nay bao độ",
+        state=state,
+        push_event=push_event,
+        tool_call_events=tool_events,
+        get_tool_by_name=lambda tools, name: tools[0] if name == "tool_web_search" else None,
+        invoke_tool_with_runtime=invoke_tool_with_runtime,
+        runtime_context_base=None,
+        is_search_tool_name=lambda name: name == "tool_web_search",
+        prefer_official_query_for_known_docs=lambda args, _query: args,
+        summarize_tool_result_for_stream=lambda _name, value: value,
+        logger_obj=SimpleNamespace(warning=lambda *_args, **_kwargs: None),
+    )
+
+    assert invoked is False
+    assert result.matched is False
+    assert result.tool_name == "tool_web_search"
+    assert "Tool bị chặn bởi chính sách" in result.result
+    assert emitted[0]["content"]["policy"]["allowed"] is False
+    assert emitted[1]["type"] == "tool_result"
+    assert tool_events[0]["policy"]["reason"] == "not_allowed_by_path_policy"


### PR DESCRIPTION
## Summary
- Adds a Wiii-native `ToolPolicySession` layer after `TurnPathDecision` so each direct chat turn records candidate tools, visible/bound tools, allow/deny rules, connection status, and approval-required tools.
- Replaces direct path filtering in tool collection with policy-session filtering and records final visible tools after runtime selection.
- Adds execution-time denial in direct tool dispatch so stale/raw/provider-generated tool calls outside the active policy return a visible policy result and are not invoked.
- Documents the standard in `docs/operations/WIII_TOOL_POLICY_SESSION_STANDARD.md`.

## Linked Issue
Closes #690

## Scope
- Backend direct chat tool policy, selection metadata, and direct tool execution guard.
- Connection/approval metadata for LMS authoring, host actions, and weather provider status.
- Focused unit coverage for weather policy visibility, LMS authoring connection gating, and execution denial.

## Non-Scope
- New frontend connection UI.
- New LMS OAuth/Facebook-style connector implementation.
- Provider/model routing changes.
- Database migrations.
- Code Studio/tutor/product-search agent tool loops; this PR establishes the direct-chat foundation first.

## Verification
Local:
- `python -m pytest tests/unit/test_tool_policy_session.py tests/unit/test_turn_path_governor.py tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_utility_weather_tool.py tests/unit/test_direct_node_tool_selection.py tests/unit/test_tool_collection_visual_requirements.py tests/unit/test_sprint99_forced_tool_calling.py tests/unit/test_sprint97_living_character.py::TestDirectNodeCharacterTools::test_tools_bound_when_enabled -q --tb=short` -> 152 passed
- `python -m ruff check app/ tests/unit/ --select=E9,F63,F7` -> All checks passed
- `git diff --check` -> clean
- Docker runtime probe: weather query records `weather_lookup`, visible `['tool_current_weather']`, weather connection `missing_weather_provider`; COLREG query records `maritime_search`, includes `tool_search_maritime`, excludes `tool_current_weather`.

Attempted but not used as pass evidence:
- `python -m pytest tests/unit/ -q --tb=short` timed out locally after 15 minutes. GitHub CI should provide full unit signal.

## Risk
- Tool execution is a high-risk surface. The new guard fails closed: denied tools are not invoked and return a visible policy-denied result.
- Host/LMS behavior should stay safer than before because LMS authoring tools are additionally checked against active LMS connection metadata.
- Direct-chat behavior changes are intentional only for out-of-policy tool calls; valid bound tools should continue to execute normally.

## Rollback
Revert this PR to remove `ToolPolicySession` and return to the previous `TurnPathDecision`-only filtering plus direct dispatch behavior.

## Reviewer Focus
- `tool_policy_session.py` contract shape and metadata stability.
- Direct dispatch denial behavior in `direct_tool_dispatch_runtime.py`.
- Whether the LMS/weather connection metadata is strict enough without blocking fail-closed user feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Tool authorization now enforced: tool visibility and execution controlled based on user role and system connection states.
* Denied tool calls return explanatory messages.

## Documentation
* Added operations guide documenting tool authorization standards and enforcement rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->