### PR TITLE
feat(chat): emit runtime lifecycle events

### DIFF
--- a/maritime-ai-service/app/api/v1/chat_stream_presenter.py
+++ b/maritime-ai-service/app/api/v1/chat_stream_presenter.py
@@ -139,6 +139,7 @@ PRESENTATION_BY_EVENT: dict[str, str] = {
     "preview": "compact",
     "action_text": "compact",
     "status": "compact",
+    "chat_lifecycle": "compact",
     "answer": "compact",
     "artifact": "compact",
     "code_open": "compact",
@@ -253,7 +254,7 @@ def _step_state_for_event(event_type: str) -> str | None:
         "visual_patch",
     }:
         return "live"
-    if event_type in {"answer", "artifact", "visual", "visual_commit", "visual_dispose", "sources", "metadata", "done", "error"}:
+    if event_type in {"answer", "artifact", "chat_lifecycle", "visual", "visual_commit", "visual_dispose", "sources", "metadata", "done", "error"}:
         return "completed"
     return None
 
@@ -423,6 +424,25 @@ def serialize_stream_event(
         )
         return [
             format_sse("status", data, event_id=event_counter)
+        ], event_counter, False
+
+    if event_type == "chat_lifecycle":
+        payload = dict(event.content) if isinstance(event.content, Mapping) else {}
+        if event.node:
+            payload.setdefault("node", event.node)
+        if event.step:
+            payload.setdefault("step", event.step)
+        if event.details:
+            payload.setdefault("details", event.details)
+        data = _apply_presentation_metadata(
+            payload=payload,
+            event_type=event_type,
+            event_counter=event_counter,
+            event=event,
+            presentation_state=presentation_state,
+        )
+        return [
+            format_sse("chat_lifecycle", data, event_id=event_counter)
         ], event_counter, False
 
     if event_type == "thinking":

--- a/maritime-ai-service/app/engine/multi_agent/stream_utils.py
+++ b/maritime-ai-service/app/engine/multi_agent/stream_utils.py
@@ -30,6 +30,7 @@ class StreamEventType:
     ANSWER = "answer"           # Response tokens (streamed real-time)
     SOURCES = "sources"         # Citation list with image_url
     METADATA = "metadata"       # reasoning_trace, confidence, timing
+    CHAT_LIFECYCLE = "chat_lifecycle"  # Typed chat runtime lifecycle/progress
     THINKING_DELTA = "thinking_delta"   # Incremental thinking token (real-time)
     THINKING_START = "thinking_start"  # Thinking block opened (lifecycle)
     THINKING_END = "thinking_end"      # Thinking block closed (lifecycle)

--- a/maritime-ai-service/app/services/REQUEST_FLOW_CONTRACT.md
+++ b/maritime-ai-service/app/services/REQUEST_FLOW_CONTRACT.md
@@ -213,6 +213,32 @@ The streaming path may emit intermediate events, but it should preserve the same
 
 Streaming-specific transport behavior does not create a separate business contract.
 
+### Streaming Lifecycle Observability
+
+`/api/v1/chat/stream/v3` emits additive `chat_lifecycle` SSE events so clients
+and acceptance harnesses can observe the live turn without parsing display copy
+or waiting for terminal metadata.
+
+Lifecycle payloads use schema `wiii.chat_runtime_lifecycle.v1` and include:
+
+- `chat.accepted`
+- `turn.prepared`
+- `path.selected`
+- `capability.checked`
+- `finalization.completed` or `finalization.failed`
+- `chat.done`
+- `chat.error`
+
+Rules:
+
+- lifecycle events are observational only and must not drive LMS mutation
+- lifecycle payloads must stay privacy-safe; do not include prompt text,
+  raw document content, full user identifiers, secrets, or provider tokens
+- path and capability state should be emitted from typed runtime state, not
+  inferred from Vietnamese status labels
+- existing `status`, `thinking`, `answer`, `metadata`, and `done` consumers must
+  keep working when a client ignores `chat_lifecycle`
+
 Policy note:
 
 - sync `/api/v1/chat` and streaming `/api/v1/chat/stream/v3` both use the

--- a/maritime-ai-service/app/services/chat_runtime_lifecycle.py
+++ b/maritime-ai-service/app/services/chat_runtime_lifecycle.py
@@ -32,9 +32,24 @@ class ChatLifecycleName:
 
 _MAX_ITEMS = 24
 _MAX_STRING_LENGTH = 128
+_ELLIPSIS = "..."
+_ALLOWED_METADATA_KEYS = {
+    "bound_tools",
+    "domain_id",
+    "error_type",
+    "fallback_used",
+    "model",
+    "organization_id_present",
+    "provider",
+    "reason_code",
+    "recoverable",
+    "transport",
+}
 
 
 def _safe_string(value: Any, *, max_length: int = _MAX_STRING_LENGTH) -> str | None:
+    if max_length <= 0:
+        return None
     if value is None:
         return None
     text = str(value).strip()
@@ -42,7 +57,9 @@ def _safe_string(value: Any, *, max_length: int = _MAX_STRING_LENGTH) -> str | N
         return None
     text = " ".join(text.split())
     if len(text) > max_length:
-        return text[: max_length - 1] + "..."
+        if max_length <= len(_ELLIPSIS):
+            return _ELLIPSIS[:max_length]
+        return text[: max_length - len(_ELLIPSIS)] + _ELLIPSIS
     return text
 
 
@@ -63,6 +80,30 @@ def _safe_mapping(value: Any) -> Mapping[str, Any]:
     if isinstance(value, Mapping):
         return value
     return {}
