### PR TITLE
docs(architecture): define Wiii Connect blueprint

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@ Use this folder for repository-level documentation that explains the product, th
 - `../README.md`: repository overview and deployment model
 - `WIII_PROJECT_MENTAL_MODEL.md`: one-page product and system mental model
 - `architecture/WIII_CODEBASE_MAP.md`: concise codebase map for maintainers and coding agents
+- `architecture/wiii-connect/README.md`: Wiii Connect blueprint for connection registry, capability governor, provider adapters, and extraction criteria
+- `architecture/wiii-connect/CONNECTION_CONTRACT_V0.md`: first Wiii Connect connection and path capability contract
 - `WIII_ARCHITECTURE_AUDIT.md`: opinionated audit of architectural center, strengths, and risk areas
 - `WIII_TECHNICAL_SIMPLIFICATION_ROADMAP.md`: phased simplification plan and first landed slice
 - `operations/WIII_AGENTIC_CODEBASE_HARNESS.md`: large-codebase agent workflow, context layering, and WIP recovery pattern

--- a/docs/WIII_PROJECT_MENTAL_MODEL.md
+++ b/docs/WIII_PROJECT_MENTAL_MODEL.md
@@ -19,7 +19,10 @@ It is built around the combination of five ideas that must coexist:
 4. It must respect organizational ownership, permissions, and isolation.
 5. It must feel like a living intelligence with continuity, not a stateless responder.
 
-Those five ideas map cleanly to five system layers: Wiii Core, Wiii Living, Wiii Host, Wiii Org, and Wiii Data.
+Those five ideas map cleanly to five system layers: Wiii Core, Wiii Living,
+Wiii Host, Wiii Org, and Wiii Data. Wiii Connect is the emerging cross-layer
+capability boundary that keeps those layers honest before tools or host actions
+are exposed.
 
 ## Wiii Core
 
@@ -84,6 +87,8 @@ In practical terms, Wiii Host includes:
 - MCP exposure and MCP consumption
 - browser and host action bridges
 - cross-platform identity surfaces
+- Wiii Connect connection and capability status for native host, LMS,
+  document, visual, Pointy, MCP, and external app providers
 
 The right way to think about Host is this:
 
@@ -94,6 +99,36 @@ It should be able to act as desktop companion, iframe tutor, LMS-aware assistant
 That makes Wiii less like an app and more like an intelligence substrate that can inhabit multiple runtime surfaces.
 
 Without Host, Wiii becomes narrow and channel-bound.
+
+## Wiii Connect
+
+Wiii Connect is the connection and capability control layer that should make
+Host, Core, Org, and Data agree on what Wiii can safely access or mutate in the
+current turn.
+
+In practical terms, Wiii Connect should include:
+
+- connection registry for Wiii-native, Composio, MCP, custom OAuth, and workflow
+  providers
+- capability snapshots for LMS, desktop host, document corpus, Code Studio,
+  Pointy, web/search/weather, and external apps
+- path-scoped permission policy before tool binding
+- provider adapters that keep OAuth, API keys, and tool execution outside the
+  model prompt
+- audit and runtime-ledger facts for connection decisions
+
+The right way to think about Connect is this:
+
+Wiii Connect decides what Wiii is allowed to touch right now.
+
+Core still decides what to do now. Host still decides where Wiii is operating.
+Org still decides ownership and tenant boundaries. Connect is the shared
+contract that prevents those layers from disagreeing about whether a tool,
+host action, or external app is actually available.
+
+Wiii Connect should start inside this monorepo and become a separate
+`wiii-connect` project only after the connection contract is stable across
+native Wiii providers and at least one external adapter.
 
 ## Wiii Org
 
@@ -147,15 +182,16 @@ If Living is the continuity layer, Data is what makes that continuity real inste
 
 Without Data, Wiii becomes stateless and forgetful.
 
-## How The Five Layers Work Together
+## How The Layers Work Together
 
 The shortest runtime model is:
 
 1. Host provides the current environment and interaction surface.
 2. Org applies ownership, permissions, and isolation constraints.
