### PR TITLE
fix(frontend): debounce disconnected health banner

### DIFF
--- a/wiii-desktop/src/__tests__/sprint106-polish.test.ts
+++ b/wiii-desktop/src/__tests__/sprint106-polish.test.ts
@@ -46,6 +46,7 @@ beforeEach(() => {
     serverVersion: null,
     lastCheckedAt: null,
     errorMessage: null,
+    consecutiveFailures: 0,
     pollIntervalId: null,
   });
 });
@@ -157,6 +158,53 @@ describe("ConnectionBadge — Reconnect logic", () => {
 
     expect(useConnectionStore.getState().status).toBe("disconnected");
     expect(useConnectionStore.getState().errorMessage).toBe("Connection refused");
+  });
+
+  it("should treat a single connected-state health failure as degraded", async () => {
+    useConnectionStore.setState({
+      status: "connected",
+      consecutiveFailures: 0,
+    });
+    vi.mocked(healthApi.checkHealth).mockRejectedValue(
+      new Error("Backend hot reload")
+    );
+
+    await useConnectionStore.getState().checkHealth();
+
+    expect(useConnectionStore.getState().status).toBe("degraded");
+    expect(useConnectionStore.getState().consecutiveFailures).toBe(1);
+  });
+
+  it("should mark disconnected after repeated health failures", async () => {
+    useConnectionStore.setState({
+      status: "degraded",
+      consecutiveFailures: 1,
+    });
+    vi.mocked(healthApi.checkHealth).mockRejectedValue(
+      new Error("Connection refused")
+    );
+
+    await useConnectionStore.getState().checkHealth();
+
+    expect(useConnectionStore.getState().status).toBe("disconnected");
+    expect(useConnectionStore.getState().consecutiveFailures).toBe(2);
+  });
+
+  it("should reset failure count after successful health check", async () => {
+    useConnectionStore.setState({
+      status: "degraded",
+      consecutiveFailures: 1,
+    });
+    vi.mocked(healthApi.checkHealth).mockResolvedValue({
+      status: "ok",
+      version: "1.0.0",
+      environment: "development",
+    });
+
+    await useConnectionStore.getState().checkHealth();
+
+    expect(useConnectionStore.getState().status).toBe("connected");
+    expect(useConnectionStore.getState().consecutiveFailures).toBe(0);
   });
 
   it("should set degraded for non-ok health response", async () => {

--- a/wiii-desktop/src/stores/connection-store.ts
+++ b/wiii-desktop/src/stores/connection-store.ts
@@ -13,6 +13,7 @@ interface ConnectionState {
   serverVersion: string | null;
   lastCheckedAt: string | null;
   errorMessage: string | null;
+  consecutiveFailures: number;
   pollIntervalId: ReturnType<typeof setInterval> | null;
   /** Fires once when connection recovers from disconnected → connected */
   onReconnect: (() => void) | null;
@@ -25,15 +26,17 @@ interface ConnectionState {
 }
 
 export const useConnectionStore = create<ConnectionState>((set, get) => ({
-  status: "disconnected",
+  status: "checking",
   serverVersion: null,
   lastCheckedAt: null,
   errorMessage: null,
+  consecutiveFailures: 0,
   pollIntervalId: null,
   onReconnect: null,
 
   checkHealth: async () => {
     const prevStatus = get().status;
+    const prevFailures = get().consecutiveFailures;
     set({ status: "checking" });
     try {
       const health = await checkHealth();
@@ -43,16 +46,20 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         serverVersion: health.version ?? null,
         lastCheckedAt: new Date().toISOString(),
         errorMessage: null,
+        consecutiveFailures: 0,
       });
       // Detect reconnection: was disconnected/degraded, now connected
       if (newStatus === "connected" && (prevStatus === "disconnected" || prevStatus === "degraded")) {
         get().onReconnect?.();
       }
     } catch (err) {
+      const consecutiveFailures = prevFailures + 1;
+      const shouldDisconnect = prevStatus === "disconnected" || consecutiveFailures >= 2;
       set({
-        status: "disconnected",
+        status: shouldDisconnect ? "disconnected" : "degraded",
         lastCheckedAt: new Date().toISOString(),
         errorMessage: err instanceof Error ? err.message : "Unknown error",
+        consecutiveFailures,
       });
     }
   },


### PR DESCRIPTION
## Summary
- Start connection status in checking instead of immediately showing disconnected.
- Treat the first transient health-check failure from a connected/checking state as degraded.
- Mark the red disconnected banner only after repeated health failures or an already-disconnected retry failure.
- Add focused tests for transient failure, repeated failure, and recovery reset.

## Scope
- Frontend connection-store policy and tests only.

## Non-scope
- No backend health endpoint changes.
- No auth refresh behavior changes.
- No capability status bar redesign.

## Verification
- cd wiii-desktop; npx vitest run src/__tests__/sprint106-polish.test.ts src/__tests__/sprint111-soul.test.ts — 33 passed.
- cd wiii-desktop; npx tsc --noEmit — passed.
- git diff --check — passed.

## Risk
Low frontend UX risk. A true outage may show as degraded for one health-check cycle before becoming disconnected, avoiding false red banners during hot reload/transient local recovery.

## Rollback
Revert this PR to restore immediate disconnected status on any health-check failure.

Closes #702