+
+
+def _safe_metadata_value(value: Any) -> Any:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float):
+        return value
+    if isinstance(value, str):
+        return _safe_string(value)
+    if isinstance(value, (list, tuple, set)):
+        return _safe_string_list(value)
+    return "<redacted>"
+
+
+def _safe_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    safe: dict[str, Any] = {}
+    for key, value in metadata.items():
+        key_text = str(key)
+        if key_text not in _ALLOWED_METADATA_KEYS or value is None:
+            continue
+        safe_value = _safe_metadata_value(value)
+        if safe_value is not None:
+            safe[key_text] = safe_value
+    return safe
 
 
 def capability_snapshot_from_ledger_payload(
@@ -122,11 +163,9 @@ class ChatRuntimeLifecycleEvent:
         if self.capabilities is not None:
             payload["capabilities"] = dict(self.capabilities)
         if self.metadata:
-            payload["metadata"] = {
-                str(key): value
-                for key, value in self.metadata.items()
-                if value is not None
-            }
+            metadata = _safe_metadata(self.metadata)
+            if metadata:
+                payload["metadata"] = metadata
         return payload
 
 

--- a/maritime-ai-service/app/services/chat_runtime_lifecycle.py
+++ b/maritime-ai-service/app/services/chat_runtime_lifecycle.py
@@ -1,0 +1,154 @@
+"""Typed lifecycle events for the SSE V3 chat runtime.
+
+These events are additive observability: they let clients and harnesses follow
+the turn path without parsing Vietnamese status copy or waiting for terminal
+metadata.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from app.engine.multi_agent.stream_utils import StreamEvent
+
+
+CHAT_RUNTIME_LIFECYCLE_SCHEMA_VERSION = "wiii.chat_runtime_lifecycle.v1"
+CHAT_RUNTIME_LIFECYCLE_EVENT_TYPE = "chat_lifecycle"
+
+
+class ChatLifecycleName:
+    """Stable lifecycle names emitted on the SSE wire."""
+
+    CHAT_ACCEPTED = "chat.accepted"
+    TURN_PREPARED = "turn.prepared"
+    PATH_SELECTED = "path.selected"
+    CAPABILITY_CHECKED = "capability.checked"
+    FINALIZATION_COMPLETED = "finalization.completed"
+    FINALIZATION_FAILED = "finalization.failed"
+    CHAT_DONE = "chat.done"
+    CHAT_ERROR = "chat.error"
+
+
+_MAX_ITEMS = 24
+_MAX_STRING_LENGTH = 128
+
+
+def _safe_string(value: Any, *, max_length: int = _MAX_STRING_LENGTH) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    text = " ".join(text.split())
+    if len(text) > max_length:
+        return text[: max_length - 1] + "..."
+    return text
+
+
+def _safe_string_list(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    output: list[str] = []
+    for item in value:
+        text = _safe_string(item)
+        if text and text not in output:
+            output.append(text)
+        if len(output) >= _MAX_ITEMS:
+            break
+    return output
+
+
+def _safe_mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def capability_snapshot_from_ledger_payload(
+    ledger_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return the lifecycle-safe capability/tool subset from a flow ledger."""
+
+    request = _safe_mapping(ledger_payload.get("request"))
+    tools = _safe_mapping(ledger_payload.get("tools"))
+    host_actions = _safe_mapping(ledger_payload.get("host_actions"))
+    return {
+        "host_surface": _safe_string(request.get("host_surface")) or "unknown",
+        "host_capabilities": _safe_string_list(request.get("host_capabilities")),
+        "observed_tools": _safe_string_list(tools.get("observed")),
+        "suppressed_tools": _safe_string_list(tools.get("suppressed")),
+        "preview_required": bool(host_actions.get("preview_required")),
+        "preview_emitted": bool(host_actions.get("preview_emitted")),
+        "approval_token_present": bool(host_actions.get("approval_token_present")),
+        "apply_attempted": bool(host_actions.get("apply_attempted")),
+    }
+
+
+@dataclass(frozen=True)
+class ChatRuntimeLifecycleEvent:
+    """Privacy-safe lifecycle event for streaming chat clients."""
+
+    name: str
+    phase: str
+    status: str
+    message: str
+    request_id: str | None = None
+    session_id: str | None = None
+    lane: str | None = None
+    reason: str | None = None
+    node: str | None = None
+    capabilities: Mapping[str, Any] | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": CHAT_RUNTIME_LIFECYCLE_SCHEMA_VERSION,
+            "event_name": self.name,
+            "phase": self.phase,
+            "status": self.status,
+            "message": self.message,
+        }
+        for key, value in (
+            ("request_id", self.request_id),
+            ("session_id", self.session_id),
+            ("lane", self.lane),
+            ("reason", self.reason),
+            ("node", self.node),
+        ):
+            text = _safe_string(value)
+            if text:
+                payload[key] = text
+        if self.capabilities is not None:
+            payload["capabilities"] = dict(self.capabilities)
+        if self.metadata:
+            payload["metadata"] = {
+                str(key): value
+                for key, value in self.metadata.items()
+                if value is not None
+            }
+        return payload
+
+
+def create_chat_lifecycle_event(
+    lifecycle: ChatRuntimeLifecycleEvent,
+) -> StreamEvent:
+    """Wrap a typed lifecycle payload in the existing StreamEvent transport."""
+
+    return StreamEvent(
+        type=CHAT_RUNTIME_LIFECYCLE_EVENT_TYPE,
+        content=lifecycle.to_payload(),
+        node=lifecycle.node,
+        step=lifecycle.phase,
+        details={"event_name": lifecycle.name},
+    )
+
+
+__all__ = [
+    "CHAT_RUNTIME_LIFECYCLE_EVENT_TYPE",
+    "CHAT_RUNTIME_LIFECYCLE_SCHEMA_VERSION",
+    "ChatLifecycleName",
+    "ChatRuntimeLifecycleEvent",
+    "capability_snapshot_from_ledger_payload",
+    "create_chat_lifecycle_event",
+]

