### PR TITLE
test(desktop): assert chat lifecycle in baseline harness

### DIFF
--- a/wiii-desktop/playwright/chat-baseline-acceptance.spec.ts
+++ b/wiii-desktop/playwright/chat-baseline-acceptance.spec.ts
@@ -160,6 +160,85 @@ function terminalLedgerFrom(stream: ObservedChatBaselineStream): Record<string, 
   return ledger && typeof ledger === "object" ? ledger as Record<string, unknown> : undefined;
 }
 
+function chatLifecycleEventsFromStream(
+  stream: ObservedChatBaselineStream,
+): Record<string, unknown>[] {
+  return stream.events
+    .filter((event) => event.type === "chat_lifecycle")
+    .map((event) => asRecord(event.data));
+}
+
+function chatLifecycleEventsFromMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown>[] {
+  const lifecycle = metadata?.chat_lifecycle;
+  expect(Array.isArray(lifecycle)).toBe(true);
+  return (lifecycle as unknown[]).map((event) => asRecord(event));
+}
+
+function expectOptionalArrayValue(
+  record: Record<string, unknown>,
+  key: string,
+): unknown[] {
+  const value = record[key];
+  if (typeof value === "undefined") return [];
+  expect(Array.isArray(value)).toBe(true);
+  return value as unknown[];
+}
+
+function expectChatLifecycleTelemetry(
+  events: Record<string, unknown>[],
+  scenario: ChatBaselineScenario,
+) {
+  expect(events.map((event) => event.event_name)).toEqual([
+    "path.selected",
+    "capability.checked",
+    "finalization.completed",
+    "chat.done",
+  ]);
+
+  const pathSelected = events[0];
+  expect(pathSelected.schema_version).toBe("wiii.chat_runtime_lifecycle.v1");
+  expect(pathSelected.phase).toBe("routing");
+  expect(pathSelected.status).toBe("selected");
+  expect(pathSelected.lane).toBe("native_turn");
+
+  const capabilities = nestedRecord(pathSelected, "capabilities");
+  expect(capabilities.host_surface).toBe("desktop_chat");
+  expect(expectOptionalArrayValue(capabilities, "observed_tools")).toEqual([]);
+  expect(expectOptionalArrayValue(capabilities, "suppressed_tools")).toEqual(
+    expect.arrayContaining([
+      "host_action",
+      "pointy_action",
+      "visual_runtime",
+      "code_studio",
+    ]),
+  );
+  expect(capabilities.preview_required).toBe(false);
+  expect(capabilities.preview_emitted).toBe(false);
+  expect(capabilities.approval_token_present).toBe(false);
+  expect(capabilities.apply_attempted).toBe(false);
+
+  const metadata = nestedRecord(pathSelected, "metadata");
+  expect(metadata.model).toBe("browser-chat-baseline-mock");
+  expect(metadata.turn_path).toBe(scenario.expectedTurnPath);
+  expect(metadata.runtime_authoritative).toBe(true);
+
+  const capabilityChecked = events[1];
+  expect(capabilityChecked.phase).toBe("capability");
+  expect(capabilityChecked.status).toBe("allowed");
+  const finalization = events[2];
+  expect(finalization.phase).toBe("finalization");
+  expect(finalization.status).toBe("completed");
+  const terminal = events[3];
+  expect(terminal.phase).toBe("terminal");
+  expect(terminal.status).toBe("completed");
+
+  const serialized = JSON.stringify(events);
+  expect(serialized).not.toContain("raw_payload");
+  expect(serialized).not.toContain('"function_call"');
+}
+
 async function latestPersistedAssistant(
   page: Page,
   userId: string,
@@ -208,11 +287,20 @@ test.describe("browser chat-baseline acceptance", () => {
       expect(observedStream.status).toBe(200);
 
       const observedEvents = eventTypes(observedStream);
-      expect(observedEvents).toEqual(expect.arrayContaining(["status", "answer", "metadata", "done"]));
+      expect(observedEvents).toEqual(expect.arrayContaining([
+        "chat_lifecycle",
+        "status",
+        "answer",
+        "metadata",
+        "done",
+      ]));
+      expect(observedEvents.filter((eventType) => eventType === "chat_lifecycle")).toHaveLength(4);
+      expect(observedEvents.indexOf("chat_lifecycle")).toBeLessThan(observedEvents.indexOf("answer"));
       expect(observedEvents[observedEvents.length - 1]).toBe("done");
       for (const eventType of DISALLOWED_BASELINE_EVENTS) {
         expect(observedEvents).not.toContain(eventType);
       }
+      expectChatLifecycleTelemetry(chatLifecycleEventsFromStream(observedStream), scenario);
 
       const assistant = lastAssistantMessage(page);
       await expect(assistant).toContainText(scenario.expectedText, { timeout: 30_000 });
@@ -237,6 +325,10 @@ test.describe("browser chat-baseline acceptance", () => {
       expect(persistedTurnPath.bind_tools).toBe(false);
       expect(persistedTurnPath.force_tools).toBe(false);
       expectSafeLedger(asRecord(persisted.metadata?.runtime_flow_ledger), scenario);
+      expectChatLifecycleTelemetry(
+        chatLifecycleEventsFromMetadata(persisted.metadata),
+        scenario,
+      );
     }
   });
 });