-3. Core interprets the request and decides what work to do.
-4. Data supplies memory, retrieval, history, and durable state.
-5. Living updates identity, mood, goals, and long-term continuity after the interaction.
+3. Connect declares which capabilities are actually connected and allowed.
+4. Core interprets the request and decides what work to do.
+5. Data supplies memory, retrieval, history, and durable state.
+6. Living updates identity, mood, goals, and long-term continuity after the interaction.
 
 That means Wiii should not be read as a chatbot with extra features.
 It should be read as a layered intelligence system where chat is only the most visible interface.
@@ -167,6 +203,7 @@ If you are trying to understand the project quickly, keep these priorities in mi
 - Core is the operational center of gravity.
 - Living is the product differentiator.
 - Host is the expansion strategy.
+- Connect is the runtime capability boundary.
 - Org is the production scaling boundary.
 - Data is the glue that keeps the other four honest.
 
@@ -179,3 +216,4 @@ That is also the reason the system feels more ambitious than a normal AI product
 - [../maritime-ai-service/docs/architecture/SYSTEM_ARCHITECTURE.md](../maritime-ai-service/docs/architecture/SYSTEM_ARCHITECTURE.md): full architecture reference
 - [../maritime-ai-service/docs/architecture/SYSTEM_FLOW.md](../maritime-ai-service/docs/architecture/SYSTEM_FLOW.md): request and streaming flow
 - [../wiii-desktop/README.md](../wiii-desktop/README.md): desktop and embed runtime
+- [architecture/wiii-connect/README.md](architecture/wiii-connect/README.md): Wiii Connect blueprint

--- a/docs/architecture/WIII_CODEBASE_MAP.md
+++ b/docs/architecture/WIII_CODEBASE_MAP.md
@@ -14,7 +14,8 @@ architecture references.
 
 Wiii is a multi-surface agentic AI platform with a FastAPI backend, a React/Tauri
 desktop and embed frontend, organization-aware data boundaries, retrieval and
-memory, LMS host actions, visual artifacts, and voice.
+memory, LMS host actions, visual artifacts, voice, and an emerging Wiii Connect
+capability boundary.
 
 ## Top-Level Folders
 
@@ -23,6 +24,7 @@ memory, LMS host actions, visual artifacts, and voice.
 | `maritime-ai-service/` | FastAPI backend, orchestration, RAG, tools, memory, LMS, deploy assets | Highest-risk runtime surface |
 | `wiii-desktop/` | React 18, Tauri v2, embed app, chat UX, Pointy, voice controls | User-visible behavior and stream rendering |
 | `docs/` | Architecture, operations, integration, release, governance | Durable knowledge belongs here |
+| `docs/architecture/wiii-connect/` | Wiii Connect blueprint and connection/capability contracts | Incubation docs before any standalone repo extraction |
 | `specs/` | Spec Kit artifacts for architecture-sensitive work | Use for multi-phase or contract changes |
 | `.github/` | GitHub Actions, templates, CodeRabbit, CODEOWNERS | Merge safety and review automation |
 | `.agents/skills/` | Repo-local Codex skills | Skills should be focused and loaded on demand |
@@ -30,13 +32,14 @@ memory, LMS host actions, visual artifacts, and voice.
 | `scripts/` | Repository-level helper scripts | Avoid adding one-off local probes here |
 | `chaos/`, `loadtest/` | Stress and load tooling | Run only when task requires it |
 
-## Five-Layer Product Model
+## Product Layer Model
 
 | Layer | Meaning | Main code areas |
 |---|---|---|
 | Core | Decide and execute the current turn | chat services, multi-agent runtime, tool loop |
 | Living | Maintain continuity and identity over time | memory, emotion, reflection, post-turn hooks |
 | Host | Understand where Wiii is operating | desktop, embed, LMS, Pointy, host actions |
