### PR TITLE
fix(chat): fast-path short social follow-ups

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_node_turn_policy.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_turn_policy.py
@@ -15,6 +15,9 @@ from app.engine.multi_agent.direct_node_thinking_effort import (
     _resolve_direct_thinking_effort,
 )
 from app.engine.multi_agent.direct_reasoning import _is_codebase_analysis_query
+from app.engine.multi_agent.social_followup_policy import (
+    looks_short_social_followup_turn,
+)
 from app.engine.multi_agent.state import AgentState
 
 
@@ -90,9 +93,16 @@ def resolve_direct_node_turn_policy(
         routing_method == "always_on_chatter_fast_path"
         or (hint_kind == "fast_chatter" and hint_shape in {"reaction", "vague_banter"})
     )
+    is_social_followup_chatter = (
+        not is_identity_turn
+        and (
+            (hint_kind == "fast_chatter" and hint_shape == "social_followup")
+            or looks_short_social_followup_turn(normalized_query)
+        )
+    )
     is_social_fast_path = (
         routing_method == "always_on_social_fast_path"
-        or (hint_kind == "fast_chatter" and hint_shape == "social")
+        or (hint_kind == "fast_chatter" and hint_shape in {"social", "social_followup"})
     )
     visual_decision = resolve_visual_intent(query)
     is_short_house_chatter = (
@@ -109,7 +119,7 @@ def resolve_direct_node_turn_policy(
             )
         )
     )
