### PR TITLE
feat(runtime): surface Wiii Connect snapshot in dashboard

### DIFF
--- a/docs/architecture/wiii-connect/CONNECTION_CONTRACT_V0.md
+++ b/docs/architecture/wiii-connect/CONNECTION_CONTRACT_V0.md
@@ -169,6 +169,29 @@ Existing Wiii code already has several pieces of this direction:
 Wiii Connect V0 should consolidate these pieces behind one snapshot instead of
 creating a parallel status system.
 
+## SSE Runtime Projection
+
+The first frontend-facing projection is additive on the existing SSE V3
+`chat_lifecycle` event:
+
+```text
+chat_lifecycle.capabilities.wiii_connect = WiiiConnectionSnapshot
+```
+
+This projection is for observability and browser acceptance only. It must use
+the same privacy rules as the backend snapshot:
+
+- no raw document text or filenames
+- no raw user prompt
+- no provider request/response bodies
+- no API keys, OAuth tokens, or approval token values
+- only connection status, capability labels, path policy, counts, warnings, and
+  safe reason codes
+
+Frontend storage must sanitize the projection again before persisting lifecycle
+metadata. The UI may summarize connection rows and path counts, but should not
+show raw tool schema payloads in chat.
+
 ## Implementation Order
 
 1. Add typed backend snapshot builders around current runtime status.

--- a/maritime-ai-service/app/services/chat_runtime_lifecycle.py
+++ b/maritime-ai-service/app/services/chat_runtime_lifecycle.py
@@ -106,15 +106,144 @@ def _safe_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
     return safe
 
 
