### PR TITLE
feat(backend): guard code studio tool policy

### DIFF
--- a/docs/operations/WIII_TOOL_POLICY_SESSION_STANDARD.md
+++ b/docs/operations/WIII_TOOL_POLICY_SESSION_STANDARD.md
@@ -32,6 +32,11 @@ approval, mutation, group, and surface-scope metadata must come from
 Every direct chat turn should have a `ToolPolicySession` in `AgentState` when
 tool selection is evaluated.
 
+Runtimes that already perform their own tool selection, such as Code Studio,
+should record the same contract with `build_visible_tool_policy_session`: the
+candidate set is the collected tool inventory, and the visible set is the
+runtime-selected tool bundle actually bound to the model.
+
 The session records:
 
 - `path`: active path such as `casual_chat`, `weather_lookup`, `web_search`,

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_tool_rounds.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_tool_rounds.py
@@ -22,6 +22,11 @@ from app.engine.multi_agent.code_studio_template_scaffold import (
     build_code_studio_scaffold,
 )
 from app.engine.multi_agent.state import AgentState
+from app.engine.multi_agent.tool_policy_session import (
+    ToolPolicyDecision,
+    tool_policy_denial_message,
+    tool_policy_session_from_state,
+)
 from app.engine.runtime.runtime_metrics import inc_counter
 
 logger = logging.getLogger(__name__)
@@ -85,6 +90,19 @@ def _normalize_tc(tc: object) -> dict:
         "name": str(getattr(tc, "name", "") or ""),
         "args": getattr(tc, "arguments", None) or getattr(tc, "args", {}) or {},
     }