+| Connect | Decide which connected capabilities can be used now | tool policy, host capabilities, future Wiii Connect contracts |
 | Org | Enforce ownership and tenant boundaries | auth, org middleware, settings, repositories |
 | Data | Preserve durable state and retrieval substrate | PostgreSQL, pgvector, repositories, migrations |
 
@@ -47,11 +50,12 @@ The normal chat turn should be read in this order:
 1. FastAPI route receives request and auth context.
 2. `ChatOrchestrator` prepares the turn.
 3. Context, org, host, history, document, and memory state are assembled.
-4. Multi-agent runtime chooses direct, RAG, tool, visual, LMS, or other lanes.
-5. Tools and retrieval execute with tenant and host constraints.
-6. Backend emits sync response or SSE V3 events.
-7. Frontend assembles visible answer, previews, sources, and artifacts.
-8. Post-turn hooks update continuity outside the critical response path.
+4. Connection and capability status gates which tools can be visible.
+5. Multi-agent runtime chooses direct, RAG, tool, visual, LMS, or other lanes.
+6. Tools and retrieval execute with tenant, host, and capability constraints.
+7. Backend emits sync response or SSE V3 events.
+8. Frontend assembles visible answer, previews, sources, and artifacts.
+9. Post-turn hooks update continuity outside the critical response path.
 
 ## Backend Navigation
 
@@ -66,6 +70,7 @@ The normal chat turn should be read in this order:
 | Routing and supervisor behavior | `maritime-ai-service/app/engine/multi_agent/supervisor*.py` |
 | Direct prompt assembly | `maritime-ai-service/app/engine/multi_agent/direct_prompts.py` (main assembly)<br>Tool binding: `direct_prompt_tool_binding.py`<br>Tool-context prompt builders: `direct_prompt_tool_context.py`<br>Turn contract and forced-skill prompt helpers: `direct_prompt_turn_contracts.py` |
 | Tool registry | `maritime-ai-service/app/engine/tools/registry.py` and `maritime-ai-service/app/engine/multi_agent/tool_collection.py` |
+| Tool policy and connection status | `maritime-ai-service/app/engine/multi_agent/tool_policy_session.py`, `maritime-ai-service/app/engine/tools/tool_capability_registry.py`, `docs/architecture/wiii-connect/CONNECTION_CONTRACT_V0.md` |
 | LMS host actions | `maritime-ai-service/app/engine/context/action_tools.py`, `maritime-ai-service/app/engine/tools/lms_tools.py` |
 | Document context | `maritime-ai-service/app/api/v1/document_context.py`, document runtime helpers |
 | Uploaded-document preview/course contract | `maritime-ai-service/app/engine/multi_agent/document_preview_contract.py` |
@@ -94,6 +99,7 @@ Keep these contracts explicit and tested:
 - agent turn lifecycle
 - native provider stream lifecycle
 - tool call dispatch and result handling
+- connection and capability snapshots before tool binding
 - document context provenance and source references
 - host action preview/apply approval
 - SSE V3 event names and order

