### PR TITLE
feat(backend): guard tutor product tool policy

### DIFF
--- a/docs/operations/WIII_TOOL_POLICY_SESSION_STANDARD.md
+++ b/docs/operations/WIII_TOOL_POLICY_SESSION_STANDARD.md
@@ -6,7 +6,7 @@ Owner: Backend maintainers
 
 Last updated: 2026-05-26
 
-Applies to: Direct chat tool binding, runtime tool execution, host actions, LMS authoring, Pointy, web/search, weather, visual tools
+Applies to: Direct chat tool binding, runtime tool execution, host actions, LMS authoring, Pointy, web/search, weather, product search, tutor, visual tools
 
 ## Purpose
 
@@ -33,9 +33,10 @@ Every direct chat turn should have a `ToolPolicySession` in `AgentState` when
 tool selection is evaluated.
 
 Runtimes that already perform their own tool selection, such as Code Studio,
-should record the same contract with `build_visible_tool_policy_session`: the
-candidate set is the collected tool inventory, and the visible set is the
-runtime-selected tool bundle actually bound to the model.
+tutor, and product search, should record the same contract with
+`build_visible_tool_policy_session`: the candidate set is the collected tool
+inventory, and the visible set is the runtime-selected tool bundle actually
+bound to the model.
 
 The session records:
 
@@ -56,12 +57,12 @@ The session records:
 The capability registry records:
 
 - capability group: web search, weather, LMS authoring, host action, Pointy,
-  visual, knowledge search, utility, or Code Studio output;
+  product search, visual, knowledge search, utility, or Code Studio output;
 - permission level: read, write, or host control;
 - required connection: LMS authoring, weather provider, or host actions;
 - whether the tool mutates state or requires host-issued approval evidence;
-- intended surface scope, such as direct chat, tutor, Code Studio, host, LMS, or
-  visual runtime.
+- intended surface scope, such as direct chat, tutor, product search,
+  Code Studio, host, LMS, or visual runtime.
 
 ## Runtime Rules
 

--- a/maritime-ai-service/app/engine/multi_agent/agents/product_search_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/agents/product_search_runtime.py
@@ -32,9 +32,18 @@ from app.engine.multi_agent.agents.product_search_runtime_bindings import (
     select_runtime_tools,
 )
 from app.engine.multi_agent.graph_runtime_helpers import _get_requested_model, _remember_runtime_target
+from app.engine.multi_agent.tool_policy_session import (
+    build_visible_tool_policy_session,
+    record_tool_policy_session,
+    resolve_tool_policy_denial,
+)
 
 
 logger = logging.getLogger(__name__)
+
+
+def _tool_name(tool: object) -> str:
+    return str(getattr(tool, "name", "") or getattr(tool, "__name__", "") or "").strip()
 
 
 def init_llm_impl(node) -> None:
@@ -86,6 +95,7 @@ async def react_loop_impl(
         node._tools,
         (context or {}).get("user_role", "student"),
     )
+    candidate_tool_names = [_tool_name(tool) for tool in active_tools]
     llm_to_use = node._llm_with_tools
 
     async def _push(event):
@@ -223,6 +233,16 @@ async def react_loop_impl(
             )
     except Exception as selection_err:
         logger.debug("[PRODUCT_SEARCH] Runtime tool selection skipped: %s", selection_err)
+
+    policy_session = build_visible_tool_policy_session(
+        path="product_search",
+        reason="product_search_tool_setup",
+        state=state,
+        query=query,
+        candidate_tool_names=candidate_tool_names,
+        visible_tool_names=[_tool_name(tool) for tool in active_tools],
+    )
+    record_tool_policy_session(state, policy_session)
 
     runtime_llm_source = node._llm
     llm_to_use = node._llm.bind_tools(active_tools) if node._llm and active_tools else node._llm_with_tools
@@ -367,6 +387,62 @@ BƯỚC 3: So sánh giá và tổng hợp kết quả.
             tool_name = tool_call.get("name", "unknown")
             tool_args = tool_call.get("args", {})
             tool_id = tool_call.get("id", f"tc_{iteration}")