--- a/maritime-ai-service/app/services/chat_stream_coordinator.py
+++ b/maritime-ai-service/app/services/chat_stream_coordinator.py
@@ -16,6 +16,12 @@ from app.core.exceptions import (
 from app.engine.llm_runtime_metadata import resolve_runtime_llm_metadata
 from app.engine.multi_agent.runtime_flow_ledger import RuntimeFlowLedger
 from app.services.chat_orchestrator_runtime import build_wiii_turn_request
+from app.services.chat_runtime_lifecycle import (
+    ChatLifecycleName,
+    ChatRuntimeLifecycleEvent,
+    capability_snapshot_from_ledger_payload,
+    create_chat_lifecycle_event,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -499,6 +505,60 @@ async def generate_stream_v3_events(
         request_id=request_id,
     )
 
+    def _payload_section(payload: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+        section = payload.get(key)
+        return section if isinstance(section, Mapping) else {}
+
+    def _serialize_coordinator_event(event) -> tuple[list[str], bool]:
+        nonlocal event_counter
+        event = _with_runtime_flow_metadata(
+            event,
+            latency_tracker,
+            flow_ledger,
+        )
+        chunks, event_counter, should_stop = serialize_stream_event(
+            event=event,
+            event_counter=event_counter,
+            enable_artifacts=settings.enable_artifacts,
+            presentation_state=presentation_state,
+        )
+        return chunks, should_stop
+
+    def _serialize_lifecycle_event(
+        *,
+        name: str,
+        phase: str,
+        status: str,
+        message: str,
+        node: str = "system",
+        lane: str | None = None,
+        reason: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> tuple[list[str], bool]:
+        ledger_payload = flow_ledger.to_payload()
+        route_payload = _payload_section(ledger_payload, "route")
+        request_payload = _payload_section(ledger_payload, "request")
+        return _serialize_coordinator_event(
+            create_chat_lifecycle_event(
+                ChatRuntimeLifecycleEvent(
+                    name=name,
+                    phase=phase,
+                    status=status,
+                    message=message,
+                    request_id=request_id,
+                    session_id=str(request_payload.get("session_id") or "")
+                    or None,
+                    lane=lane or str(route_payload.get("lane") or "") or None,
+                    reason=reason or str(route_payload.get("reason") or "") or None,
+                    node=node,
+                    capabilities=capability_snapshot_from_ledger_payload(
+                        ledger_payload
+                    ),
+                    metadata=metadata or {},
+                )
+            )
+        )
+
     event_counter += 1
     flow_ledger.record_wire_event("status")
     yield format_sse(
@@ -514,6 +574,18 @@ async def generate_stream_v3_events(
         },
         event_id=event_counter,
     )
+    chunks, should_stop = _serialize_lifecycle_event(
+        name=ChatLifecycleName.CHAT_ACCEPTED,
+        phase="accepted",
+        status="started",
+        message="Đã nhận lượt chat.",
+        node="system",
+        metadata={"transport": "sse_v3"},
+    )
+    for chunk in chunks:
+        yield chunk
+    if should_stop:
+        return
 
     fb_cookie = request_headers.get("x-facebook-cookie", "")
     if fb_cookie and settings.enable_facebook_cookie:
@@ -607,9 +679,51 @@ async def generate_stream_v3_events(
             organization_id=resolved_org_id,
             domain_id=resolved_domain_id,
         )
+        chunks, should_stop = _serialize_lifecycle_event(
+            name=ChatLifecycleName.TURN_PREPARED,
+            phase="prepared",
+            status="ready",
+            message="Đã mở phiên và kiểm tra quyền truy cập.",
+            node="system",
+            metadata={
+                "domain_id": resolved_domain_id,
+                "organization_id_present": bool(resolved_org_id),
+            },
+        )
+        for chunk in chunks:
+            yield chunk
+        if should_stop:
+            return
 
         if prepared_turn.validation.blocked:
             flow_ledger.mark_route("blocked", reason="prepared_turn_validation")
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.PATH_SELECTED,
+                phase="routing",
+                status="blocked",
+                message="Lượt này bị chặn bởi kiểm tra an toàn.",
+                node="system",
+                lane="blocked",
+                reason="prepared_turn_validation",
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.CAPABILITY_CHECKED,
+                phase="capability",
+                status="blocked",
+                message="Không bind tool vì lượt đã bị chặn.",
+                node="system",
+                lane="blocked",
+                reason="prepared_turn_validation",
+                metadata={"bound_tools": []},
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
             flow_ledger.record_wire_event("answer")
             flow_ledger.record_wire_event("metadata")
             blocked_chunks, event_counter = (
@@ -623,8 +737,23 @@ async def generate_stream_v3_events(
                     },
                 )
             )
-            for chunk in blocked_chunks:
+            for chunk in blocked_chunks[:-1]:
                 yield chunk
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.CHAT_DONE,
+                phase="done",
+                status="blocked",
+                message="Lượt chat đã kết thúc ở bước kiểm tra an toàn.",
+                node="system",
+                lane="blocked",
+                reason="prepared_turn_validation",
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
+            if blocked_chunks:
+                yield blocked_chunks[-1]
             return
 
         finalization_context = prepared_turn.chat_context
@@ -651,6 +780,34 @@ async def generate_stream_v3_events(
                 "visual_fast_path",
                 reason="structured_visual_fast_path",
             )
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.PATH_SELECTED,
+                phase="routing",
+                status="selected",
+                message="Đã chọn lane minh họa trực quan.",
+                node="visual_fast_path",
+                lane="visual_fast_path",
+                reason="structured_visual_fast_path",
+                metadata={"bound_tools": ["visual_runtime"]},
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.CAPABILITY_CHECKED,
+                phase="capability",
+                status="ready",
+                message="Đã khóa capability cho runtime minh họa.",
+                node="visual_fast_path",
+                lane="visual_fast_path",
+                reason="structured_visual_fast_path",
+                metadata={"bound_tools": ["visual_runtime"]},
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
             visual_started_ms = latency_tracker.elapsed_ms()
             visual_events = [
                 await create_thinking_start_event(
@@ -692,7 +849,6 @@ async def generate_stream_v3_events(
                     stream_latency=latency_tracker.to_payload(),
                     streaming_version="v3-visual_fast_path",
                 ),
-                await create_done_event(time.time() - start_time),
             ]
 
             for event in visual_events:
@@ -743,6 +899,48 @@ async def generate_stream_v3_events(
                     "[STREAM-V3] Visual fast-path finalization failed: %s",
                     finalize_err,
                 )
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=(
+                    ChatLifecycleName.FINALIZATION_FAILED
+                    if flow_ledger.finalization_status == "failed"
+                    else ChatLifecycleName.FINALIZATION_COMPLETED
+                ),
+                phase="finalization",
+                status=flow_ledger.finalization_status,
+                message="Đã hoàn tất bước lưu trạng thái lượt trả lời.",
+                node="visual_fast_path",
+                lane="visual_fast_path",
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.CHAT_DONE,
+                phase="done",
+                status="complete",
+                message="Lượt chat đã hoàn tất.",
+                node="visual_fast_path",
+                lane="visual_fast_path",
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
+            done_event = await create_done_event(time.time() - start_time)
+            done_event = _with_runtime_flow_metadata(
+                done_event,
+                latency_tracker,
+                flow_ledger,
+            )
+            done_chunks, event_counter, _ = serialize_stream_event(
+                event=done_event,
+                event_counter=event_counter,
+                enable_artifacts=settings.enable_artifacts,
+                presentation_state=presentation_state,
+            )
+            for chunk in done_chunks:
+                yield chunk
             return
 
         pointy_highlight_action_name = "ui.highlight"
@@ -769,6 +967,34 @@ async def generate_stream_v3_events(
                 "pointy_fast_path",
                 reason="pointy_prepared_fast_path",
             )
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.PATH_SELECTED,
+                phase="routing",
+                status="selected",
+                message="Đã chọn lane chỉ vị trí trên giao diện.",
+                node="pointy_fast_path",
+                lane="pointy_fast_path",
+                reason="pointy_prepared_fast_path",
+                metadata={"bound_tools": ["pointy_action"]},
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.CAPABILITY_CHECKED,
+                phase="capability",
+                status="ready",
+                message="Đã khóa capability Pointy an toàn.",
+                node="pointy_fast_path",
+                lane="pointy_fast_path",
+                reason="pointy_prepared_fast_path",
+                metadata={"bound_tools": ["pointy_action"]},
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
             pointy_answer = _pointy_action_answer(pointy_fast_path)
             pointy_thinking = _pointy_action_thinking(pointy_fast_path)
             pointy_label = _pointy_action_label(pointy_fast_path)
@@ -829,7 +1055,6 @@ async def generate_stream_v3_events(
                     stream_latency=latency_tracker.to_payload(),
                     streaming_version="v3-pointy_fast_path",
                 ),
-                await create_done_event(time.time() - start_time),
             ]
 
             for event in pointy_events:
@@ -880,6 +1105,48 @@ async def generate_stream_v3_events(
                     "[STREAM-V3] Pointy fast-path finalization failed: %s",
                     finalize_err,
                 )
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=(
+                    ChatLifecycleName.FINALIZATION_FAILED
+                    if flow_ledger.finalization_status == "failed"
+                    else ChatLifecycleName.FINALIZATION_COMPLETED
+                ),
+                phase="finalization",
+                status=flow_ledger.finalization_status,
+                message="Đã hoàn tất bước lưu trạng thái lượt trả lời.",
+                node="pointy_fast_path",
+                lane="pointy_fast_path",
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.CHAT_DONE,
+                phase="done",
+                status="complete",
+                message="Lượt chat đã hoàn tất.",
+                node="pointy_fast_path",
+                lane="pointy_fast_path",
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
+            done_event = await create_done_event(time.time() - start_time)
+            done_event = _with_runtime_flow_metadata(
+                done_event,
+                latency_tracker,
+                flow_ledger,
+            )
+            done_chunks, event_counter, _ = serialize_stream_event(
+                event=done_event,
+                event_counter=event_counter,
+                enable_artifacts=settings.enable_artifacts,
+                presentation_state=presentation_state,
+            )
+            for chunk in done_chunks:
+                yield chunk
             logger.info(
                 "[STREAM-V3] Completed in %.3fs (prepared pointy fast path)",
                 time.time() - start_time,
@@ -894,6 +1161,34 @@ async def generate_stream_v3_events(
                 fallback_used=True,
                 fallback_reason="multi_agent_disabled",
             )
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.PATH_SELECTED,
+                phase="routing",
+                status="selected",
+                message="Đã chọn lane trả lời dự phòng.",
+                node="direct",
+                lane="fallback",
+                reason="multi_agent_disabled",
+                metadata={"fallback_used": True, "bound_tools": []},
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.CAPABILITY_CHECKED,
+                phase="capability",
+                status="ready",
+                message="Không bind tool cho lane trả lời dự phòng.",
+                node="direct",
+                lane="fallback",
+                reason="multi_agent_disabled",
+                metadata={"bound_tools": []},
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
             fallback_status = await create_status_event(
                 "Wiii đang mở đường trả lời nhanh...",
                 node="direct",
@@ -1002,7 +1297,6 @@ async def generate_stream_v3_events(
                         routing_metadata=fallback_meta.get("routing_metadata"),
                         **extra_meta,
                     ),
-                    await create_done_event(processing_time),
                 ]
             )
 
@@ -1054,10 +1348,65 @@ async def generate_stream_v3_events(
                     "[STREAM-V3] Fallback post-response finalization failed: %s",
                     finalize_err,
                 )
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=(
+                    ChatLifecycleName.FINALIZATION_FAILED
+                    if flow_ledger.finalization_status == "failed"
+                    else ChatLifecycleName.FINALIZATION_COMPLETED
+                ),
+                phase="finalization",
+                status=flow_ledger.finalization_status,
+                message="Đã hoàn tất bước lưu trạng thái lượt trả lời.",
+                node="direct",
+                lane="fallback",
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.CHAT_DONE,
+                phase="done",
+                status="complete",
+                message="Lượt chat đã hoàn tất.",
+                node="direct",
+                lane="fallback",
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
+            done_event = await create_done_event(processing_time)
+            done_event = _with_runtime_flow_metadata(
+                done_event,
+                latency_tracker,
+                flow_ledger,
+            )
+            done_chunks, event_counter, _ = serialize_stream_event(
+                event=done_event,
+                event_counter=event_counter,
+                enable_artifacts=settings.enable_artifacts,
+                presentation_state=presentation_state,
+            )
+            for chunk in done_chunks:
+                yield chunk
             return
 
         _provider = requested_provider
         flow_ledger.mark_route("native_turn", reason="multi_agent_stream")
+        chunks, should_stop = _serialize_lifecycle_event(
+            name=ChatLifecycleName.PATH_SELECTED,
+            phase="routing",
+            status="selected",
+            message="Đã chọn lane runtime chính.",
+            node="runtime",
+            lane="native_turn",
+            reason="multi_agent_stream",
+        )
+        for chunk in chunks:
+            yield chunk
+        if should_stop:
+            return
         context_status = await create_status_event(
             "Wiii đang gom ngữ cảnh và trí nhớ...",
             node="context",
@@ -1130,6 +1479,19 @@ async def generate_stream_v3_events(
                     "build_multi_agent_execution_input did not return context"
                 )
             flow_ledger.mark_execution_input(execution_input)
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.CAPABILITY_CHECKED,
+                phase="capability",
+                status="ready",
+                message="Đã kiểm tra capability và tool bridge cho lượt này.",
+                node="context",
+                lane="native_turn",
+                reason="multi_agent_stream",
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
         except Exception as ctx_err:
             logger.warning(
                 "[STREAM-V3] Full context build failed, using minimal: %s",
@@ -1161,12 +1523,25 @@ async def generate_stream_v3_events(
                 latency_tracker.finish("minimal_execution_input", status="error")
                 raise
             latency_tracker.finish("minimal_execution_input")
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.CAPABILITY_CHECKED,
+                phase="capability",
+                status="degraded",
+                message="Đã dùng context tối thiểu sau khi gom ngữ cảnh đầy đủ lỗi.",
+                node="context",
+                lane="native_turn",
+                reason="minimal_context_after_build_failure",
+                metadata={"fallback_used": True},
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
 
         accumulated_answer: list[str] = []
         saw_done_event = False
         terminal_done_event = None
         stream_current_agent = ""
-        answer_started = False
 
         latency_tracker.start("build_turn_request")
         try:
@@ -1257,7 +1632,6 @@ async def generate_stream_v3_events(
                 )
                 if event.type == "answer":
                     accumulated_answer.append(event.content)
-                    answer_started = True
                 elif early_context_thinking and event.type in {
                     "thinking_start",
                     "thinking_delta",
@@ -1338,6 +1712,23 @@ async def generate_stream_v3_events(
                 finalize_err,
             )
 
+        chunks, should_stop = _serialize_lifecycle_event(
+            name=(
+                ChatLifecycleName.FINALIZATION_FAILED
+                if flow_ledger.finalization_status == "failed"
+                else ChatLifecycleName.FINALIZATION_COMPLETED
+            ),
+            phase="finalization",
+            status=flow_ledger.finalization_status,
+            message="Đã hoàn tất bước lưu trạng thái lượt trả lời.",
+            node=stream_current_agent or "runtime",
+            lane=flow_ledger.route_lane,
+        )
+        for chunk in chunks:
+            yield chunk
+        if should_stop:
+            return
+
         processing_time = time.time() - start_time
         logger.info(
             "[STREAM-V3] Completed in %.3fs (full graph)",
@@ -1374,6 +1765,18 @@ async def generate_stream_v3_events(
                 )
                 for chunk in metadata_chunks:
                     yield chunk
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.CHAT_DONE,
+                phase="done",
+                status="complete",
+                message="Lượt chat đã hoàn tất.",
+                node=stream_current_agent or "runtime",
+                lane=flow_ledger.route_lane,
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
             done_event = await create_done_event(processing_time)
             done_event = _with_runtime_flow_metadata(
                 done_event,
@@ -1420,6 +1823,18 @@ async def generate_stream_v3_events(
                 for chunk in metadata_chunks:
                     yield chunk
 
+            chunks, should_stop = _serialize_lifecycle_event(
+                name=ChatLifecycleName.CHAT_DONE,
+                phase="done",
+                status="complete",
+                message="Lượt chat đã hoàn tất.",
+                node=stream_current_agent or "runtime",
+                lane=flow_ledger.route_lane,
+            )
+            for chunk in chunks:
+                yield chunk
+            if should_stop:
+                return
             done_event = _with_runtime_flow_metadata(
                 terminal_done_event,
                 latency_tracker,
@@ -1447,6 +1862,24 @@ async def generate_stream_v3_events(
             exc.model,
             exc.partial_chars,
         )
+        chunks, should_stop = _serialize_lifecycle_event(
+            name=ChatLifecycleName.CHAT_ERROR,
+            phase="error",
+            status="failed",
+            message="Provider stream bị ngắt trước khi hoàn tất.",
+            node="runtime",
+            lane="provider_stream_interrupted",
+            reason=exc.reason_code,
+            metadata={
+                "provider": exc.provider,
+                "model": exc.model,
+                "recoverable": True,
+            },
+        )
+        for chunk in chunks:
+            yield chunk
+        if should_stop:
+            return
         error_event = await create_error_event(exc.message)
         error_event.content["type"] = "provider_stream_interrupted"
         error_event.content["provider"] = exc.provider
@@ -1477,6 +1910,23 @@ async def generate_stream_v3_events(
             exc.provider,
             exc.reason_code,
         )
+        chunks, should_stop = _serialize_lifecycle_event(
+            name=ChatLifecycleName.CHAT_ERROR,
+            phase="error",
+            status="failed",
+            message="Provider được chọn chưa sẵn sàng cho lượt này.",
+            node="runtime",
+            lane="provider_unavailable",
+            reason=exc.reason_code or "provider_unavailable",
+            metadata={
+                "provider": exc.provider,
+                "reason_code": exc.reason_code,
+            },
+        )
+        for chunk in chunks:
+            yield chunk
+        if should_stop:
+            return
         try:
             _record_llm_runtime_observation(
                 provider=exc.provider,
@@ -1562,6 +2012,20 @@ async def generate_stream_v3_events(
 
         tb = traceback.format_exc()
         logger.error("[STREAM-V3] Error: %s\n%s", exc, tb)
+        chunks, should_stop = _serialize_lifecycle_event(
+            name=ChatLifecycleName.CHAT_ERROR,
+            phase="error",
+            status="failed",
+            message="Runtime gặp lỗi nội bộ khi xử lý lượt chat.",
+            node="runtime",
+            lane=flow_ledger.route_lane,
+            reason=type(exc).__name__,
+            metadata={"error_type": type(exc).__name__},
+        )
+        for chunk in chunks:
+            yield chunk
+        if should_stop:
+            return
         error_chunks, _ = emit_internal_error_sse_events(
             processing_time=time.time() - start_time,
         )

--- a/maritime-ai-service/tests/unit/test_chat_runtime_lifecycle.py
+++ b/maritime-ai-service/tests/unit/test_chat_runtime_lifecycle.py
@@ -1,0 +1,43 @@
+from app.services.chat_runtime_lifecycle import (
+    CHAT_RUNTIME_LIFECYCLE_SCHEMA_VERSION,
+    ChatLifecycleName,
+    ChatRuntimeLifecycleEvent,
+)
+
+
+def test_chat_runtime_lifecycle_truncates_strings_to_limit():
+    payload = ChatRuntimeLifecycleEvent(
+        name=ChatLifecycleName.PATH_SELECTED,
+        phase="routing",
+        status="selected",
+        message="x" * 200,
+        reason="r" * 200,
+    ).to_payload()
+
+    assert payload["schema_version"] == CHAT_RUNTIME_LIFECYCLE_SCHEMA_VERSION
+    assert len(payload["reason"]) == 128
+    assert payload["reason"].endswith("...")
+
+
+def test_chat_runtime_lifecycle_metadata_is_allowlisted_and_bounded():
+    payload = ChatRuntimeLifecycleEvent(
+        name=ChatLifecycleName.CAPABILITY_CHECKED,
+        phase="capability",
+        status="ready",
+        message="ok",
+        metadata={
+            "bound_tools": ["visual_runtime", "x" * 200],
+            "provider": "nvidia",
+            "fallback_used": False,
+            "secret_token": "must-not-leak",
+            "nested": {"unsafe": "payload"},
+        },
+    ).to_payload()
+
+    metadata = payload["metadata"]
+    assert metadata["provider"] == "nvidia"
+    assert metadata["fallback_used"] is False
+    assert metadata["bound_tools"][0] == "visual_runtime"
+    assert len(metadata["bound_tools"][1]) == 128
+    assert "secret_token" not in metadata
+    assert "nested" not in metadata

--- a/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
@@ -13,6 +13,10 @@ from app.core.exceptions import (
 )
 from app.engine.multi_agent.runtime_flow_ledger import RUNTIME_FLOW_LEDGER_SCHEMA_VERSION
 from app.engine.multi_agent.runtime_contracts import WiiiStreamEvent, WiiiTurnRequest
+from app.services.chat_runtime_lifecycle import (
+    CHAT_RUNTIME_LIFECYCLE_SCHEMA_VERSION,
+    ChatLifecycleName,
+)
 from app.services.chat_orchestrator import AgentType
 from app.services.chat_orchestrator import RequestScope
 from app.services.output_processor import ProcessingResult
@@ -44,6 +48,20 @@ def _event_payloads(chunks, event_name):
                 payloads.append(json.loads(line.removeprefix("data: ")))
                 break
     return payloads
+
+
+def _event_names(chunks):
+    names = []
+    for chunk in chunks:
+        for line in chunk.splitlines():
+            if line.startswith("event: "):
+                names.append(line.removeprefix("event: "))
+                break
+    return names
+
+
+def _lifecycle_payloads(chunks):
+    return _event_payloads(chunks, "chat_lifecycle")
 
 
 def _runtime_flow_ledgers(chunks):
@@ -83,10 +101,22 @@ async def test_generate_stream_v3_events_emits_blocked_sequence():
         chunks.append(chunk)
 
     assert chunks[0] == "retry: 3000\n\n"
-    assert "event: status" in chunks[1]
-    assert "event: answer" in chunks[2]
-    assert "event: metadata" in chunks[3]
-    assert "event: done" in chunks[4]
+    events = _event_names(chunks)
+    assert events[0] == "status"
+    assert "chat_lifecycle" in events
+    assert "answer" in events
+    assert "metadata" in events
+    assert events[-1] == "done"
+    lifecycle_names = [
+        payload["event_name"] for payload in _lifecycle_payloads(chunks)
+    ]
+    assert lifecycle_names[:4] == [
+        ChatLifecycleName.CHAT_ACCEPTED,
+        ChatLifecycleName.TURN_PREPARED,
+        ChatLifecycleName.PATH_SELECTED,
+        ChatLifecycleName.CAPABILITY_CHECKED,
+    ]
+    assert _lifecycle_payloads(chunks)[2]["lane"] == "blocked"
     ledgers = _runtime_flow_ledgers(chunks)
     assert ledgers
     assert ledgers[0]["schema_version"] == RUNTIME_FLOW_LEDGER_SCHEMA_VERSION
@@ -157,6 +187,80 @@ async def test_generate_stream_v3_events_finalizes_answer_after_stream():
         ]
         is False
     )
+
+
+@pytest.mark.asyncio
+async def test_generate_stream_v3_events_emits_typed_lifecycle_for_native_path():
+    orchestrator = MagicMock()
+    prepared_turn = SimpleNamespace(
+        request_scope=RequestScope("org-1", "general"),
+        session_id="session-1",
+        validation=SimpleNamespace(blocked=False),
+        chat_context=SimpleNamespace(user_name="Minh"),
+    )
+    orchestrator.prepare_turn = AsyncMock(return_value=prepared_turn)
+    orchestrator.build_multi_agent_execution_input = AsyncMock(
+        return_value=SimpleNamespace(
+            query="short chat",
+            user_id="user-1",
+            session_id="session-1",
+            context={
+                "conversation_history": "",
+                "source_refs": [],
+                "memories": [],
+            },
+            domain_id="general",
+            thinking_effort=None,
+            provider="nvidia",
+            model="qwen/qwen3-next-80b-a3b-instruct",
+        )
+    )
+
+    async def fake_stream_fn(**_kwargs):
+        yield SimpleNamespace(type="answer", content="Xin chào.")
+        yield SimpleNamespace(type="metadata", content={"provider": "nvidia"})
+        yield SimpleNamespace(type="done", content={"processing_time": 0.2})
+
+    chunks = []
+    async for chunk in generate_stream_v3_events(
+        chat_request=_make_request(
+            message="short chat",
+            user_context={"host_context": {"surface": "desktop_chat"}},
+        ),
+        request_headers={"X-Request-ID": "req-lifecycle"},
+        background_save=MagicMock(),
+        start_time=time.time(),
+        orchestrator=orchestrator,
+        stream_fn=fake_stream_fn,
+    ):
+        chunks.append(chunk)
+
+    lifecycle = _lifecycle_payloads(chunks)
+    names = [payload["event_name"] for payload in lifecycle]
+    assert names == [
+        ChatLifecycleName.CHAT_ACCEPTED,
+        ChatLifecycleName.TURN_PREPARED,
+        ChatLifecycleName.PATH_SELECTED,
+        ChatLifecycleName.CAPABILITY_CHECKED,
+        ChatLifecycleName.FINALIZATION_COMPLETED,
+        ChatLifecycleName.CHAT_DONE,
+    ]
+    assert all(
+        payload["schema_version"] == CHAT_RUNTIME_LIFECYCLE_SCHEMA_VERSION
+        for payload in lifecycle
+    )
+    path_payload = lifecycle[2]
+    assert path_payload["lane"] == "native_turn"
+    assert path_payload["reason"] == "multi_agent_stream"
+    capability_payload = lifecycle[3]
+    assert capability_payload["capabilities"]["host_surface"] == "desktop_chat"
+    assert "host_action" in capability_payload["capabilities"]["suppressed_tools"]
+    assert capability_payload["capabilities"]["observed_tools"] == []
+    assert lifecycle[-1]["status"] == "complete"
+
+    lifecycle_json = json.dumps(lifecycle, ensure_ascii=False)
+    assert "short chat" not in lifecycle_json
+    assert "user-1" not in lifecycle_json
 
 
 @pytest.mark.asyncio

--- a/wiii-desktop/src/__tests__/sse.test.ts
+++ b/wiii-desktop/src/__tests__/sse.test.ts
@@ -33,6 +33,7 @@ function createHandlers(): SSEEventHandler & { calls: Record<string, unknown[]> 
     tool_call: [],
     tool_result: [],
     status: [],
+    chat_lifecycle: [],
     visual: [],
     visual_open: [],
     visual_patch: [],
@@ -52,6 +53,7 @@ function createHandlers(): SSEEventHandler & { calls: Record<string, unknown[]> 
     onToolCall: (data) => calls.tool_call.push(data),
     onToolResult: (data) => calls.tool_result.push(data),
     onStatus: (data) => calls.status.push(data),
+    onChatLifecycle: (data) => calls.chat_lifecycle.push(data),
     onVisual: (data) => calls.visual.push(data),
     onVisualOpen: (data) => calls.visual_open.push(data),
     onVisualPatch: (data) => calls.visual_patch.push(data),
@@ -444,6 +446,33 @@ describe("SSE Parser", () => {
       step: "routing",
       node: "supervisor",
     });
+  });
+
+  it("should parse chat lifecycle events without warning as unknown", async () => {
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stream = createStream([
+      'event: chat_lifecycle\ndata: {"schema_version":"wiii.chat_runtime_lifecycle.v1","event_name":"path.selected","phase":"routing","status":"selected","message":"Đã chọn lane runtime chính.","lane":"native_turn","capabilities":{"host_surface":"desktop_chat","suppressed_tools":["host_action"]}}\n\n',
+    ]);
+
+    const handlers = createHandlers();
+    const result = await parseSSEStream(stream, handlers);
+
+    expect(handlers.calls.chat_lifecycle).toHaveLength(1);
+    expect(handlers.calls.chat_lifecycle[0]).toMatchObject({
+      event_name: "path.selected",
+      phase: "routing",
+      lane: "native_turn",
+      capabilities: {
+        host_surface: "desktop_chat",
+        suppressed_tools: ["host_action"],
+      },
+    });
+    expect(result.eventOrder).toEqual(["chat_lifecycle"]);
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("Unknown event type")
+    );
+
+    consoleSpy.mockRestore();
   });
 
   it("should handle tool_call and tool_result in sequence", async () => {

--- a/wiii-desktop/src/api/sse.ts
+++ b/wiii-desktop/src/api/sse.ts
@@ -18,6 +18,7 @@ import type {
   SSEToolCallEvent,
   SSEToolResultEvent,
   SSEStatusEvent,
+  SSEChatLifecycleEvent,
   SSEThinkingStartEvent,
   SSEThinkingEndEvent,
   SSEDomainNoticeEvent,
@@ -47,6 +48,7 @@ export interface SSEEventHandler {
   onToolCall: (data: SSEToolCallEvent) => void;
   onToolResult: (data: SSEToolResultEvent) => void;
   onStatus: (data: SSEStatusEvent) => void;
+  onChatLifecycle?: (data: SSEChatLifecycleEvent) => void;
   onThinkingStart?: (data: SSEThinkingStartEvent) => void;
   onThinkingEnd?: (data: SSEThinkingEndEvent) => void;
   onDomainNotice?: (data: SSEDomainNoticeEvent) => void;
@@ -265,6 +267,9 @@ function dispatchEvent(
     }
     case "status":
       handlers.onStatus(data as SSEStatusEvent);
+      break;
+    case "chat_lifecycle":
+      handlers.onChatLifecycle?.(data as SSEChatLifecycleEvent);
       break;
     case "thinking_delta": {
       // Sprint 153b: Guard — content must be string

--- a/wiii-desktop/src/api/sse.ts
+++ b/wiii-desktop/src/api/sse.ts
@@ -6,7 +6,7 @@
  *   data: <json>\n
  *   \n
  *
- * Event types: thinking, answer, sources, metadata, done, error
+ * Supported event types are defined by SSEEventHandler below.
  */
 import type {
   SSEThinkingEvent,

--- a/wiii-desktop/src/api/types.ts
+++ b/wiii-desktop/src/api/types.ts
@@ -537,6 +537,7 @@ export type SSEEventType =
   | "answer"
   | "sources"
   | "metadata"
+  | "chat_lifecycle"
   | "done"
   | "error"
   | "tool_call"

--- a/wiii-desktop/src/api/types.ts
+++ b/wiii-desktop/src/api/types.ts
@@ -413,6 +413,37 @@ export interface SSEStatusEvent {
   presentation?: PresentationMode;
 }
 
+export interface SSEChatLifecycleEvent {
+  schema_version: string;
+  event_name: string;
+  phase: string;
+  status: string;
+  message: string;
+  request_id?: string;
+  session_id?: string;
+  lane?: string;
+  reason?: string;
+  node?: string;
+  step?: string;
+  capabilities?: {
+    host_surface?: string;
+    host_capabilities?: string[];
+    observed_tools?: string[];
+    suppressed_tools?: string[];
+    preview_required?: boolean;
+    preview_emitted?: boolean;
+    approval_token_present?: boolean;
+    apply_attempted?: boolean;
+  };
+  metadata?: Record<string, unknown>;
+  details?: Record<string, unknown>;
+  display_role?: DisplayRole;
+  sequence_id?: number;
+  step_id?: string;
+  step_state?: StepState;
+  presentation?: PresentationMode;
+}
+
 export interface SSEDomainNoticeEvent {
   content: string;
   display_role?: DisplayRole;


### PR DESCRIPTION
## Summary
Adds an additive typed `chat_lifecycle` SSE contract for `/api/v1/chat/stream/v3` so Wiii can expose live turn state without asking the frontend or harness to infer path/capability state from generic status copy.

Lifecycle events now cover:
- `chat.accepted`
- `turn.prepared`
- `path.selected`
- `capability.checked`
- `finalization.completed` / `finalization.failed`
- `chat.done`
- `chat.error`

## Linked issue
Closes #706

## Scope
- Add backend lifecycle payload contract: `wiii.chat_runtime_lifecycle.v1`.
- Serialize `chat_lifecycle` through the existing SSE presenter.
- Emit lifecycle events from stream coordinator for blocked, visual fast path, Pointy fast path, fallback, native runtime, provider error, and internal error paths.
- Add frontend SSE parser/types support so the new event is not treated as unknown.
- Document the streaming lifecycle observability contract.

## Non-scope
- No provider/model routing change.
- No LMS mutation behavior change.
- No Code Studio timeout or scaffold behavior change.
- No visual/frontend redesign; parser-only frontend change.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_chat_stream_coordinator.py tests/unit/test_chat_stream_presenter.py tests/unit/test_chat_baseline_acceptance_harness.py tests/unit/test_chat_request_flow.py -q --tb=short` -> 70 passed
- `cd maritime-ai-service; python -m ruff check app/services/chat_runtime_lifecycle.py app/services/chat_stream_coordinator.py app/api/v1/chat_stream_presenter.py app/engine/multi_agent/stream_utils.py tests/unit/test_chat_stream_coordinator.py` -> passed
- `cd wiii-desktop; npx vitest run src/__tests__/sse.test.ts --pool forks --maxWorkers=1` -> 33 passed
- `cd wiii-desktop; npx tsc --noEmit` -> passed
- `git diff --cached --check` -> passed

## Risk
Streaming contracts are high-risk because the desktop chat UI depends on SSE ordering and event parsing. This change is additive: existing `status`, `thinking`, `answer`, `metadata`, `done`, and `error` events remain supported, and clients that ignore `chat_lifecycle` should continue to work.

Lifecycle payloads are privacy-safe and do not include prompt text, uploaded document body, raw user identifiers, secrets, or provider tokens.

## Rollback
Revert this PR. The previous SSE V3 status/thinking/metadata/done flow remains the fallback behavior.

## Reviewer focus
- Confirm `chat_lifecycle` payloads are additive and privacy-safe.
- Confirm event ordering does not break existing stream finalization.
- Confirm frontend parser treats the new event as known without requiring UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat sessions now emit lifecycle events for real-time progress monitoring. New events capture key runtime stages including chat acceptance, turn preparation, routing decisions, capability validation, and finalization outcomes. Lifecycle events are observational-only, designed to be privacy-safe, and maintain full backward compatibility with clients that do not yet support them.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->