+_ALLOWED_WIII_CONNECT_CONNECTION_KEYS = {
+    "id",
+    "provider_kind",
+    "slug",
+    "label",
+    "status",
+    "active",
+    "agent_ready",
+    "scopes",
+    "capabilities",
+    "required_for_paths",
+    "source",
+    "last_checked_at",
+    "reason",
+    "warnings",
+    "host_type",
+    "connector_id",
+    "resource_count",
+    "surface_count",
+    "tool_count",
+    "mutating_tool_count",
+    "attachment_count",
+    "document_count",
+    "source_ref_count",
+    "target_count",
+    "fail_closed_tool",
+    "default_city",
+}
+_ALLOWED_WIII_CONNECT_PATH_KEYS = {
+    "path",
+    "allowed_connection_slugs",
+    "required_connection_slugs",
+    "allowed_tool_groups",
+    "forbidden_tool_groups",
+    "mutation_policy",
+    "delegation_policy",
+}
+_WIII_CONNECT_SCOPE_KEYS = {"read", "preview", "write", "apply", "admin"}
+
+
+def _safe_bool_mapping(value: Any, allowed_keys: set[str]) -> dict[str, bool]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {
+        key: bool(value.get(key))
+        for key in allowed_keys
+        if isinstance(value.get(key), bool)
+    }
+
+
+def _safe_wiii_connect_record(
+    value: Any,
+    *,
+    allowed_keys: set[str],
+) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    record: dict[str, Any] = {}
+    for key in allowed_keys:
+        raw_value = value.get(key)
+        if raw_value is None:
+            continue
+        if key == "scopes":
+            scopes = _safe_bool_mapping(raw_value, _WIII_CONNECT_SCOPE_KEYS)
+            if scopes:
+                record[key] = scopes
+            continue
+        if isinstance(raw_value, bool | int | float):
+            record[key] = raw_value
+            continue
+        if isinstance(raw_value, str):
+            text = _safe_string(raw_value)
+            if text:
+                record[key] = text
+            continue
+        strings = _safe_string_list(raw_value)
+        if strings:
+            record[key] = strings
+    return record if record else None
+
+
+def _safe_wiii_connect_snapshot(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    snapshot: dict[str, Any] = {}
+    for key in ("version", "generated_at", "surface"):
+        text = _safe_string(value.get(key))
+        if text:
+            snapshot[key] = text
+
+    connections = value.get("connections")
+    if isinstance(connections, (list, tuple)):
+        safe_connections: list[dict[str, Any]] = []
+        for item in connections:
+            record = _safe_wiii_connect_record(
+                item,
+                allowed_keys=_ALLOWED_WIII_CONNECT_CONNECTION_KEYS,
+            )
+            if record:
+                safe_connections.append(record)
+            if len(safe_connections) >= _MAX_ITEMS:
+                break
+        if safe_connections:
+            snapshot["connections"] = safe_connections
+
+    path_capabilities = value.get("path_capabilities")
+    if isinstance(path_capabilities, (list, tuple)):
+        safe_paths: list[dict[str, Any]] = []
+        for item in path_capabilities:
+            record = _safe_wiii_connect_record(
+                item,
+                allowed_keys=_ALLOWED_WIII_CONNECT_PATH_KEYS,
+            )
+            if record:
+                safe_paths.append(record)
+            if len(safe_paths) >= _MAX_ITEMS:
+                break
+        if safe_paths:
+            snapshot["path_capabilities"] = safe_paths
+
+    warnings = _safe_string_list(value.get("warnings"))
+    if warnings:
+        snapshot["warnings"] = warnings
+
+    return snapshot if snapshot else None
+
+
 def capability_snapshot_from_ledger_payload(
     ledger_payload: Mapping[str, Any],
+    *,
+    wiii_connect_snapshot: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Return the lifecycle-safe capability/tool subset from a flow ledger."""
 
     request = _safe_mapping(ledger_payload.get("request"))
     tools = _safe_mapping(ledger_payload.get("tools"))
     host_actions = _safe_mapping(ledger_payload.get("host_actions"))
-    return {
+    payload: dict[str, Any] = {
         "host_surface": _safe_string(request.get("host_surface")) or "unknown",
         "host_capabilities": _safe_string_list(request.get("host_capabilities")),
         "observed_tools": _safe_string_list(tools.get("observed")),
@@ -124,6 +253,10 @@ def capability_snapshot_from_ledger_payload(
         "approval_token_present": bool(host_actions.get("approval_token_present")),
         "apply_attempted": bool(host_actions.get("apply_attempted")),
     }
+    safe_wiii_connect = _safe_wiii_connect_snapshot(wiii_connect_snapshot)
+    if safe_wiii_connect:
+        payload["wiii_connect"] = safe_wiii_connect
+    return payload
 
 
 @dataclass(frozen=True)

--- a/maritime-ai-service/app/services/chat_stream_coordinator.py
+++ b/maritime-ai-service/app/services/chat_stream_coordinator.py
@@ -15,6 +15,7 @@ from app.core.exceptions import (
 )
 from app.engine.llm_runtime_metadata import resolve_runtime_llm_metadata
 from app.engine.multi_agent.runtime_flow_ledger import RuntimeFlowLedger
+from app.engine.wiii_connect.snapshot import build_wiii_connect_snapshot
 from app.services.chat_orchestrator_runtime import build_wiii_turn_request
 from app.services.chat_runtime_lifecycle import (
     ChatLifecycleName,
@@ -63,6 +64,34 @@ def build_model_switch_prompt_for_unavailable(**kwargs: Any) -> dict[str, Any]:
     )
 
     return build_model_switch_prompt_for_unavailable(**kwargs)
+
+
+def _mapping_from_value(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if hasattr(value, "model_dump"):
+        dumped = value.model_dump()
+        return dict(dumped) if isinstance(dumped, Mapping) else {}
+    if hasattr(value, "dict"):
+        dumped = value.dict()
+        return dict(dumped) if isinstance(dumped, Mapping) else {}
+    return {}
+
+
+def _request_attr(source: Any, key: str) -> Any:
+    if isinstance(source, Mapping):
+        return source.get(key)
+    return getattr(source, key, None)
+
+
+def _state_for_wiii_connect_snapshot(chat_request: Any) -> dict[str, Any]:
+    user_context = _mapping_from_value(_request_attr(chat_request, "user_context"))
+    context: dict[str, Any] = {}
+    for key in ("host_context", "host_capabilities", "document_context"):
+        value = _mapping_from_value(user_context.get(key))
+        if value:
+            context[key] = value
+    return {"context": context}
 
 
 def _stream_agent_for_finalization(event: Any, current_agent: str = "") -> str:
@@ -504,6 +533,11 @@ async def generate_stream_v3_events(
         chat_request=chat_request,
         request_id=request_id,
     )
+    wiii_connect_snapshot = build_wiii_connect_snapshot(
+        state=_state_for_wiii_connect_snapshot(chat_request),
+        query=str(getattr(chat_request, "message", "") or ""),
+        surface=flow_ledger.host_surface,
+    ).to_metadata()
 
     def _payload_section(payload: Mapping[str, Any], key: str) -> Mapping[str, Any]:
         section = payload.get(key)
@@ -552,7 +586,8 @@ async def generate_stream_v3_events(
                     reason=reason or str(route_payload.get("reason") or "") or None,
                     node=node,
                     capabilities=capability_snapshot_from_ledger_payload(
-                        ledger_payload
+                        ledger_payload,
+                        wiii_connect_snapshot=wiii_connect_snapshot,
                     ),
                     metadata=metadata or {},
                 )

--- a/maritime-ai-service/tests/unit/test_chat_runtime_lifecycle.py
+++ b/maritime-ai-service/tests/unit/test_chat_runtime_lifecycle.py
@@ -2,6 +2,7 @@ from app.services.chat_runtime_lifecycle import (
     CHAT_RUNTIME_LIFECYCLE_SCHEMA_VERSION,
     ChatLifecycleName,
     ChatRuntimeLifecycleEvent,
+    capability_snapshot_from_ledger_payload,
 )
 
 
@@ -41,3 +42,57 @@ def test_chat_runtime_lifecycle_metadata_is_allowlisted_and_bounded():
     assert len(metadata["bound_tools"][1]) == 128
     assert "secret_token" not in metadata
     assert "nested" not in metadata
+
+
+def test_capability_snapshot_includes_redacted_wiii_connect_snapshot():
+    payload = capability_snapshot_from_ledger_payload(
+        {
+            "request": {
+                "host_surface": "lms_course_editor",
+                "host_capabilities": ["lms", "host_action"],
+            },
+            "tools": {"observed": ["tool_web_search"]},
+            "host_actions": {
+                "preview_required": True,
+                "approval_token_present": True,
+            },
+        },
+        wiii_connect_snapshot={
+            "version": "wiii_connect_snapshot.v0",
+            "generated_at": "2026-05-27T00:00:00Z",
+            "surface": "lms_course_editor",
+            "connections": [
+                {
+                    "slug": "document_corpus",
+                    "label": "Document corpus",
+                    "status": "connected",
+                    "active": True,
+                    "agent_ready": True,
+                    "scopes": {"read": True, "write": False},
+                    "capabilities": ["document.read", "document.cite"],
+                    "attachment_count": 1,
+                    "filename": "private.docx",
+                    "approval_token": "must-not-leak",
+                }
+            ],
+            "path_capabilities": [
+                {
+                    "path": "lms_document_apply",
+                    "mutation_policy": "approval_token_required",
+                    "raw_prompt": "must-not-leak",
+                }
+            ],
+            "warnings": ["document_context_without_source_refs"],
+        },
+    )
+
+    snapshot = payload["wiii_connect"]
+    assert snapshot["version"] == "wiii_connect_snapshot.v0"
+    assert snapshot["connections"][0]["slug"] == "document_corpus"
+    assert snapshot["connections"][0]["attachment_count"] == 1
+    assert snapshot["connections"][0]["scopes"] == {"read": True, "write": False}
+    assert snapshot["path_capabilities"][0]["mutation_policy"] == "approval_token_required"
+    serialized = str(snapshot)
+    assert "private.docx" not in serialized
+    assert "must-not-leak" not in serialized
+    assert "raw_prompt" not in serialized

--- a/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
+++ b/maritime-ai-service/tests/unit/test_chat_stream_coordinator.py
@@ -437,6 +437,19 @@ async def test_generate_stream_v3_events_flow_ledger_omits_uploaded_document_bod
     ledger_json = json.dumps(ledger, ensure_ascii=False)
     assert "SECRET DOCUMENT BODY" not in ledger_json
     assert "Tao cho minh bai hoc" not in ledger_json
+    wiii_connect_snapshots = [
+        payload["capabilities"].get("wiii_connect")
+        for payload in _lifecycle_payloads(chunks)
+        if isinstance(payload.get("capabilities"), dict)
+        and isinstance(payload["capabilities"].get("wiii_connect"), dict)
+    ]
+    assert wiii_connect_snapshots
+    snapshot_json = json.dumps(wiii_connect_snapshots, ensure_ascii=False)
+    assert "wiii_connect_snapshot.v0" in snapshot_json
+    assert "document_corpus" in snapshot_json
+    assert "SECRET DOCUMENT BODY" not in snapshot_json
+    assert "private.docx" not in snapshot_json
+    assert "Tao cho minh bai hoc" not in snapshot_json
 
 
 @pytest.mark.asyncio

--- a/wiii-desktop/src/__tests__/capability-status-bar.test.tsx
+++ b/wiii-desktop/src/__tests__/capability-status-bar.test.tsx
@@ -107,6 +107,28 @@ describe("CapabilityStatusBar", () => {
             host_surface: "desktop_chat",
             observed_tools: ["memory.lookup"],
             suppressed_tools: ["host_action"],
+            wiii_connect: {
+              version: "wiii_connect_snapshot.v0",
+              surface: "desktop_chat",
+              connections: [
+                {
+                  slug: "document_corpus",
+                  label: "Document corpus",
+                  status: "connected",
+                  active: true,
+                  agent_ready: true,
+                  capabilities: ["document.read"],
+                  attachment_count: 1,
+                  source_ref_count: 2,
+                },
+              ],
+              path_capabilities: [
+                {
+                  path: "document_grounded_answer",
+                  required_connection_slugs: ["document_corpus"],
+                },
+              ],
+            },
           },
           received_at_ms: 1779825600000,
         },
@@ -119,10 +141,14 @@ describe("CapabilityStatusBar", () => {
 
     expect(screen.getByTestId("capability-dashboard-section-path")).toBeTruthy();
     expect(screen.getAllByText("native_turn").length).toBeGreaterThan(0);
-    expect(screen.getByText("desktop_chat")).toBeTruthy();
+    expect(screen.getAllByText("desktop_chat").length).toBeGreaterThan(0);
     expect(screen.getByText("1 tool (Memory)")).toBeTruthy();
     expect(screen.getByText("1 tool (Host)")).toBeTruthy();
+    expect(screen.getByTestId("capability-dashboard-section-wiii_connect")).toBeTruthy();
+    expect(screen.getByText("Document corpus")).toBeTruthy();
+    expect(screen.getByText(/1 file/)).toBeTruthy();
     expect(screen.queryByText("host_action")).toBeNull();
+    expect(screen.queryByText("document.read")).toBeNull();
   });
 
   it("shows disconnected server and missing host action bridge", () => {

--- a/wiii-desktop/src/__tests__/capability-status.test.ts
+++ b/wiii-desktop/src/__tests__/capability-status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildCapabilityStatuses } from "@/lib/capability-status";
+import { buildCapabilityStatuses, buildCapabilityStatusViewModel } from "@/lib/capability-status";
 
 describe("buildCapabilityStatuses", () => {
   it("marks standalone Wiii as personal host with local Pointy", () => {
@@ -89,5 +89,55 @@ describe("buildCapabilityStatuses", () => {
       value: "Đang chờ",
       tone: "pending",
     });
+  });
+
+  it("summarizes backend Wiii Connect snapshot without exposing raw tool names", () => {
+    const viewModel = buildCapabilityStatusViewModel({
+      connectionStatus: "connected",
+      capabilities: null,
+      currentContext: null,
+      isEmbedded: false,
+      runtimePath: {
+        lane: "native_turn",
+        wiiiConnect: {
+          version: "wiii_connect_snapshot.v0",
+          surface: "desktop_chat",
+          connections: [
+            {
+              slug: "document_corpus",
+              label: "Document corpus",
+              status: "connected",
+              active: true,
+              agent_ready: true,
+              capabilities: ["document.read"],
+              attachment_count: 1,
+              source_ref_count: 2,
+            },
+            {
+              slug: "weather",
+              label: "Weather",
+              status: "disabled",
+              active: false,
+              agent_ready: false,
+              reason: "missing_weather_provider",
+            },
+          ],
+          path_capabilities: [
+            {
+              path: "lms_document_apply",
+              mutation_policy: "approval_token_required",
+            },
+          ],
+        },
+      },
+    });
+
+    const section = viewModel.sections.find((item) => item.id === "wiii_connect");
+    expect(section).toBeTruthy();
+    expect(section?.summary).toContain("1/2");
+    expect(section?.metrics.some((metric) => metric.value.includes("1 file"))).toBe(true);
+    const serialized = JSON.stringify(section);
+    expect(serialized).not.toContain("document.read");
+    expect(serialized).not.toContain("approval_token_required");
   });
 });

--- a/wiii-desktop/src/__tests__/use-sse-stream-concurrency.test.ts
+++ b/wiii-desktop/src/__tests__/use-sse-stream-concurrency.test.ts
@@ -269,6 +269,28 @@ describe("useSSEStream concurrency", () => {
           observed_tools: ["tool_web_search"],
           suppressed_tools: ["host_action"],
           preview_required: false,
+          wiii_connect: {
+            version: "wiii_connect_snapshot.v0",
+            surface: "desktop_chat",
+            connections: [
+              {
+                slug: "document_corpus",
+                label: "Document corpus",
+                status: "connected",
+                active: true,
+                agent_ready: true,
+                attachment_count: 1,
+                filename: "private.docx",
+                approval_token: "must-not-persist",
+              },
+            ],
+            path_capabilities: [
+              {
+                path: "document_grounded_answer",
+                raw_prompt: "must-not-persist",
+              },
+            ],
+          },
         },
         metadata: {
           model: "qwen/qwen3-next-80b-a3b-instruct",
@@ -310,6 +332,16 @@ describe("useSSEStream concurrency", () => {
       capabilities: {
         observed_tools: ["tool_web_search"],
         suppressed_tools: ["host_action"],
+        wiii_connect: {
+          version: "wiii_connect_snapshot.v0",
+          connections: [
+            {
+              slug: "document_corpus",
+              label: "Document corpus",
+              attachment_count: 1,
+            },
+          ],
+        },
       },
       metadata: {
         model: "qwen/qwen3-next-80b-a3b-instruct",
@@ -325,6 +357,12 @@ describe("useSSEStream concurrency", () => {
     expect(state.lastCompletedLifecycleEvents[0]?.details).not.toHaveProperty(
       "raw_payload",
     );
+    const sanitizedLifecycle = JSON.stringify(
+      state.lastCompletedLifecycleEvents[0]?.capabilities,
+    );
+    expect(sanitizedLifecycle).not.toContain("private.docx");
+    expect(sanitizedLifecycle).not.toContain("approval_token");
+    expect(sanitizedLifecycle).not.toContain("raw_prompt");
 
     const conversation = state.activeConversation();
     const assistantMessages =

--- a/wiii-desktop/src/api/types.ts
+++ b/wiii-desktop/src/api/types.ts
@@ -414,6 +414,44 @@ export interface SSEStatusEvent {
   presentation?: PresentationMode;
 }
 
+export interface WiiiConnectRuntimeConnection {
+  id?: string | null;
+  provider_kind?: string;
+  slug: string;
+  label: string;
+  status: string;
+  active?: boolean;
+  agent_ready?: boolean;
+  scopes?: Record<string, boolean>;
+  capabilities?: string[];
+  required_for_paths?: string[];
+  source?: string;
+  last_checked_at?: string | null;
+  reason?: string;
+  warnings?: string[];
+  [key: string]: unknown;
+}
+
+export interface WiiiConnectRuntimePathCapability {
+  path: string;
+  allowed_connection_slugs?: string[];
+  required_connection_slugs?: string[];
+  allowed_tool_groups?: string[];
+  forbidden_tool_groups?: string[];
+  mutation_policy?: string;
+  delegation_policy?: string;
+  [key: string]: unknown;
+}
+
+export interface WiiiConnectRuntimeSnapshot {
+  version: string;
+  generated_at?: string;
+  surface?: string;
+  connections?: WiiiConnectRuntimeConnection[];
+  path_capabilities?: WiiiConnectRuntimePathCapability[];
+  warnings?: string[];
+}
+
 export interface SSEChatLifecycleEvent {
   schema_version: string;
   event_name: string;
@@ -435,6 +473,7 @@ export interface SSEChatLifecycleEvent {
     preview_emitted?: boolean;
     approval_token_present?: boolean;
     apply_attempted?: boolean;
+    wiii_connect?: WiiiConnectRuntimeSnapshot;
   };
   metadata?: Record<string, unknown>;
   details?: Record<string, unknown>;

--- a/wiii-desktop/src/components/chat/CapabilityStatusBar.tsx
+++ b/wiii-desktop/src/components/chat/CapabilityStatusBar.tsx
@@ -4,6 +4,7 @@ import {
   ChevronDown,
   GraduationCap,
   MousePointer2,
+  Network,
   Route,
   Server,
   Workflow,
@@ -56,6 +57,7 @@ const sectionIconById: Record<CapabilityDashboardSection["id"], typeof Server> =
   host_actions: Workflow,
   lms_authoring: GraduationCap,
   pointy: MousePointer2,
+  wiii_connect: Network,
   path: Route,
 };
 
@@ -149,6 +151,7 @@ function runtimePathFromLifecycle(
     previewEmitted: event.capabilities?.preview_emitted,
     approvalTokenPresent: event.capabilities?.approval_token_present,
     applyAttempted: event.capabilities?.apply_attempted,
+    wiiiConnect: event.capabilities?.wiii_connect ?? null,
     receivedAtMs: event.received_at_ms,
   };
 }

--- a/wiii-desktop/src/lib/capability-status.ts
+++ b/wiii-desktop/src/lib/capability-status.ts
@@ -2,6 +2,7 @@ import type {
   HostCapabilities,
   HostContext,
 } from "@/stores/host-context-store";
+import type { WiiiConnectRuntimeConnection, WiiiConnectRuntimeSnapshot } from "@/api/types";
 
 export type RuntimeConnectionStatus =
   | "connected"
@@ -39,6 +40,7 @@ export interface RuntimePathSnapshot {
   previewEmitted?: boolean;
   approvalTokenPresent?: boolean;
   applyAttempted?: boolean;
+  wiiiConnect?: WiiiConnectRuntimeSnapshot | null;
   receivedAtMs?: number;
 }
 
@@ -50,6 +52,7 @@ export interface CapabilityDashboardMetric {
 
 export type CapabilityDashboardSectionId =
   | CapabilityStatusItemId
+  | "wiii_connect"
   | "path";
 
 export interface CapabilityDashboardSection {
@@ -165,6 +168,30 @@ function formatToolGroupSummary(names: string[] | undefined): string {
     }),
   );
   return `${names.length} tool (${Array.from(groups).join(", ")})`;
+}
+
+function isWiiiConnectReady(connection: WiiiConnectRuntimeConnection): boolean {
+  return connection.agent_ready === true || connection.active === true || connection.status === "connected";
+}
+
+function wiiiConnectConnectionTone(
+  connection: WiiiConnectRuntimeConnection,
+): CapabilityStatusTone {
+  if (connection.status === "error" || connection.status === "expired") return "warn";
+  if (connection.status === "pending" || connection.status === "preview") return "pending";
+  if (connection.status === "disabled" || connection.status === "not_connected") return "off";
+  return isWiiiConnectReady(connection) ? "ok" : "warn";
+}
+
+function formatConnectionStatus(status: string | undefined): string {
+  if (status === "connected") return "Đã kết nối";
+  if (status === "preview") return "Preview";
+  if (status === "pending") return "Đang chờ";
+  if (status === "expired") return "Hết hạn";
+  if (status === "error") return "Lỗi";
+  if (status === "disabled") return "Tắt";
+  if (status === "not_connected") return "Chưa nối";
+  return compactValue(status, "Không rõ");
 }
 
 function serverStatusItem(status: RuntimeConnectionStatus): CapabilityStatusItem {
@@ -481,6 +508,71 @@ function buildPointySection(
   };
 }
 
+function buildWiiiConnectSection(
+  snapshot: WiiiConnectRuntimeSnapshot | null | undefined,
+): CapabilityDashboardSection {
+  if (!snapshot) {
+    return {
+      id: "wiii_connect",
+      title: "Wiii Connect",
+      summary: "Chưa có snapshot",
+      tone: "pending",
+      metrics: [
+        { label: "Snapshot", value: "Chưa có" },
+        { label: "Nguồn", value: "Chờ chat_lifecycle" },
+      ],
+    };
+  }
+
+  const connections = snapshot.connections ?? [];
+  const readyCount = connections.filter(isWiiiConnectReady).length;
+  const warningCount = (snapshot.warnings?.length ?? 0)
+    + connections.reduce((total, connection) => total + (connection.warnings?.length ?? 0), 0);
+  const pathCount = snapshot.path_capabilities?.length ?? 0;
+  const metrics: CapabilityDashboardMetric[] = [
+    { label: "Phiên bản", value: compactValue(snapshot.version) },
+    { label: "Surface", value: compactValue(snapshot.surface, "Không rõ") },
+    {
+      label: "Agent-ready",
+      value: `${readyCount}/${connections.length} kết nối`,
+      tone: readyCount > 0 ? "ok" : "pending",
+    },
+    {
+      label: "Cảnh báo",
+      value: warningCount > 0 ? `${warningCount} cảnh báo` : "Không",
+      tone: warningCount > 0 ? "warn" : "ok",
+    },
+    {
+      label: "Path policy",
+      value: pathCount > 0 ? `${pathCount} path` : "Chưa có",
+      tone: pathCount > 0 ? "ok" : "pending",
+    },
+  ];
+
+  for (const connection of connections.slice(0, 10)) {
+    const status = formatConnectionStatus(connection.status);
+    const detailCount = [
+      typeof connection.attachment_count === "number" ? `${connection.attachment_count} file` : "",
+      typeof connection.source_ref_count === "number" ? `${connection.source_ref_count} nguồn` : "",
+      typeof connection.target_count === "number" ? `${connection.target_count} target` : "",
+      typeof connection.tool_count === "number" ? `${connection.tool_count} tool` : "",
+    ].filter(Boolean);
+    metrics.push({
+      label: compactValue(connection.label || connection.slug),
+      value: detailCount.length > 0 ? `${status} · ${detailCount.join(", ")}` : status,
+      tone: wiiiConnectConnectionTone(connection),
+    });
+  }
+
+  return {
+    id: "wiii_connect",
+    title: "Wiii Connect",
+    summary: `${readyCount}/${connections.length} sẵn sàng`,
+    tone: warningCount > 0 ? "warn" : readyCount > 0 ? "ok" : "pending",
+    metrics,
+  };
+}
+
 function buildPathSection(
   runtimePath: RuntimePathSnapshot | null | undefined,
 ): CapabilityDashboardSection {
@@ -556,6 +648,7 @@ export function buildCapabilityStatusViewModel(
       buildHostActionSection(byId.get("host_actions")!, input.capabilities),
       buildLmsAuthoringSection(byId.get("lms_authoring")!, input, toolNames),
       buildPointySection(byId.get("pointy")!, input.currentContext, toolNames, input.isEmbedded),
+      buildWiiiConnectSection(input.runtimePath?.wiiiConnect),
       buildPathSection(input.runtimePath),
     ],
     summary: overall.summary,

--- a/wiii-desktop/src/stores/chat-store.ts
+++ b/wiii-desktop/src/stores/chat-store.ts
@@ -43,6 +43,9 @@ import type {
   VisualBlockData,
   VisualSessionState,
   WidgetFeedbackItem,
+  WiiiConnectRuntimeConnection,
+  WiiiConnectRuntimePathCapability,
+  WiiiConnectRuntimeSnapshot,
 } from "@/api/types";
 
 const BASE_STORE_NAME = "conversations.json";
@@ -686,6 +689,134 @@ function sanitizeChatLifecycleRecord(
   return Object.keys(output).length > 0 ? output : undefined;
 }
 
+const WIII_CONNECT_CONNECTION_KEYS = new Set([
+  "id",
+  "provider_kind",
+  "slug",
+  "label",
+  "status",
+  "active",
+  "agent_ready",
+  "scopes",
+  "capabilities",
+  "required_for_paths",
+  "source",
+  "last_checked_at",
+  "reason",
+  "warnings",
+  "host_type",
+  "connector_id",
+  "resource_count",
+  "surface_count",
+  "tool_count",
+  "mutating_tool_count",
+  "attachment_count",
+  "document_count",
+  "source_ref_count",
+  "target_count",
+  "fail_closed_tool",
+  "default_city",
+]);
+
+const WIII_CONNECT_PATH_KEYS = new Set([
+  "path",
+  "allowed_connection_slugs",
+  "required_connection_slugs",
+  "allowed_tool_groups",
+  "forbidden_tool_groups",
+  "mutation_policy",
+  "delegation_policy",
+]);
+
+function sanitizeWiiiConnectScopes(value: unknown): Record<string, boolean> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const output: Record<string, boolean> = {};
+  for (const key of ["read", "preview", "write", "apply", "admin"]) {
+    const rawValue = (value as Record<string, unknown>)[key];
+    if (typeof rawValue === "boolean") output[key] = rawValue;
+  }
+  return Object.keys(output).length > 0 ? output : undefined;
+}
+
+function sanitizeWiiiConnectRecord(
+  value: unknown,
+  allowedKeys: Set<string>,
+): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const source = value as Record<string, unknown>;
+  const output: Record<string, unknown> = {};
+  for (const key of allowedKeys) {
+    const rawValue = source[key];
+    if (rawValue === undefined) continue;
+    if (key === "scopes") {
+      const scopes = sanitizeWiiiConnectScopes(rawValue);
+      if (scopes) output[key] = scopes;
+      continue;
+    }
+    if (typeof rawValue === "string") {
+      const normalized = clampChatLifecycleString(rawValue);
+      if (normalized) output[key] = normalized;
+      continue;
+    }
+    if (
+      typeof rawValue === "number" ||
+      typeof rawValue === "boolean" ||
+      rawValue === null
+    ) {
+      output[key] = rawValue;
+      continue;
+    }
+    const strings = sanitizeChatLifecycleStringArray(rawValue);
+    if (strings) output[key] = strings;
+  }
+  return Object.keys(output).length > 0 ? output : undefined;
+}
+
+function sanitizeWiiiConnectSnapshot(
+  value: unknown,
+): WiiiConnectRuntimeSnapshot | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const source = value as Record<string, unknown>;
+  const version = clampChatLifecycleString(source.version);
+  if (!version) return undefined;
+  const snapshot: WiiiConnectRuntimeSnapshot = { version };
+  const generatedAt = clampChatLifecycleString(source.generated_at);
+  if (generatedAt) snapshot.generated_at = generatedAt;
+  const surface = clampChatLifecycleString(source.surface);
+  if (surface) snapshot.surface = surface;
+
+  if (Array.isArray(source.connections)) {
+    const connections = source.connections
+      .map((item) => sanitizeWiiiConnectRecord(item, WIII_CONNECT_CONNECTION_KEYS))
+      .filter((item): item is WiiiConnectRuntimeConnection => {
+        return Boolean(
+          item &&
+          typeof item.slug === "string" &&
+          typeof item.label === "string" &&
+          typeof item.status === "string",
+        );
+      })
+      .slice(0, MAX_CHAT_LIFECYCLE_ARRAY_ITEMS);
+    if (connections.length > 0) snapshot.connections = connections;
+  }
+
+  if (Array.isArray(source.path_capabilities)) {
+    const pathCapabilities = source.path_capabilities
+      .map((item) => sanitizeWiiiConnectRecord(item, WIII_CONNECT_PATH_KEYS))
+      .filter((item): item is WiiiConnectRuntimePathCapability => {
+        return Boolean(item && typeof item.path === "string");
+      })
+      .slice(0, MAX_CHAT_LIFECYCLE_ARRAY_ITEMS);
+    if (pathCapabilities.length > 0) {
+      snapshot.path_capabilities = pathCapabilities;
+    }
+  }
+
+  const warnings = sanitizeChatLifecycleStringArray(source.warnings);
+  if (warnings) snapshot.warnings = warnings;
+  return snapshot;
+}
+
 function sanitizeChatLifecycleCapabilities(
   capabilities: SSEChatLifecycleEvent["capabilities"],
 ): SSEChatLifecycleEvent["capabilities"] | undefined {
@@ -717,6 +848,8 @@ function sanitizeChatLifecycleCapabilities(
   if (typeof capabilities.apply_attempted === "boolean") {
     output.apply_attempted = capabilities.apply_attempted;
   }
+  const wiiiConnect = sanitizeWiiiConnectSnapshot(capabilities.wiii_connect);
+  if (wiiiConnect) output.wiii_connect = wiiiConnect;
   return Object.keys(output).length > 0 ? output : undefined;
 }
 
@@ -776,6 +909,42 @@ function cloneChatLifecycleEvents(
             : undefined,
           suppressed_tools: event.capabilities.suppressed_tools
             ? [...event.capabilities.suppressed_tools]
+            : undefined,
+          wiii_connect: event.capabilities.wiii_connect
+            ? {
+                ...event.capabilities.wiii_connect,
+                connections: event.capabilities.wiii_connect.connections
+                  ? event.capabilities.wiii_connect.connections.map((connection) => ({
+                      ...connection,
+                      capabilities: connection.capabilities ? [...connection.capabilities] : undefined,
+                      required_for_paths: connection.required_for_paths
+                        ? [...connection.required_for_paths]
+                        : undefined,
+                      warnings: connection.warnings ? [...connection.warnings] : undefined,
+                      scopes: connection.scopes ? { ...connection.scopes } : undefined,
+                    }))
+                  : undefined,
+                path_capabilities: event.capabilities.wiii_connect.path_capabilities
+                  ? event.capabilities.wiii_connect.path_capabilities.map((path) => ({
+                      ...path,
+                      allowed_connection_slugs: path.allowed_connection_slugs
+                        ? [...path.allowed_connection_slugs]
+                        : undefined,
+                      required_connection_slugs: path.required_connection_slugs
+                        ? [...path.required_connection_slugs]
+                        : undefined,
+                      allowed_tool_groups: path.allowed_tool_groups
+                        ? [...path.allowed_tool_groups]
+                        : undefined,
+                      forbidden_tool_groups: path.forbidden_tool_groups
+                        ? [...path.forbidden_tool_groups]
+                        : undefined,
+                    }))
+                  : undefined,
+                warnings: event.capabilities.wiii_connect.warnings
+                  ? [...event.capabilities.wiii_connect.warnings]
+                  : undefined,
+              }
             : undefined,
         }
       : undefined,


### PR DESCRIPTION
## Summary
- Emits the privacy-safe Wiii Connect snapshot on `chat_lifecycle.capabilities.wiii_connect`.
- Sanitizes and persists the lifecycle projection on the desktop client.
- Adds a Wiii Connect section to the runtime/capability dashboard so browser tests can see backend connection/path state.
- Documents the SSE projection contract.

## Scope
- Backend lifecycle projection only; no new endpoint.
- Frontend dashboard display for connection/path summary.
- Focused privacy tests for backend and frontend lifecycle storage.

## Non-scope
- No new external OAuth/provider adapter.
- No LMS mutation behavior changes.
- No separate Wiii Connect repository.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_chat_runtime_lifecycle.py tests/unit/test_chat_stream_coordinator.py -q --tb=short` -> 27 passed
- `cd maritime-ai-service; python -m ruff check app/ tests/unit/test_chat_runtime_lifecycle.py tests/unit/test_chat_stream_coordinator.py --select=E9,F63,F7` -> passed
- `cd wiii-desktop; npx vitest run src/__tests__/capability-status.test.ts src/__tests__/capability-status-bar.test.tsx src/__tests__/use-sse-stream-concurrency.test.ts` -> 11 passed
- `cd wiii-desktop; npx tsc --noEmit` -> passed
- `cd wiii-desktop; npm run build:embed` -> passed with existing chunk-size/plugin timing warnings
- `git diff --check` -> passed

## Risk
- Low-to-medium: adds nested lifecycle metadata to streaming events and persisted chat lifecycle records. Payload is bounded and allowlisted on both backend and frontend.
- UI risk is limited to the existing runtime dashboard panel.

## Rollback
- Revert this PR to remove the SSE projection and dashboard section. Tool policy remains on the already-merged backend Wiii Connect snapshot from #723.

Closes #724