--- a/docs/architecture/wiii-connect/CONNECTION_CONTRACT_V0.md
+++ b/docs/architecture/wiii-connect/CONNECTION_CONTRACT_V0.md
@@ -1,0 +1,178 @@
+# Wiii Connect Contract V0
+
+Status: Draft for implementation
+
+Owner: Architecture maintainers
+
+Created: 2026-05-27
+
+Related issue: #720
+
+## Purpose
+
+This document defines the first shared data contract for Wiii Connect. It is the
+shape that backend runtime policy, frontend capability UI, and later provider
+adapters should converge on.
+
+V0 is observational and policy-facing. It must not carry secrets, raw user
+content, raw document text, provider request bodies, provider response bodies,
+or approval tokens.
+
+## Connection Snapshot
+
+```text
+WiiiConnectionSnapshot
+  version
+  generated_at
+  surface
+  connections[]
+  path_capabilities[]
+  warnings[]
+```
+
+### Connection Record
+
+```text
+WiiiConnection
+  id
+  provider_kind
+  slug
+  label
+  status
+  agent_ready
+  scopes
+  capabilities
+  required_for_paths
+  source
+  last_checked_at
+  reason
+  warnings
+```
+
+Allowed `provider_kind` values:
+
+- `wiii_native`
+- `composio`
+- `mcp`
+- `custom_oauth`
+- `workflow`
+
+Allowed `status` values:
+
+- `connected`
+- `not_connected`
+- `pending`
+- `expired`
+- `error`
+- `preview`
+- `disabled`
+
+Allowed scope booleans:
+
+- `read`
+- `preview`
+- `write`
+- `apply`
+- `admin`
+
+## V0 Native Connections
+
+| Slug | Provider kind | Meaning |
+|---|---|---|
+| `server` | `wiii_native` | Backend reachable from current client. |
+| `host` | `wiii_native` | Desktop/embed host context is present. |
+| `host_actions` | `wiii_native` | Host bridge exposed callable actions. |
+| `lms_authoring` | `wiii_native` | LMS authoring preview/apply path is available. |
+| `document_corpus` | `wiii_native` | Uploaded or indexed document context is present. |
+| `pointy` | `wiii_native` | Pointy target inventory or mode is available. |
+| `web_search` | `wiii_native` | Web search provider can be bound. |
+| `weather` | `wiii_native` | Weather provider can be bound or fail-closed. |
+| `visual_runtime` | `wiii_native` | Inline visual/article figure tools can be bound. |
+| `code_studio` | `wiii_native` | Code Studio app/artifact tools can be bound. |
+
+## Path Capability Record
+
+```text
+WiiiPathCapability
+  path
+  allowed_connection_slugs
+  required_connection_slugs
+  allowed_tool_groups
+  forbidden_tool_groups
+  mutation_policy
+  delegation_policy
+```
+
+Allowed `mutation_policy` values:
+
+- `none`
+- `preview_only`
+- `approval_token_required`
+- `explicit_user_confirmation_required`
+
+Allowed `delegation_policy` values:
+
+- `direct_only`
+- `delegate_to_path_agent`
+- `delegate_to_integration_agent`
+
+## Required Path Rules
+
+| Path | Required connection | Mutation policy | Notes |
+|---|---|---|---|
+| `casual_chat` | none | `none` | No broad tool binding. |
+| `weather_lookup` | `weather` | `none` | No generic web fallback unless user asks. |
+| `web_search` | `web_search` | `none` | Explicit live/current/search intent only. |
+| `document_grounded_answer` | `document_corpus` | `none` | No unsupported outside facts. |
+| `lms_document_preview` | `lms_authoring` | `preview_only` | Must preserve citations/source refs. |
+| `lms_document_apply` | `lms_authoring` | `approval_token_required` | Never execute without host-issued approval evidence. |
+| `host_ui_action` | `host_actions` | `explicit_user_confirmation_required` | Host control must be audited. |
+| `pointy_guidance` | `pointy` | `none` | Only explicit Pointy-like turns. |
+| `visual_generation` | `visual_runtime` | `none` | Do not bind Pointy click tools. |
+| `code_studio_output` | `code_studio` | `none` | Use Code Studio path tools only. |
+| `external_app_action` | external provider slug | path-specific | Delegate to integration agent after connection verification. |
+
+## Privacy Rules
+
+The snapshot may contain:
+
+- connection slug and status
+- capability names
+- scope booleans
+- counts
+- warning codes
+- hashed or opaque connection identifiers
+- high-level reason strings
+
+The snapshot must not contain:
+
+- OAuth access or refresh tokens
+- API keys
+- raw approval tokens
+- uploaded document text
+- raw user messages
+- raw assistant messages
+- provider request/response bodies
+- personally identifying account fields unless explicitly allowed by the
+  surface and sanitized for UI
+
+## Relationship To Existing Runtime
+
+Existing Wiii code already has several pieces of this direction:
+
+- `ToolCapabilityRegistry` describes tool policy metadata.
+- `ToolPolicySession` records per-turn tool visibility and connection status.
+- `TurnPathDecision` chooses the path before tools are bound.
+- Frontend `CapabilityStatusBar` displays server, host, LMS, Pointy, and path
+  state.
+
+Wiii Connect V0 should consolidate these pieces behind one snapshot instead of
+creating a parallel status system.
+
+## Implementation Order
+
+1. Add typed backend snapshot builders around current runtime status.
+2. Add tests for snapshot privacy and fail-closed statuses.
+3. Make `ToolPolicySession` consume snapshot connection status.
+4. Surface snapshot to frontend runtime dashboard.
+5. Add provider adapters after native paths are stable.