--- a/wiii-desktop/playwright/support/local-chat-harness.ts
+++ b/wiii-desktop/playwright/support/local-chat-harness.ts
@@ -248,6 +248,85 @@ function createChatBaselineLedger(
   };
 }
 
+function createChatLifecycleEvent(
+  eventName: string,
+  phase: string,
+  status: string,
+  message: string,
+  request: Record<string, unknown>,
+  scenario: ChatBaselineScenario,
+): Record<string, unknown> {
+  return {
+    schema_version: "wiii.chat_runtime_lifecycle.v1",
+    event_name: eventName,
+    phase,
+    status,
+    message,
+    request_id: "browser-chat-baseline",
+    session_id: typeof request.session_id === "string" ? request.session_id : "browser-session",
+    lane: "native_turn",
+    reason: "browser_chat_baseline_acceptance",
+    node: "browser_harness",
+    capabilities: {
+      host_surface: "desktop_chat",
+      host_capabilities: [],
+      observed_tools: [],
+      suppressed_tools: CHAT_BASELINE_SUPPRESSED_TOOLS,
+      preview_required: false,
+      preview_emitted: false,
+      approval_token_present: false,
+      apply_attempted: false,
+    },
+    metadata: {
+      provider: "browser-harness",
+      model: "browser-chat-baseline-mock",
+      bound_tools: [],
+      turn_path: scenario.expectedTurnPath,
+      runtime_authoritative: true,
+    },
+  };
+}
+
+function createChatBaselineLifecycleEvents(
+  request: Record<string, unknown>,
+  scenario: ChatBaselineScenario,
+): Array<Record<string, unknown>> {
+  return [
+    createChatLifecycleEvent(
+      "path.selected",
+      "routing",
+      "selected",
+      "Browser baseline selected ordinary chat lane.",
+      request,
+      scenario,
+    ),
+    createChatLifecycleEvent(
+      "capability.checked",
+      "capability",
+      "allowed",
+      "Browser baseline suppressed tool-capable surfaces.",
+      request,
+      scenario,
+    ),
+    createChatLifecycleEvent(
+      "finalization.completed",
+      "finalization",
+      "completed",
+      "Browser baseline assistant message finalized.",
+      request,
+      scenario,
+    ),
+    createChatLifecycleEvent(
+      "chat.done",
+      "terminal",
+      "completed",
+      "Browser baseline stream completed.",
+      request,
+      scenario,
+    ),
+  ];
+}
+
 function parseChatRequestBody(raw: string | null): Record<string, unknown> {
   if (!raw) return {};
   try {
@@ -376,7 +455,9 @@ export async function installChatBaselineStreamMock(
       return;
     }
 
+    const lifecycleEvents = createChatBaselineLifecycleEvents(request, scenario);
     const eventTypes = [
+      ...lifecycleEvents.map(() => "chat_lifecycle"),
       "status",
       ...scenario.answerChunks.map(() => "answer"),
       "metadata",
@@ -390,6 +471,10 @@ export async function installChatBaselineStreamMock(
     );
     const terminalLedger = createChatBaselineLedger(request, scenario, eventTypes, "saved");
     const sseEvents: Array<{ type: string; data: Record<string, unknown> }> = [
+      ...lifecycleEvents.map((data) => ({
+        type: "chat_lifecycle",
+        data,
+      })),
       {
         type: "status",
         data: {


### PR DESCRIPTION
Closes #710

## Summary
- Extend the deterministic browser chat baseline mock to emit typed chat_lifecycle SSE events.
- Assert lifecycle path, capability, finalization, and terminal events in observed browser SSE streams.
- Assert persisted assistant metadata retains sanitized chat_lifecycle telemetry after finalization.

## Scope
- Playwright chat-baseline harness only.
- No live provider calls; stream remains deterministic and mocked.
- No LMS/host action/Pointy mutations.

## Non-scope
- No backend runtime behavior changes.
- No UI redesign.
- No provider/model policy changes.

## Verification
- cd wiii-desktop; npx tsc --noEmit -> passed
- cd wiii-desktop; npx playwright test -c playwright.visual.config.ts playwright/chat-baseline-acceptance.spec.ts -> 1 passed
- git diff --check -> passed

## Risk
Low. The change is limited to the local Playwright baseline harness, but it intentionally guards a high-risk contract: SSE lifecycle telemetry and persisted chat metadata.

## Rollback
Revert this PR. The app runtime remains unchanged; only the stricter browser acceptance assertions are removed.