### PR TITLE
feat(backend): add tool capability registry

### DIFF
--- a/docs/operations/WIII_TOOL_POLICY_SESSION_STANDARD.md
+++ b/docs/operations/WIII_TOOL_POLICY_SESSION_STANDARD.md
@@ -22,6 +22,11 @@ The canonical backend shape is:
 query/context -> TurnPathDecision -> ToolPolicySession -> bound tools -> execution guard
 ```
 
+`ToolCapabilityRegistry` is the policy metadata source underneath that shape.
+Tool construction remains in the native tool modules, but connection,
+approval, mutation, group, and surface-scope metadata must come from
+`app.engine.tools.tool_capability_registry`.
+
 ## Required Contract
 
 Every direct chat turn should have a `ToolPolicySession` in `AgentState` when
@@ -40,6 +45,18 @@ The session records:
 - `connection_status`: fail-closed service status such as LMS authoring
   connection, host capability presence, and weather provider availability.
 - `approval_required_tool_names`: tools that require preview/approval evidence.
+- `tool_capabilities`: serialized registry metadata for candidate tools, used
+  for auditability and later loop migration.
+
+The capability registry records:
+
+- capability group: web search, weather, LMS authoring, host action, Pointy,
+  visual, knowledge search, utility, or Code Studio output;
+- permission level: read, write, or host control;
+- required connection: LMS authoring, weather provider, or host actions;
+- whether the tool mutates state or requires host-issued approval evidence;
+- intended surface scope, such as direct chat, tutor, Code Studio, host, LMS, or
+  visual runtime.
 
 ## Runtime Rules
 

--- a/maritime-ai-service/app/engine/context/action_tools.py
+++ b/maritime-ai-service/app/engine/context/action_tools.py
@@ -9,6 +9,10 @@ import re
 from typing import Any
 
 from app.engine.tools.native_tool import StructuredTool
+from app.engine.tools.tool_capability_registry import (
+    host_action_requires_approval_token,
+    host_action_tool_name,
+)
 
 from app.engine.context.action_bridge import HostActionBridge
 
@@ -22,13 +26,6 @@ _EXPLICIT_CONFIRM_RE = re.compile(
     r")\b",
     re.IGNORECASE,
 )
-
-
-def host_action_tool_name(action_name: str) -> str:
-    """Map dotted/slashed action names to OpenAI-safe tool names."""
-    normalized = re.sub(r"[^a-zA-Z0-9_-]+", "__", action_name.strip())
-    normalized = normalized.strip("_") or "host_action"
-    return f"host_action__{normalized}"
 
 
 def _query_explicitly_confirms(query: str) -> bool:
@@ -81,8 +78,7 @@ def _expected_preview_kind(action_name: str) -> str | None:
 
 
 def _action_requires_approval_token(action_name: str) -> bool:
-    normalized = action_name.strip().lower()
-    return normalized.endswith("apply_lesson_patch") or normalized.endswith("apply_course_plan")
+    return host_action_requires_approval_token(action_name)
 
 
 def _latest_preview_matches(

--- a/maritime-ai-service/app/engine/multi_agent/document_preview_contract.py
+++ b/maritime-ai-service/app/engine/multi_agent/document_preview_contract.py
@@ -6,20 +6,12 @@ import unicodedata
 from collections.abc import Callable
 from typing import Any
 
-DOC_PREVIEW_HOST_ACTION_TOOL = "host_action__authoring__preview_lesson_patch"
-DOC_COURSE_HOST_ACTION_TOOL = "host_action__authoring__generate_course_from_document"
-
-DOCUMENT_PREVIEW_CAPABILITY_NAMES = {
-    "authoring.preview_lesson_patch",
-    "authoring.generate_course_from_document",
-}
-
-LMS_AUTHORING_CAPABILITY_NAMES = {
-    "authoring.preview_lesson_patch",
-    "authoring.generate_course_from_document",
-    "authoring.apply_lesson_patch",
-    "authoring.apply_course_plan",
-}
+from app.engine.tools.tool_capability_registry import (
+    DOC_COURSE_HOST_ACTION_TOOL,
+    DOC_PREVIEW_HOST_ACTION_TOOL,
+    DOCUMENT_PREVIEW_CAPABILITY_NAMES,
+    LMS_AUTHORING_CAPABILITY_NAMES,
+)
 
 _COURSE_REQUEST_BLOCKERS = (
     "preview_lesson_patch",

--- a/maritime-ai-service/app/engine/multi_agent/tool_collection.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_collection.py
@@ -29,6 +29,13 @@ from app.engine.multi_agent.tool_policy_session import (
     finalize_tool_policy_visible_tools,
     record_tool_policy_session,
 )
+from app.engine.tools.tool_capability_registry import (
+    DOC_COURSE_HOST_ACTION_TOOL,
+    DOC_PREVIEW_HOST_ACTION_TOOL,
+    DOCUMENT_PREVIEW_CAPABILITY_NAMES,
+    HOST_ACTION_PREFIX,
+    POINTY_TOOL_PREFIX,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -414,12 +421,12 @@ def _document_preview_host_action_tools(tools: list[Any]) -> list[Any]:
     course_tools = [
         tool
         for tool in tools
-        if _tool_name(tool).lower() == "host_action__authoring__generate_course_from_document"
+        if _tool_name(tool).lower() == DOC_COURSE_HOST_ACTION_TOOL
     ]
     lesson_tools = [
         tool
         for tool in tools
-        if _tool_name(tool).lower() == "host_action__authoring__preview_lesson_patch"
+        if _tool_name(tool).lower() == DOC_PREVIEW_HOST_ACTION_TOOL
     ]
     return course_tools + lesson_tools
 
@@ -429,9 +436,9 @@ def _preferred_document_preview_host_action_tools(
     query: str,
     state: Optional[AgentState],
 ) -> list[Any]:
-    preferred = "host_action__authoring__generate_course_from_document" if (
+    preferred = DOC_COURSE_HOST_ACTION_TOOL if (
         _looks_like_document_course_preview_request(query, state)
-    ) else "host_action__authoring__preview_lesson_patch"
+    ) else DOC_PREVIEW_HOST_ACTION_TOOL
     return [
         tool
         for tool in tools
@@ -468,11 +475,7 @@ def _safe_document_preview_capability_tools(
     return [
         tool
         for tool in capabilities_tools
-        if str(tool.get("name") or "").strip().lower()
-        in {
-            "authoring.preview_lesson_patch",
-            "authoring.generate_course_from_document",
-        }
+        if str(tool.get("name") or "").strip().lower() in DOCUMENT_PREVIEW_CAPABILITY_NAMES
     ]
 
 
@@ -688,7 +691,7 @@ def _host_action_tools(tools: list[Any]) -> list[Any]:
     way Wiii answers "where is X" / "click Y" questions on STANDALONE
     Wiii desktop / Wiii web — there is no host_action bridge there.
     """
-    allowed_prefixes = ("host_action__", "tool_pointy_")
+    allowed_prefixes = (HOST_ACTION_PREFIX, POINTY_TOOL_PREFIX)
     return [tool for tool in tools if _tool_name(tool).startswith(allowed_prefixes)]
 
 

--- a/maritime-ai-service/app/engine/multi_agent/tool_policy_session.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_policy_session.py
@@ -7,19 +7,18 @@ from typing import Any, Callable
 
 from app.core.config import settings
 from app.engine.multi_agent.document_preview_contract import (
-    LMS_AUTHORING_CAPABILITY_NAMES,
     lms_authoring_connection_status,
 )
 from app.engine.multi_agent.turn_path_governor import TurnPathDecision
+from app.engine.tools.tool_capability_registry import (
+    approval_required_tool_names_for,
+    tool_capability_metadata_for_names,
+    tool_requires_inactive_connection,
+)
 
 
 TOOL_POLICY_SESSION_VERSION = "tool_policy_session.v1"
 TOOL_POLICY_STATE_KEY = "_tool_policy_session"
-
-HOST_ACTION_PREFIX = "host_action__"
-LMS_AUTHORING_PREFIX = "host_action__authoring__"
-POINTY_PREFIX = "tool_pointy_"
-WEATHER_TOOL_NAME = "tool_current_weather"
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,6 +50,7 @@ class ToolPolicySession:
     visible_tool_names: frozenset[str] = frozenset()
     connection_status: dict[str, dict[str, Any]] | None = None
     approval_required_tool_names: frozenset[str] = frozenset()
+    tool_capabilities: dict[str, dict[str, Any]] | None = None
     allow_agent_handoff: bool = True
     allow_rag_delegation: bool = False
 
@@ -133,6 +133,7 @@ class ToolPolicySession:
             "visible_tool_names": sorted(self.visible_tool_names),
             "connection_status": dict(self.connection_status or {}),
             "approval_required_tool_names": sorted(self.approval_required_tool_names),
+            "tool_capabilities": dict(self.tool_capabilities or {}),
             "allow_agent_handoff": self.allow_agent_handoff,
             "allow_rag_delegation": self.allow_rag_delegation,
         }
@@ -158,15 +159,16 @@ class ToolPolicySession:
             approval_required_tool_names=_frozen_name_set(
                 metadata.get("approval_required_tool_names")
             ),
+            tool_capabilities=_plain_tool_capabilities(metadata.get("tool_capabilities")),
             allow_agent_handoff=bool(metadata.get("allow_agent_handoff", True)),
             allow_rag_delegation=bool(metadata.get("allow_rag_delegation", False)),
         )
 
     def _requires_inactive_connection(self, tool_name: str) -> bool:
-        if _is_lms_authoring_tool(tool_name):
-            status = (self.connection_status or {}).get("lms_authoring") or {}
-            return not bool(status.get("active"))
-        return False
+        return tool_requires_inactive_connection(
+            tool_name,
+            self.connection_status or {},
+        )
 
 
 def build_tool_policy_session(
@@ -183,9 +185,7 @@ def build_tool_policy_session(
         _normalize_tool_name(name) for name in candidate_tool_names if _normalize_tool_name(name)
     )
     connection_status = _connection_status_for_turn(state=state, query=query)
-    approval_required_names = frozenset(
-        name for name in normalized_candidates if _requires_approval_token(name)
-    )
+    approval_required_names = approval_required_tool_names_for(normalized_candidates)
     return ToolPolicySession(
         version=TOOL_POLICY_SESSION_VERSION,
         path=decision.path,
@@ -200,6 +200,7 @@ def build_tool_policy_session(
         candidate_tool_names=normalized_candidates,
         connection_status=connection_status,
         approval_required_tool_names=approval_required_names,
+        tool_capabilities=tool_capability_metadata_for_names(normalized_candidates),
         allow_agent_handoff=decision.allow_agent_handoff,
         allow_rag_delegation=decision.allow_rag_delegation,
     )
@@ -335,18 +336,6 @@ def _host_action_connection_status(state: dict[str, Any] | None) -> dict[str, An
     }
 
 
-def _is_lms_authoring_tool(tool_name: str) -> bool:
-    if not tool_name.startswith(LMS_AUTHORING_PREFIX):
-        return False
-    action_name = tool_name.removeprefix(HOST_ACTION_PREFIX).replace("__", ".")
-    return action_name in LMS_AUTHORING_CAPABILITY_NAMES
-
-
-def _requires_approval_token(tool_name: str) -> bool:
-    normalized = tool_name.strip().lower()
-    return normalized.endswith("apply_lesson_patch") or normalized.endswith("apply_course_plan")
-
-
 def _normalize_tool_name(value: Any) -> str:
     return str(value or "").strip()
 
@@ -370,4 +359,14 @@ def _plain_connection_status(value: Any) -> dict[str, dict[str, Any]]:
     for key, item in value.items():
         if isinstance(item, dict):
             plain[str(key)] = dict(item)
+    return plain
+
+
+def _plain_tool_capabilities(value: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(value, dict):
+        return {}
+    plain: dict[str, dict[str, Any]] = {}
+    for key, item in value.items():
+        if isinstance(item, dict):
+            plain[_normalize_tool_name(key)] = dict(item)
     return plain

--- a/maritime-ai-service/app/engine/multi_agent/turn_path_governor.py
+++ b/maritime-ai-service/app/engine/multi_agent/turn_path_governor.py
@@ -11,6 +11,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Literal
 
+from app.engine.tools.tool_capability_registry import (
+    HOST_ACTION_PREFIX,
+    LMS_DOCUMENT_PREVIEW_TOOL_NAMES,
+    POINTY_TOOL_PREFIX,
+    WEATHER_TOOL_NAMES,
+)
 
 TurnPathName = Literal[
     "casual_chat",
@@ -31,15 +37,8 @@ TurnPathName = Literal[
 ]
 
 
-POINTY_TOOL_PREFIXES: tuple[str, ...] = ("tool_pointy_",)
-HOST_ACTION_TOOL_PREFIXES: tuple[str, ...] = ("host_action__",)
-LMS_DOCUMENT_PREVIEW_TOOL_NAMES = frozenset(
-    {
-        "host_action__authoring__generate_course_from_document",
-        "host_action__authoring__preview_lesson_patch",
-    }
-)
-WEATHER_TOOL_NAMES = frozenset({"tool_current_weather"})
+POINTY_TOOL_PREFIXES: tuple[str, ...] = (POINTY_TOOL_PREFIX,)
+HOST_ACTION_TOOL_PREFIXES: tuple[str, ...] = (HOST_ACTION_PREFIX,)
 
 
 @dataclass(frozen=True, slots=True)

--- a/maritime-ai-service/app/engine/tools/tool_capability_registry.py
+++ b/maritime-ai-service/app/engine/tools/tool_capability_registry.py
@@ -1,0 +1,390 @@
+"""Typed policy metadata for Wiii tool capabilities.
+
+This registry is intentionally about policy metadata, not tool construction.
+Runtime collectors can still build tools from their native modules, while path
+policy and execution guards share one source of truth for connection and
+approval requirements.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Literal
+
+ToolCapabilityGroup = Literal[
+    "utility",
+    "web_search",
+    "weather",
+    "knowledge_search",
+    "lms_query",
+    "lms_authoring",
+    "host_action",
+    "pointy",
+    "visual",
+    "code_studio_output",
+]
+ToolPermissionLevel = Literal["read", "write", "host_control"]
+ToolConnectionName = Literal["lms_authoring", "weather", "host_actions"]
+ToolSurfaceScope = Literal[
+    "direct_chat",
+    "tutor",
+    "code_studio",
+    "host",
+    "lms",
+    "visual",
+]
+
+TOOL_CAPABILITY_REGISTRY_VERSION = "tool_capability_registry.v1"
+
+HOST_ACTION_PREFIX = "host_action__"
+POINTY_TOOL_PREFIX = "tool_pointy_"
+LMS_AUTHORING_PREFIX = f"{HOST_ACTION_PREFIX}authoring__"
+WEATHER_TOOL_NAME = "tool_current_weather"
+WEATHER_TOOL_NAMES = frozenset({WEATHER_TOOL_NAME})
+
+DOC_PREVIEW_HOST_ACTION_TOOL = "host_action__authoring__preview_lesson_patch"
+DOC_COURSE_HOST_ACTION_TOOL = "host_action__authoring__generate_course_from_document"
+DOC_APPLY_LESSON_PATCH_TOOL = "host_action__authoring__apply_lesson_patch"
+DOC_APPLY_COURSE_PLAN_TOOL = "host_action__authoring__apply_course_plan"
+
+DOCUMENT_PREVIEW_CAPABILITY_NAMES = frozenset(
+    {
+        "authoring.preview_lesson_patch",
+        "authoring.generate_course_from_document",
+    }
+)
+LMS_AUTHORING_APPLY_CAPABILITY_NAMES = frozenset(
+    {
+        "authoring.apply_lesson_patch",
+        "authoring.apply_course_plan",
+    }
+)
+LMS_AUTHORING_CAPABILITY_NAMES = (
+    DOCUMENT_PREVIEW_CAPABILITY_NAMES | LMS_AUTHORING_APPLY_CAPABILITY_NAMES
+)
+LMS_DOCUMENT_PREVIEW_TOOL_NAMES = frozenset(
+    {
+        DOC_PREVIEW_HOST_ACTION_TOOL,
+        DOC_COURSE_HOST_ACTION_TOOL,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCapability:
+    """Policy-facing metadata for a tool name or dynamic tool family."""
+
+    name: str
+    group: ToolCapabilityGroup
+    permission: ToolPermissionLevel = "read"
+    required_connection: ToolConnectionName | None = None
+    expose_when_connection_inactive: bool = False
+    mutates_state: bool = False
+    requires_approval: bool = False
+    surface_scopes: tuple[ToolSurfaceScope, ...] = ("direct_chat",)
+    dynamic: bool = False
+    host_action_name: str | None = None
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "group": self.group,
+            "permission": self.permission,
+            "required_connection": self.required_connection,
+            "expose_when_connection_inactive": self.expose_when_connection_inactive,
+            "mutates_state": self.mutates_state,
+            "requires_approval": self.requires_approval,
+            "surface_scopes": list(self.surface_scopes),
+            "dynamic": self.dynamic,
+            "host_action_name": self.host_action_name,
+        }
+
+
+def host_action_tool_name(action_name: str) -> str:
+    """Map a host action name to the OpenAI-safe tool name Wiii binds."""
+
+    normalized = re.sub(r"[^a-zA-Z0-9_-]+", "__", str(action_name or "").strip())
+    normalized = normalized.strip("_") or "host_action"
+    return f"{HOST_ACTION_PREFIX}{normalized}"
+
+
+def host_action_name_from_tool_name(tool_name: str) -> str:
+    """Recover a dotted host action name from a generated host action tool."""
+
+    name = _normalize_tool_name(tool_name)
+    if not name.startswith(HOST_ACTION_PREFIX):
+        return ""
+    return name.removeprefix(HOST_ACTION_PREFIX).replace("__", ".")
+
+
+def host_action_requires_approval_token(action_name: str) -> bool:
+    """Return whether a host action needs host-issued approval evidence."""
+
+    return _normalize_action_name(action_name) in LMS_AUTHORING_APPLY_CAPABILITY_NAMES
+
+
+def lookup_tool_capability(tool_name: Any) -> ToolCapability | None:
+    """Return policy metadata for a tool name, including dynamic host actions."""
+
+    name = _normalize_tool_name(tool_name)
+    if not name:
+        return None
+    static = TOOL_CAPABILITIES.get(name)
+    if static is not None:
+        return static
+    if name.startswith(HOST_ACTION_PREFIX):
+        return _dynamic_host_action_capability(name)
+    if name.startswith(POINTY_TOOL_PREFIX):
+        return ToolCapability(
+            name=name,
+            group="pointy",
+            permission="host_control",
+            surface_scopes=("direct_chat", "host"),
+            dynamic=True,
+        )
+    return None
+
+
+def is_lms_authoring_tool(tool_name: Any) -> bool:
+    capability = lookup_tool_capability(tool_name)
+    return bool(capability and capability.group == "lms_authoring")
+
+
+def tool_requires_approval(tool_name: Any) -> bool:
+    capability = lookup_tool_capability(tool_name)
+    return bool(capability and capability.requires_approval)
+
+
+def approval_required_tool_names_for(
+    tool_names: list[str] | tuple[str, ...] | set[str] | frozenset[str],
+) -> frozenset[str]:
+    return frozenset(
+        _normalize_tool_name(name)
+        for name in tool_names
+        if _normalize_tool_name(name) and tool_requires_approval(name)
+    )
+
+
+def tool_requires_inactive_connection(
+    tool_name: Any,
+    connection_status: dict[str, dict[str, Any]] | None,
+) -> bool:
+    """Return True when a tool must be hidden because its connection is inactive."""
+
+    capability = lookup_tool_capability(tool_name)
+    if capability is None or capability.required_connection is None:
+        return False
+    if capability.expose_when_connection_inactive:
+        return False
+    status_map = connection_status if isinstance(connection_status, dict) else {}
+    status = status_map.get(capability.required_connection)
+    if not isinstance(status, dict):
+        return True
+    return not bool(status.get("active"))
+
+
+def tool_capability_metadata_for_names(
+    tool_names: list[str] | tuple[str, ...] | set[str] | frozenset[str],
+) -> dict[str, dict[str, Any]]:
+    """Return serializable metadata for known tools in a candidate set."""
+
+    metadata: dict[str, dict[str, Any]] = {}
+    for raw_name in tool_names:
+        name = _normalize_tool_name(raw_name)
+        if not name:
+            continue
+        capability = lookup_tool_capability(name)
+        if capability is not None:
+            metadata[name] = capability.to_metadata()
+    return metadata
+
+
+def capability_names_for_group(group: ToolCapabilityGroup) -> frozenset[str]:
+    return frozenset(
+        name for name, capability in TOOL_CAPABILITIES.items()
+        if capability.group == group
+    )
+
+
+def _dynamic_host_action_capability(tool_name: str) -> ToolCapability:
+    action_name = host_action_name_from_tool_name(tool_name)
+    if _normalize_action_name(action_name) in LMS_AUTHORING_CAPABILITY_NAMES:
+        requires_approval = host_action_requires_approval_token(action_name)
+        return ToolCapability(
+            name=tool_name,
+            group="lms_authoring",
+            permission="write" if requires_approval else "host_control",
+            required_connection="lms_authoring",
+            mutates_state=requires_approval,
+            requires_approval=requires_approval,
+            surface_scopes=("direct_chat", "host", "lms"),
+            dynamic=True,
+            host_action_name=action_name,
+        )
+    return ToolCapability(
+        name=tool_name,
+        group="host_action",
+        permission="host_control",
+        required_connection="host_actions",
+        mutates_state=True,
+        surface_scopes=("direct_chat", "host"),
+        dynamic=True,
+        host_action_name=action_name or None,
+    )
+
+
+def _normalize_tool_name(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_action_name(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _capability(
+    name: str,
+    group: ToolCapabilityGroup,
+    *,
+    permission: ToolPermissionLevel = "read",
+    required_connection: ToolConnectionName | None = None,
+    expose_when_connection_inactive: bool = False,
+    mutates_state: bool = False,
+    requires_approval: bool = False,
+    surface_scopes: tuple[ToolSurfaceScope, ...] = ("direct_chat",),
+    host_action_name: str | None = None,
+) -> ToolCapability:
+    return ToolCapability(
+        name=name,
+        group=group,
+        permission=permission,
+        required_connection=required_connection,
+        expose_when_connection_inactive=expose_when_connection_inactive,
+        mutates_state=mutates_state,
+        requires_approval=requires_approval,
+        surface_scopes=surface_scopes,
+        host_action_name=host_action_name,
+    )
+
+
+TOOL_CAPABILITIES: dict[str, ToolCapability] = {
+    "tool_calculator": _capability("tool_calculator", "utility"),
+    "tool_current_datetime": _capability("tool_current_datetime", "utility"),
+    WEATHER_TOOL_NAME: _capability(
+        WEATHER_TOOL_NAME,
+        "weather",
+        required_connection="weather",
+        expose_when_connection_inactive=True,
+    ),
+    "tool_web_search": _capability("tool_web_search", "web_search"),
+    "tool_search_news": _capability("tool_search_news", "web_search"),
+    "tool_search_legal": _capability("tool_search_legal", "web_search"),
+    "tool_search_maritime": _capability("tool_search_maritime", "web_search"),
+    "tool_fetch_url": _capability("tool_fetch_url", "web_search"),
+    "tool_knowledge_search": _capability("tool_knowledge_search", "knowledge_search"),
+    "tool_rag_knowledge": _capability("tool_rag_knowledge", "knowledge_search"),
+    "tool_check_student_grades": _capability("tool_check_student_grades", "lms_query"),
+    "tool_list_upcoming_assignments": _capability("tool_list_upcoming_assignments", "lms_query"),
+    "tool_check_course_progress": _capability("tool_check_course_progress", "lms_query"),
+    "tool_get_class_overview": _capability("tool_get_class_overview", "lms_query"),
+    "tool_find_at_risk_students": _capability("tool_find_at_risk_students", "lms_query"),
+    "tool_pointy_show": _capability(
+        "tool_pointy_show",
+        "pointy",
+        permission="host_control",
+        surface_scopes=("direct_chat", "host"),
+    ),
+    "tool_pointy_clear": _capability(
+        "tool_pointy_clear",
+        "pointy",
+        permission="host_control",
+        surface_scopes=("direct_chat", "host"),
+    ),
+    "tool_pointy_inventory": _capability(
+        "tool_pointy_inventory",
+        "pointy",
+        permission="read",
+        surface_scopes=("direct_chat", "host"),
+    ),
+    "tool_generate_visual": _capability(
+        "tool_generate_visual",
+        "visual",
+        surface_scopes=("direct_chat", "visual"),
+    ),
+    "tool_create_visual_code": _capability(
+        "tool_create_visual_code",
+        "visual",
+        surface_scopes=("direct_chat", "code_studio", "visual"),
+    ),
+    "tool_generate_mermaid": _capability(
+        "tool_generate_mermaid",
+        "visual",
+        surface_scopes=("direct_chat", "visual"),
+    ),
+    "tool_generate_chart": _capability(
+        "tool_generate_chart",
+        "visual",
+        surface_scopes=("direct_chat", "visual"),
+    ),
+    "tool_generate_interactive_chart": _capability(
+        "tool_generate_interactive_chart",
+        "visual",
+        surface_scopes=("direct_chat", "visual"),
+    ),
+    "tool_generate_html_file": _capability(
+        "tool_generate_html_file",
+        "code_studio_output",
+        permission="write",
+        mutates_state=False,
+        surface_scopes=("code_studio",),
+    ),
+    "tool_generate_excel_file": _capability(
+        "tool_generate_excel_file",
+        "code_studio_output",
+        permission="write",
+        mutates_state=False,
+        surface_scopes=("code_studio",),
+    ),
+    "tool_generate_word_document": _capability(
+        "tool_generate_word_document",
+        "code_studio_output",
+        permission="write",
+        mutates_state=False,
+        surface_scopes=("code_studio",),
+    ),
+    DOC_PREVIEW_HOST_ACTION_TOOL: _capability(
+        DOC_PREVIEW_HOST_ACTION_TOOL,
+        "lms_authoring",
+        permission="host_control",
+        required_connection="lms_authoring",
+        surface_scopes=("direct_chat", "host", "lms"),
+        host_action_name="authoring.preview_lesson_patch",
+    ),
+    DOC_COURSE_HOST_ACTION_TOOL: _capability(
+        DOC_COURSE_HOST_ACTION_TOOL,
+        "lms_authoring",
+        permission="host_control",
+        required_connection="lms_authoring",
+        surface_scopes=("direct_chat", "host", "lms"),
+        host_action_name="authoring.generate_course_from_document",
+    ),
+    DOC_APPLY_LESSON_PATCH_TOOL: _capability(
+        DOC_APPLY_LESSON_PATCH_TOOL,
+        "lms_authoring",
+        permission="write",
+        required_connection="lms_authoring",
+        mutates_state=True,
+        requires_approval=True,
+        surface_scopes=("direct_chat", "host", "lms"),
+        host_action_name="authoring.apply_lesson_patch",
+    ),
+    DOC_APPLY_COURSE_PLAN_TOOL: _capability(
+        DOC_APPLY_COURSE_PLAN_TOOL,
+        "lms_authoring",
+        permission="write",
+        required_connection="lms_authoring",
+        mutates_state=True,
+        requires_approval=True,
+        surface_scopes=("direct_chat", "host", "lms"),
+        host_action_name="authoring.apply_course_plan",
+    ),
+}

--- a/maritime-ai-service/tests/unit/test_tool_capability_registry.py
+++ b/maritime-ai-service/tests/unit/test_tool_capability_registry.py
@@ -1,0 +1,71 @@
+def test_tool_capability_registry_records_policy_groups():
+    from app.engine.tools.tool_capability_registry import (
+        lookup_tool_capability,
+        tool_capability_metadata_for_names,
+    )
+
+    weather = lookup_tool_capability("tool_current_weather")
+    assert weather is not None
+    assert weather.group == "weather"
+    assert weather.required_connection == "weather"
+    assert weather.expose_when_connection_inactive is True
+
+    pointy = lookup_tool_capability("tool_pointy_show")
+    assert pointy is not None
+    assert pointy.group == "pointy"
+    assert pointy.permission == "host_control"
+
+    visual = lookup_tool_capability("tool_create_visual_code")
+    assert visual is not None
+    assert visual.group == "visual"
+    assert "code_studio" in visual.surface_scopes
+
+    metadata = tool_capability_metadata_for_names(
+        {
+            "tool_current_weather",
+            "tool_pointy_show",
+            "tool_create_visual_code",
+            "unknown_tool",
+        }
+    )
+    assert set(metadata) == {
+        "tool_current_weather",
+        "tool_pointy_show",
+        "tool_create_visual_code",
+    }
+
+
+def test_tool_capability_registry_handles_dynamic_host_actions():
+    from app.engine.tools.tool_capability_registry import (
+        host_action_name_from_tool_name,
+        host_action_requires_approval_token,
+        host_action_tool_name,
+        lookup_tool_capability,
+        tool_requires_inactive_connection,
+    )
+
+    preview_tool_name = host_action_tool_name("authoring.preview_lesson_patch")
+    assert preview_tool_name == "host_action__authoring__preview_lesson_patch"
+    assert host_action_name_from_tool_name(preview_tool_name) == "authoring.preview_lesson_patch"
+
+    preview = lookup_tool_capability(preview_tool_name)
+    assert preview is not None
+    assert preview.group == "lms_authoring"
+    assert preview.required_connection == "lms_authoring"
+    assert preview.requires_approval is False
+
+    apply_tool_name = host_action_tool_name("authoring.apply_lesson_patch")
+    assert host_action_requires_approval_token("authoring.apply_lesson_patch") is True
+    apply_tool = lookup_tool_capability(apply_tool_name)
+    assert apply_tool is not None
+    assert apply_tool.mutates_state is True
+    assert apply_tool.requires_approval is True
+
+    generic_host_tool = lookup_tool_capability("host_action__dashboard__focus_widget")
+    assert generic_host_tool is not None
+    assert generic_host_tool.group == "host_action"
+    assert generic_host_tool.required_connection == "host_actions"
+    assert tool_requires_inactive_connection(
+        "host_action__dashboard__focus_widget",
+        {"host_actions": {"active": False}},
+    ) is True

--- a/maritime-ai-service/tests/unit/test_tool_policy_session.py
+++ b/maritime-ai-service/tests/unit/test_tool_policy_session.py
@@ -54,6 +54,8 @@ def test_tool_policy_session_records_visible_weather_tool_only():
     assert final_session is not None
     assert final_session.path == "weather_lookup"
     assert final_session.visible_tool_names == frozenset({"tool_current_weather"})
+    assert final_session.tool_capabilities is not None
+    assert final_session.tool_capabilities["tool_current_weather"]["group"] == "weather"
     assert final_session.decision_for("tool_current_weather").allowed is True
     assert final_session.decision_for("tool_web_search").allowed is False
 
@@ -84,8 +86,36 @@ def test_tool_policy_session_denies_lms_authoring_without_connection():
 
     assert session.connection_status is not None
     assert session.connection_status["lms_authoring"]["active"] is False
+    assert session.tool_capabilities is not None
+    assert (
+        session.tool_capabilities["host_action__authoring__apply_lesson_patch"][
+            "requires_approval"
+        ]
+        is True
+    )
     assert session.should_expose_tool("host_action__authoring__preview_lesson_patch") is False
     assert "host_action__authoring__apply_lesson_patch" in session.approval_required_tool_names
+
+
+def test_tool_policy_session_denies_generic_host_action_without_connection():
+    from app.engine.multi_agent.tool_policy_session import ToolPolicySession
+
+    session = ToolPolicySession(
+        version="tool_policy_session.v1",
+        path="host_ui_navigation",
+        reason="routing_intent_host_ui_navigation",
+        bind_tools=True,
+        force_tools=True,
+        allow_all_tools=False,
+        allowed_tool_prefixes=("host_action__",),
+        candidate_tool_names=frozenset({"host_action__dashboard__focus_widget"}),
+        connection_status={"host_actions": {"active": False}},
+    )
+
+    assert session.should_expose_tool("host_action__dashboard__focus_widget") is False
+    decision = session.decision_for("host_action__dashboard__focus_widget")
+    assert decision.allowed is False
+    assert decision.reason == "not_allowed_by_path_policy"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds a typed ToolCapabilityRegistry for Wiii tool policy metadata: capability group, permission, required connection, mutation, approval, and surface scope.
- Wires direct-chat ToolPolicySession to derive connection/approval gating and audit metadata from the registry instead of local duplicated LMS/weather/host logic.
- Moves LMS preview/apply constants, host action tool naming, turn-path tool constants, and document-preview fallback filtering onto the shared registry contract.
- Updates the tool policy standard and adds focused registry/policy tests.

Closes #692.

## In Scope
- Backend tool policy metadata contract.
- Direct-chat policy session integration.
- LMS authoring/apply approval metadata.
- Weather fail-closed visibility metadata.
- Host action, Pointy, web-search, visual, and Code Studio output capability metadata.
- Focused backend tests and docs.

## Non-Scope
- No frontend connection UI.
- No production deploy change.
- No LMS mutation behavior change.
- No full Code Studio/Tutor/Product Search loop migration in this PR.

## Verification
- cd maritime-ai-service; python -m pytest tests/unit/test_tool_capability_registry.py tests/unit/test_tool_policy_session.py tests/unit/test_turn_path_governor.py tests/unit/test_tool_collection_host_ui.py tests/unit/test_tool_collection_visual_requirements.py tests/unit/test_sprint222b_action_tools.py -q --tb=short -> 54 passed.
- cd maritime-ai-service; python -m pytest tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_direct_node_tool_selection.py tests/unit/test_utility_weather_tool.py tests/unit/test_tool_collection_analytical.py -q --tb=short -> 89 passed.
- cd maritime-ai-service; python -m pytest tests/unit/test_document_preview_contract.py tests/unit/test_direct_node_document_preview_runtime.py tests/unit/test_direct_node_tool_selection.py -q --tb=short -> 16 passed.
- cd maritime-ai-service; python -m ruff check app/ tests/unit/ --select=E9,F63,F7 -> All checks passed.
- git diff --cached --check -> clean before commit.

## Risk
- High-risk surface: MCP/tool exposure and execution gating. Main risk is accidentally hiding or exposing a tool due to centralized metadata.
- Mitigation: behavior is routed through existing TurnPathDecision first; focused tests cover weather, LMS authoring, generic host-action stale calls, host action approval, visual narrowing, and direct runtime execution guard.

## Rollback
- Revert this PR to restore previous local constants and ToolPolicySession name-list checks. No database migration or persistent data change is included.

## Reviewer Focus
- Confirm registry metadata matches current tool safety boundaries.
- Confirm weather remains fail-closed-but-visible, while LMS authoring and generic host actions require active connection.
- Confirm this is narrow enough and leaves Code Studio/Tutor/Product Search loop migration for follow-up PRs.