--- a/docs/architecture/wiii-connect/README.md
+++ b/docs/architecture/wiii-connect/README.md
@@ -1,0 +1,155 @@
+# Wiii Connect Blueprint
+
+Status: Draft for implementation
+
+Owner: Architecture maintainers
+
+Created: 2026-05-27
+
+Related issue: #720
+
+## Purpose
+
+Wiii Connect is the planned connection and capability control layer for Wiii.
+It exists so Wiii can reason about external apps, LMS, host bridges, documents,
+visual runtimes, and future MCP tools through one contract instead of scattered
+tool-specific checks.
+
+The immediate goal is not to clone Composio. The immediate goal is to give Wiii
+its own connection registry, capability snapshot, and path governor so runtime
+tools can fail closed and UI can show what is actually connected.
+
+## Product Decision
+
+Start Wiii Connect inside the Wiii monorepo.
+
+Create a separate `wiii-connect` repository later only after the contracts are
+stable enough that package boundaries help more than they slow product repair.
+
+Rationale:
+
+- The first Wiii Connect providers are Wiii-native: LMS, desktop host,
+  document corpus, Code Studio, Pointy, and runtime path policy.
+- Those providers must be tested against current Wiii chat, SSE, preview/apply,
+  and host bridge flows.
+- Extracting too early would add versioning, packaging, and deployment overhead
+  before the core contract is proven.
+- External systems such as Composio, MCP, Nango, Klavis, Activepieces, n8n, and
+  Windmill should inform provider adapters, not replace Wiii's safety model.
+
+## OpenHuman Pattern To Adopt
+
+OpenHuman uses Composio underneath, but its important architectural move is the
+connection discipline around Composio:
+
+1. Connections are visible runtime state, not hidden prompt assumptions.
+2. Connected is distinct from agent-ready.
+3. Main chat does not hold every integration action schema.
+4. The orchestrator sees a small delegation handle and a set of connected
+   toolkit slugs.
+5. The toolkit-scoped integration agent receives the real action schemas only
+   after the toolkit is selected and verified.
+6. UI connection flow is a state machine: disconnected, authorizing, waiting,
+   connected, expired, error, disconnecting.
+7. Scope and permission toggles gate what actions the agent may call.
+
+Wiii should adopt those rules. Wiii should not copy OpenHuman code or inherit a
+personal-agent trust boundary that does not fit LMS, org, and host control.
+
+## Provider Model
+
+Wiii Connect should treat every connector as a provider behind a Wiii-owned
+contract.
+
+| Provider kind | Examples | Ownership |
+|---|---|---|
+| `wiii_native` | LMS, desktop host, document corpus, Code Studio, Pointy | Wiii owns contract and policy |
+| `composio` | Facebook, Gmail, Notion, Slack, GitHub through Composio | Wiii owns policy; Composio brokers OAuth/actions |
+| `mcp` | Remote or local MCP servers | Wiii owns visibility and permission gating |
+| `custom_oauth` | Future Wiii-owned OAuth apps such as Facebook app branded as Wiii | Wiii owns OAuth, token vault, review, policy |
+| `workflow` | Activepieces, n8n, Windmill, Pipedream-style workflow bridges | Wiii owns action exposure and approval gates |
+
+Composio is therefore an adapter, not the foundation. Wiii-native providers must
+continue working without Composio.
+
+## Runtime Shape
+
+The target runtime flow is:
+
+```text
+host/request context
+  -> connection registry
+  -> capability snapshot
+  -> path governor
+  -> delegated path/toolkit agent
+  -> narrowed tool/action schema
+  -> execution gateway
+  -> audit/ledger/stream metadata
+```
+
+The main chat path should not bind broad tool surfaces. It should choose the
+active product path first, then bind only the tools allowed by the current
+connection and capability snapshot.
+
+## V0 Scope
+
+Wiii Connect V0 should stay small:
+
+- Define typed connection and capability snapshot records.
+- Normalize current runtime status for server, host bridge, LMS authoring,
+  host actions, Pointy, document corpus, web/weather/search, and visual/Code
+  Studio paths.
+- Feed `ToolPolicySession` and `TurnPathDecision` from the same snapshot shape.
+- Expose the snapshot to the frontend runtime dashboard without leaking tokens,
+  raw documents, prompt text, or provider payloads.
+- Keep all mutating tools behind preview and approval evidence.
+- Record enough metadata in runtime ledgers to debug wrong-path behavior.
+
+V0 must not:
+
+- Build native Facebook/Gmail OAuth connectors.
+- Store third-party OAuth tokens before an encrypted vault and revocation model
+  exist.
+- Let any provider adapter bypass Wiii's path governor.
+- Make production LMS mutations possible without `approval_token`.
+
+## Fail-Closed Product Rules
+
+| Surface | Rule |
+|---|---|
+| LMS preview | Requires active LMS/host authoring connection. |
+| LMS apply | Requires active LMS connection, write/apply scope, preview evidence, and `approval_token`. |
+| Host actions | Require host bridge capability presence for this surface. |
+| Pointy | Must not execute for code, visual, simulation, artifact, or LMS authoring output paths unless explicitly allowed by that path. |
+| Document-grounded chat | If uploaded documents are the active source, do not invent outside facts or silently fall back to web search. |
+| Web/weather/search | Bind only for explicit live/current/search intent, not generic conversation drift. |
+| External apps | If not connected, tell the user to connect the app in Wiii Connections. Do not fake a live app answer from stale memory. |
+| External writes | Require explicit scope, preview when available, and action audit. |
+
+## Extraction Criteria
+
+Create a standalone `wiii-connect` repository only when all of these are true:
+
+- V0 contract is stable across backend tests and frontend dashboard.
+- At least two Wiii-native providers use the same registry shape.
+- At least one external adapter, such as Composio or MCP, uses the same shape.
+- Runtime ledgers show connection/capability decisions without raw secrets.
+- CI can test contract packages without booting the full product stack.
+- Maintainers agree that versioned packages reduce coupling instead of adding
+  integration friction.
+
+Until then, Wiii Connect remains an architecture and implementation area inside
+this repository.
+
+## Next Implementation Slices
+
+1. Add a backend `wiii_connect` contract module that emits a privacy-safe
+   capability snapshot from existing LMS, host, weather, document, Pointy, and
+   tool policy state.
+2. Update `ToolPolicySession` to consume the snapshot as the source of
+   connection status instead of building ad hoc connection maps.
+3. Extend the frontend runtime dashboard to display the same snapshot, grouped
+   by provider and path.
+4. Add tests proving that LMS apply, Pointy, web/weather, document-grounded
+   chat, and visual/Code Studio paths bind only the right tools.
+5. Add a Composio adapter only after the native Wiii snapshot is stable.

