### PR TITLE
Expose runtime capability dashboard in chat composer

### DIFF
--- a/wiii-desktop/src/__tests__/capability-status-bar.test.tsx
+++ b/wiii-desktop/src/__tests__/capability-status-bar.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { CapabilityStatusBar } from "@/components/chat/CapabilityStatusBar";
+import { useChatStore } from "@/stores/chat-store";
 import { useConnectionStore } from "@/stores/connection-store";
 import { useHostContextStore } from "@/stores/host-context-store";
 
@@ -13,6 +14,10 @@ describe("CapabilityStatusBar", () => {
       lastCheckedAt: null,
       errorMessage: null,
       pollIntervalId: null,
+    });
+    useChatStore.setState({
+      streamingLifecycleEvents: [],
+      lastCompletedLifecycleEvents: [],
     });
   });
 
@@ -42,6 +47,82 @@ describe("CapabilityStatusBar", () => {
     expect(screen.getByText("Maritime LMS")).toBeTruthy();
     expect(screen.getByText("Preview + Apply")).toBeTruthy();
     expect(screen.queryByText("authoring.preview_lesson_patch")).toBeNull();
+  });
+
+  it("opens an integration dashboard without raw tool names", () => {
+    useConnectionStore.setState({
+      serverVersion: "test-version",
+      lastCheckedAt: "2026-05-27T12:00:00.000Z",
+    });
+    useHostContextStore.getState().setCapabilities({
+      host_type: "lms",
+      host_name: "Maritime LMS",
+      connector_id: "maritime-lms-dev",
+      resources: ["current-page"],
+      surfaces: ["desktop-chat"],
+      tools: [
+        {
+          name: "authoring.preview_lesson_patch",
+          description: "Preview lesson",
+          requires_confirmation: true,
+        },
+        {
+          name: "authoring.apply_lesson_patch",
+          description: "Apply lesson",
+          mutates_state: true,
+          requires_confirmation: true,
+        },
+        {
+          name: "ui.highlight",
+          description: "Highlight target",
+        },
+      ],
+    });
+
+    render(<CapabilityStatusBar />);
+
+    fireEvent.click(screen.getByTestId("capability-dashboard-toggle"));
+
+    expect(screen.getByTestId("capability-dashboard-panel")).toBeTruthy();
+    expect(screen.getByText("Dashboard runtime")).toBeTruthy();
+    expect(screen.getByTestId("capability-dashboard-section-server")).toBeTruthy();
+    expect(screen.getByTestId("capability-dashboard-section-host")).toBeTruthy();
+    expect(screen.getByTestId("capability-dashboard-section-lms_authoring")).toBeTruthy();
+    expect(screen.getByText("Qua approval_token")).toBeTruthy();
+    expect(screen.getByText("Preview trước, apply sau")).toBeTruthy();
+    expect(screen.queryByText("authoring.apply_lesson_patch")).toBeNull();
+  });
+
+  it("shows the latest lifecycle path in the dashboard", () => {
+    useChatStore.setState({
+      lastCompletedLifecycleEvents: [
+        {
+          schema_version: "1",
+          event_name: "path.selected",
+          phase: "routing",
+          status: "selected",
+          message: "Selected native turn",
+          lane: "native_turn",
+          capabilities: {
+            host_surface: "desktop_chat",
+            observed_tools: ["memory.lookup"],
+            suppressed_tools: ["host_action"],
+          },
+          received_at_ms: 1779825600000,
+        },
+      ],
+    });
+
+    render(<CapabilityStatusBar />);
+
+    fireEvent.click(screen.getByTestId("capability-dashboard-toggle"));
+
+    expect(screen.getByTestId("capability-dashboard-section-path")).toBeTruthy();
+    expect(screen.getAllByText("native_turn").length).toBeGreaterThan(0);
+    expect(screen.getByText("desktop_chat")).toBeTruthy();
+    expect(screen.getByText("1 tool (Memory)")).toBeTruthy();
+    expect(screen.getByText("1 tool (Host)")).toBeTruthy();
+    expect(screen.queryByText("host_action")).toBeNull();
   });
 
   it("shows disconnected server and missing host action bridge", () => {

--- a/wiii-desktop/src/components/chat/CapabilityStatusBar.tsx
+++ b/wiii-desktop/src/components/chat/CapabilityStatusBar.tsx
@@ -1,16 +1,23 @@
+import type { ChatLifecycleTelemetryEvent } from "@/api/types";
 import {
   Cable,
+  ChevronDown,
   GraduationCap,
   MousePointer2,
+  Route,
   Server,
   Workflow,
 } from "lucide-react";
-import { useMemo } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import {
-  buildCapabilityStatuses,
+  buildCapabilityStatusViewModel,
+  type CapabilityDashboardSection,
   type CapabilityStatusItem,
   type CapabilityStatusTone,
+  type RuntimePathSnapshot,
 } from "@/lib/capability-status";
+import { useChatStore } from "@/stores/chat-store";
 import { useConnectionStore } from "@/stores/connection-store";
 import { useHostContextStore } from "@/stores/host-context-store";
 
@@ -21,6 +28,20 @@ const toneClasses: Record<CapabilityStatusTone, string> = {
   off: "border-[var(--border)] bg-surface-secondary text-text-tertiary",
 };
 
+const dashboardToneClasses: Record<CapabilityStatusTone, string> = {
+  ok: "border-emerald-200 bg-white text-emerald-700 hover:bg-emerald-50",
+  warn: "border-amber-200 bg-white text-amber-800 hover:bg-amber-50",
+  pending: "border-sky-200 bg-white text-sky-700 hover:bg-sky-50",
+  off: "border-[var(--border)] bg-white text-text-tertiary hover:bg-surface-secondary",
+};
+
+const subtleToneClasses: Record<CapabilityStatusTone, string> = {
+  ok: "bg-emerald-500",
+  warn: "bg-amber-500",
+  pending: "bg-sky-500",
+  off: "bg-zinc-400",
+};
+
 const iconById: Record<CapabilityStatusItem["id"], typeof Server> = {
   server: Server,
   host: Cable,
@@ -29,55 +50,315 @@ const iconById: Record<CapabilityStatusItem["id"], typeof Server> = {
   pointy: MousePointer2,
 };
 
+const sectionIconById: Record<CapabilityDashboardSection["id"], typeof Server> = {
+  server: Server,
+  host: Cable,
+  host_actions: Workflow,
+  lms_authoring: GraduationCap,
+  pointy: MousePointer2,
+  path: Route,
+};
+
 interface CapabilityStatusBarProps {
   compact?: boolean;
 }
+
+interface PanelPosition {
+  top: number;
+  left: number;
+  width: number;
+  maxHeight: number;
+}
+
+const DEFAULT_PANEL_POSITION: PanelPosition = {
+  top: 48,
+  left: 12,
+  width: 768,
+  maxHeight: 448,
+};
 
 function isEmbeddedWindow(): boolean {
   if (typeof window === "undefined") return false;
   return window.parent !== window;
 }
 
+function computePanelPosition(anchor: HTMLElement | null): PanelPosition {
+  if (typeof window === "undefined" || !anchor) {
+    return DEFAULT_PANEL_POSITION;
+  }
+  const margin = 12;
+  const gap = 8;
+  const minHeight = 240;
+  const preferredHeight = 448;
+  const preferredWidth = 768;
+  const rect = anchor.getBoundingClientRect();
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const width = Math.min(preferredWidth, Math.max(320, viewportWidth - margin * 2));
+  const left = Math.min(
+    Math.max(rect.left, margin),
+    Math.max(margin, viewportWidth - width - margin),
+  );
+  const spaceBelow = viewportHeight - rect.bottom - margin;
+  const spaceAbove = rect.top - margin;
+  const openBelow = spaceBelow >= minHeight || spaceBelow >= spaceAbove;
+  const availableHeight = Math.max(
+    minHeight,
+    openBelow ? spaceBelow - gap : spaceAbove - gap,
+  );
+  const maxHeight = Math.min(preferredHeight, availableHeight);
+  const top = openBelow
+    ? Math.min(rect.bottom + gap, viewportHeight - maxHeight - margin)
+    : Math.max(margin, rect.top - maxHeight - gap);
+
+  return { top, left, width, maxHeight };
+}
+
+function latestLifecycleEvent(
+  streamingEvents: ChatLifecycleTelemetryEvent[],
+  completedEvents: ChatLifecycleTelemetryEvent[],
+): ChatLifecycleTelemetryEvent | null {
+  const source = streamingEvents.length > 0 ? streamingEvents : completedEvents;
+  for (let index = source.length - 1; index >= 0; index -= 1) {
+    const event = source[index];
+    if (event) return event;
+  }
+  return null;
+}
+
+function runtimePathFromLifecycle(
+  streamingEvents: ChatLifecycleTelemetryEvent[],
+  completedEvents: ChatLifecycleTelemetryEvent[],
+): RuntimePathSnapshot | null {
+  const event = latestLifecycleEvent(streamingEvents, completedEvents);
+  if (!event) return null;
+  return {
+    lane: event.lane,
+    eventName: event.event_name,
+    phase: event.phase,
+    status: event.status,
+    message: event.message,
+    hostSurface: event.capabilities?.host_surface,
+    observedTools: event.capabilities?.observed_tools
+      ? [...event.capabilities.observed_tools]
+      : undefined,
+    suppressedTools: event.capabilities?.suppressed_tools
+      ? [...event.capabilities.suppressed_tools]
+      : undefined,
+    previewRequired: event.capabilities?.preview_required,
+    previewEmitted: event.capabilities?.preview_emitted,
+    approvalTokenPresent: event.capabilities?.approval_token_present,
+    applyAttempted: event.capabilities?.apply_attempted,
+    receivedAtMs: event.received_at_ms,
+  };
+}
+
 export function CapabilityStatusBar({ compact = false }: CapabilityStatusBarProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [panelPosition, setPanelPosition] = useState<PanelPosition>(
+    DEFAULT_PANEL_POSITION,
+  );
+  const toggleRef = useRef<HTMLButtonElement | null>(null);
+  const panelId = useId();
   const connectionStatus = useConnectionStore((state) => state.status);
+  const serverVersion = useConnectionStore((state) => state.serverVersion);
+  const lastCheckedAt = useConnectionStore((state) => state.lastCheckedAt);
+  const errorMessage = useConnectionStore((state) => state.errorMessage);
   const capabilities = useHostContextStore((state) => state.capabilities);
   const currentContext = useHostContextStore((state) => state.currentContext);
+  const streamingLifecycleEvents = useChatStore(
+    (state) => state.streamingLifecycleEvents,
+  );
+  const lastCompletedLifecycleEvents = useChatStore(
+    (state) => state.lastCompletedLifecycleEvents,
+  );
   const isEmbedded = isEmbeddedWindow();
 
-  const items = useMemo(
+  const runtimePath = useMemo(
     () =>
-      buildCapabilityStatuses({
+      runtimePathFromLifecycle(
+        streamingLifecycleEvents,
+        lastCompletedLifecycleEvents,
+      ),
+    [streamingLifecycleEvents, lastCompletedLifecycleEvents],
+  );
+
+  const viewModel = useMemo(
+    () =>
+      buildCapabilityStatusViewModel({
         connectionStatus,
         capabilities,
         currentContext,
         isEmbedded,
+        serverVersion,
+        lastCheckedAt,
+        errorMessage,
+        runtimePath,
       }),
-    [connectionStatus, capabilities, currentContext, isEmbedded],
+    [
+      connectionStatus,
+      capabilities,
+      currentContext,
+      isEmbedded,
+      serverVersion,
+      lastCheckedAt,
+      errorMessage,
+      runtimePath,
+    ],
   );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const updatePosition = () => {
+      setPanelPosition(computePanelPosition(toggleRef.current));
+    };
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [isOpen]);
+
+  const dashboardPanel = isOpen ? (
+    <div
+      id={panelId}
+      role="region"
+      aria-label="Dashboard trạng thái runtime"
+      className="fixed z-[1000] overflow-hidden rounded-lg border border-[var(--border)] bg-white shadow-xl"
+      style={{
+        top: panelPosition.top,
+        left: panelPosition.left,
+        width: panelPosition.width,
+        maxHeight: panelPosition.maxHeight,
+      }}
+      data-testid="capability-dashboard-panel"
+    >
+      <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Route size={15} className="shrink-0 text-text-secondary" aria-hidden="true" />
+          <span className="truncate text-sm font-semibold text-text">
+            Dashboard runtime
+          </span>
+        </div>
+        <span
+          className={`shrink-0 rounded-md border px-2 py-1 text-[11px] ${toneClasses[viewModel.overallTone]}`}
+        >
+          {viewModel.summary}
+        </span>
+      </div>
+
+      <div
+        className="overflow-auto px-3 py-1"
+        style={{ maxHeight: Math.max(160, panelPosition.maxHeight - 45) }}
+      >
+        {viewModel.sections.map((section) => {
+          const Icon = sectionIconById[section.id];
+          return (
+            <section
+              key={section.id}
+              className="border-b border-[var(--border)] py-3 last:border-b-0"
+              data-testid={`capability-dashboard-section-${section.id}`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span
+                    className={`mt-0.5 h-2 w-2 shrink-0 rounded-full ${subtleToneClasses[section.tone]}`}
+                    aria-hidden="true"
+                  />
+                  <Icon size={14} className="shrink-0 text-text-secondary" aria-hidden="true" />
+                  <h3 className="truncate text-xs font-semibold uppercase text-text-secondary">
+                    {section.title}
+                  </h3>
+                </div>
+                <span className="max-w-[45%] truncate text-right text-xs font-medium text-text">
+                  {section.summary}
+                </span>
+              </div>
+
+              <dl className="mt-2 grid gap-2 sm:grid-cols-2">
+                {section.metrics.map((metric, index) => (
+                  <div
+                    key={`${section.id}-${metric.label}-${index}`}
+                    className="min-w-0 rounded-md bg-surface-secondary px-2 py-1.5"
+                  >
+                    <dt className="truncate text-[10px] uppercase tracking-wide text-text-tertiary">
+                      {metric.label}
+                    </dt>
+                    <dd
+                      className={`mt-0.5 truncate text-xs font-medium ${
+                        metric.tone ? toneTextClass(metric.tone) : "text-text"
+                      }`}
+                    >
+                      {metric.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  ) : null;
 
   return (
     <div
-      className={`flex max-w-full items-center gap-1.5 overflow-x-auto ${
-        compact ? "pb-0.5" : "pb-2"
-      }`}
+      className={`relative max-w-full ${compact ? "pb-0.5" : "pb-2"}`}
       aria-label="Trạng thái kết nối Wiii"
       data-testid="capability-status-bar"
     >
-      {items.map((item) => {
-        const Icon = iconById[item.id];
-        return (
-          <span
-            key={item.id}
-            className={`inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border px-2 text-[11px] leading-none ${toneClasses[item.tone]}`}
-            title={item.title}
-            data-testid={`capability-status-${item.id}`}
-          >
-            <Icon size={13} aria-hidden="true" />
-            <span className="font-medium">{item.label}</span>
-            <span className="opacity-80">{item.value}</span>
-          </span>
-        );
-      })}
+      <div className="flex max-w-full items-center gap-1.5 overflow-x-auto">
+        <button
+          ref={toggleRef}
+          type="button"
+          className={`inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border px-2 text-[11px] leading-none transition-colors ${dashboardToneClasses[viewModel.overallTone]}`}
+          aria-expanded={isOpen}
+          aria-controls={panelId}
+          title="Mở dashboard runtime và capability"
+          data-testid="capability-dashboard-toggle"
+          onClick={() => setIsOpen((current) => !current)}
+        >
+          <Route size={13} aria-hidden="true" />
+          <span className="font-medium">Runtime</span>
+          <span className="opacity-80">{viewModel.summary}</span>
+          <ChevronDown
+            size={12}
+            className={`transition-transform ${isOpen ? "rotate-180" : ""}`}
+            aria-hidden="true"
+          />
+        </button>
+
+        {viewModel.items.map((item) => {
+          const Icon = iconById[item.id];
+          return (
+            <span
+              key={item.id}
+              className={`inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border px-2 text-[11px] leading-none ${toneClasses[item.tone]}`}
+              title={item.title}
+              data-testid={`capability-status-${item.id}`}
+            >
+              <Icon size={13} aria-hidden="true" />
+              <span className="font-medium">{item.label}</span>
+              <span className="opacity-80">{item.value}</span>
+            </span>
+          );
+        })}
+      </div>
+
+      {dashboardPanel
+        ? typeof document === "undefined"
+          ? dashboardPanel
+          : createPortal(dashboardPanel, document.body)
+        : null}
     </div>
   );
+}
+
+function toneTextClass(tone: CapabilityStatusTone): string {
+  if (tone === "ok") return "text-emerald-700";
+  if (tone === "warn") return "text-amber-800";
+  if (tone === "pending") return "text-sky-700";
+  return "text-text-tertiary";
 }

--- a/wiii-desktop/src/lib/capability-status.ts
+++ b/wiii-desktop/src/lib/capability-status.ts
@@ -11,12 +11,60 @@ export type RuntimeConnectionStatus =
 
 export type CapabilityStatusTone = "ok" | "warn" | "off" | "pending";
 
+export type CapabilityStatusItemId =
+  | "server"
+  | "host"
+  | "host_actions"
+  | "lms_authoring"
+  | "pointy";
+
 export interface CapabilityStatusItem {
-  id: "server" | "host" | "host_actions" | "lms_authoring" | "pointy";
+  id: CapabilityStatusItemId;
   label: string;
   value: string;
   tone: CapabilityStatusTone;
   title: string;
+}
+
+export interface RuntimePathSnapshot {
+  lane?: string;
+  eventName?: string;
+  phase?: string;
+  status?: string;
+  message?: string;
+  hostSurface?: string;
+  observedTools?: string[];
+  suppressedTools?: string[];
+  previewRequired?: boolean;
+  previewEmitted?: boolean;
+  approvalTokenPresent?: boolean;
+  applyAttempted?: boolean;
+  receivedAtMs?: number;
+}
+
+export interface CapabilityDashboardMetric {
+  label: string;
+  value: string;
+  tone?: CapabilityStatusTone;
+}
+
+export type CapabilityDashboardSectionId =
+  | CapabilityStatusItemId
+  | "path";
+
+export interface CapabilityDashboardSection {
+  id: CapabilityDashboardSectionId;
+  title: string;
+  summary: string;
+  tone: CapabilityStatusTone;
+  metrics: CapabilityDashboardMetric[];
+}
+
+export interface CapabilityStatusViewModel {
+  items: CapabilityStatusItem[];
+  sections: CapabilityDashboardSection[];
+  summary: string;
+  overallTone: CapabilityStatusTone;
 }
 
 interface BuildCapabilityStatusInput {
@@ -24,7 +72,21 @@ interface BuildCapabilityStatusInput {
   capabilities: HostCapabilities | null;
   currentContext: HostContext | null;
   isEmbedded: boolean;
+  serverVersion?: string | null;
+  lastCheckedAt?: string | null;
+  errorMessage?: string | null;
+  runtimePath?: RuntimePathSnapshot | null;
 }
+
+const LMS_PREVIEW_TOOLS = [
+  "authoring.preview_lesson_patch",
+  "authoring.generate_course_from_document",
+];
+
+const LMS_APPLY_TOOLS = [
+  "authoring.apply_lesson_patch",
+  "authoring.apply_course_plan",
+];
 
 function normalizedToolNames(capabilities: HostCapabilities | null): Set<string> {
   const names = new Set<string>();
@@ -44,6 +106,65 @@ function hasToolPrefix(names: Set<string>, prefix: string): boolean {
     if (name.startsWith(prefix)) return true;
   }
   return false;
+}
+
+function hostIdentity(
+  capabilities: HostCapabilities | null,
+  currentContext: HostContext | null,
+) {
+  const hostType = String(
+    currentContext?.host_type || capabilities?.host_type || "",
+  ).trim();
+  const hostName = String(
+    currentContext?.host_name || capabilities?.host_name || "",
+  ).trim();
+  const connectorId = String(
+    currentContext?.connector_id || capabilities?.connector_id || "",
+  ).trim();
+  return {
+    hostType,
+    hostName,
+    connectorId,
+    isLms: hostType.toLowerCase() === "lms",
+  };
+}
+
+function availableTargetCount(currentContext: HostContext | null): number {
+  const availableTargets = currentContext?.page?.metadata?.available_targets;
+  return Array.isArray(availableTargets) ? availableTargets.length : 0;
+}
+
+function compactValue(value: string | null | undefined, fallback = "Chưa có"): string {
+  const trimmed = String(value ?? "").trim();
+  if (!trimmed) return fallback;
+  return trimmed.length > 64 ? `${trimmed.slice(0, 61)}...` : trimmed;
+}
+
+function formatCheckedAt(value: string | null | undefined): string {
+  if (!value) return "Chưa kiểm tra";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return compactValue(value);
+  return date.toLocaleTimeString("vi-VN", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function formatToolGroupSummary(names: string[] | undefined): string {
+  if (!names || names.length === 0) return "Không";
+  const groups = new Set(
+    names.map((name) => {
+      const lower = name.toLowerCase();
+      if (lower.includes("authoring") || lower.includes("lms")) return "LMS";
+      if (lower.includes("host")) return "Host";
+      if (lower.startsWith("ui.") || lower.includes("pointy")) return "UI";
+      if (lower.includes("web") || lower.includes("search")) return "Web";
+      if (lower.includes("memory")) return "Memory";
+      return "Khác";
+    }),
+  );
+  return `${names.length} tool (${Array.from(groups).join(", ")})`;
 }
 
 function serverStatusItem(status: RuntimeConnectionStatus): CapabilityStatusItem {
@@ -88,16 +209,10 @@ function hostStatusItem(
   currentContext: HostContext | null,
   isEmbedded: boolean,
 ): CapabilityStatusItem {
-  const hostType = String(
-    currentContext?.host_type || capabilities?.host_type || "",
-  ).trim();
-  const hostName = String(
-    currentContext?.host_name || capabilities?.host_name || "",
-  ).trim();
-  const connectorId = String(
-    currentContext?.connector_id || capabilities?.connector_id || "",
-  ).trim();
-  const isLms = hostType.toLowerCase() === "lms";
+  const { hostType, hostName, connectorId, isLms } = hostIdentity(
+    capabilities,
+    currentContext,
+  );
   if (hostType || hostName || connectorId) {
     return {
       id: "host",
@@ -145,17 +260,9 @@ function lmsAuthoringStatusItem(
   currentContext: HostContext | null,
   toolNames: Set<string>,
 ): CapabilityStatusItem {
-  const isLms = String(
-    currentContext?.host_type || capabilities?.host_type || "",
-  ).toLowerCase() === "lms";
-  const hasPreview = hasTool(toolNames, [
-    "authoring.preview_lesson_patch",
-    "authoring.generate_course_from_document",
-  ]);
-  const hasApply = hasTool(toolNames, [
-    "authoring.apply_lesson_patch",
-    "authoring.apply_course_plan",
-  ]);
+  const { isLms } = hostIdentity(capabilities, currentContext);
+  const hasPreview = hasTool(toolNames, LMS_PREVIEW_TOOLS);
+  const hasApply = hasTool(toolNames, LMS_APPLY_TOOLS);
 
   if (isLms && hasPreview && hasApply) {
     return {
@@ -191,10 +298,10 @@ function pointyStatusItem(
   toolNames: Set<string>,
   isEmbedded: boolean,
 ): CapabilityStatusItem {
-  const hasHostPointy = hasTool(toolNames, ["ui.cursor_move", "ui.highlight"])
+  const hasHostPointy =
+    hasTool(toolNames, ["ui.cursor_move", "ui.highlight"])
     || hasToolPrefix(toolNames, "ui.");
-  const availableTargets = currentContext?.page?.metadata?.available_targets;
-  const hasLocalTargets = Array.isArray(availableTargets) && availableTargets.length > 0;
+  const targets = availableTargetCount(currentContext);
 
   if (hasHostPointy) {
     return {
@@ -205,11 +312,11 @@ function pointyStatusItem(
       title: "Host đã khai báo UI actions cho Pointy.",
     };
   }
-  if (hasLocalTargets) {
+  if (targets > 0) {
     return {
       id: "pointy",
       label: "Pointy",
-      value: `${availableTargets.length} target`,
+      value: `${targets} target`,
       tone: "ok",
       title: "Pointy đã quét được target trong giao diện hiện tại.",
     };
@@ -232,18 +339,232 @@ function pointyStatusItem(
   };
 }
 
-export function buildCapabilityStatuses({
-  connectionStatus,
-  capabilities,
-  currentContext,
-  isEmbedded,
-}: BuildCapabilityStatusInput): CapabilityStatusItem[] {
-  const toolNames = normalizedToolNames(capabilities);
-  return [
-    serverStatusItem(connectionStatus),
-    hostStatusItem(capabilities, currentContext, isEmbedded),
-    hostActionStatusItem(toolNames),
-    lmsAuthoringStatusItem(capabilities, currentContext, toolNames),
-    pointyStatusItem(currentContext, toolNames, isEmbedded),
+function buildRuntimeSection(
+  item: CapabilityStatusItem,
+  input: BuildCapabilityStatusInput,
+): CapabilityDashboardSection {
+  const metrics: CapabilityDashboardMetric[] = [
+    { label: "Kết nối", value: item.value, tone: item.tone },
+    { label: "Phiên bản", value: compactValue(input.serverVersion, "Chưa báo") },
+    { label: "Health check", value: formatCheckedAt(input.lastCheckedAt) },
   ];
+  if (input.errorMessage) {
+    metrics.push({
+      label: "Lỗi gần nhất",
+      value: compactValue(input.errorMessage),
+      tone: "warn",
+    });
+  }
+  return {
+    id: "server",
+    title: "Runtime backend",
+    summary: item.value,
+    tone: item.tone,
+    metrics,
+  };
+}
+
+function buildHostSection(
+  item: CapabilityStatusItem,
+  input: BuildCapabilityStatusInput,
+): CapabilityDashboardSection {
+  const { hostType, hostName, connectorId } = hostIdentity(
+    input.capabilities,
+    input.currentContext,
+  );
+  return {
+    id: "host",
+    title: "Host & LMS",
+    summary: item.value,
+    tone: item.tone,
+    metrics: [
+      { label: "Loại host", value: compactValue(hostType, input.isEmbedded ? "Đang chờ" : "Standalone") },
+      { label: "Tên host", value: compactValue(hostName, "Chưa có") },
+      { label: "Connector", value: compactValue(connectorId, "Chưa có") },
+      {
+        label: "Tài nguyên",
+        value: `${input.capabilities?.resources?.length ?? 0} resource`,
+      },
+      {
+        label: "Surface",
+        value: `${input.capabilities?.surfaces?.length ?? 0} surface`,
+      },
+    ],
+  };
+}
+
+function buildHostActionSection(
+  item: CapabilityStatusItem,
+  capabilities: HostCapabilities | null,
+): CapabilityDashboardSection {
+  const tools = capabilities?.tools ?? [];
+  const mutating = tools.filter((tool) => tool.mutates_state).length;
+  const confirmations = tools.filter((tool) => tool.requires_confirmation).length;
+  return {
+    id: "host_actions",
+    title: "Hành động host",
+    summary: item.value,
+    tone: item.tone,
+    metrics: [
+      { label: "Tổng tác vụ", value: `${tools.length} tác vụ` },
+      {
+        label: "Ghi dữ liệu",
+        value: mutating > 0 ? `${mutating} tác vụ` : "Không",
+        tone: mutating > 0 ? "warn" : "ok",
+      },
+      {
+        label: "Cần xác nhận",
+        value: confirmations > 0 ? `${confirmations} tác vụ` : "Không",
+        tone: confirmations > 0 ? "warn" : "ok",
+      },
+      {
+        label: "Mặc định",
+        value: tools.length > 0 ? "Bind theo host" : "Không bind",
+      },
+    ],
+  };
+}
+
+function buildLmsAuthoringSection(
+  item: CapabilityStatusItem,
+  input: BuildCapabilityStatusInput,
+  toolNames: Set<string>,
+): CapabilityDashboardSection {
+  const { isLms } = hostIdentity(input.capabilities, input.currentContext);
+  const hasPreview = hasTool(toolNames, LMS_PREVIEW_TOOLS);
+  const hasApply = hasTool(toolNames, LMS_APPLY_TOOLS);
+  return {
+    id: "lms_authoring",
+    title: "LMS soạn bài",
+    summary: item.value,
+    tone: item.tone,
+    metrics: [
+      { label: "Kết nối LMS", value: isLms ? "Có" : "Chưa nối", tone: isLms ? "ok" : "off" },
+      { label: "Preview", value: hasPreview ? "Có" : "Thiếu", tone: hasPreview ? "ok" : "warn" },
+      {
+        label: "Apply",
+        value: hasApply ? "Qua approval_token" : "Thiếu",
+        tone: hasApply ? "ok" : "warn",
+      },
+      {
+        label: "An toàn",
+        value: isLms ? "Preview trước, apply sau" : "Không mutate",
+      },
+    ],
+  };
+}
+
+function buildPointySection(
+  item: CapabilityStatusItem,
+  currentContext: HostContext | null,
+  toolNames: Set<string>,
+  isEmbedded: boolean,
+): CapabilityDashboardSection {
+  const hasHostPointy =
+    hasTool(toolNames, ["ui.cursor_move", "ui.highlight"])
+    || hasToolPrefix(toolNames, "ui.");
+  const targets = availableTargetCount(currentContext);
+  return {
+    id: "pointy",
+    title: "Pointy",
+    summary: item.value,
+    tone: item.tone,
+    metrics: [
+      { label: "Bridge UI", value: hasHostPointy ? "Host" : isEmbedded ? "Chưa nối" : "Local" },
+      { label: "Target", value: `${targets} target` },
+      {
+        label: "Trạng thái",
+        value: hasHostPointy || targets > 0 || !isEmbedded ? "Sẵn sàng" : "Chờ host",
+        tone: item.tone,
+      },
+    ],
+  };
+}
+
+function buildPathSection(
+  runtimePath: RuntimePathSnapshot | null | undefined,
+): CapabilityDashboardSection {
+  if (!runtimePath) {
+    return {
+      id: "path",
+      title: "Path lượt gần nhất",
+      summary: "Chưa có lượt chạy",
+      tone: "pending",
+      metrics: [
+        { label: "Path", value: "Chưa có" },
+        { label: "Tool đã thấy", value: "Không" },
+        { label: "Tool bị chặn", value: "Không" },
+      ],
+    };
+  }
+
+  const blocked = runtimePath.suppressedTools?.length ?? 0;
+  return {
+    id: "path",
+    title: "Path lượt gần nhất",
+    summary: compactValue(runtimePath.lane || runtimePath.eventName, "Đang theo dõi"),
+    tone: runtimePath.status === "error" ? "warn" : "ok",
+    metrics: [
+      { label: "Path", value: compactValue(runtimePath.lane, "Chưa phân loại") },
+      { label: "Pha", value: compactValue(runtimePath.phase, "Chưa có") },
+      { label: "Sự kiện", value: compactValue(runtimePath.eventName, "Chưa có") },
+      { label: "Surface", value: compactValue(runtimePath.hostSurface, "Không") },
+      { label: "Tool đã thấy", value: formatToolGroupSummary(runtimePath.observedTools) },
+      {
+        label: "Tool bị chặn",
+        value: formatToolGroupSummary(runtimePath.suppressedTools),
+        tone: blocked > 0 ? "warn" : "ok",
+      },
+    ],
+  };
+}
+
+function summarizeOverall(items: CapabilityStatusItem[]): {
+  summary: string;
+  tone: CapabilityStatusTone;
+} {
+  const server = items.find((item) => item.id === "server");
+  const host = items.find((item) => item.id === "host");
+  const lms = items.find((item) => item.id === "lms_authoring");
+  if (server?.tone === "off") return { summary: "Runtime mất kết nối", tone: "off" };
+  if (server?.tone === "warn") return { summary: "Runtime gián đoạn", tone: "warn" };
+  if (server?.tone === "pending") return { summary: "Đang kiểm tra runtime", tone: "pending" };
+  if (lms?.tone === "ok") return { summary: "LMS sẵn sàng", tone: "ok" };
+  if (host?.tone === "ok") return { summary: "Host đã nối", tone: "ok" };
+  return { summary: "Runtime sẵn sàng", tone: "ok" };
+}
+
+export function buildCapabilityStatusViewModel(
+  input: BuildCapabilityStatusInput,
+): CapabilityStatusViewModel {
+  const toolNames = normalizedToolNames(input.capabilities);
+  const items = [
+    serverStatusItem(input.connectionStatus),
+    hostStatusItem(input.capabilities, input.currentContext, input.isEmbedded),
+    hostActionStatusItem(toolNames),
+    lmsAuthoringStatusItem(input.capabilities, input.currentContext, toolNames),
+    pointyStatusItem(input.currentContext, toolNames, input.isEmbedded),
+  ];
+  const byId = new Map(items.map((item) => [item.id, item]));
+  const overall = summarizeOverall(items);
+
+  return {
+    items,
+    sections: [
+      buildRuntimeSection(byId.get("server")!, input),
+      buildHostSection(byId.get("host")!, input),
+      buildHostActionSection(byId.get("host_actions")!, input.capabilities),
+      buildLmsAuthoringSection(byId.get("lms_authoring")!, input, toolNames),
+      buildPointySection(byId.get("pointy")!, input.currentContext, toolNames, input.isEmbedded),
+      buildPathSection(input.runtimePath),
+    ],
+    summary: overall.summary,
+    overallTone: overall.tone,
+  };
+}
+
+export function buildCapabilityStatuses(
+  input: BuildCapabilityStatusInput,
+): CapabilityStatusItem[] {
+  return buildCapabilityStatusViewModel(input).items;
 }


### PR DESCRIPTION
## Summary
- Adds a typed runtime capability dashboard view model on top of the existing capability chips.
- Makes the chat composer status bar expandable with runtime, host/LMS, host action, LMS authoring, Pointy, and latest path/lifecycle sections.
- Renders the dashboard through a viewport-positioned portal so it does not clip or overlap welcome suggestions on desktop/mobile.

## Scope
- Frontend capability status contract and dashboard UI.
- Component tests for dashboard open state, lifecycle path display, and no raw tool-name leakage.

## Non-scope
- No backend path-policy changes.
- No LMS mutation, deployment, or provider/model routing change.

## Verification
- `cd wiii-desktop; npx vitest run src/__tests__/capability-status-bar.test.tsx` -> 4 passed.
- `cd wiii-desktop; npx tsc --noEmit` -> passed.
- `cd wiii-desktop; npx vitest run` -> 135 files passed, 2518 tests passed. Existing jsdom navigation/localstorage warnings printed but exit code 0.
- `cd wiii-desktop; npm run build:embed` -> passed. Existing Vite bundle/dynamic import/plugin timing warnings printed.
- Playwright local visual check on `http://127.0.0.1:1420`: desktop 1440x900 and mobile 390x844 dashboard panel stayed inside viewport after dev login.
- `git diff --check` -> passed.

## Risk
- Frontend-only composer surface change. Main risk is dashboard placement in unusual viewport/embedded layouts; mitigated by portal positioning, viewport clamping, max-height scrolling, and desktop/mobile Playwright checks.
- No raw host capability payload or tool JSON is rendered; lifecycle tool lists are summarized by category.

## Rollback
- Revert this PR to return to the previous chip-only status bar.

Closes #716

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Capability status display enhanced with an expandable dashboard showing comprehensive runtime metrics, connection details, and system telemetry.

* **Tests**
  * Added test coverage for the new capability status dashboard functionality and data displays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->