+            if not isinstance(tool_args, dict):
+                tool_args = {"value": tool_args}
+                tool_call["args"] = tool_args
+
+            policy_denial = resolve_tool_policy_denial(state, str(tool_name or "").strip())
+            if policy_denial is not None:
+                policy_decision, policy_message = policy_denial
+                policy_payload = {
+                    "allowed": False,
+                    "path": policy_decision.path,
+                    "reason": policy_decision.reason,
+                }
+                logger.warning(
+                    "[PRODUCT_SEARCH] Tool policy denied tool=%r path=%s reason=%s",
+                    tool_name,
+                    policy_decision.path,
+                    policy_decision.reason,
+                )
+                await _push(
+                    {
+                        "type": "tool_call",
+                        "content": {
+                            "name": tool_name,
+                            "args": tool_args,
+                            "id": tool_id,
+                            "policy": policy_payload,
+                        },
+                        "node": "product_search_agent",
+                    }
+                )
+                await _push(
+                    {
+                        "type": "tool_result",
+                        "content": {
+                            "name": tool_name,
+                            "result": str(policy_message)[:500],
+                            "id": tool_id,
+                        },
+                        "node": "product_search_agent",
+                    }
+                )
+                messages.append(
+                    Message(
+                        role="assistant",
+                        content="",
+                        tool_calls=[
+                            ToolCall(
+                                id=str(tool_id),
+                                name=str(tool_name or ""),
+                                arguments=tool_args,
+                            )
+                        ],
+                    )
+                )
+                messages.append(Message(role="tool", content=str(policy_message), tool_call_id=tool_id))
+                continue
 
             await _push(
                 {

--- a/maritime-ai-service/app/engine/multi_agent/agents/tutor_node.py
+++ b/maritime-ai-service/app/engine/multi_agent/agents/tutor_node.py
@@ -51,6 +51,7 @@ from app.engine.multi_agent.agents.tutor_request_runtime import (
 )
 from app.engine.multi_agent.agents.tutor_runtime import initialize_tutor_llm
 from app.engine.multi_agent.agents.tutor_tool_dispatch_runtime import (
+    deny_tutor_tool_call_by_policy,
     dispatch_tutor_tool_call,
 )
 from app.engine.multi_agent.graph_surface_runtime import (
@@ -1373,6 +1374,22 @@ class TutorAgentNode:
                 tool_name = tool_call.get("name", "")
                 tool_args = tool_call.get("args", {})
                 tool_id = tool_call.get("id", f"call_{iteration}")
+
+                denied_dispatch = await deny_tutor_tool_call_by_policy(
+                    state=state,
+                    tool_call=tool_call,
+                    iteration=iteration,
+                    messages=messages,
+                    push=_push,
+                    phase_transition_count=_phase_transition_count,
+                    logger_obj=logger,
+                )
+                if denied_dispatch is not None:
+                    _phase_transition_count = denied_dispatch.phase_transition_count
+                    last_tool_name_seen = str(tool_name or "")
+                    last_tool_result_text = denied_dispatch.tool_result_text
+                    last_tool_args = denied_dispatch.tool_args
+                    continue
 
                 # Sprint 69: Push tool_call event
                 await _push({

--- a/maritime-ai-service/app/engine/multi_agent/agents/tutor_request_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/agents/tutor_request_runtime.py
@@ -9,6 +9,10 @@ from app.engine.tools.runtime_context import (
     filter_tools_for_role,
 )
 from app.engine.multi_agent.graph_runtime_helpers import _copy_runtime_metadata
+from app.engine.multi_agent.tool_policy_session import (
+    build_visible_tool_policy_session,
+    record_tool_policy_session,
+)
 from app.engine.multi_agent.visual_intent_resolver import (
     filter_tools_for_visual_intent,
 )
@@ -26,6 +30,10 @@ class PreparedTutorRequest:
     visual_decision: Any
     active_tools: list[Any]
     runtime_context_base: Any
+
+
+def _tool_name(tool: Any) -> str:
+    return str(getattr(tool, "name", "") or getattr(tool, "__name__", "") or "").strip()
 
 
 def build_tutor_tools(
@@ -173,6 +181,7 @@ def prepare_tutor_request(
         visual_decision,
         structured_visuals_enabled=getattr(settings_obj, "enable_structured_visuals", False),
     )
+    candidate_tool_names = [_tool_name(tool) for tool in active_tools]
 
     try:
         from app.engine.skills.skill_recommender import select_runtime_tools
@@ -203,6 +212,7 @@ def prepare_tutor_request(
         logger_obj.debug("[TUTOR_AGENT] Runtime tool selection skipped: %s", exc)
 
     llm_with_tools_for_request = None
+    visible_tools_for_policy = list(active_tools)
     if llm_for_request:
         if visual_decision.force_tool:
             required_visual_names = set(required_visual_tool_names_fn(visual_decision))
@@ -212,6 +222,7 @@ def prepare_tutor_request(
                 if getattr(tool, "name", "") in required_visual_names
             ]
             if visual_tools_only:
+                visible_tools_for_policy = list(visual_tools_only)
                 forced_choice = resolve_tool_choice_fn(True, visual_tools_only, provider_override)
                 llm_with_tools_for_request = _copy_runtime_metadata(
                     llm_for_request,
@@ -247,6 +258,17 @@ def prepare_tutor_request(
         node="tutor_agent",
         source="agentic_loop",
     )
+
+    policy_session = build_visible_tool_policy_session(
+        path="tutor",
+        reason="tutor_tool_setup",
+        state=state,
+        query=query,
+        candidate_tool_names=candidate_tool_names,
+        visible_tool_names=[_tool_name(tool) for tool in visible_tools_for_policy],
+        force_tools=bool(getattr(visual_decision, "force_tool", False)),
+    )
+    record_tool_policy_session(state, policy_session)
 
     return PreparedTutorRequest(
         thinking_effort=thinking_effort,

--- a/maritime-ai-service/app/engine/multi_agent/agents/tutor_tool_dispatch_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/agents/tutor_tool_dispatch_runtime.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Sequence
 
 from app.engine.messages import Message, ToolCall
+from app.engine.multi_agent.tool_policy_session import resolve_tool_policy_denial
 from app.engine.multi_agent.visual_events import (
     _emit_visual_commit_events,
     _maybe_emit_visual_event,
@@ -164,6 +165,72 @@ def _record_tool_use(
             "description": description,
             "iteration": iteration + 1,
         }
+    )
+
+
+async def deny_tutor_tool_call_by_policy(
+    *,
+    state: dict[str, Any] | None,
+    tool_call: dict[str, Any],
+    iteration: int,
+    messages: list[Any],
+    push: Callable[[dict[str, Any]], Awaitable[None]],
+    phase_transition_count: int,
+    logger_obj: Any,
+) -> TutorToolDispatchResult | None:
+    """Emit a visible policy denial when tutor receives an out-of-session tool call."""
+
+    tool_name = str(tool_call.get("name", "") or "")
+    tool_args = tool_call.get("args", {}) or {}
+    if not isinstance(tool_args, dict):
+        tool_args = {"value": tool_args}
+        tool_call["args"] = tool_args
+    tool_id = str(tool_call.get("id") or f"call_{iteration}")
+
+    denial = resolve_tool_policy_denial(state, tool_name.strip())
+    if denial is None:
+        return None
+
+    decision, message = denial
+    policy_payload = {
+        "allowed": False,
+        "path": decision.path,
+        "reason": decision.reason,
+    }
+    logger_obj.warning(
+        "[TUTOR_AGENT] Tool policy denied tool=%r path=%s reason=%s",
+        tool_name,
+        decision.path,
+        decision.reason,
+    )
+    await push(
+        {
+            "type": "tool_call",
+            "content": {
+                "name": tool_name,
+                "args": tool_args,
+                "id": tool_id,
+                "policy": policy_payload,
+            },
+            "node": "tutor_agent",
+        }
+    )
+    await _emit_tool_result(
+        push=push,
+        tool_name=tool_name,
+        result=message,
+        tool_id=tool_id,
+    )
+    _append_tool_observation(
+        messages=messages,
+        tool_call=tool_call,
+        tool_id=tool_id,
+        result=message,
+    )
+    return TutorToolDispatchResult(
+        phase_transition_count=phase_transition_count,
+        tool_result_text=message,
+        tool_args=tool_args,
     )
 
 

--- a/maritime-ai-service/app/engine/multi_agent/code_studio_tool_rounds.py
+++ b/maritime-ai-service/app/engine/multi_agent/code_studio_tool_rounds.py
@@ -24,8 +24,7 @@ from app.engine.multi_agent.code_studio_template_scaffold import (
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.tool_policy_session import (
     ToolPolicyDecision,
-    tool_policy_denial_message,
-    tool_policy_session_from_state,
+    resolve_tool_policy_denial,
 )
 from app.engine.runtime.runtime_metrics import inc_counter
 
@@ -96,13 +95,7 @@ def _code_studio_tool_policy_denial(
     state: Optional[AgentState],
     tool_name: str,
 ) -> tuple[ToolPolicyDecision, str] | None:
-    session = tool_policy_session_from_state(state)
-    if session is None:
-        return None
-    decision = session.decision_for(str(tool_name or "").strip())
-    if decision.allowed:
-        return None
-    return decision, tool_policy_denial_message(decision)
+    return resolve_tool_policy_denial(state, str(tool_name or "").strip())
 
 
 def _build_streamed_code_html_tool_round_outcome(

--- a/maritime-ai-service/app/engine/multi_agent/tool_policy_session.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_policy_session.py
@@ -282,6 +282,21 @@ def tool_policy_session_from_state(state: dict[str, Any] | None) -> ToolPolicySe
     return None
 
 
+def resolve_tool_policy_denial(
+    state: dict[str, Any] | None,
+    tool_name: str,
+) -> tuple[ToolPolicyDecision, str] | None:
+    """Return a policy denial decision/message for a runtime tool call."""
+
+    session = tool_policy_session_from_state(state)
+    if session is None:
+        return None
+    decision = session.decision_for(tool_name)
+    if decision.allowed:
+        return None
+    return decision, tool_policy_denial_message(decision)
+
+
 def filter_tools_for_policy_session(
     tools: list[Any],
     session: ToolPolicySession,

--- a/maritime-ai-service/app/engine/tools/tool_capability_registry.py
+++ b/maritime-ai-service/app/engine/tools/tool_capability_registry.py
@@ -21,6 +21,7 @@ ToolCapabilityGroup = Literal[
     "lms_authoring",
     "host_action",
     "pointy",
+    "product_search",
     "visual",
     "code_studio_output",
 ]
@@ -32,6 +33,7 @@ ToolSurfaceScope = Literal[
     "code_studio",
     "host",
     "lms",
+    "product_search",
     "visual",
 ]
 
@@ -67,6 +69,27 @@ LMS_DOCUMENT_PREVIEW_TOOL_NAMES = frozenset(
     {
         DOC_PREVIEW_HOST_ACTION_TOOL,
         DOC_COURSE_HOST_ACTION_TOOL,
+    }
+)
+PRODUCT_SEARCH_TOOL_NAMES = frozenset(
+    {
+        "tool_search_google_shopping",
+        "tool_search_shopee",
+        "tool_search_tiktok_shop",
+        "tool_search_lazada",
+        "tool_search_facebook_marketplace",
+        "tool_search_instagram_shopping",
+        "tool_search_facebook_search",
+        "tool_search_facebook_group",
+        "tool_search_facebook_groups_auto",
+        "tool_search_websosanh",
+        "tool_search_all_web",
+        "tool_fetch_product_detail",
+        "tool_identify_product_from_image",
+        "tool_dealer_search",
+        "tool_international_search",
+        "tool_extract_contacts",
+        "tool_generate_product_report",
     }
 )
 
@@ -287,6 +310,15 @@ TOOL_CAPABILITIES: dict[str, ToolCapability] = {
     "tool_check_course_progress": _capability("tool_check_course_progress", "lms_query"),
     "tool_get_class_overview": _capability("tool_get_class_overview", "lms_query"),
     "tool_find_at_risk_students": _capability("tool_find_at_risk_students", "lms_query"),
+    **{
+        name: _capability(
+            name,
+            "product_search",
+            permission="write" if name == "tool_generate_product_report" else "read",
+            surface_scopes=("product_search",),
+        )
+        for name in sorted(PRODUCT_SEARCH_TOOL_NAMES)
+    },
     "tool_pointy_show": _capability(
         "tool_pointy_show",
         "pointy",

--- a/maritime-ai-service/tests/unit/test_product_search_tools.py
+++ b/maritime-ai-service/tests/unit/test_product_search_tools.py
@@ -520,6 +520,153 @@ class TestProductSearchAgentNode:
         assert result["current_agent"] == "product_search_agent"
         assert len(result["tools_used"]) == 1
 
+    @pytest.mark.asyncio
+    async def test_react_loop_records_visible_tool_policy(self, monkeypatch):
+        from app.engine.multi_agent.agents import product_search_runtime as runtime
+
+        class _Tool:
+            def __init__(self, name: str):
+                self.name = name
+
+        class _Settings:
+            enable_query_planner = False
+            enable_product_preview_cards = False
+            product_preview_max_cards = 0
+            enable_curated_product_cards = False
+            product_search_max_iterations = 1
+
+        response = MagicMock()
+        response.tool_calls = []
+        response.content = "done"
+
+        llm = MagicMock()
+        llm.bind_tools = MagicMock(return_value=llm)
+        llm.ainvoke = AsyncMock(return_value=response)
+
+        node = MagicMock()
+        node._llm = llm
+        node._llm_with_tools = llm
+        node._tools = [_Tool("tool_search_google_shopping"), _Tool("tool_search_shopee")]
+        node._extract_text.side_effect = lambda content: str(content)
+        node._extract_thinking.return_value = ""
+
+        monkeypatch.setattr(runtime, "get_settings", lambda: _Settings())
+        monkeypatch.setattr(runtime, "build_wiii_runtime_prompt", lambda **_kwargs: "")
+        monkeypatch.setattr(runtime, "filter_tools_for_role", lambda tools, _role: list(tools))
+        monkeypatch.setattr(
+            runtime,
+            "select_runtime_tools",
+            lambda tools, **_kwargs: [tool for tool in tools if tool.name == "tool_search_shopee"],
+        )
+        monkeypatch.setattr(runtime, "get_effective_provider_impl", lambda _state: None)
+
+        state = {"context": {"user_role": "student"}}
+        result, tools_used, _thinking, _streamed = await runtime.react_loop_impl(
+            node,
+            query="tim iphone cu",
+            context={"user_role": "student"},
+            state=state,
+            max_iterations_default=1,
+            chunk_size=40,
+            chunk_delay=0,
+            product_result_tools=set(),
+            product_search_required_tools=lambda *_args, **_kwargs: ["tool_search_shopee"],
+        )
+
+        policy = state["_tool_policy_session"]
+        assert result == "done"
+        assert tools_used == []
+        assert policy["path"] == "product_search"
+        assert policy["reason"] == "product_search_tool_setup"
+        assert policy["candidate_tool_names"] == [
+            "tool_search_google_shopping",
+            "tool_search_shopee",
+        ]
+        assert policy["visible_tool_names"] == ["tool_search_shopee"]
+        assert policy["tool_capabilities"]["tool_search_shopee"]["group"] == "product_search"
+
+    @pytest.mark.asyncio
+    async def test_react_loop_denies_out_of_policy_product_tool(self, monkeypatch):
+        from app.engine.multi_agent.agents import product_search_runtime as runtime
+
+        class _Tool:
+            def __init__(self, name: str):
+                self.name = name
+
+        class _Settings:
+            enable_query_planner = False
+            enable_product_preview_cards = False
+            product_preview_max_cards = 0
+            enable_curated_product_cards = False
+            product_search_max_iterations = 2
+
+        stale_response = MagicMock()
+        stale_response.tool_calls = [
+            {"name": "tool_search_google_shopping", "args": {"query": "iphone"}, "id": "stale"}
+        ]
+        stale_response.content = ""
+        final_response = MagicMock()
+        final_response.tool_calls = []
+        final_response.content = "done"
+
+        llm = MagicMock()
+        llm.bind_tools = MagicMock(return_value=llm)
+        llm.ainvoke = AsyncMock(side_effect=[stale_response, final_response])
+
+        node = MagicMock()
+        node._llm = llm
+        node._llm_with_tools = llm
+        node._tools = [_Tool("tool_search_google_shopping"), _Tool("tool_search_shopee")]
+        node._extract_text.side_effect = lambda content: str(content)
+        node._extract_thinking.return_value = ""
+
+        state = {
+            "context": {"user_role": "student"},
+            "_tool_policy_session": {
+                "version": "tool_policy_session.v1",
+                "path": "product_search",
+                "reason": "product_search_tool_setup",
+                "bind_tools": True,
+                "force_tools": False,
+                "allow_all_tools": False,
+                "allowed_tool_names": ["tool_search_shopee"],
+                "allowed_tool_prefixes": [],
+                "forbidden_tool_names": [],
+                "forbidden_tool_prefixes": [],
+                "candidate_tool_names": ["tool_search_google_shopping", "tool_search_shopee"],
+                "visible_tool_names": ["tool_search_shopee"],
+                "connection_status": {},
+                "approval_required_tool_names": [],
+            },
+        }
+
+        monkeypatch.setattr(runtime, "get_settings", lambda: _Settings())
+        monkeypatch.setattr(runtime, "build_wiii_runtime_prompt", lambda **_kwargs: "")
+        monkeypatch.setattr(runtime, "filter_tools_for_role", lambda tools, _role: list(tools))
+        monkeypatch.setattr(runtime, "select_runtime_tools", lambda tools, **_kwargs: list(tools))
+        monkeypatch.setattr(runtime, "get_effective_provider_impl", lambda _state: None)
+        monkeypatch.setattr(runtime, "record_tool_policy_session", lambda *_args, **_kwargs: None)
+
+        async def fail_invoke(*_args, **_kwargs):
+            raise AssertionError("denied product tool must not be invoked")
+
+        monkeypatch.setattr(runtime, "invoke_tool_with_runtime", fail_invoke)
+
+        result, tools_used, _thinking, _streamed = await runtime.react_loop_impl(
+            node,
+            query="tim iphone cu",
+            context={"user_role": "student"},
+            state=state,
+            max_iterations_default=2,
+            chunk_size=40,
+            chunk_delay=0,
+            product_result_tools=set(),
+            product_search_required_tools=lambda *_args, **_kwargs: [],
+        )
+
+        assert result == "done"
+        assert tools_used == []
+
     def test_lazy_import_in_agents_init(self):
         """agents/__init__.py lazy import works for ProductSearchAgentNode."""
         from app.engine.multi_agent.agents import _ATTR_MAP

--- a/maritime-ai-service/tests/unit/test_tool_capability_registry.py
+++ b/maritime-ai-service/tests/unit/test_tool_capability_registry.py
@@ -35,6 +35,31 @@ def test_tool_capability_registry_records_policy_groups():
     }
 
 
+def test_tool_capability_registry_records_product_search_tools():
+    from app.engine.tools.tool_capability_registry import (
+        PRODUCT_SEARCH_TOOL_NAMES,
+        lookup_tool_capability,
+        tool_capability_metadata_for_names,
+    )
+
+    assert "tool_search_websosanh" in PRODUCT_SEARCH_TOOL_NAMES
+    search_tool = lookup_tool_capability("tool_search_websosanh")
+    assert search_tool is not None
+    assert search_tool.group == "product_search"
+    assert search_tool.surface_scopes == ("product_search",)
+
+    report_tool = lookup_tool_capability("tool_generate_product_report")
+    assert report_tool is not None
+    assert report_tool.group == "product_search"
+    assert report_tool.permission == "write"
+
+    metadata = tool_capability_metadata_for_names(
+        {"tool_search_websosanh", "tool_generate_product_report"}
+    )
+    assert metadata["tool_search_websosanh"]["group"] == "product_search"
+    assert metadata["tool_generate_product_report"]["permission"] == "write"
+
+
 def test_tool_capability_registry_handles_dynamic_host_actions():
     from app.engine.tools.tool_capability_registry import (
         host_action_name_from_tool_name,

--- a/maritime-ai-service/tests/unit/test_tutor_agent_node.py
+++ b/maritime-ai-service/tests/unit/test_tutor_agent_node.py
@@ -462,9 +462,15 @@ class TestTutorProcess:
 
         bound_tools = mock_llm.bind_tools.call_args[0][0]
         bound_names = [tool.name for tool in bound_tools]
+        policy = state["_tool_policy_session"]
 
         assert "tool_generate_visual" in bound_names
         assert "tool_generate_interactive_chart" not in bound_names
+        assert policy["path"] == "tutor"
+        assert policy["reason"] == "tutor_tool_setup"
+        assert "tool_generate_visual" in policy["visible_tool_names"]
+        assert "tool_generate_interactive_chart" not in policy["visible_tool_names"]
+        assert policy["tool_capabilities"]["tool_generate_visual"]["group"] == "visual"
         assert result["tutor_output"] == "Visual answer"
 
     def test_build_system_prompt_mentions_structured_visual_priority(self, mock_llm, base_state):
@@ -616,6 +622,68 @@ class TestReactLoop:
         assert "Rule 13" in response
         assert len(tools_used) == 1
         assert tools_used[0]["name"] == "tool_knowledge_search"
+
+    @pytest.mark.asyncio
+    async def test_tool_policy_denies_stale_tutor_tool_without_dispatch(self, mock_llm):
+        stale_tool_response = MagicMock()
+        stale_tool_response.tool_calls = [
+            {"name": "tool_web_search", "args": {"query": "outside policy"}, "id": "call_stale"}
+        ]
+        stale_tool_response.content = ""
+
+        final_response = MagicMock()
+        final_response.tool_calls = []
+        final_response.content = "Final tutor answer"
+
+        mock_llm.ainvoke.side_effect = [stale_tool_response, final_response]
+        node = _make_tutor(llm=mock_llm, llm_with_tools=mock_llm)
+        state = {
+            "_tool_policy_session": {
+                "version": "tool_policy_session.v1",
+                "path": "tutor",
+                "reason": "tutor_tool_setup",
+                "bind_tools": True,
+                "force_tools": False,
+                "allow_all_tools": False,
+                "allowed_tool_names": ["tool_knowledge_search"],
+                "allowed_tool_prefixes": [],
+                "forbidden_tool_names": [],
+                "forbidden_tool_prefixes": [],
+                "candidate_tool_names": ["tool_knowledge_search", "tool_web_search"],
+                "visible_tool_names": ["tool_knowledge_search"],
+                "connection_status": {},
+                "approval_required_tool_names": [],
+            }
+        }
+
+        with patch(
+            "app.engine.multi_agent.agents.tutor_node.extract_thinking_from_response",
+            return_value=("Final tutor answer", None),
+        ), patch(
+            "app.engine.multi_agent.agents.tutor_node.clear_retrieved_sources",
+        ), patch(
+            "app.engine.multi_agent.agents.tutor_node.get_last_retrieved_sources",
+            return_value=[],
+        ), patch(
+            "app.engine.multi_agent.agents.tutor_node.get_last_native_thinking",
+            return_value=None,
+        ), patch(
+            "app.engine.multi_agent.agents.tutor_node.get_last_confidence",
+            return_value=(0.0, False),
+        ), patch(
+            "app.engine.multi_agent.agents.tutor_node.dispatch_tutor_tool_call",
+            AsyncMock(side_effect=AssertionError("denied tool must not dispatch")),
+        ) as dispatch_mock:
+            response, sources, tools_used, _thinking, _streamed = await node._react_loop(
+                "Explain Rule 13",
+                {},
+                state=state,
+            )
+
+        assert response == "Final tutor answer"
+        assert sources == []
+        assert tools_used == []
+        dispatch_mock.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_tool_call_sync_collects_public_tutor_thinking_for_state_parity(self, mock_llm):


### PR DESCRIPTION
## Summary
- Extends the centralized tool capability registry with product-search tool metadata.
- Records `tool_policy_session.v1` for tutor and product-search runtimes that already perform their own tool selection.
- Denies stale/out-of-session tutor and product-search tool calls before invocation, with visible tool-result feedback.
- Reuses the shared policy-denial helper from Code Studio/direct policy flow.

## Scope
- Backend agent-loop policy only: tutor, product-search, shared tool-policy metadata/helpers, and focused tests.
- Docs update for the Tool Policy Session standard.

## Non-scope
- No frontend connection UI changes.
- No LMS mutation, approval-token, or host-action behavior changes.
- No model/provider routing changes.
- No product-search scraper/provider changes.

## Verification
- `python -m pytest tests/unit/test_tool_capability_registry.py tests/unit/test_tool_policy_session.py tests/unit/test_tutor_agent_node.py::TestTutorProcess::test_process_filters_legacy_visual_tools_for_structured_visual_intent tests/unit/test_tutor_agent_node.py::TestReactLoop::test_tool_policy_denies_stale_tutor_tool_without_dispatch tests/unit/test_product_search_tools.py::TestProductSearchAgentNode::test_react_loop_records_visible_tool_policy tests/unit/test_product_search_tools.py::TestProductSearchAgentNode::test_react_loop_denies_out_of_policy_product_tool -q --tb=short` -> 11 passed
- `python -m pytest tests/unit/test_tutor_agent_node.py tests/unit/test_product_search_tools.py -q --tb=short` -> 82 passed
- `python -m pytest tests/unit/test_tool_capability_registry.py tests/unit/test_tool_policy_session.py tests/unit/test_code_studio_scaffold_fallback_policy.py tests/unit/test_code_studio_tool_setup.py tests/unit/test_direct_tool_rounds_runtime.py -q --tb=short` -> 106 passed
- `python -m pytest tests/unit/test_product_code_lifecycle_e2e_matrix.py tests/unit/test_chat_lifecycle_e2e_matrix.py -q --tb=short` -> 10 passed
- `python -m ruff check app/ tests/unit/ --select=E9,F63,F7` -> passed
- `git diff --check` -> clean

## Risk
- Medium: tutor/product-search are active agent loops, and this changes their runtime policy metadata and stale-tool-call behavior.
- Expected behavior change: a model-emitted tool not in the bound visible set now receives an explicit policy-denied tool result instead of attempting generic handling.

## Rollback
- Revert this PR to restore previous tutor/product-search tool-loop behavior. No migration or persistent data shape change is introduced.

Closes #696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tool visibility and policy enforcement now enabled for product search and tutor agents, restricting tool access based on user roles and request context.

* **Refactor**
  * Consolidated tool policy denial logic into shared components for consistency across agent runtimes.

* **Documentation**
  * Updated tool policy standards documentation to reflect product search and tutor support in policy enforcement scope.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->