--- a/docs/operations/WIII_SYSTEM_CONTROL_PLANE.md
+++ b/docs/operations/WIII_SYSTEM_CONTROL_PLANE.md
@@ -26,6 +26,8 @@ It complements:
 
 - `docs/WIII_PROJECT_MENTAL_MODEL.md` for the five-layer product model.
 - `docs/architecture/WIII_CODEBASE_MAP.md` for source navigation.
+- `docs/architecture/wiii-connect/README.md` for the emerging connection and
+  capability boundary.
 - `docs/operations/WIII_REFERENCE_SYSTEMS_AUDIT_2026-05-25.md` for external
   systems Wiii should compare against before deeper runtime changes.
 - `docs/operations/WIII_OPENHUMAN_REFERENCE_AUDIT_2026-05-26.md` for the
@@ -67,13 +69,15 @@ As of 2026-05-25:
 
 ## Control Plane Model
 
-Wiii should be operated through five product layers and one governance layer:
+Wiii should be operated through five product layers, one connection/capability
+layer, and one governance layer:
 
 | Layer | Owns | Typical failure symptom | First place to inspect |
 |---|---|---|---|
 | Wiii Core | turn routing, provider calls, tool loops, SSE events | wrong lane, silence, raw payloads, slow turn | `maritime-ai-service/app/services/chat_*`, `app/engine/multi_agent/**` |
 | Wiii Living | continuity, identity, post-turn memory behavior | Wiii forgets, repeats, or changes persona incoherently | memory/living services and post-turn hooks |
 | Wiii Host | desktop, embed, LMS, Pointy, visual/code frames | preview missing, Pointy wrong action, visual clipped | `wiii-desktop/src/**`, LMS/host bridge modules |