+
+
+def _code_studio_tool_policy_denial(
+    state: Optional[AgentState],
+    tool_name: str,
+) -> tuple[ToolPolicyDecision, str] | None:
+    session = tool_policy_session_from_state(state)
+    if session is None:
+        return None
+    decision = session.decision_for(str(tool_name or "").strip())
+    if decision.allowed:
+        return None
+    return decision, tool_policy_denial_message(decision)
 
 
 def _build_streamed_code_html_tool_round_outcome(
@@ -702,10 +720,68 @@ async def execute_code_studio_tool_rounds_impl(
             tc_id = tc_dict.get("id") or f"tc_{tool_round}"
             tc_name = tc_dict.get("name", "unknown")
             tc_args = tc_dict.get("args") or {}
+            policy_denial = _code_studio_tool_policy_denial(state, str(tc_name))
             logger.info(
                 "[CODE_STUDIO] Invoking tool %s (id=%s, args_keys=%s)",
                 tc_name, tc_id, list(tc_args.keys()) if isinstance(tc_args, dict) else "?",
             )
+            if policy_denial is not None:
+                policy_decision, result = policy_denial
+                policy_metadata = {
+                    "allowed": False,
+                    "path": policy_decision.path,
+                    "reason": policy_decision.reason,
+                }
+                logger.warning(
+                    "[CODE_STUDIO] Tool policy denied tool=%r path=%s reason=%s",
+                    tc_name,
+                    policy_decision.path,
+                    policy_decision.reason,
+                )
+                await push_event({
+                    "type": "tool_call",
+                    "content": {
+                        "name": tc_name,
+                        "args": sanitize_code_studio_tool_call_args_for_stream(
+                            tc_name,
+                            tc_args,
+                        ),
+                        "id": tc_id,
+                        "policy": policy_metadata,
+                    },
+                    "node": "code_studio_agent",
+                })
+                tool_call_events.append(
+                    {
+                        "type": "call",
+                        "name": tc_name,
+                        "args": tc_args,
+                        "id": tc_id,
+                        "policy": policy_metadata,
+                    }
+                )
+                await push_event(
+                    {
+                        "type": "tool_result",
+                        "content": {
+                            "name": tc_name,
+                            "result": summarize_tool_result_for_stream(tc_name, result),
+                            "id": tc_id,
+                        },
+                        "node": "code_studio_agent",
+                    }
+                )
+                tool_call_events.append(
+                    {
+                        "type": "result",
+                        "name": tc_name,
+                        "result": str(result),
+                        "id": tc_id,
+                        "policy": policy_metadata,
+                    }
+                )
+                messages.append(_TM(content=str(result), tool_call_id=tc_id))
+                continue
             await push_event({
                 "type": "tool_call",
                 "content": {

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_tool_setup.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_tool_setup.py
@@ -7,6 +7,10 @@ import logging
 from typing import Any, Callable
 
 from app.engine.multi_agent.state import AgentState
+from app.engine.multi_agent.tool_policy_session import (
+    build_visible_tool_policy_session,
+    record_tool_policy_session,
+)
 from app.engine.skills.skill_recommender import select_runtime_tools
 
 
@@ -26,6 +30,10 @@ BuildVisualToolRuntimeMetadata = Callable[[AgentState, str], dict[str, Any]]
 RuntimeToolSelector = Callable[..., list[Any] | None]
 
 
+def _tool_name(tool: Any) -> str:
+    return str(getattr(tool, "name", "") or getattr(tool, "__name__", "") or "").strip()
+
+
 def prepare_code_studio_tool_setup(
     *,
     effective_query: str,
@@ -43,6 +51,7 @@ def prepare_code_studio_tool_setup(
 
     user_role = str(ctx.get("user_role", "student") or "student")
     tools, force_tools = collect_code_studio_tools(effective_query, user_role)
+    candidate_tool_names = [_tool_name(tool) for tool in tools if _tool_name(tool)]
 
     try:
         selected_tools = select_runtime_tools_fn(
@@ -70,6 +79,19 @@ def prepare_code_studio_tool_setup(
             "[CODE_STUDIO] Runtime tool selection skipped: %s",
             selection_error,
         )
+
+    record_tool_policy_session(
+        state,
+        build_visible_tool_policy_session(
+            path="code_studio",
+            reason="code_studio_tool_setup",
+            state=state,
+            query=effective_query,
+            candidate_tool_names=candidate_tool_names,
+            visible_tool_names=[_tool_name(tool) for tool in tools if _tool_name(tool)],
+            force_tools=force_tools,
+        ),
+    )
 
     runtime_context_base = build_tool_runtime_context_fn(
         event_bus_id=bus_id,

--- a/maritime-ai-service/app/engine/multi_agent/tool_policy_session.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_policy_session.py
@@ -206,6 +206,45 @@ def build_tool_policy_session(
     )
 
 
+def build_visible_tool_policy_session(
+    *,
+    path: str,
+    reason: str,
+    state: dict[str, Any] | None,
+    query: str = "",
+    candidate_tool_names: list[str] | tuple[str, ...] | set[str] = (),
+    visible_tool_names: list[str] | tuple[str, ...] | set[str] | None = None,
+    force_tools: bool = False,
+) -> ToolPolicySession:
+    """Build a policy session for runtimes that already selected visible tools."""
+
+    normalized_candidates = frozenset(
+        _normalize_tool_name(name) for name in candidate_tool_names if _normalize_tool_name(name)
+    )
+    normalized_visible = frozenset(
+        _normalize_tool_name(name)
+        for name in (visible_tool_names if visible_tool_names is not None else normalized_candidates)
+        if _normalize_tool_name(name)
+    )
+    connection_status = _connection_status_for_turn(state=state, query=query)
+    return ToolPolicySession(
+        version=TOOL_POLICY_SESSION_VERSION,
+        path=str(path or "unknown"),
+        reason=str(reason or ""),
+        bind_tools=bool(normalized_visible),
+        force_tools=bool(force_tools),
+        allow_all_tools=False,
+        allowed_tool_names=normalized_visible,
+        candidate_tool_names=normalized_candidates,
+        visible_tool_names=normalized_visible,
+        connection_status=connection_status,
+        approval_required_tool_names=approval_required_tool_names_for(normalized_candidates),
+        tool_capabilities=tool_capability_metadata_for_names(normalized_candidates),
+        allow_agent_handoff=False,
+        allow_rag_delegation=False,
+    )
+
+
 def record_tool_policy_session(
     state: dict[str, Any] | None,
     session: ToolPolicySession,

--- a/maritime-ai-service/tests/unit/test_code_studio_scaffold_fallback_policy.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_scaffold_fallback_policy.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from app.engine.multi_agent.code_studio_scaffold_fallback_policy import (
     CodeStudioScaffoldFallbackIntent,
     resolve_code_studio_scaffold_fallback,
@@ -274,3 +276,184 @@ def test_streamed_code_html_outcome_is_not_scaffold_fallback() -> None:
         outcome.first_tool_call["args"]["code_html"]
         == "<html><body>stopwatch</body></html>"
     )
+
+
+def test_code_studio_tool_policy_denies_stale_tool_call() -> None:
+    state = {
+        "_tool_policy_session": {
+            "version": "tool_policy_session.v1",
+            "path": "code_studio",
+            "reason": "code_studio_tool_setup",
+            "bind_tools": True,
+            "force_tools": True,
+            "allow_all_tools": False,
+            "allowed_tool_names": ["tool_create_visual_code"],
+            "allowed_tool_prefixes": [],
+            "forbidden_tool_names": [],
+            "forbidden_tool_prefixes": [],
+            "candidate_tool_names": ["tool_create_visual_code", "tool_web_search"],
+            "visible_tool_names": ["tool_create_visual_code"],
+            "connection_status": {},
+            "approval_required_tool_names": [],
+        }
+    }
+
+    denial = code_studio_tool_rounds._code_studio_tool_policy_denial(
+        state,
+        "tool_web_search",
+    )
+
+    assert denial is not None
+    decision, message = denial
+    assert decision.allowed is False
+    assert decision.path == "code_studio"
+    assert decision.reason == "not_allowed_by_path_policy"
+    assert "Tool bị chặn bởi chính sách" in message
+
+
+def test_code_studio_tool_policy_allows_visible_tool_call() -> None:
+    state = {
+        "_tool_policy_session": {
+            "version": "tool_policy_session.v1",
+            "path": "code_studio",
+            "reason": "code_studio_tool_setup",
+            "bind_tools": True,
+            "force_tools": True,
+            "allow_all_tools": False,
+            "allowed_tool_names": ["tool_create_visual_code"],
+            "allowed_tool_prefixes": [],
+            "forbidden_tool_names": [],
+            "forbidden_tool_prefixes": [],
+            "candidate_tool_names": ["tool_create_visual_code"],
+            "visible_tool_names": ["tool_create_visual_code"],
+            "connection_status": {},
+            "approval_required_tool_names": [],
+        }
+    }
+
+    assert (
+        code_studio_tool_rounds._code_studio_tool_policy_denial(
+            state,
+            "tool_create_visual_code",
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_code_studio_tool_round_denies_out_of_policy_call_without_invoking() -> None:
+    from app.engine.messages import Message
+
+    emitted: list[dict] = []
+    invoke_called = False
+    ainvoke_calls = 0
+    state = {
+        "_tool_policy_session": {
+            "version": "tool_policy_session.v1",
+            "path": "code_studio",
+            "reason": "code_studio_tool_setup",
+            "bind_tools": True,
+            "force_tools": True,
+            "allow_all_tools": False,
+            "allowed_tool_names": ["tool_create_visual_code"],
+            "allowed_tool_prefixes": [],
+            "forbidden_tool_names": [],
+            "forbidden_tool_prefixes": [],
+            "candidate_tool_names": ["tool_create_visual_code", "tool_web_search"],
+            "visible_tool_names": ["tool_create_visual_code"],
+            "connection_status": {},
+            "approval_required_tool_names": [],
+        }
+    }
+
+    async def push_event(event):
+        emitted.append(event)
+
+    async def ainvoke_with_fallback(*_args, **_kwargs):
+        nonlocal ainvoke_calls
+        ainvoke_calls += 1
+        if ainvoke_calls == 1:
+            return SimpleNamespace(
+                content="",
+                tool_calls=[
+                    {
+                        "id": "tc-stale",
+                        "name": "tool_web_search",
+                        "args": {"query": "should not run"},
+                    }
+                ],
+            )
+        return Message(role="assistant", content="done")
+
+    async def invoke_tool_with_runtime(*_args, **_kwargs):
+        nonlocal invoke_called
+        invoke_called = True
+        raise AssertionError("out-of-policy Code Studio tool must not invoke")
+
+    async def render_reasoning_fast(**_kwargs):
+        return SimpleNamespace(
+            label="policy",
+            summary="policy",
+            phase="ground",
+            action_text="policy",
+        )
+
+    async def stream_code_studio_wait_heartbeats(*_args, **_kwargs):
+        return None
+
+    async def noop_async(*_args, **_kwargs):
+        return None
+
+    llm_response, _messages, tool_events = await code_studio_tool_rounds.execute_code_studio_tool_rounds_impl(
+        SimpleNamespace(),
+        SimpleNamespace(),
+        [],
+        [SimpleNamespace(name="tool_create_visual_code")],
+        push_event,
+        query="build a simulation",
+        state=state,
+        should_enable_real_code_streaming=lambda *_args, **_kwargs: False,
+        derive_code_stream_session_id=lambda **_kwargs: "code-session",
+        ainvoke_with_fallback=ainvoke_with_fallback,
+        build_code_studio_progress_messages=lambda _query, _state: ["planning"],
+        render_reasoning_fast=render_reasoning_fast,
+        infer_code_studio_reasoning_cue=lambda _query, _tool_names: "policy",
+        thinking_start_label=lambda label: label,
+        code_studio_delta_chunks=lambda _beat: [],
+        stream_code_studio_wait_heartbeats=stream_code_studio_wait_heartbeats,
+        format_code_studio_progress_message=lambda msg, _elapsed: msg,
+        build_code_studio_retry_status=lambda *_args, **_kwargs: "retry",
+        build_code_studio_missing_tool_response=lambda *_args, **_kwargs: "missing",
+        requires_code_studio_visual_delivery=lambda _query, _tools: False,
+        collect_active_visual_session_ids=lambda _state: [],
+        get_tool_by_name=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("get_tool_by_name should not run for denied tool")
+        ),
+        invoke_tool_with_runtime=invoke_tool_with_runtime,
+        summarize_tool_result_for_stream=lambda _name, value: value,
+        maybe_emit_visual_event=lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("visual event should not run for denied tool")
+        ),
+        emit_visual_commit_events=noop_async,
+        build_code_studio_tool_reflection=lambda *_args, **_kwargs: None,
+        is_terminal_code_studio_tool_error=lambda _name, _result: False,
+        build_code_studio_terminal_failure_response=lambda *_args, **_kwargs: "terminal",
+        build_code_studio_synthesis_observations=lambda _events: [],
+        inject_widget_blocks_from_tool_results=lambda response, *_args, **_kwargs: response,
+        push_status_only_progress=noop_async,
+        settings_obj=SimpleNamespace(
+            code_studio_llm_hard_timeout_seconds=5,
+            code_studio_post_tool_synthesis_timeout_seconds=5,
+            enable_structured_visuals=True,
+        ),
+    )
+
+    assert invoke_called is False
+    assert getattr(llm_response, "content", "") == "done"
+    assert tool_events[0]["policy"]["allowed"] is False
+    assert tool_events[0]["policy"]["path"] == "code_studio"
+    assert "Tool bị chặn bởi chính sách" in tool_events[1]["result"]
+    tool_call_event = next(event for event in emitted if event["type"] == "tool_call")
+    tool_result_event = next(event for event in emitted if event["type"] == "tool_result")
+    assert tool_call_event["content"]["policy"]["allowed"] is False
+    assert tool_result_event["content"]["name"] == "tool_web_search"

--- a/maritime-ai-service/tests/unit/test_code_studio_tool_setup.py
+++ b/maritime-ai-service/tests/unit/test_code_studio_tool_setup.py
@@ -14,6 +14,12 @@ def test_prepare_code_studio_tool_setup_selects_tools_and_builds_runtime_context
     ]
     selected_tools = [original_tools[0]]
     runtime_context = SimpleNamespace(runtime="ctx")
+    state = {
+        "routing_metadata": {"intent": "visual_app"},
+        "session_id": "session-1",
+        "organization_id": "org-1",
+        "user_id": "user-1",
+    }
 
     def select_runtime_tools_fn(tools, **kwargs):
         assert tools == original_tools
@@ -38,12 +44,7 @@ def test_prepare_code_studio_tool_setup_selects_tools_and_builds_runtime_context
 
     result = prepare_code_studio_tool_setup(
         effective_query="build a simulation",
-        state={
-            "routing_metadata": {"intent": "visual_app"},
-            "session_id": "session-1",
-            "organization_id": "org-1",
-            "user_id": "user-1",
-        },
+        state=state,
         ctx={"user_role": "teacher", "request_id": "req-1"},
         bus_id="bus-1",
         collect_code_studio_tools=lambda _query, _role: (original_tools, True),
@@ -58,18 +59,27 @@ def test_prepare_code_studio_tool_setup_selects_tools_and_builds_runtime_context
     assert result.tools == selected_tools
     assert result.force_tools is True
     assert result.runtime_context_base is runtime_context
+    policy = state["_tool_policy_session"]
+    assert policy["path"] == "code_studio"
+    assert policy["candidate_tool_names"] == [
+        "tool_create_visual_code",
+        "tool_python",
+    ]
+    assert policy["visible_tool_names"] == ["tool_create_visual_code"]
+    assert policy["tool_capabilities"]["tool_create_visual_code"]["group"] == "visual"
 
 
 def test_prepare_code_studio_tool_setup_keeps_tools_when_selection_fails() -> None:
     tools = [SimpleNamespace(name="tool_create_visual_code")]
     logger = MagicMock()
+    state = {}
 
     def select_runtime_tools_fn(*_args, **_kwargs):
         raise RuntimeError("selector unavailable")
 
     result = prepare_code_studio_tool_setup(
         effective_query="build a simulation",
-        state={},
+        state=state,
         ctx={},
         bus_id=None,
         collect_code_studio_tools=lambda _query, _role: (tools, False),
@@ -83,4 +93,5 @@ def test_prepare_code_studio_tool_setup_keeps_tools_when_selection_fails() -> No
     assert result.tools == tools
     assert result.force_tools is False
     assert result.runtime_context_base["user_role"] == "student"
+    assert state["_tool_policy_session"]["visible_tool_names"] == ["tool_create_visual_code"]
     logger.debug.assert_called_once()


### PR DESCRIPTION
## Summary
- Records Code Studio candidate and visible tool sets using the shared ToolPolicySession contract.
- Adds uild_visible_tool_policy_session for runtimes that already select a final visible tool bundle.
- Guards Code Studio tool-round execution so stale/out-of-policy model tool calls emit a policy denial result and never invoke the underlying tool.
- Updates the tool policy standard and adds focused setup/tool-round tests.

Closes #694.

## In Scope
- Code Studio backend tool setup and tool-round policy guard.
- Shared policy helper for selected-tool runtimes.
- Focused Code Studio and policy tests.
- Tool policy standard documentation.

## Non-Scope
- No frontend Code Studio UI change.
- No Tutor or Product Search loop migration in this PR.
- No LMS mutation behavior change and no deployment changes.

## Verification
- cd maritime-ai-service; python -m pytest tests/unit/test_code_studio_tool_setup.py tests/unit/test_code_studio_scaffold_fallback_policy.py tests/unit/test_tool_policy_session.py tests/unit/test_tool_capability_registry.py -q --tb=short -> 23 passed.
- cd maritime-ai-service; python -m pytest tests/unit/test_code_studio_provider_execution.py -q --tb=short -> 3 passed.
- cd maritime-ai-service; python -m pytest tests/unit/test_graph_routing.py -k code_studio -q --tb=short -> 9 passed, 66 deselected.
- cd maritime-ai-service; python -m pytest tests/unit/test_code_studio_tool_setup.py tests/unit/test_code_studio_scaffold_fallback_policy.py tests/unit/test_code_studio_provider_execution.py tests/unit/test_graph_routing.py -k code_studio -q --tb=short -> 29 passed, 66 deselected.
- cd maritime-ai-service; python -m ruff check app/ tests/unit/ --select=E9,F63,F7 -> All checks passed.
- git diff --cached --check -> clean before commit.

## Risk
- High-risk surface: backend tool execution. Main risk is blocking a legitimate Code Studio tool call if the visible tool policy is recorded incorrectly.
- Mitigation: policy is recorded after existing runtime selection; normal selected-tool execution remains unchanged, while stale calls are denied before lookup/invocation.

## Rollback
- Revert this PR to remove Code Studio policy recording/guard. No database migration or persistent data change is included.

## Reviewer Focus
- Confirm selected Code Studio tools become the exact visible allow-list.
- Confirm denied stale calls produce visible 	ool_call/	ool_result events and do not invoke tools.
- Confirm Tutor/Product Search migration remains intentionally out of scope.