### PR TITLE
fix(backend): keep direct prose off broad tool path

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/tool_collection.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_collection.py
@@ -146,6 +146,17 @@ def _looks_reasoning_safety_meta_turn(query: str) -> bool:
         return False
 
 
+def _looks_wiii_pipeline_meta_turn(query: str) -> bool:
+    try:
+        normalized = _normalize_for_intent(query)
+        return _load_attr(
+            "app.engine.multi_agent.supervisor_runtime_support",
+            "_looks_wiii_pipeline_meta_turn",
+        )(normalized)
+    except Exception:
+        return False
+
+
 def _infer_direct_thinking_mode(
     query: str,
     state: Optional[AgentState] = None,
@@ -559,6 +570,7 @@ def _resolve_direct_turn_path_decision(
         host_ui_navigation=host_ui_navigation,
         looks_document_preview=_looks_like_document_preview_request(query, state),
         looks_reasoning_safety_meta=_looks_reasoning_safety_meta_turn(query),
+        looks_wiii_pipeline_meta=_looks_wiii_pipeline_meta_turn(query),
         needs_weather_lookup=_safe_intent_flag(_needs_weather_lookup, query),
         needs_web_search=_safe_intent_flag(_needs_web_search, query),
         needs_datetime=_safe_intent_flag(_needs_datetime, query),
@@ -657,6 +669,8 @@ def _should_use_no_tools_for_direct_prose(
 ) -> bool:
     """Keep plain prose direct turns off the heavy tool-schema path."""
     if _looks_reasoning_safety_meta_turn(query):
+        return True
+    if _looks_wiii_pipeline_meta_turn(query):
         return True
     if force_tools:
         return False

--- a/maritime-ai-service/app/engine/multi_agent/tool_collection.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_collection.py
@@ -39,6 +39,18 @@ from app.engine.tools.tool_capability_registry import (
 
 logger = logging.getLogger(__name__)
 
+_CHARACTER_MEMORY_FACT_MARKERS: tuple[str, ...] = (
+    "goi toi la",
+    "goi minh la",
+    "minh ten la",
+    "my name is",
+    "ten cua minh la",
+    "ten cua toi la",
+    "ten minh la",
+    "ten toi la",
+    "toi ten la",
+)
+
 
 def _load_attr(module_name: str, attr_name: str):
     """Load a helper lazily to reduce static tool-collection coupling."""
@@ -153,6 +165,25 @@ def _looks_wiii_pipeline_meta_turn(query: str) -> bool:
             "app.engine.multi_agent.supervisor_runtime_support",
             "_looks_wiii_pipeline_meta_turn",
         )(normalized)
+    except Exception:
+        return False
+
+
+def _looks_character_memory_tool_turn(query: str) -> bool:
+    try:
+        normalized = _normalize_for_intent(query)
+    except Exception:
+        normalized = str(query or "").lower().strip()
+    if not normalized:
+        return False
+    if any(marker in normalized for marker in _CHARACTER_MEMORY_FACT_MARKERS):
+        return True
+    try:
+        support = "app.engine.multi_agent.supervisor_runtime_support"
+        return bool(
+            _load_attr(support, "_looks_memory_write_turn")(normalized)
+            or _load_attr(support, "_looks_session_memory_write_turn")(normalized)
+        )
     except Exception:
         return False
 
@@ -581,6 +612,7 @@ def _resolve_direct_turn_path_decision(
             _needs_direct_knowledge_search,
             query,
         ),
+        needs_character_memory_tool=_looks_character_memory_tool_turn(query),
         needs_analysis_tool=_safe_intent_flag(_needs_analysis_tool, query),
         prefers_code_execution_lane=_prefers_code_execution_lane_from_normalized(
             normalized_query
@@ -673,6 +705,8 @@ def _should_use_no_tools_for_direct_prose(
     if _looks_wiii_pipeline_meta_turn(query):
         return True
     if force_tools:
+        return False
+    if _looks_character_memory_tool_turn(query):
         return False
     if _routing_intent(state) not in {
         "general",

--- a/maritime-ai-service/app/engine/multi_agent/turn_path_governor.py
+++ b/maritime-ai-service/app/engine/multi_agent/turn_path_governor.py
@@ -9,6 +9,7 @@ capability exposure in the same block.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 from typing import Any, Callable, Literal
 
 from app.engine.multi_agent.social_followup_policy import (
@@ -57,6 +58,7 @@ class TurnPathSignals:
     host_ui_navigation: bool = False
     looks_document_preview: bool = False
     looks_reasoning_safety_meta: bool = False
+    looks_wiii_pipeline_meta: bool = False
     needs_weather_lookup: bool = False
     needs_web_search: bool = False
     needs_datetime: bool = False
@@ -150,6 +152,15 @@ def resolve_turn_path_decision(signals: TurnPathSignals) -> TurnPathDecision:
             allow_agent_handoff=False,
         )
 
+    if signals.looks_wiii_pipeline_meta:
+        return TurnPathDecision(
+            path="direct_prose",
+            reason="wiii_pipeline_meta_no_tool",
+            bind_tools=False,
+            allow_all_tools=False,
+            allow_agent_handoff=False,
+        )
+
     if signals.looks_document_preview:
         return TurnPathDecision(
             path="lms_document_preview",
@@ -174,6 +185,17 @@ def resolve_turn_path_decision(signals: TurnPathSignals) -> TurnPathDecision:
         return TurnPathDecision(
             path="casual_chat",
             reason="plain_casual_chat",
+            bind_tools=False,
+            allow_all_tools=False,
+            allow_agent_handoff=False,
+        )
+
+    if not _has_tool_or_output_signal(signals) and _looks_low_signal_noise(
+        signals.normalized_query
+    ):
+        return TurnPathDecision(
+            path="direct_prose",
+            reason="low_signal_noise_no_tool",
             bind_tools=False,
             allow_all_tools=False,
             allow_agent_handoff=False,
@@ -312,7 +334,10 @@ def resolve_turn_path_decision(signals: TurnPathSignals) -> TurnPathDecision:
 
     return TurnPathDecision(
         path="direct_prose",
-        reason="default_direct_prose",
+        reason="default_direct_prose_no_tool",
+        bind_tools=False,
+        allow_all_tools=False,
+        allow_agent_handoff=False,
         allow_rag_delegation=False,
     )
 
@@ -388,6 +413,27 @@ def _looks_casual_chat(signals: TurnPathSignals) -> bool:
     return normalized.startswith(greeting_prefixes) and not any(
         cue in normalized for cue in action_cues
     )
+
+
+def _looks_low_signal_noise(normalized_query: str) -> bool:
+    """Detect repeated paste/key noise so it stays off broad tool binding."""
+    normalized = str(normalized_query or "").strip()
+    if not normalized:
+        return False
+
+    compact = re.sub(r"\s+", "", normalized)
+    if len(compact) < 48:
+        return False
+
+    if re.search(r"([a-z0-9])\1{31,}", compact):
+        return True
+
+    tokens = [token for token in normalized.split() if token]
+    if any(len(token) >= 48 and len(set(token)) <= 4 for token in tokens):
+        return True
+
+    alnum = [char for char in compact if char.isalnum()]
+    return len(alnum) >= 160 and (len(set(alnum)) / len(alnum)) <= 0.08
 
 
 def _has_tool_or_output_signal(signals: TurnPathSignals) -> bool:

--- a/maritime-ai-service/app/engine/multi_agent/turn_path_governor.py
+++ b/maritime-ai-service/app/engine/multi_agent/turn_path_governor.py
@@ -43,6 +43,13 @@ TurnPathName = Literal[
 
 POINTY_TOOL_PREFIXES: tuple[str, ...] = (POINTY_TOOL_PREFIX,)
 HOST_ACTION_TOOL_PREFIXES: tuple[str, ...] = (HOST_ACTION_PREFIX,)
+CHARACTER_MEMORY_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "tool_character_note",
+        "tool_character_read",
+        "tool_character_log_experience",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,6 +73,7 @@ class TurnPathSignals:
     needs_legal_search: bool = False
     needs_lms_query: bool = False
     needs_direct_knowledge_search: bool = False
+    needs_character_memory_tool: bool = False
     needs_analysis_tool: bool = False
     prefers_code_execution_lane: bool = False
     needs_maritime_search: bool = False
@@ -263,6 +271,15 @@ def resolve_turn_path_decision(signals: TurnPathSignals) -> TurnPathDecision:
             allow_agent_handoff=False,
         )
 
+    if signals.needs_character_memory_tool:
+        return TurnPathDecision(
+            path="direct_prose",
+            reason="character_memory_tool_request",
+            allow_all_tools=False,
+            allowed_tool_names=CHARACTER_MEMORY_TOOL_NAMES,
+            allow_agent_handoff=False,
+        )
+
     if signals.prefers_code_execution_lane:
         return TurnPathDecision(
             path="code_execution",
@@ -451,6 +468,7 @@ def _has_tool_or_output_signal(signals: TurnPathSignals) -> bool:
             signals.needs_legal_search,
             signals.needs_lms_query,
             signals.needs_direct_knowledge_search,
+            signals.needs_character_memory_tool,
             signals.needs_analysis_tool,
             signals.prefers_code_execution_lane,
             signals.needs_maritime_search,

--- a/maritime-ai-service/tests/unit/test_sprint97_living_character.py
+++ b/maritime-ai-service/tests/unit/test_sprint97_living_character.py
@@ -260,8 +260,8 @@ class TestDirectNodeCharacterTools:
     """Sprint 97: Character tools bound and dispatched in direct node."""
 
     @pytest.mark.asyncio
-    async def test_tools_bound_when_enabled(self):
-        """bind_tools should be called when enable_character_tools=True."""
+    async def test_plain_direct_prose_does_not_bind_character_tools_when_enabled(self):
+        """Plain direct prose should stay off tools even when character tools are enabled."""
         from app.engine.multi_agent.state import AgentState
 
         state: AgentState = {
@@ -309,21 +309,12 @@ class TestDirectNodeCharacterTools:
             from app.engine.multi_agent.graph import direct_response_node
             await direct_response_node(state)
 
-            mock_llm.bind_tools.assert_called_once()
-            bound_tools = mock_llm.bind_tools.call_args[0][0]
-            assert len(bound_tools) >= 9
-            bound_names = {getattr(tool, "name", "") for tool in bound_tools}
-            assert "tool_character_note" in bound_names
-            assert "tool_character_log_experience" in bound_names
-            names = [t.name for t in bound_tools]
-            assert "tool_character_note" in names
-            assert "tool_current_datetime" in names
-            assert "tool_web_search" in names
-            assert "tool_search_maritime" not in names
+            mock_llm.bind_tools.assert_not_called()
+            assert state["_turn_path_decision"]["reason"] == "default_direct_prose_no_tool"
 
     @pytest.mark.asyncio
     async def test_no_character_tools_when_disabled(self):
-        """When enable_character_tools=False, only web_search tool should be bound."""
+        """Plain direct prose stays no-tool when character tools are disabled."""
         from app.engine.multi_agent.state import AgentState
 
         state: AgentState = {
@@ -369,13 +360,8 @@ class TestDirectNodeCharacterTools:
             from app.engine.multi_agent.graph import direct_response_node
             await direct_response_node(state)
 
-            # Utility tools always bound even without character tools
-            mock_llm.bind_tools.assert_called_once()
-            bound_tools = mock_llm.bind_tools.call_args[0][0]
-            names = [t.name for t in bound_tools]
-            assert "tool_current_datetime" in names
-            assert "tool_web_search" in names
-            assert "tool_character_note" not in names
+            mock_llm.bind_tools.assert_not_called()
+            assert state["_turn_path_decision"]["reason"] == "default_direct_prose_no_tool"
 
     @pytest.mark.asyncio
     async def test_tool_dispatch_works(self):

--- a/maritime-ai-service/tests/unit/test_sprint99_forced_tool_calling.py
+++ b/maritime-ai-service/tests/unit/test_sprint99_forced_tool_calling.py
@@ -310,6 +310,62 @@ class TestForcedToolChoice:
             mock_llm.bind_tools.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_plain_meta_complaint_does_not_bind_tools(self):
+        """No-tool direct prose must not expose broad tools to the model."""
+        from app.engine.multi_agent.state import AgentState
+
+        mock_llm = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = "Mình sẽ kiểm tra luồng trực tiếp."
+        mock_response.tool_calls = []
+        mock_llm.bind_tools.return_value = mock_llm
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+
+        state: AgentState = {
+            "query": "flow noi chuyen thuong van bi keo sang search/tool",
+            "context": {"is_follow_up": False},
+            "current_agent": "",
+            "final_response": "",
+            "agent_outputs": {},
+        }
+
+        with patched_direct_node_runtime(
+                "Mình sẽ kiểm tra luồng trực tiếp.",
+                mock_llm=mock_llm,
+                patch_bind=False,
+                collect_tools=None,
+             ), \
+             patch("app.prompts.prompt_loader.get_prompt_loader") as mock_pl, \
+             patch("app.engine.multi_agent.graph.settings") as mock_settings, \
+             patch("app.engine.multi_agent.graph._get_or_create_tracer") as mock_tracer_fn, \
+             patch("app.engine.multi_agent.graph._get_domain_greetings", return_value={}):
+
+            mock_settings.app_name = "Wiii"
+            mock_settings.default_domain = "maritime"
+            mock_settings.enable_character_tools = False
+            mock_settings.enable_code_execution = False
+
+            mock_loader = MagicMock()
+            mock_loader.get_identity.return_value = {
+                "identity": {
+                    "voice": {"emoji_usage": "emoji"},
+                    "personality": {"summary": "nice"},
+                    "response_style": {"avoid": []},
+                }
+            }
+            mock_loader.build_system_prompt.return_value = "Bạn là Wiii, trợ lý đa lĩnh vực."
+            mock_pl.return_value = mock_loader
+
+            mock_tracer = MagicMock()
+            mock_tracer_fn.return_value = mock_tracer
+
+            from app.engine.multi_agent.graph import direct_response_node
+            await direct_response_node(state)
+
+            mock_llm.bind_tools.assert_not_called()
+            assert state["_turn_path_decision"]["reason"] == "default_direct_prose_no_tool"
+
+    @pytest.mark.asyncio
     async def test_datetime_query_forces_tool_choice(self):
         """When query asks for time/date, bind_tools gets tool_choice='any'."""
         from app.engine.multi_agent.state import AgentState

--- a/maritime-ai-service/tests/unit/test_turn_path_governor.py
+++ b/maritime-ai-service/tests/unit/test_turn_path_governor.py
@@ -111,6 +111,28 @@ def test_turn_path_governor_marks_wiii_pipeline_meta_as_no_tool_direct_prose():
     assert decision.bind_tools is False
 
 
+def test_turn_path_governor_scopes_character_memory_tools():
+    from app.engine.multi_agent.turn_path_governor import (
+        TurnPathSignals,
+        resolve_turn_path_decision,
+    )
+
+    decision = resolve_turn_path_decision(
+        TurnPathSignals(
+            normalized_query="ten toi la an",
+            needs_character_memory_tool=True,
+        )
+    )
+
+    assert decision.path == "direct_prose"
+    assert decision.reason == "character_memory_tool_request"
+    assert decision.bind_tools is True
+    assert decision.force_tools is False
+    assert decision.allow_all_tools is False
+    assert decision.should_keep_tool_name("tool_character_note") is True
+    assert decision.should_keep_tool_name("tool_web_search") is False
+
+
 def test_turn_path_governor_narrows_visual_app_to_required_tool():
     from app.engine.multi_agent.turn_path_governor import (
         TurnPathSignals,
@@ -298,6 +320,24 @@ def test_collect_direct_tools_keeps_explicit_web_search_path():
     assert state["_turn_path_decision"]["path"] == "web_search"
     assert "tool_web_search" in names
     assert "tool_current_weather" not in names
+
+
+def test_collect_direct_tools_scopes_personal_fact_to_character_tools():
+    from app.engine.multi_agent import tool_collection as module
+
+    state = {"context": {}}
+    tools, force_tools = module._collect_direct_tools(
+        "Ten toi la An",
+        user_role="student",
+        state=state,
+    )
+    names = {getattr(tool, "name", getattr(tool, "__name__", "")) for tool in tools}
+
+    assert force_tools is False
+    assert state["_turn_path_decision"]["reason"] == "character_memory_tool_request"
+    assert "tool_character_note" in names
+    assert "tool_character_log_experience" in names
+    assert "tool_web_search" not in names
 
 
 def test_collect_direct_tools_routes_weather_followup_to_weather_tool():

--- a/maritime-ai-service/tests/unit/test_turn_path_governor.py
+++ b/maritime-ai-service/tests/unit/test_turn_path_governor.py
@@ -46,11 +46,69 @@ def test_turn_path_governor_does_not_treat_task_query_as_social_followup():
     )
 
     decision = resolve_turn_path_decision(
-        TurnPathSignals(normalized_query="sao lai colreg rule 15 ap dung")
+        TurnPathSignals(
+            normalized_query="sao lai colreg rule 15 ap dung",
+            needs_maritime_search=True,
+        )
+    )
+
+    assert decision.path == "maritime_search"
+    assert decision.bind_tools is True
+    assert decision.force_tools is True
+
+
+def test_turn_path_governor_defaults_plain_direct_prose_to_no_tool():
+    from app.engine.multi_agent.turn_path_governor import (
+        TurnPathSignals,
+        resolve_turn_path_decision,
+    )
+
+    decision = resolve_turn_path_decision(
+        TurnPathSignals(normalized_query="giai thich ngan ve cach hoc tot hon")
     )
 
     assert decision.path == "direct_prose"
-    assert decision.bind_tools is True
+    assert decision.reason == "default_direct_prose_no_tool"
+    assert decision.bind_tools is False
+    assert decision.allow_agent_handoff is False
+
+
+def test_turn_path_governor_keeps_low_signal_noise_off_tool_path():
+    from app.engine.multi_agent.turn_path_governor import (
+        TurnPathSignals,
+        resolve_turn_path_decision,
+    )
+
+    decision = resolve_turn_path_decision(
+        TurnPathSignals(
+            normalized_query=(
+                "flow noi chuyen thuong van bi keo sang search tool "
+                + ("r" * 128)
+            )
+        )
+    )
+
+    assert decision.path == "direct_prose"
+    assert decision.reason == "low_signal_noise_no_tool"
+    assert decision.bind_tools is False
+
+
+def test_turn_path_governor_marks_wiii_pipeline_meta_as_no_tool_direct_prose():
+    from app.engine.multi_agent.turn_path_governor import (
+        TurnPathSignals,
+        resolve_turn_path_decision,
+    )
+
+    decision = resolve_turn_path_decision(
+        TurnPathSignals(
+            normalized_query="wiii flow noi chuyen sai route, kiem tra pipeline",
+            looks_wiii_pipeline_meta=True,
+        )
+    )
+
+    assert decision.path == "direct_prose"
+    assert decision.reason == "wiii_pipeline_meta_no_tool"
+    assert decision.bind_tools is False
 
 
 def test_turn_path_governor_narrows_visual_app_to_required_tool():
@@ -182,6 +240,64 @@ def test_collect_direct_tools_keeps_short_social_followup_off_tool_path():
     assert tools == []
     assert force_tools is False
     assert state["_turn_path_decision"]["path"] == "casual_chat"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "flow noi chuyen thuong van bi keo sang search/tool",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "sao lai z " + ("R" * 256),
+    ],
+)
+def test_collect_direct_tools_keeps_plain_meta_and_noise_off_tool_path(query):
+    from app.engine.multi_agent import tool_collection as module
+
+    state = {"context": {}}
+    tools, force_tools = module._collect_direct_tools(
+        query,
+        user_role="student",
+        state=state,
+    )
+
+    assert tools == []
+    assert force_tools is False
+    assert state["_turn_path_decision"]["path"] == "direct_prose"
+    assert state["_turn_path_decision"]["bind_tools"] is False
+    assert state["_tool_policy_session"]["visible_tool_names"] == []
+
+
+def test_collect_direct_tools_marks_wiii_pipeline_meta_as_no_tool():
+    from app.engine.multi_agent import tool_collection as module
+
+    state = {"context": {}}
+    tools, force_tools = module._collect_direct_tools(
+        "Wiii flow noi chuyen bi sai route, kiem tra pipeline tool policy.",
+        user_role="student",
+        state=state,
+    )
+
+    assert tools == []
+    assert force_tools is False
+    assert state["_turn_path_decision"]["path"] == "direct_prose"
+    assert state["_turn_path_decision"]["reason"] == "wiii_pipeline_meta_no_tool"
+
+
+def test_collect_direct_tools_keeps_explicit_web_search_path():
+    from app.engine.multi_agent import tool_collection as module
+
+    state = {"context": {}}
+    tools, force_tools = module._collect_direct_tools(
+        "hom nay co gi hot?",
+        user_role="student",
+        state=state,
+    )
+    names = {getattr(tool, "name", getattr(tool, "__name__", "")) for tool in tools}
+
+    assert force_tools is True
+    assert state["_turn_path_decision"]["path"] == "web_search"
+    assert "tool_web_search" in names
+    assert "tool_current_weather" not in names
 
 
 def test_collect_direct_tools_routes_weather_followup_to_weather_tool():


### PR DESCRIPTION
## Summary
- Fixes #714.
- Makes no-signal `direct_prose` fail closed with `bind_tools=false` instead of exposing the broad direct tool bundle.
- Adds explicit no-tool handling for Wiii pipeline/meta turns and low-signal repeated input noise.
- Adds a narrow character-memory exception so personal fact/memory-write turns can expose only character memory tools, not the broad utility/web/LMS bundle.
- Keeps explicit weather, web search, LMS/host, visual/code, datetime, maritime, and knowledge lanes ahead of the no-tool default.

## Scope
- Backend turn path governor and direct tool collection policy.
- Regression tests for no-tool direct prose, noisy input, Wiii pipeline meta complaints, scoped character-memory tools, and runtime `bind_tools` avoidance.

## Non-Scope
- Frontend UI changes.
- Provider/model selection changes.
- LMS preview/apply contract changes.
- Deployment or Docker changes.

## Verification
- `cd maritime-ai-service`
- `python -m pytest tests/unit/test_turn_path_governor.py tests/unit/test_tool_collection_host_ui.py tests/unit/test_sprint99_forced_tool_calling.py tests/unit/test_direct_node_llm_tool_loop.py tests/unit/test_tool_collection_analytical.py tests/unit/test_direct_node_tool_selection.py tests/unit/test_sprint97_living_character.py -q --tb=short` -> 115 passed in 4.23s
- `python -m ruff check app/ tests/unit/ --select=E9,F63,F7` -> All checks passed
- `git diff --check` -> passed

Additional local attempts:
- `python -m pytest tests/unit/ -p no:capture --tb=short -q` -> timed out after 304s before the sprint97 CI failure was known.
- `python -m pytest tests/unit/ -x -p no:capture --tb=short -q` -> local Python 3.13/env stopped at `test_agent_tier_config.py::TestDefaultTierMapping::test_code_studio_is_deep` (`moderate` vs `deep`); the prior GitHub run had already passed this point and failed later at sprint97, which is addressed in this PR update.

## Risk
- Medium: this changes the default direct prose tool exposure policy in the active chat path.
- Tool-bearing lanes remain explicit and tested: weather, web search, LMS preview, host UI, visual generation, datetime, maritime, knowledge search, and scoped character-memory tools are not downgraded by the no-tool default.
- This should reduce unintended tool calls for ordinary chat and noisy/meta turns.

## Rollback
- Revert this PR to restore the previous `default_direct_prose` behavior that exposed the broad direct tool bundle and agent handoff by default.

## Reviewer Focus
- Confirm the default no-tool policy is acceptable for ordinary direct prose.
- Confirm explicit tool lanes still bind the intended capabilities before no-tool fallback.
- Confirm Wiii pipeline/meta detection and character-memory scoping do not weaken LMS/host approval constraints.