+| Wiii Connect | connection registry, capability snapshot, provider adapters, path gating | tool appears on wrong path, connected state unclear, external action not auditable | `tool_policy_session.py`, `tool_capability_registry.py`, `docs/architecture/wiii-connect/**` |
 | Wiii Org | auth, membership, tenant boundaries, permissions | wrong user/org, auth loop, cross-tenant risk | `app/auth/**`, org middleware, repositories |
 | Wiii Data | PostgreSQL, pgvector, MinIO, Valkey, migrations | missing history, citations, uploads, memory, or source refs | repositories, migrations, document context paths |
 | Governance | issue/branch/PR/release/harness controls | risky or unreviewable changes keep landing | `.github/**`, `docs/operations/**`, `tools/wiii_self_harness/**`, `tools/wiii_understand_harness/**` |
@@ -108,6 +112,7 @@ turn. Some signals already exist; missing signals are the next monitoring work.
 | Intent/routing | selected lane and reason | typed visual/tool requirements, Code Studio outcomes | emit a compact route decision record per turn |
 | Retrieval/memory | query scope, tenant filters, source IDs, citation count | repository tests and source-reference helpers | add golden source-backed replay cases for active LMS documents |
 | Provider/tool loop | provider/model, tool bound, tool started/result/error | tool events, visual telemetry, focused unit tests | centralize a turn ledger instead of scattering log-only evidence |
+| Connection/capability | connected provider slugs, scopes, path-ready status, suppressed tools | `ToolPolicySession`, frontend capability status bar | consolidate into Wiii Connect snapshot |
 | SSE assembly | event order, first useful chunk, final `done` | stream coordinator tests and production smoke | assert sync/stream parity for high-risk lanes |
 | Frontend assembly | visible answer, previews, sources, visual frames | Vitest, local E2E harness, visual frame tests | browser acceptance matrix for authenticated LMS/visual flows |
 | Host mutation | preview request ID, approval token hash, apply result | host action audit route, token hash tests | real LMS test course acceptance run |
@@ -182,23 +187,32 @@ Proceed in this order unless production risk forces a hotfix:
    - Ask for a lesson in Vietnamese.
    - Verify preview, source refs, citations, `approval_token`, and final draft.
 
-4. **Runtime flow ledger**
+4. **Wiii Connect V0 snapshot**
+   - Consolidate current server, host, LMS, document, Pointy, weather/search,
+     visual, Code Studio, and external adapter status into a privacy-safe
+     capability snapshot.
+   - Keep it in-repo until at least two native providers and one external
+     adapter share the same shape.
+   - Use the snapshot to feed tool policy before adding a standalone
+     `wiii-connect` repository.
+
+5. **Runtime flow ledger**
    - Add a typed, privacy-safe turn trace surface.
    - Keep it log/metadata first; avoid a dashboard until the schema is stable.
    - Include route decision, selected tools, source counts, visual/host events,
      provider/model, and finalization status.
 