-    history_limit = 0 if is_short_house_chatter else 10
+    history_limit = 4 if is_social_followup_chatter else (0 if is_short_house_chatter else 10)
     tools_context_override = "" if is_short_house_chatter else None
     role_name = (
         "direct_chatter_agent"

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_turn_policy.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_turn_policy.py
@@ -110,6 +110,7 @@ def resolve_direct_node_turn_policy(
         and (
             is_chatter_fast_path
             or is_social_fast_path
+            or is_social_followup_chatter
             or (
                 routing_intent == "social"
                 and short_token_count <= 6

--- a/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_prompts.py
@@ -102,7 +102,10 @@ def _build_direct_chatter_system_prompt(state: AgentState, role_name: str) -> st
         "- Một từ như 'hehe', 'wow', 'ờ nhỉ', hay một câu rất ngắn vẫn có thể chứa ẩn ý; hãy nghe kỹ rồi mới đáp.\n"
         "- Ưu tiên 1-3 câu ngắn, có hồn, có chất, rồi mở nhẹ để người dùng nói tiếp.\n"
         "- Không gọi tool, không lôi capability/domain vào nếu user chưa thật sự gọi tới.\n"
-        "- Không phản xạ máy móc, không tự giới thiệu dài dòng, không quy kết lỗi encoding nếu vẫn đọc được ý."
+        "- Nếu user hỏi nối tiếp rất ngắn kiểu 'sao lại z' hoặc 'sao lơ lửng?', hãy dựa vào vài câu trước để tự sửa/giải thích câu vừa nói, không trả lời như một câu rời rạc.\n"
+        "- Không bịa cảm giác, âm thanh, thời tiết, cửa sổ, giấc ngủ, hay cảnh vật ngoài đời nếu ngữ cảnh không cung cấp.\n"
+        "- Không phản xạ máy móc, không tự giới thiệu dài dòng, không quy kết lỗi encoding nếu vẫn đọc được ý.\n"
+        "- Không để câu trả lời kết bằng emoticon/kaomoji đang dở; nếu dùng biểu cảm thì phải hoàn chỉnh và tiết chế."
     )
     sections.append(
         "--- TỰ THÂN CỦA WIII ---\n"

--- a/maritime-ai-service/app/engine/multi_agent/social_followup_policy.py
+++ b/maritime-ai-service/app/engine/multi_agent/social_followup_policy.py
@@ -1,0 +1,146 @@
+"""Shared policy for short social follow-up turns.
+
+These turns are not greetings, but they are still ordinary chat: the user is
+reacting to the previous assistant message and is not asking for tools, RAG, or
+host actions. Keeping this policy shared prevents the supervisor fast-path and
+the direct tool governor from drifting.
+"""
+
+from __future__ import annotations
+
+import re
+
+from app.engine.multi_agent.direct_text_utils import _fold_direct_text
+
+
+_EXACT_SHORT_SOCIAL_FOLLOWUPS = frozenset(
+    {
+        "ngu di",
+        "the ngu di",
+        "sao lai",
+        "sao lai z",
+        "sao lai vay",
+        "sao lai the",
+        "sao vay",
+        "sao the",
+        "sao lo lung",
+        "la sao",
+        "la sao z",
+        "la sao vay",
+        "vay la sao",
+        "vay ha",
+        "vay a",
+        "the ha",
+        "the a",
+    }
+)
+
+_SAFE_SAO_LAI_TAILS = frozenset(
+    {
+        "z",
+        "v",
+        "vay",
+        "the",
+        "ha",
+        "a",
+        "nhi",
+        "ta",
+        "vay nhi",
+        "vay ta",
+    }
+)
+
+_TASK_OR_TOOL_BLOCKERS = (
+    "assignment",
+    "bai hoc",
+    "bao cao",
+    "bao do",
+    "chart",
+    "click",
+    "code",
+    "colreg",
+    "css",
+    "deadline",
+    "deploy",
+    "diem",
+    "docker",
+    "docx",
+    "excel",
+    "file",
+    "fix",
+    "giai thich",
+    "gia",
+    "hang hai",
+    "html",
+    "huong dan",
+    "javascript",
+    "kiem tra",
+    "legal",
+    "lms",
+    "log",
+    "marpol",
+    "mo phong",
+    "news",
+    "nhiet do",
+    "pdf",
+    "phan tich",
+    "python",
+    "quy dinh",
+    "quy tac",
+    "react",
+    "rule",
+    "search",
+    "so sanh",
+    "solas",
+    "sua",
+    "tai lieu",
+    "tao",
+    "tau",
+    "test",
+    "thoi tiet",
+    "tin tuc",
+    "tim",
+    "tra cuu",
+    "ve",
+    "viet",
+    "weather",
+    "word",
+)
+
+
+def _clean_social_followup_text(value: str) -> str:
+    folded = _fold_direct_text(value)
+    return " ".join(re.sub(r"[^\w\s]", " ", folded).split())
+
+
+def _contains_phrase(haystack: str, phrase: str) -> bool:
+    if " " in phrase:
+        return phrase in haystack
+    return f" {phrase} " in f" {haystack} "
+
+
+def looks_short_social_followup_turn(query: str) -> bool:
+    """Return True for short, no-tool follow-ups to the previous message."""
+
+    normalized = _clean_social_followup_text(query)
+    if not normalized:
+        return False
+
+    tokens = [token for token in normalized.split() if token]
+    if len(tokens) > 6:
+        return False
+
+    if any(_contains_phrase(normalized, blocker) for blocker in _TASK_OR_TOOL_BLOCKERS):
+        return False
+
+    if normalized in _EXACT_SHORT_SOCIAL_FOLLOWUPS:
+        return True
+
+    if normalized.startswith("sao lai "):
+        tail = normalized.removeprefix("sao lai ").strip()
+        return tail in _SAFE_SAO_LAI_TAILS
+
+    return False
+
+
+__all__ = ["looks_short_social_followup_turn"]

--- a/maritime-ai-service/app/engine/multi_agent/supervisor_hint_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/supervisor_hint_runtime.py
@@ -9,6 +9,9 @@ from app.engine.multi_agent.direct_node_chatter_runtime import (
 )
 from app.engine.multi_agent.state import AgentState
 from app.engine.multi_agent.direct_intent import _looks_selfhood_followup_turn
+from app.engine.multi_agent.social_followup_policy import (
+    looks_short_social_followup_turn,
+)
 from app.engine.multi_agent.visual_intent_resolver import resolve_visual_intent
 
 _NORMALIZED_SOCIAL_PREFIXES = (
@@ -311,7 +314,11 @@ def _looks_hunger_chatter_impl(normalized: str) -> bool:
 
 def is_obvious_social_turn_impl(query: str) -> bool:
     normalized = _normalize_router_text_impl(query)
-    return _looks_clear_social_impl(normalized) or _looks_hunger_chatter_impl(normalized)
+    return (
+        _looks_clear_social_impl(normalized)
+        or _looks_hunger_chatter_impl(normalized)
+        or looks_short_social_followup_turn(normalized)
+    )
 
 
 def classify_fast_chatter_turn_impl(query: str) -> tuple[str, str] | None:
@@ -324,6 +331,8 @@ def classify_fast_chatter_turn_impl(query: str) -> tuple[str, str] | None:
         return ("social", "hunger_chatter")
     if _looks_social_status_chatter_turn(normalized):
         return ("social", "social_status")
+    if looks_short_social_followup_turn(normalized):
+        return ("social", "social_followup")
     if _looks_clear_social_impl(normalized):
         return ("social", "social")
     tokens = [token for token in re.sub(r"[^\w\s]", " ", normalized).split() if token]

--- a/maritime-ai-service/app/engine/multi_agent/turn_path_governor.py
+++ b/maritime-ai-service/app/engine/multi_agent/turn_path_governor.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Literal
 
+from app.engine.multi_agent.social_followup_policy import (
+    looks_short_social_followup_turn,
+)
 from app.engine.tools.tool_capability_registry import (
     HOST_ACTION_PREFIX,
     LMS_DOCUMENT_PREVIEW_TOOL_NAMES,
@@ -357,6 +360,11 @@ def _looks_casual_chat(signals: TurnPathSignals) -> bool:
         "hom qua toi",
     )
     if any(cue in normalized for cue in casual_cues):
+        return True
+
+    if not _has_tool_or_output_signal(signals) and looks_short_social_followup_turn(
+        normalized
+    ):
         return True
 
     if _has_tool_or_output_signal(signals):

--- a/maritime-ai-service/tests/unit/test_direct_node_turn_policy.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_turn_policy.py
@@ -73,6 +73,22 @@ def test_resolve_direct_node_turn_policy_social_followup_keeps_recent_history():
     assert result.role_name == "direct_chatter_agent"
 
 
+def test_resolve_direct_node_turn_policy_social_followup_without_hint_uses_chatter():
+    state = {
+        "context": {"response_language": "vi"},
+        "routing_metadata": {"intent": "unknown"},
+    }
+
+    result = resolve_direct_node_turn_policy(
+        **_base_policy_kwargs(query="sao lại z", state=state)
+    )
+
+    assert result.is_short_house_chatter is True
+    assert result.history_limit == 4
+    assert result.tools_context_override == ""
+    assert result.role_name == "direct_chatter_agent"
+
+
 def test_resolve_direct_node_turn_policy_identity_keeps_context_history():
     state = {
         "context": {"response_language": "vi"},

--- a/maritime-ai-service/tests/unit/test_direct_node_turn_policy.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_turn_policy.py
@@ -52,6 +52,27 @@ def test_resolve_direct_node_turn_policy_short_social_chatter():
     assert result.direct_provider_override == "qwen"
 
 
+def test_resolve_direct_node_turn_policy_social_followup_keeps_recent_history():
+    state = {
+        "context": {"response_language": "vi"},
+        "routing_metadata": {"intent": "social", "method": "conservative_fast_path"},
+        "_routing_hint": {
+            "kind": "fast_chatter",
+            "intent": "social",
+            "shape": "social_followup",
+        },
+    }
+
+    result = resolve_direct_node_turn_policy(
+        **_base_policy_kwargs(query="sao lại z", state=state)
+    )
+
+    assert result.is_short_house_chatter is True
+    assert result.history_limit == 4
+    assert result.tools_context_override == ""
+    assert result.role_name == "direct_chatter_agent"
+
+
 def test_resolve_direct_node_turn_policy_identity_keeps_context_history():
     state = {
         "context": {"response_language": "vi"},

--- a/maritime-ai-service/tests/unit/test_direct_prompts_identity_contract.py
+++ b/maritime-ai-service/tests/unit/test_direct_prompts_identity_contract.py
@@ -112,6 +112,9 @@ def test_direct_chatter_messages_also_get_visible_thinking_supplement():
     assert "native thinking" in system_prompt
     assert "<thinking>...</thinking>" in system_prompt
     assert "colregs" in system_prompt
+    assert "sao lại z" in system_prompt
+    assert "không bịa cảm giác" in system_prompt
+    assert "cửa sổ" in system_prompt
 
 
 def test_direct_chatter_identity_still_receives_living_context_prompt():

--- a/maritime-ai-service/tests/unit/test_supervisor_agent.py
+++ b/maritime-ai-service/tests/unit/test_supervisor_agent.py
@@ -193,6 +193,39 @@ class TestSupervisorRoute:
         mock_route.assert_not_awaited()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "thế ngủ đi",
+            "sao lại z",
+            "sao lơ lửng ?",
+        ],
+    )
+    async def test_route_short_social_followup_uses_fast_path(
+        self,
+        mock_llm,
+        query,
+    ):
+        sup = _make_supervisor(mock_llm)
+        state = {
+            "query": query,
+            "context": {},
+            "domain_config": {},
+        }
+
+        with patch.object(sup, "_route_structured", new=AsyncMock(return_value="direct")) as mock_route:
+            result = await sup.route(state)
+
+        assert result == "direct"
+        assert state["_routing_hint"] == {
+            "kind": "fast_chatter",
+            "intent": "social",
+            "shape": "social_followup",
+        }
+        assert state["routing_metadata"]["method"] == "conservative_fast_path"
+        mock_route.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_route_greeting_learning_request_does_not_use_fast_path(self, mock_llm, monkeypatch):
         from app.core.config import settings
 

--- a/maritime-ai-service/tests/unit/test_turn_path_governor.py
+++ b/maritime-ai-service/tests/unit/test_turn_path_governor.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 
 def test_turn_path_governor_marks_plain_greeting_as_no_tool_chat():
     from app.engine.multi_agent.turn_path_governor import (
@@ -16,17 +18,25 @@ def test_turn_path_governor_marks_plain_greeting_as_no_tool_chat():
     assert decision.force_tools is False
 
 
-def test_turn_path_governor_marks_short_social_followup_as_no_tool_chat():
+@pytest.mark.parametrize(
+    "query",
+    [
+        "sao lai z",
+        "sao lo lung ?",
+        "the ngu di",
+    ],
+)
+def test_turn_path_governor_marks_short_social_followup_as_no_tool_chat(query):
     from app.engine.multi_agent.turn_path_governor import (
         TurnPathSignals,
         resolve_turn_path_decision,
     )
 
-    for query in ("sao lai z", "sao lo lung ?", "the ngu di"):
-        decision = resolve_turn_path_decision(TurnPathSignals(normalized_query=query))
-        assert decision.path == "casual_chat"
-        assert decision.bind_tools is False
-        assert decision.force_tools is False
+    decision = resolve_turn_path_decision(TurnPathSignals(normalized_query=query))
+
+    assert decision.path == "casual_chat"
+    assert decision.bind_tools is False
+    assert decision.force_tools is False
 
 
 def test_turn_path_governor_does_not_treat_task_query_as_social_followup():
@@ -161,7 +171,6 @@ def test_collect_direct_tools_keeps_short_social_followup_off_tool_path():
         "context": {},
         "routing_metadata": {
             "intent": "unknown",
-            "method": "rule_based_timeout",
         },
     }
     tools, force_tools = module._collect_direct_tools(

--- a/maritime-ai-service/tests/unit/test_turn_path_governor.py
+++ b/maritime-ai-service/tests/unit/test_turn_path_governor.py
@@ -16,6 +16,33 @@ def test_turn_path_governor_marks_plain_greeting_as_no_tool_chat():
     assert decision.force_tools is False
 
 
+def test_turn_path_governor_marks_short_social_followup_as_no_tool_chat():
+    from app.engine.multi_agent.turn_path_governor import (
+        TurnPathSignals,
+        resolve_turn_path_decision,
+    )
+
+    for query in ("sao lai z", "sao lo lung ?", "the ngu di"):
+        decision = resolve_turn_path_decision(TurnPathSignals(normalized_query=query))
+        assert decision.path == "casual_chat"
+        assert decision.bind_tools is False
+        assert decision.force_tools is False
+
+
+def test_turn_path_governor_does_not_treat_task_query_as_social_followup():
+    from app.engine.multi_agent.turn_path_governor import (
+        TurnPathSignals,
+        resolve_turn_path_decision,
+    )
+
+    decision = resolve_turn_path_decision(
+        TurnPathSignals(normalized_query="sao lai colreg rule 15 ap dung")
+    )
+
+    assert decision.path == "direct_prose"
+    assert decision.bind_tools is True
+
+
 def test_turn_path_governor_narrows_visual_app_to_required_tool():
     from app.engine.multi_agent.turn_path_governor import (
         TurnPathSignals,
@@ -118,6 +145,27 @@ def test_collect_direct_tools_keeps_daily_status_off_search_path():
     state = {"context": {}}
     tools, force_tools = module._collect_direct_tools(
         "Hôm nay mình ăn cơm rồi",
+        user_role="student",
+        state=state,
+    )
+
+    assert tools == []
+    assert force_tools is False
+    assert state["_turn_path_decision"]["path"] == "casual_chat"
+
+
+def test_collect_direct_tools_keeps_short_social_followup_off_tool_path():
+    from app.engine.multi_agent import tool_collection as module
+
+    state = {
+        "context": {},
+        "routing_metadata": {
+            "intent": "unknown",
+            "method": "rule_based_timeout",
+        },
+    }
+    tools, force_tools = module._collect_direct_tools(
+        "sao lơ lửng ?",
         user_role="student",
         state=state,
     )


### PR DESCRIPTION
## Summary
- Adds a shared short social follow-up policy used by both supervisor fast routing and direct turn-path governance.
- Routes prompts like sao lại z, sao lơ lửng?, and 	hế ngủ đi through the no-tool chatter lane without waiting on structured supervisor routing.
- Preserves recent chat history for social follow-ups so Wiii can answer the previous turn instead of treating the message as context-free chatter.
- Tightens chatter prompt rules against invented sensory context and incomplete emoticons.

## Scope
- Backend chat routing/path-governor behavior.
- Direct-node chatter prompt and history window policy.
- Focused unit regressions for supervisor, tool governor, direct turn policy, and prompt contract.

## Non-scope
- Code Studio visual/tool-call timeout debt.
- Provider/model selection changes.
- LMS document preview/apply E2E.
- Frontend visual changes.

## Verification
- cd maritime-ai-service; python -m pytest tests/unit/test_direct_node_turn_policy.py tests/unit/test_direct_prompts_identity_contract.py tests/unit/test_turn_path_governor.py tests/unit/test_supervisor_agent.py tests/unit/test_chat_baseline_acceptance_harness.py tests/unit/test_chat_request_flow.py tests/unit/test_supervisor_route_timeout.py -q --tb=short → 126 passed
- cd maritime-ai-service; python -m pytest tests/unit/test_turn_path_governor.py tests/unit/test_supervisor_agent.py tests/unit/test_conservative_evolution.py -q --tb=short → 138 passed
- cd maritime-ai-service; python -m pytest tests/unit/test_chat_baseline_acceptance_harness.py tests/unit/test_chat_request_flow.py tests/unit/test_supervisor_route_timeout.py -q --tb=short → 38 passed
- cd maritime-ai-service; python -m ruff check app/engine/multi_agent/social_followup_policy.py app/engine/multi_agent/supervisor_hint_runtime.py app/engine/multi_agent/turn_path_governor.py app/engine/multi_agent/direct_node_turn_policy.py app/engine/multi_agent/direct_prompts.py → passed
- git diff --check → passed
- Local runtime smoke via /api/v1/chat/stream/v3 for sao lai z: supervisor routed method=conservative_fast_path, direct bound 	ools=0, completed without ule_based_timeout.

## Risk
- False positives in short social follow-up classification could skip tools on a real task. Mitigation: the shared policy is exact/short-tail oriented and blocks task/tool/domain markers such as COLREG, weather, LMS, code, visual, logs, search, file, and document terms.
- Keeping four recent messages for social follow-ups increases prompt size slightly, but only for a narrow short-follow-up lane.

## Rollback
- Revert this PR to restore previous conservative fast-route and direct history behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved detection and handling of brief follow-up messages to enable more natural, contextual responses within conversations.

* **Improvements**
  * Enhanced response guidelines for short conversational exchanges to prevent robotic phrasing and avoid inventing unnecessary details without user input.

* **Tests**
  * Added comprehensive unit tests to verify proper routing and conversation history management for follow-up messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->