### PR TITLE
fix(backend): reject interrupted provider stream finals

### DIFF
--- a/maritime-ai-service/app/core/exceptions.py
+++ b/maritime-ai-service/app/core/exceptions.py
@@ -79,3 +79,27 @@ class ProviderUnavailableError(WiiiException):
         super().__init__(message=message, details=details)
         self.provider = provider
         self.reason_code = reason_code
+
+
+class ProviderStreamInterruptedError(LLMError):
+    """Provider stream ended before a complete assistant answer was received."""
+
+    error_code = "PROVIDER_STREAM_INTERRUPTED"
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        model: str,
+        partial_chars: int = 0,
+        message: str = (
+            "Luồng phản hồi từ model bị ngắt giữa chừng. "
+            "Wiii chưa chốt câu trả lời này; bạn thử gửi lại hoặc đổi provider."
+        ),
+        details: Optional[str] = None,
+    ):
+        super().__init__(message=message, details=details)
+        self.provider = provider
+        self.model = model
+        self.partial_chars = max(0, int(partial_chars or 0))
+        self.reason_code = "provider_stream_interrupted"

--- a/maritime-ai-service/app/engine/llm_failover_runtime.py
+++ b/maritime-ai-service/app/engine/llm_failover_runtime.py
@@ -147,6 +147,7 @@ _FAILOVER_REASON_LABELS: dict[str, str] = {
     "host_down": "Host dịch vụ hoặc local runtime hiện không sẵn sàng.",
     "server_error": "Provider trả về lỗi máy chủ.",
     "timeout": "Provider phản hồi quá lâu và đã bị timeout.",
+    "provider_stream_interrupted": "Luồng phản hồi từ provider bị ngắt giữa chừng.",
 }
 
 
@@ -207,6 +208,15 @@ def classify_failover_reason_impl(
     ):
         reason_code = "auth_error"
         reason_category = "auth_error"