-5. **Stream and route replay cases**
+6. **Stream and route replay cases**
    - Add golden replay scenarios for uploaded document, visual, Code Studio,
      RAG, and Pointy no-action cases.
    - Keep production smoke lightweight; keep mutation acceptance isolated.
 
-6. **Frontend acceptance matrix**
+7. **Frontend acceptance matrix**
    - Authenticated LMS/embed browser run.
    - Visual/Code Studio frame screenshots.
    - Markdown/code streaming and source-reference visibility.
 
-7. **Living/memory audit**
+8. **Living/memory audit**
    - Map post-turn hooks and memory write/read paths.
    - Add tenant-safe replay checks before changing memory behavior.
 

--- a/docs/operations/WIII_TOOL_POLICY_SESSION_STANDARD.md
+++ b/docs/operations/WIII_TOOL_POLICY_SESSION_STANDARD.md
@@ -27,6 +27,12 @@ Tool construction remains in the native tool modules, but connection,
 approval, mutation, group, and surface-scope metadata must come from
 `app.engine.tools.tool_capability_registry`.
 
+Wiii Connect is the next consolidation layer for the same contract. The current
+`connection_status` map is the V0 seed of the Wiii Connect capability snapshot
+documented in `docs/architecture/wiii-connect/CONNECTION_CONTRACT_V0.md`.
+Policy work should extend that snapshot rather than adding unrelated
+service-specific status maps.
+
 ## Required Contract
 
 Every direct chat turn should have a `ToolPolicySession` in `AgentState` when
@@ -88,6 +94,10 @@ Policy changes should include focused tests for:
 - narrow path dominance over broad fallback paths;
 - connection-gated host/LMS tools;
 - no raw internal tool names leaking into user-facing prose.
+
+When Wiii Connect snapshot code lands, also test that snapshots contain only
+status, scopes, counts, and warning codes, never tokens, raw uploaded document
+content, prompt text, or provider payloads.
 
 Recommended commands:
 


### PR DESCRIPTION
## Summary
- Adds the Wiii Connect architecture blueprint and V0 connection/capability contract.
- Records the product decision to incubate Wiii Connect inside the Wiii monorepo before any standalone `wiii-connect` repo extraction.
- Links the new contract into the project mental model, codebase map, system control plane, and tool policy standard.

## Scope
In scope:
- Documentation and governance alignment for Wiii Connect.
- OpenHuman/Composio-derived connection discipline, Composio-as-adapter boundary, fail-closed product rules, extraction criteria, and next implementation slices.

Out of scope:
- Runtime code changes.
- Native OAuth connectors.
- Frontend dashboard changes.
- LMS, host, Pointy, or provider behavior changes.

## Verification
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Manual consistency review against `AGENTS.md`, `WIII_GITHUB_GOVERNANCE.md`, `WIII_AGENTIC_CODEBASE_HARNESS.md`, `WIII_PROJECT_MENTAL_MODEL.md`, `WIII_TOOL_POLICY_SESSION_STANDARD.md`, and `WIII_SYSTEM_CONTROL_PLANE.md`.

## Risk
Low runtime risk: docs-only change. Product risk is directional: it names Wiii Connect as a future connection/capability boundary. The docs explicitly avoid making Composio the foundation and keep LMS/host/document/code paths Wiii-native.

## Rollback
Revert this PR or remove `docs/architecture/wiii-connect/**` plus the entry-point references if maintainers reject the direction.

## Reviewer Focus
- Whether Wiii Connect should stay in-monorepo for V0.
- Whether Composio is correctly framed as an adapter, not the core architecture.
- Whether fail-closed LMS, host, Pointy, document, web/weather, and external app rules match current product safety constraints.

Closes #720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Wiii Connect architecture documentation defining the connection and capability control layer.
  * Introduced connection snapshot data contract (V0) specifying structure for connections, capabilities, and permissions.
  * Updated system mental model, codebase map, and operations documentation to reflect Wiii Connect as a cross-layer boundary.
  * Enhanced control plane documentation with connection and capability monitoring guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/721?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->