+    elif any(
+        marker in err_text
+        for marker in (
+            "incomplete chunked read",
+            "peer closed connection without sending complete message body",
+        )
+    ):
+        reason_code = "provider_stream_interrupted"
+        reason_category = "provider_stream_interrupted"
     elif any(
         marker in err_text
         for marker in (

--- a/maritime-ai-service/app/engine/llm_model_health.py
+++ b/maritime-ai-service/app/engine/llm_model_health.py
@@ -22,6 +22,7 @@ _DEGRADING_REASON_CODES = {
     "provider_unavailable",
     "host_down",
     "auth_error",
+    "provider_stream_interrupted",
 }
 
 

--- a/maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py
@@ -8,6 +8,7 @@ import logging
 import uuid
 from typing import Any, Optional
 
+from app.core.exceptions import ProviderStreamInterruptedError
 from app.core import config as app_config
 from app.core.config import settings
 from app.engine.openai_compatible_credentials import (
@@ -656,7 +657,12 @@ async def _stream_openai_compatible_answer_with_route_impl(
         )
         if emitted_answer:
             await _close_thinking_for_non_answer()
-            return make_assistant_message(emitted_answer), True
+            raise ProviderStreamInterruptedError(
+                provider=provider_name,
+                model=model_name or "",
+                partial_chars=len(emitted_answer),
+                details=str(exc),
+            ) from exc
         await _close_thinking_for_non_answer()
     logger.info(
         "[%s] Native stream result: provider=%s model=%s answer=%d chars",

--- a/maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py
@@ -655,7 +655,8 @@ async def _stream_openai_compatible_answer_with_route_impl(
             exc,
             exc_info=True,
         )
-        if emitted_answer:
+        reason_code = str(classified.get("reason_code") or "")
+        if emitted_answer and reason_code == "provider_stream_interrupted":
             await _close_thinking_for_non_answer()
             raise ProviderStreamInterruptedError(
                 provider=provider_name,
@@ -663,6 +664,9 @@ async def _stream_openai_compatible_answer_with_route_impl(
                 partial_chars=len(emitted_answer),
                 details=str(exc),
             ) from exc
+        if emitted_answer:
+            await _close_thinking_for_non_answer()
+            raise
         await _close_thinking_for_non_answer()
     logger.info(
         "[%s] Native stream result: provider=%s model=%s answer=%d chars",

--- a/maritime-ai-service/app/services/chat_stream_coordinator.py
+++ b/maritime-ai-service/app/services/chat_stream_coordinator.py
@@ -9,7 +9,10 @@ from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Awaitable, Mapping
 
 from app.core.config import settings
-from app.core.exceptions import ProviderUnavailableError
+from app.core.exceptions import (
+    ProviderStreamInterruptedError,
+    ProviderUnavailableError,
+)
 from app.engine.llm_runtime_metadata import resolve_runtime_llm_metadata
 from app.engine.multi_agent.runtime_flow_ledger import RuntimeFlowLedger
 from app.services.chat_orchestrator_runtime import build_wiii_turn_request
@@ -1431,6 +1434,39 @@ async def generate_stream_v3_events(
             for chunk in done_chunks:
                 yield chunk
 
+    except ProviderStreamInterruptedError as exc:
+        flow_ledger.mark_route(
+            "provider_stream_interrupted",
+            reason=exc.reason_code,
+            fallback_used=False,
+            fallback_reason=exc.reason_code,
+        )
+        logger.warning(
+            "[STREAM-V3] Provider stream interrupted: provider=%s model=%s partial_chars=%s",
+            exc.provider,
+            exc.model,
+            exc.partial_chars,
+        )
+        error_event = await create_error_event(exc.message)
+        error_event.content["type"] = "provider_stream_interrupted"
+        error_event.content["provider"] = exc.provider
+        error_event.content["model"] = exc.model
+        error_event.content["reason_code"] = exc.reason_code
+        error_event.content["partial_chars"] = exc.partial_chars
+        error_event.content["recoverable"] = True
+        error_event = _with_runtime_flow_metadata(
+            error_event,
+            latency_tracker,
+            flow_ledger,
+        )
+        error_chunks, event_counter, _ = serialize_stream_event(
+            event=error_event,
+            event_counter=event_counter,
+            enable_artifacts=settings.enable_artifacts,
+            presentation_state=presentation_state,
+        )
+        for chunk in error_chunks:
+            yield chunk
     except ProviderUnavailableError as exc:
         flow_ledger.mark_route(
             "provider_unavailable",

--- a/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
@@ -207,7 +207,14 @@ async def test_generate_stream_v3_events_does_not_finalize_interrupted_provider_
     assert "event: answer" in joined
     assert "À... vì mình thấy cậu đang" in joined
     assert "event: error" in joined
-    assert "provider_stream_interrupted" in joined
+    error_payloads = _event_payloads(chunks, "error")
+    assert len(error_payloads) == 1
+    assert error_payloads[0]["type"] == "provider_stream_interrupted"
+    assert error_payloads[0]["provider"] == "nvidia"
+    assert error_payloads[0]["model"] == "qwen/qwen3-next-80b-a3b-instruct"
+    assert error_payloads[0]["reason_code"] == "provider_stream_interrupted"
+    assert error_payloads[0]["partial_chars"] == 27
+    assert error_payloads[0]["recoverable"] is True
     assert "event: done" not in joined
     orchestrator.finalize_response_turn.assert_not_called()
 

--- a/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
@@ -7,7 +7,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from app.models.schemas import UserRole
-from app.core.exceptions import ProviderUnavailableError
+from app.core.exceptions import (
+    ProviderStreamInterruptedError,
+    ProviderUnavailableError,
+)
 from app.engine.multi_agent.runtime_flow_ledger import RUNTIME_FLOW_LEDGER_SCHEMA_VERSION
 from app.engine.multi_agent.runtime_contracts import WiiiStreamEvent, WiiiTurnRequest
 from app.services.chat_orchestrator import AgentType
@@ -154,6 +157,59 @@ async def test_generate_stream_v3_events_finalizes_answer_after_stream():
         ]
         is False
     )
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_v3_events_does_not_finalize_interrupted_provider_stream():
+    orchestrator = MagicMock()
+    prepared_turn = SimpleNamespace(
+        request_scope=RequestScope("org-1", "maritime"),
+        session_id="session-1",
+        validation=SimpleNamespace(blocked=False),
+        chat_context=SimpleNamespace(user_name="Minh"),
+    )
+    orchestrator.prepare_turn = AsyncMock(return_value=prepared_turn)
+    orchestrator.build_multi_agent_execution_input = AsyncMock(
+        return_value=SimpleNamespace(
+            query="Explain Rule 5",
+            user_id="user-1",
+            session_id="session-1",
+            context={"conversation_history": ""},
+            domain_id="maritime",
+            thinking_effort=None,
+            provider="nvidia",
+            model="qwen/qwen3-next-80b-a3b-instruct",
+        )
+    )
+    orchestrator.finalize_response_turn = MagicMock()
+
+    async def fake_stream_fn(**_kwargs):
+        yield SimpleNamespace(type="answer", content="À... vì mình thấy cậu đang")
+        raise ProviderStreamInterruptedError(
+            provider="nvidia",
+            model="qwen/qwen3-next-80b-a3b-instruct",
+            partial_chars=27,
+            details="peer closed connection without sending complete message body",
+        )
+
+    chunks = []
+    async for chunk in generate_stream_v3_events(
+        chat_request=_make_request(),
+        request_headers={"X-Request-ID": "req-provider-interrupt"},
+        background_save=MagicMock(),
+        start_time=time.time(),
+        orchestrator=orchestrator,
+        stream_fn=fake_stream_fn,
+    ):
+        chunks.append(chunk)
+
+    joined = "\n".join(chunks)
+    assert "event: answer" in joined
+    assert "À... vì mình thấy cậu đang" in joined
+    assert "event: error" in joined
+    assert "provider_stream_interrupted" in joined
+    assert "event: done" not in joined
+    orchestrator.finalize_response_turn.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/maritime-ai-service/tests/unit/test_openai_stream_runtime.py
+++ b/maritime-ai-service/tests/unit/test_openai_stream_runtime.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from app.core.exceptions import ProviderStreamInterruptedError
 from app.engine.multi_agent.openai_stream_runtime import (
     _ainvoke_openai_compatible_chat_impl,
     _stream_openai_compatible_answer_with_route_impl,
@@ -499,24 +500,27 @@ async def test_native_direct_stream_partial_exception_does_not_mark_model_health
         chat = _FakeChat()
 
     try:
-        response, streamed = await _stream_openai_compatible_answer_with_route_impl(
-            SimpleNamespace(
-                provider="nvidia",
-                llm=SimpleNamespace(_wiii_tier_key="light", _wiii_model_name="deepseek-ai/deepseek-v4-flash"),
-            ),
-            messages=[{"role": "user", "content": "Hi Wiii"}],
-            push_event=_push_event,
-            node="direct",
-            thinking_stop_signal=None,
-            supports_native_answer_streaming=lambda provider: provider == "nvidia",
-            create_openai_compatible_stream_client=lambda _provider: _FakeClient(),
-            resolve_openai_stream_model_name=lambda *_args: "deepseek-ai/deepseek-v4-flash",
-            langchain_message_to_openai_payload=lambda message: message,
-            extract_openai_delta_text=lambda delta: ("", str(getattr(delta, "content", "") or "")),
-        )
+        with pytest.raises(ProviderStreamInterruptedError) as exc_info:
+            await _stream_openai_compatible_answer_with_route_impl(
+                SimpleNamespace(
+                    provider="nvidia",
+                    llm=SimpleNamespace(_wiii_tier_key="light", _wiii_model_name="deepseek-ai/deepseek-v4-flash"),
+                ),
+                messages=[{"role": "user", "content": "Hi Wiii"}],
+                push_event=_push_event,
+                node="direct",
+                thinking_stop_signal=None,
+                supports_native_answer_streaming=lambda provider: provider == "nvidia",
+                create_openai_compatible_stream_client=lambda _provider: _FakeClient(),
+                resolve_openai_stream_model_name=lambda *_args: "deepseek-ai/deepseek-v4-flash",
+                langchain_message_to_openai_payload=lambda message: message,
+                extract_openai_delta_text=lambda delta: ("", str(getattr(delta, "content", "") or "")),
+            )
 
-        assert streamed is True
-        assert response.content == "Xin chao"
+        assert exc_info.value.provider == "nvidia"
+        assert exc_info.value.model == "deepseek-ai/deepseek-v4-flash"
+        assert exc_info.value.partial_chars == len("Xin chao")
+        assert exc_info.value.reason_code == "provider_stream_interrupted"
         assert events == [{"type": "answer_delta", "content": "Xin chao", "node": "direct"}]
         assert is_model_degraded("nvidia", "deepseek-ai/deepseek-v4-flash") is True
     finally:

--- a/maritime-ai-service/tests/unit/test_openai_stream_runtime.py
+++ b/maritime-ai-service/tests/unit/test_openai_stream_runtime.py
@@ -485,7 +485,10 @@ async def test_native_direct_stream_partial_exception_does_not_mark_model_health
                         SimpleNamespace(delta=SimpleNamespace(content="Xin chao"))
                     ]
                 )
-                raise RuntimeError("503 service unavailable")
+                raise RuntimeError(
+                    "peer closed connection without sending complete message body "
+                    "(incomplete chunked read)"
+                )
 
             return _gen()
 
@@ -525,3 +528,52 @@ async def test_native_direct_stream_partial_exception_does_not_mark_model_health
         assert is_model_degraded("nvidia", "deepseek-ai/deepseek-v4-flash") is True
     finally:
         reset_model_health_state()
+
+
+@pytest.mark.asyncio
+async def test_native_direct_stream_partial_internal_exception_is_not_reclassified():
+    events = []
+
+    async def _push_event(event):
+        events.append(event)
+
+    class _PartialThenInternalFailStream:
+        def __aiter__(self):
+            async def _gen():
+                yield SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(delta=SimpleNamespace(content="Xin chao"))
+                    ]
+                )
+                raise ValueError("local stream parser bug")
+
+            return _gen()
+
+    class _FakeChatCompletions:
+        async def create(self, **_kwargs):
+            return _PartialThenInternalFailStream()
+
+    class _FakeChat:
+        completions = _FakeChatCompletions()
+
+    class _FakeClient:
+        chat = _FakeChat()
+
+    with pytest.raises(ValueError, match="local stream parser bug"):
+        await _stream_openai_compatible_answer_with_route_impl(
+            SimpleNamespace(
+                provider="nvidia",
+                llm=SimpleNamespace(_wiii_tier_key="light", _wiii_model_name="deepseek-ai/deepseek-v4-flash"),
+            ),
+            messages=[{"role": "user", "content": "Hi Wiii"}],
+            push_event=_push_event,
+            node="direct",
+            thinking_stop_signal=None,
+            supports_native_answer_streaming=lambda provider: provider == "nvidia",
+            create_openai_compatible_stream_client=lambda _provider: _FakeClient(),
+            resolve_openai_stream_model_name=lambda *_args: "deepseek-ai/deepseek-v4-flash",
+            langchain_message_to_openai_payload=lambda message: message,
+            extract_openai_delta_text=lambda delta: ("", str(getattr(delta, "content", "") or "")),
+        )
+
+    assert events == [{"type": "answer_delta", "content": "Xin chao", "node": "direct"}]


### PR DESCRIPTION
## Summary
Fixes the chat-stream failure mode where NVIDIA/OpenAI-compatible provider streams could close mid-answer and Wiii would still mark the partial text as a successful completed response. The runtime now raises a typed provider-stream interruption when a provider transport error happens after answer tokens have already been emitted, and `/chat/stream/v3` sends a recoverable `provider_stream_interrupted` error without `done` or response finalization.

## Linked Work
Closes #700

## Naming and Traceability

- Branch name: `codex/700-fix-provider-stream-partial-finalization`
- Branch follows `docs/operations/WIII_GITHUB_GOVERNANCE.md`: yes
- PR title follows Conventional Commit style and is suitable for squash merge: yes
- Issue id is present in branch name or documented reason for exception: `700`

## Scope

- In scope: backend direct/native OpenAI-compatible streaming interruption handling, stream-v3 error serialization for this typed failure, focused regression tests.
- Out of scope: provider routing redesign, frontend message replacement UI, LMS/host action behavior, model selection defaults.

## Ownership and Coordination

- PR owner: Codex
- Agents involved: Codex
- Owned paths: `maritime-ai-service/app/core/exceptions.py`, `maritime-ai-service/app/engine/multi_agent/openai_stream_runtime.py`, `maritime-ai-service/app/services/chat_stream_coordinator.py`, focused backend tests
- Out-of-scope paths: frontend, deployment, generated outputs, persistent data
- Conflict risk: low-medium; touches active chat stream error behavior
- Merge decision owner: project maintainer

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation/governance
- [ ] Test-only
- [ ] Build/CI/dependency
- [ ] Security/auth/privacy
- [ ] Database/migration
- [ ] Breaking change

## Risk Checklist

- [x] No unrelated dirty worktree changes were staged.
- [x] No secrets, tokens, private data, or local-only files are committed.
- [x] PR is within the reviewability gate, or a maintainer-approved bypass rationale is documented.
- [x] Multi-agent file ownership was declared when more than one agent contributed.
- [ ] CodeRabbit findings are resolved, deferred with rationale, or explicitly not applicable.
- [x] Codex Review was requested for high-risk changes, or explicitly marked not required with rationale. Not required: scoped regression fix with focused tests; no auth/tenant/LMS mutation changes.
- [x] Auth, tenant isolation, memory, and user identity behavior were considered. No behavior changes in those surfaces.
- [x] Feature flags and default behavior were considered. No new flag; failure path changes from false-success to explicit recoverable error.
- [x] Database migrations are included or explicitly not required. Not required.
- [x] Rollback path is clear.

## Verification

```text
Command: cd maritime-ai-service; python -m pytest tests/unit/test_openai_stream_runtime.py tests/unit/test_chat_stream_coordinator.py -q --tb=short
Result: passed, 31 tests
```

```text
Command: cd maritime-ai-service; python -m pytest tests/unit/test_direct_execution_streaming.py -q --tb=short
Result: passed, 22 tests
```

```text
Command: cd maritime-ai-service; python -m ruff check app/core/exceptions.py app/engine/multi_agent/openai_stream_runtime.py app/services/chat_stream_coordinator.py tests/unit/test_openai_stream_runtime.py tests/unit/test_chat_stream_coordinator.py --select=E9,F63,F7
Result: passed
```

```text
Command: cd maritime-ai-service; python -m ruff check app/ --select=E9,F63,F7
Result: passed
```

```text
Command: git diff --check
Result: passed
```

## UI Evidence

N/A. Backend stream behavior fix. Local Docker backend auto-reloaded the changed modules; browser retest should now show an explicit recoverable provider-stream error instead of finalizing an incomplete sentence as `vừa xong` if NVIDIA closes the stream mid-answer again.

## Deployment Notes

- Environment/config changes: none
- Migration/backfill steps: none
- Monitoring/logs to watch: `provider_stream_interrupted`, `RemoteProtocolError`, NVIDIA model health degradation, frontend stream error surfacing
- Rollback: revert this PR; previous behavior returns partial provider text as a completed answer

## Reviewer Focus

- Critical paths: `_stream_openai_compatible_answer_with_route_impl` exception branch, `generate_stream_v3_events` typed error handling.
- Edge cases: provider fails before any answer tokens, provider fails after answer tokens, stream-v3 should not emit `done` or call `finalize_response_turn` for interrupted provider streams.
- Known limitations: this PR does not add frontend answer replacement/retry UI; it makes the failure honest and recoverable instead of silently successful.
- Codex Review focus: not required; verify stream finalization semantics and test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added proper handling for interrupted LLM provider streams with informative error events indicating how much of the response was received.

* **Bug Fixes**
  * Improved error handling to prevent incomplete responses from being returned when provider streams are interrupted mid-transmission.

* **Tests**
  * Added test coverage for interrupted provider stream scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->