### PR TITLE
feat(desktop): add Wiii Connect page

### DIFF
--- a/docs/architecture/wiii-connect/CONNECTION_CONTRACT_V0.md
+++ b/docs/architecture/wiii-connect/CONNECTION_CONTRACT_V0.md
@@ -192,6 +192,24 @@ Frontend storage must sanitize the projection again before persisting lifecycle
 metadata. The UI may summarize connection rows and path counts, but should not
 show raw tool schema payloads in chat.
 
+## Desktop UX Projection
+
+The desktop shell has a first-class `Wiii Connect` page for the same projection.
+It is a read-only V0 control-plane view:
+
+- connection cards show provider kind, status, agent-ready state, scopes,
+  capability counts, path usage, safe count metadata, and warnings;
+- path policy shows required connection slugs, allowed/forbidden tool groups,
+  mutation policy, and delegation policy;
+- runtime diagnostics summarize observed/suppressed tool groups instead of raw
+  tool names;
+- external provider adapters are visible only as disabled rows until Wiii has a
+  vault, permission gate, adapter contract, and execution audit for them.
+
+This page must not become a separate source of truth. Backend runtime policy,
+SSE lifecycle metadata, chat dashboard chips, and the Wiii Connect page should
+continue to read the same sanitized snapshot shape.
+
 ## Implementation Order
 
 1. Add typed backend snapshot builders around current runtime status.

--- a/docs/architecture/wiii-connect/README.md
+++ b/docs/architecture/wiii-connect/README.md
@@ -105,6 +105,25 @@ Wiii Connect V0 should stay small:
 - Keep all mutating tools behind preview and approval evidence.
 - Record enough metadata in runtime ledgers to debug wrong-path behavior.
 
+## Current UX Surface
+
+The first product-facing Wiii Connect surface lives inside the desktop shell as
+the `Wiii Connect` page. It is an observability and governance page, not a
+third-party OAuth console yet.
+
+The page must:
+
+- read only the sanitized `chat_lifecycle.capabilities.wiii_connect` snapshot;
+- show connection status, agent-ready state, scopes, counts, warnings, and path
+  policy in grouped UI;
+- summarize tool/provider state without exposing raw tool schemas, provider
+  payloads, document text, approval token values, OAuth tokens, or API keys;
+- show external providers such as Composio, MCP, custom OAuth, and workflow
+  bridges as disabled until a vault, permission gate, and provider adapter
+  exist;
+- stay observational until backend execution gateways and reviewable adapter
+  contracts are implemented.
+
 V0 must not:
 
 - Build native Facebook/Gmail OAuth connectors.
@@ -148,8 +167,8 @@ this repository.
    tool policy state.
 2. Update `ToolPolicySession` to consume the snapshot as the source of
    connection status instead of building ad hoc connection maps.
-3. Extend the frontend runtime dashboard to display the same snapshot, grouped
-   by provider and path.
+3. Extend the frontend Wiii Connect page/runtime dashboard to display the same
+   snapshot, grouped by provider and path.
 4. Add tests proving that LMS apply, Pointy, web/weather, document-grounded
    chat, and visual/Code Studio paths bind only the right tools.
 5. Add a Composio adapter only after the native Wiii snapshot is stable.

--- a/wiii-desktop/src/__tests__/full-page-views.test.ts
+++ b/wiii-desktop/src/__tests__/full-page-views.test.ts
@@ -69,8 +69,19 @@ describe("Sprint 192: ui-store activeView", () => {
     expect(useUIStore.getState().activeView).toBe("chat");
   });
 
+  it("openWiiiConnect sets activeView to wiii-connect", () => {
+    useUIStore.getState().openWiiiConnect();
+    expect(useUIStore.getState().activeView).toBe("wiii-connect");
+  });
+
+  it("closeWiiiConnect returns to chat", () => {
+    useUIStore.getState().openWiiiConnect();
+    useUIStore.getState().closeWiiiConnect();
+    expect(useUIStore.getState().activeView).toBe("chat");
+  });
+
   it("navigateToChat returns to chat from any view", () => {
-    const views: ActiveView[] = ["system-admin", "org-admin", "settings"];
+    const views: ActiveView[] = ["system-admin", "org-admin", "settings", "wiii-connect"];
     for (const view of views) {
       useUIStore.setState({ activeView: view });
       useUIStore.getState().navigateToChat();

--- a/wiii-desktop/src/__tests__/full-page-views.test.ts
+++ b/wiii-desktop/src/__tests__/full-page-views.test.ts
@@ -76,8 +76,11 @@ describe("Sprint 192: ui-store activeView", () => {
 
   it("closeWiiiConnect returns to chat", () => {
     useUIStore.getState().openWiiiConnect();
+    useUIStore.setState({ commandPaletteOpen: true });
     useUIStore.getState().closeWiiiConnect();
-    expect(useUIStore.getState().activeView).toBe("chat");
+    const state = useUIStore.getState();
+    expect(state.activeView).toBe("chat");
+    expect(state.commandPaletteOpen).toBe(false);
   });
 
   it("navigateToChat returns to chat from any view", () => {

--- a/wiii-desktop/src/__tests__/wiii-connect-page.test.tsx
+++ b/wiii-desktop/src/__tests__/wiii-connect-page.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { WiiiConnectPage } from "@/components/connect/WiiiConnectPage";
+import { useChatStore } from "@/stores/chat-store";
+import { useConnectionStore } from "@/stores/connection-store";
+import { useHostContextStore } from "@/stores/host-context-store";
+import { useUIStore } from "@/stores/ui-store";
+
+describe("WiiiConnectPage", () => {
+  beforeEach(() => {
+    useHostContextStore.getState().clear();
+    useConnectionStore.setState({
+      status: "connected",
+      serverVersion: "test-version",
+      lastCheckedAt: "2026-05-28T12:00:00.000Z",
+      errorMessage: null,
+      pollIntervalId: null,
+    });
+    useChatStore.setState({
+      streamingLifecycleEvents: [],
+      lastCompletedLifecycleEvents: [],
+    });
+    useUIStore.setState({
+      activeView: "wiii-connect",
+      commandPaletteOpen: false,
+      sidebarOpen: true,
+    });
+  });
+
+  it("renders sanitized Wiii Connect snapshot without raw tool or token payloads", async () => {
+    useChatStore.setState({
+      lastCompletedLifecycleEvents: [
+        {
+          schema_version: "1",
+          event_name: "path.selected",
+          phase: "routing",
+          status: "selected",
+          message: "Selected document path",
+          lane: "document_grounded_answer",
+          capabilities: {
+            host_surface: "desktop_chat",
+            observed_tools: ["authoring.apply_lesson_patch", "document.read"],
+            suppressed_tools: ["host_action.execute"],
+            approval_token_present: true,
+            wiii_connect: {
+              version: "wiii_connect_snapshot.v0",
+              generated_at: "2026-05-28T12:00:00.000Z",
+              surface: "desktop_chat",
+              connections: [
+                {
+                  slug: "document_corpus",
+                  label: "Document corpus",
+                  provider_kind: "wiii_native",
+                  status: "connected",
+                  active: true,
+                  agent_ready: true,
+                  capabilities: ["document.read", "document.cite"],
+                  required_for_paths: ["document_grounded_answer"],
+                  scopes: { read: true },
+                  attachment_count: 1,
+                  source_ref_count: 2,
+                  last_checked_at: "2026-05-28T12:00:00.000Z",
+                  reason: "active",
+                },
+                {
+                  slug: "lms_authoring",
+                  label: "LMS authoring",
+                  provider_kind: "wiii_native",
+                  status: "not_connected",
+                  active: false,
+                  agent_ready: false,
+                  capabilities: ["authoring.apply_lesson_patch"],
+                  required_for_paths: ["lms_document_preview", "lms_document_apply"],
+                  scopes: { read: false, preview: false, apply: false },
+                  reason: "missing_lms_host",
+                },
+              ],
+              path_capabilities: [
+                {
+                  path: "document_grounded_answer",
+                  required_connection_slugs: ["document_corpus"],
+                  allowed_tool_groups: ["knowledge_search"],
+                  mutation_policy: "none",
+                  delegation_policy: "direct_only",
+                },
+                {
+                  path: "lms_document_apply",
+                  required_connection_slugs: ["lms_authoring"],
+                  allowed_tool_groups: ["lms_authoring"],
+                  mutation_policy: "approval_token_required",
+                  delegation_policy: "direct_only",
+                },
+              ],
+            },
+          },
+          received_at_ms: 1779969600000,
+        },
+      ],
+    });
+
+    render(<WiiiConnectPage />);
+
+    expect(screen.getByTestId("wiii-connect-page")).toBeTruthy();
+    expect(screen.getByText("Document corpus")).toBeTruthy();
+    expect(screen.getByText("2 capability")).toBeTruthy();
+    expect(screen.getByText(/1 file/)).toBeTruthy();
+    expect(screen.queryByText("document.read")).toBeNull();
+    expect(screen.queryByText("authoring.apply_lesson_patch")).toBeNull();
+    expect(screen.queryByText("host_action.execute")).toBeNull();
+    expect(screen.queryByText("approval-token")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Path policy/i }));
+
+    expect(screen.getByText("document_grounded_answer")).toBeTruthy();
+    expect(await screen.findByText("lms_document_apply")).toBeTruthy();
+    expect(screen.getByText("Cần approval_token")).toBeTruthy();
+  });
+
+  it("shows local fallback and disabled external adapters before a backend snapshot exists", () => {
+    useHostContextStore.getState().setCapabilities({
+      host_type: "desktop",
+      host_name: "Wiii Desktop",
+      tools: [{ name: "ui.highlight", description: "Highlight" }],
+    });
+
+    render(<WiiiConnectPage />);
+
+    expect(screen.getByText("Chưa có snapshot")).toBeTruthy();
+    expect(screen.getByText("Fallback cục bộ")).toBeTruthy();
+    expect(screen.getByText("Provider adapter chưa bật")).toBeTruthy();
+    expect(screen.getAllByText("Composio").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Adapter chưa bật").length).toBeGreaterThan(0);
+    expect(screen.queryByText("ui.highlight")).toBeNull();
+  });
+});

--- a/wiii-desktop/src/components/chat/CapabilityStatusBar.tsx
+++ b/wiii-desktop/src/components/chat/CapabilityStatusBar.tsx
@@ -1,4 +1,3 @@
-import type { ChatLifecycleTelemetryEvent } from "@/api/types";
 import {
   Cable,
   ChevronDown,
@@ -13,10 +12,10 @@ import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   buildCapabilityStatusViewModel,
+  runtimePathFromLifecycleEvents,
   type CapabilityDashboardSection,
   type CapabilityStatusItem,
   type CapabilityStatusTone,
-  type RuntimePathSnapshot,
 } from "@/lib/capability-status";
 import { useChatStore } from "@/stores/chat-store";
 import { useConnectionStore } from "@/stores/connection-store";
@@ -116,46 +115,6 @@ function computePanelPosition(anchor: HTMLElement | null): PanelPosition {
   return { top, left, width, maxHeight };
 }
 
-function latestLifecycleEvent(
-  streamingEvents: ChatLifecycleTelemetryEvent[],
-  completedEvents: ChatLifecycleTelemetryEvent[],
-): ChatLifecycleTelemetryEvent | null {
-  const source = streamingEvents.length > 0 ? streamingEvents : completedEvents;
-  for (let index = source.length - 1; index >= 0; index -= 1) {
-    const event = source[index];
-    if (event) return event;
-  }
-  return null;
-}
-
-function runtimePathFromLifecycle(
-  streamingEvents: ChatLifecycleTelemetryEvent[],
-  completedEvents: ChatLifecycleTelemetryEvent[],
-): RuntimePathSnapshot | null {
-  const event = latestLifecycleEvent(streamingEvents, completedEvents);
-  if (!event) return null;
-  return {
-    lane: event.lane,
-    eventName: event.event_name,
-    phase: event.phase,
-    status: event.status,
-    message: event.message,
-    hostSurface: event.capabilities?.host_surface,
-    observedTools: event.capabilities?.observed_tools
-      ? [...event.capabilities.observed_tools]
-      : undefined,
-    suppressedTools: event.capabilities?.suppressed_tools
-      ? [...event.capabilities.suppressed_tools]
-      : undefined,
-    previewRequired: event.capabilities?.preview_required,
-    previewEmitted: event.capabilities?.preview_emitted,
-    approvalTokenPresent: event.capabilities?.approval_token_present,
-    applyAttempted: event.capabilities?.apply_attempted,
-    wiiiConnect: event.capabilities?.wiii_connect ?? null,
-    receivedAtMs: event.received_at_ms,
-  };
-}
-
 export function CapabilityStatusBar({ compact = false }: CapabilityStatusBarProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [panelPosition, setPanelPosition] = useState<PanelPosition>(
@@ -179,7 +138,7 @@ export function CapabilityStatusBar({ compact = false }: CapabilityStatusBarProp
 
   const runtimePath = useMemo(
     () =>
-      runtimePathFromLifecycle(
+      runtimePathFromLifecycleEvents(
         streamingLifecycleEvents,
         lastCompletedLifecycleEvents,
       ),

--- a/wiii-desktop/src/components/common/CommandPalette.tsx
+++ b/wiii-desktop/src/components/common/CommandPalette.tsx
@@ -12,6 +12,7 @@ import {
   Sun,
   Sidebar,
   Sparkles,
+  PlugZap,
 } from "lucide-react";
 import { useChatStore } from "@/stores/chat-store";
 import { useUIStore } from "@/stores/ui-store";
@@ -41,7 +42,7 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
   const listRef = useRef<HTMLDivElement>(null);
 
   const { conversations, setActiveConversation, createConversation } = useChatStore();
-  const { toggleSidebar, openSettings } = useUIStore();
+  const { toggleSidebar, openSettings, openWiiiConnect } = useUIStore();
   const theme = useSettingsStore((s) => s.settings.theme);
   const { activeDomainId } = useDomainStore();
   const { activeOrgId } = useOrgStore();
@@ -71,6 +72,14 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
         description: "Ctrl+,",
         icon: <Settings size={16} />,
         action: () => { openSettings(); onClose(); },
+        category: "action",
+      },
+      {
+        id: "open-wiii-connect",
+        label: "Wiii Connect",
+        description: "Connection registry",
+        icon: <PlugZap size={16} />,
+        action: () => { openWiiiConnect(); onClose(); },
         category: "action",
       },
       {
@@ -112,7 +121,7 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
     }));
 
     return [...actions, ...convItems];
-  }, [conversations, theme, createConversation, toggleSidebar, openSettings, setActiveConversation, onClose, activeDomainId, activeOrgId]);
+  }, [conversations, theme, createConversation, toggleSidebar, openSettings, openWiiiConnect, setActiveConversation, onClose, activeDomainId, activeOrgId]);
 
   // Filter by query
   const filtered = useMemo(() => {

--- a/wiii-desktop/src/components/common/CommandPalette.tsx
+++ b/wiii-desktop/src/components/common/CommandPalette.tsx
@@ -77,7 +77,7 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
       {
         id: "open-wiii-connect",
         label: "Wiii Connect",
-        description: "Connection registry",
+        description: "Quản lý kết nối",
         icon: <PlugZap size={16} />,
         action: () => { openWiiiConnect(); onClose(); },
         category: "action",

--- a/wiii-desktop/src/components/connect/WiiiConnectPage.tsx
+++ b/wiii-desktop/src/components/connect/WiiiConnectPage.tsx
@@ -392,8 +392,8 @@ function ProviderRoadmap() {
         <Lock size={16} className="text-text-secondary" aria-hidden="true" />
         <h3 className="text-sm font-semibold text-text">Provider adapter chưa bật</h3>
       </div>
-      <div className="overflow-hidden rounded-lg border border-[var(--border)] bg-surface">
-        <table className="w-full min-w-[720px] text-left text-sm">
+      <div className="overflow-x-auto rounded-lg border border-[var(--border)] bg-surface">
+        <table className="w-full min-w-[640px] text-left text-sm">
           <thead className="border-b border-[var(--border)] bg-surface-secondary text-xs uppercase text-text-tertiary">
             <tr>
               <th className="px-3 py-2 font-medium">Provider</th>
@@ -484,8 +484,8 @@ function PathPolicyTable({
   }
 
   return (
-    <div className="overflow-hidden rounded-lg border border-[var(--border)] bg-surface">
-      <table className="w-full min-w-[860px] text-left text-sm">
+    <div className="overflow-x-auto rounded-lg border border-[var(--border)] bg-surface">
+      <table className="w-full min-w-[760px] text-left text-sm">
         <thead className="border-b border-[var(--border)] bg-surface-secondary text-xs uppercase text-text-tertiary">
           <tr>
             <th className="px-3 py-2 font-medium">Path</th>
@@ -549,7 +549,7 @@ function RuntimeSection({
     ["Tool bị chặn", toolGroupSummary(runtimePath?.suppressedTools)],
     ["Preview", runtimePath?.previewRequired ? "Cần preview" : "Không"],
     ["Apply", runtimePath?.approvalTokenPresent ? "Có approval evidence" : "Không"],
-    ["Nhận lúc", runtimePath?.receivedAtMs ? formatDateTime(new Date(runtimePath.receivedAtMs).toISOString()) : "Chưa có"],
+    ["Nhận lúc", runtimePath?.receivedAtMs != null ? formatDateTime(new Date(runtimePath.receivedAtMs).toISOString()) : "Chưa có"],
   ];
 
   return (

--- a/wiii-desktop/src/components/connect/WiiiConnectPage.tsx
+++ b/wiii-desktop/src/components/connect/WiiiConnectPage.tsx
@@ -1,0 +1,721 @@
+import { useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import {
+  Activity,
+  AlertTriangle,
+  Cable,
+  CheckCircle2,
+  CloudSun,
+  Code2,
+  Database,
+  FileText,
+  Globe2,
+  GraduationCap,
+  Info,
+  Lock,
+  MousePointer2,
+  Network,
+  PlugZap,
+  Route,
+  Server,
+  Workflow,
+  type LucideIcon,
+  XCircle,
+} from "lucide-react";
+import type {
+  WiiiConnectRuntimeConnection,
+  WiiiConnectRuntimePathCapability,
+  WiiiConnectRuntimeSnapshot,
+} from "@/api/types";
+import { FullPageView, type FullPageTab } from "@/components/layout/FullPageView";
+import {
+  buildCapabilityStatusViewModel,
+  runtimePathFromLifecycleEvents,
+  type CapabilityDashboardSection,
+  type CapabilityStatusTone,
+  type RuntimePathSnapshot,
+} from "@/lib/capability-status";
+import { useChatStore } from "@/stores/chat-store";
+import { useConnectionStore } from "@/stores/connection-store";
+import { useHostContextStore } from "@/stores/host-context-store";
+import { useUIStore } from "@/stores/ui-store";
+
+type ConnectTab = "connections" | "paths" | "runtime";
+
+const tabs: FullPageTab[] = [
+  { id: "connections", label: "Kết nối", icon: <PlugZap size={15} /> },
+  { id: "paths", label: "Path policy", icon: <Route size={15} /> },
+  { id: "runtime", label: "Runtime", icon: <Activity size={15} /> },
+];
+
+const connectionIconBySlug: Record<string, LucideIcon> = {
+  server: Server,
+  host: Cable,
+  host_actions: Workflow,
+  lms_authoring: GraduationCap,
+  document_corpus: FileText,
+  pointy: MousePointer2,
+  web_search: Globe2,
+  weather: CloudSun,
+  visual_runtime: Network,
+  code_studio: Code2,
+};
+
+const statusToneClasses: Record<CapabilityStatusTone, string> = {
+  ok: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  warn: "border-amber-200 bg-amber-50 text-amber-800",
+  pending: "border-sky-200 bg-sky-50 text-sky-700",
+  off: "border-[var(--border)] bg-surface-secondary text-text-tertiary",
+};
+
+const statusDotClasses: Record<CapabilityStatusTone, string> = {
+  ok: "bg-emerald-500",
+  warn: "bg-amber-500",
+  pending: "bg-sky-500",
+  off: "bg-zinc-400",
+};
+
+const providerKindLabels: Record<string, string> = {
+  wiii_native: "Wiii native",
+  composio: "Composio",
+  mcp: "MCP",
+  custom_oauth: "OAuth riêng",
+  workflow: "Workflow",
+};
+
+const mutationPolicyLabels: Record<string, string> = {
+  none: "Không ghi dữ liệu",
+  preview_only: "Chỉ preview",
+  approval_token_required: "Cần approval_token",
+  explicit_user_confirmation_required: "Cần xác nhận",
+};
+
+const delegationPolicyLabels: Record<string, string> = {
+  direct_only: "Trực tiếp",
+  delegate_to_path_agent: "Path agent",
+  delegate_to_integration_agent: "Integration agent",
+};
+
+const externalProviderRows = [
+  {
+    provider: "Composio",
+    kind: "composio",
+    state: "Adapter chưa bật",
+    note: "Dùng cho Facebook, Gmail, Notion, Slack khi có policy/vault.",
+  },
+  {
+    provider: "MCP",
+    kind: "mcp",
+    state: "Adapter chưa bật",
+    note: "Dùng cho server local/remote sau khi có permission gate.",
+  },
+  {
+    provider: "OAuth riêng",
+    kind: "custom_oauth",
+    state: "Chưa triển khai",
+    note: "Dùng khi Wiii tự sở hữu app, review quyền và token vault.",
+  },
+  {
+    provider: "Workflow",
+    kind: "workflow",
+    state: "Chưa triển khai",
+    note: "Dùng cho Activepieces, n8n, Windmill, Pipedream-like bridge.",
+  },
+];
+
+function isEmbeddedWindow(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.parent !== window;
+}
+
+function connectionTone(connection: WiiiConnectRuntimeConnection): CapabilityStatusTone {
+  if (connection.status === "error" || connection.status === "expired") return "warn";
+  if (connection.status === "pending" || connection.status === "preview") return "pending";
+  if (connection.status === "disabled" || connection.status === "not_connected") return "off";
+  return connection.agent_ready || connection.active || connection.status === "connected"
+    ? "ok"
+    : "warn";
+}
+
+function statusLabel(status: string | undefined): string {
+  if (status === "connected") return "Đã kết nối";
+  if (status === "preview") return "Preview";
+  if (status === "pending") return "Đang chờ";
+  if (status === "expired") return "Hết hạn";
+  if (status === "error") return "Lỗi";
+  if (status === "disabled") return "Tắt";
+  if (status === "not_connected") return "Chưa nối";
+  return compactText(status, "Không rõ");
+}
+
+function compactText(value: unknown, fallback = "Chưa có"): string {
+  const text = String(value ?? "").trim();
+  if (!text) return fallback;
+  return text.length > 72 ? `${text.slice(0, 69)}...` : text;
+}
+
+function formatCount(value: unknown, label: string): string | null {
+  if (typeof value !== "number") return null;
+  return `${value} ${label}`;
+}
+
+function formatDateTime(value: string | undefined | null): string {
+  if (!value) return "Chưa có";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return compactText(value);
+  return date.toLocaleString("vi-VN", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    day: "2-digit",
+    month: "2-digit",
+  });
+}
+
+function scopeSummary(scopes: WiiiConnectRuntimeConnection["scopes"]): string {
+  if (!scopes) return "Không";
+  const enabled = Object.entries(scopes)
+    .filter(([, value]) => value)
+    .map(([key]) => key);
+  return enabled.length > 0 ? enabled.join(", ") : "Không";
+}
+
+function pathList(value: string[] | undefined): string {
+  if (!value || value.length === 0) return "Không";
+  return value.join(", ");
+}
+
+function capabilityCount(connection: WiiiConnectRuntimeConnection): string {
+  const count = connection.capabilities?.length ?? 0;
+  return count > 0 ? `${count} capability` : "Không";
+}
+
+function connectionCounts(connection: WiiiConnectRuntimeConnection): string {
+  return [
+    formatCount(connection.attachment_count, "file"),
+    formatCount(connection.document_count, "doc"),
+    formatCount(connection.source_ref_count, "nguồn"),
+    formatCount(connection.target_count, "target"),
+    formatCount(connection.tool_count, "tool"),
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function toolGroupSummary(names: string[] | undefined): string {
+  if (!names || names.length === 0) return "Không";
+  const groups = new Set(
+    names.map((name) => {
+      const lower = name.toLowerCase();
+      if (lower.includes("authoring") || lower.includes("lms")) return "LMS";
+      if (lower.includes("host")) return "Host";
+      if (lower.startsWith("ui.") || lower.includes("pointy")) return "UI";
+      if (lower.includes("web") || lower.includes("search")) return "Web";
+      if (lower.includes("memory")) return "Memory";
+      if (lower.includes("visual")) return "Visual";
+      if (lower.includes("code")) return "Code";
+      return "Khác";
+    }),
+  );
+  return `${names.length} nhóm (${Array.from(groups).join(", ")})`;
+}
+
+function snapshotStats(snapshot: WiiiConnectRuntimeSnapshot | null) {
+  const connections = snapshot?.connections ?? [];
+  const readyCount = connections.filter(
+    (item) => item.agent_ready || item.active || item.status === "connected",
+  ).length;
+  const warningCount =
+    (snapshot?.warnings?.length ?? 0) +
+    connections.reduce((total, item) => total + (item.warnings?.length ?? 0), 0);
+  return {
+    total: connections.length,
+    ready: readyCount,
+    warningCount,
+    pathCount: snapshot?.path_capabilities?.length ?? 0,
+  };
+}
+
+function SummaryMetric({
+  icon: icon,
+  label,
+  value,
+  tone = "off",
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  tone?: CapabilityStatusTone;
+}) {
+  const Icon = icon;
+  return (
+    <div className="min-w-0 rounded-lg border border-[var(--border)] bg-surface px-4 py-3">
+      <div className="flex items-center gap-2 text-xs font-medium uppercase text-text-tertiary">
+        <Icon size={14} aria-hidden="true" />
+        <span className="truncate">{label}</span>
+      </div>
+      <div className="mt-2 flex items-center gap-2">
+        <span className={`h-2 w-2 rounded-full ${statusDotClasses[tone]}`} aria-hidden="true" />
+        <span className="truncate text-lg font-semibold text-text">{value}</span>
+      </div>
+    </div>
+  );
+}
+
+function StatusPill({ tone, children }: { tone: CapabilityStatusTone; children: ReactNode }) {
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium ${statusToneClasses[tone]}`}>
+      <span className={`h-1.5 w-1.5 rounded-full ${statusDotClasses[tone]}`} aria-hidden="true" />
+      {children}
+    </span>
+  );
+}
+
+function ConnectionsGrid({
+  connections,
+  snapshot,
+}: {
+  connections: WiiiConnectRuntimeConnection[];
+  snapshot: WiiiConnectRuntimeSnapshot | null;
+}) {
+  if (connections.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-[var(--border)] bg-surface-secondary px-4 py-8 text-sm text-text-secondary">
+        Chưa có snapshot Wiii Connect từ backend. Trang đang chờ lượt chat runtime tiếp theo.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+      {connections.map((connection) => {
+        const Icon = connectionIconBySlug[connection.slug] ?? Network;
+        const tone = connectionTone(connection);
+        const counts = connectionCounts(connection);
+        return (
+          <article
+            key={`${connection.provider_kind ?? "provider"}-${connection.slug}`}
+            className="min-w-0 rounded-lg border border-[var(--border)] bg-surface p-4"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex min-w-0 items-start gap-3">
+                <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-surface-secondary text-text-secondary">
+                  <Icon size={18} aria-hidden="true" />
+                </span>
+                <div className="min-w-0">
+                  <h3 className="truncate text-sm font-semibold text-text">
+                    {connection.label || connection.slug}
+                  </h3>
+                  <p className="mt-0.5 truncate text-xs text-text-tertiary">
+                    {providerKindLabels[connection.provider_kind ?? ""] ?? compactText(connection.provider_kind, "Provider")}
+                  </p>
+                </div>
+              </div>
+              <StatusPill tone={tone}>{statusLabel(connection.status)}</StatusPill>
+            </div>
+
+            <dl className="mt-4 grid grid-cols-2 gap-2 text-xs">
+              <div className="min-w-0 rounded-md bg-surface-secondary px-2 py-2">
+                <dt className="text-text-tertiary">Agent-ready</dt>
+                <dd className="mt-0.5 truncate font-medium text-text">
+                  {connection.agent_ready ? "Có" : "Chưa"}
+                </dd>
+              </div>
+              <div className="min-w-0 rounded-md bg-surface-secondary px-2 py-2">
+                <dt className="text-text-tertiary">Scope</dt>
+                <dd className="mt-0.5 truncate font-medium text-text">
+                  {scopeSummary(connection.scopes)}
+                </dd>
+              </div>
+              <div className="min-w-0 rounded-md bg-surface-secondary px-2 py-2">
+                <dt className="text-text-tertiary">Capability</dt>
+                <dd className="mt-0.5 truncate font-medium text-text">
+                  {capabilityCount(connection)}
+                </dd>
+              </div>
+              <div className="min-w-0 rounded-md bg-surface-secondary px-2 py-2">
+                <dt className="text-text-tertiary">Path dùng</dt>
+                <dd className="mt-0.5 truncate font-medium text-text">
+                  {pathList(connection.required_for_paths)}
+                </dd>
+              </div>
+            </dl>
+
+            <div className="mt-3 space-y-1.5 text-xs text-text-secondary">
+              <div className="flex min-w-0 justify-between gap-3">
+                <span className="shrink-0 text-text-tertiary">Nguồn</span>
+                <span className="truncate">{compactText(connection.source)}</span>
+              </div>
+              <div className="flex min-w-0 justify-between gap-3">
+                <span className="shrink-0 text-text-tertiary">Kiểm tra</span>
+                <span className="truncate">{formatDateTime(connection.last_checked_at)}</span>
+              </div>
+              {counts && (
+                <div className="flex min-w-0 justify-between gap-3">
+                  <span className="shrink-0 text-text-tertiary">Tài nguyên</span>
+                  <span className="truncate">{counts}</span>
+                </div>
+              )}
+              {connection.reason && (
+                <div className="flex min-w-0 justify-between gap-3">
+                  <span className="shrink-0 text-text-tertiary">Lý do</span>
+                  <span className="truncate">{compactText(connection.reason)}</span>
+                </div>
+              )}
+            </div>
+
+            {connection.warnings && connection.warnings.length > 0 && (
+              <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-2 py-2 text-xs text-amber-800">
+                {connection.warnings.length} cảnh báo trong connection này.
+              </div>
+            )}
+          </article>
+        );
+      })}
+
+      {snapshot?.warnings && snapshot.warnings.length > 0 && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 md:col-span-2 xl:col-span-3">
+          <div className="flex items-center gap-2 font-medium">
+            <AlertTriangle size={16} aria-hidden="true" />
+            Snapshot có {snapshot.warnings.length} cảnh báo cần kiểm tra.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProviderRoadmap() {
+  return (
+    <section className="mt-6">
+      <div className="mb-3 flex items-center gap-2">
+        <Lock size={16} className="text-text-secondary" aria-hidden="true" />
+        <h3 className="text-sm font-semibold text-text">Provider adapter chưa bật</h3>
+      </div>
+      <div className="overflow-hidden rounded-lg border border-[var(--border)] bg-surface">
+        <table className="w-full min-w-[720px] text-left text-sm">
+          <thead className="border-b border-[var(--border)] bg-surface-secondary text-xs uppercase text-text-tertiary">
+            <tr>
+              <th className="px-3 py-2 font-medium">Provider</th>
+              <th className="px-3 py-2 font-medium">Kind</th>
+              <th className="px-3 py-2 font-medium">Trạng thái</th>
+              <th className="px-3 py-2 font-medium">Ghi chú</th>
+            </tr>
+          </thead>
+          <tbody>
+            {externalProviderRows.map((row) => (
+              <tr key={row.provider} className="border-b border-[var(--border)] last:border-b-0">
+                <td className="px-3 py-3 font-medium text-text">{row.provider}</td>
+                <td className="px-3 py-3 text-text-secondary">
+                  {providerKindLabels[row.kind] ?? row.kind}
+                </td>
+                <td className="px-3 py-3">
+                  <StatusPill tone="off">{row.state}</StatusPill>
+                </td>
+                <td className="px-3 py-3 text-text-secondary">{row.note}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function LocalRuntimeFallback({
+  sections,
+}: {
+  sections: CapabilityDashboardSection[];
+}) {
+  return (
+    <section className="mt-6">
+      <div className="mb-3 flex items-center gap-2">
+        <Activity size={16} className="text-text-secondary" aria-hidden="true" />
+        <h3 className="text-sm font-semibold text-text">Fallback cục bộ</h3>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {sections.slice(0, 5).map((section) => (
+          <article
+            key={section.id}
+            className="min-w-0 rounded-lg border border-[var(--border)] bg-surface p-4"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <h4 className="truncate text-sm font-semibold text-text">
+                  {section.title}
+                </h4>
+                <p className="mt-0.5 truncate text-xs text-text-tertiary">
+                  {section.summary}
+                </p>
+              </div>
+              <StatusPill tone={section.tone}>{section.summary}</StatusPill>
+            </div>
+            <dl className="mt-3 grid gap-2 text-xs">
+              {section.metrics.slice(0, 4).map((metric, index) => (
+                <div
+                  key={`${section.id}-${metric.label}-${index}`}
+                  className="min-w-0 rounded-md bg-surface-secondary px-2 py-2"
+                >
+                  <dt className="text-text-tertiary">{metric.label}</dt>
+                  <dd className="mt-0.5 truncate font-medium text-text">
+                    {metric.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function PathPolicyTable({
+  paths,
+}: {
+  paths: WiiiConnectRuntimePathCapability[];
+}) {
+  if (paths.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-[var(--border)] bg-surface-secondary px-4 py-8 text-sm text-text-secondary">
+        Chưa có path policy trong snapshot runtime.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-[var(--border)] bg-surface">
+      <table className="w-full min-w-[860px] text-left text-sm">
+        <thead className="border-b border-[var(--border)] bg-surface-secondary text-xs uppercase text-text-tertiary">
+          <tr>
+            <th className="px-3 py-2 font-medium">Path</th>
+            <th className="px-3 py-2 font-medium">Kết nối bắt buộc</th>
+            <th className="px-3 py-2 font-medium">Tool group được phép</th>
+            <th className="px-3 py-2 font-medium">Tool group bị chặn</th>
+            <th className="px-3 py-2 font-medium">Mutation</th>
+            <th className="px-3 py-2 font-medium">Delegation</th>
+          </tr>
+        </thead>
+        <tbody>
+          {paths.map((path) => (
+            <tr key={path.path} className="border-b border-[var(--border)] last:border-b-0">
+              <td className="px-3 py-3 font-medium text-text">{path.path}</td>
+              <td className="px-3 py-3 text-text-secondary">
+                {pathList(path.required_connection_slugs)}
+              </td>
+              <td className="px-3 py-3 text-text-secondary">
+                {pathList(path.allowed_tool_groups)}
+              </td>
+              <td className="px-3 py-3 text-text-secondary">
+                {pathList(path.forbidden_tool_groups)}
+              </td>
+              <td className="px-3 py-3">
+                <StatusPill
+                  tone={
+                    path.mutation_policy === "approval_token_required" ||
+                    path.mutation_policy === "explicit_user_confirmation_required"
+                      ? "warn"
+                      : path.mutation_policy === "preview_only"
+                        ? "pending"
+                        : "ok"
+                  }
+                >
+                  {mutationPolicyLabels[path.mutation_policy ?? "none"] ?? compactText(path.mutation_policy)}
+                </StatusPill>
+              </td>
+              <td className="px-3 py-3 text-text-secondary">
+                {delegationPolicyLabels[path.delegation_policy ?? "direct_only"] ?? compactText(path.delegation_policy)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RuntimeSection({
+  runtimePath,
+}: {
+  runtimePath: RuntimePathSnapshot | null;
+}) {
+  const rows = [
+    ["Path", compactText(runtimePath?.lane, "Chưa phân loại")],
+    ["Pha", compactText(runtimePath?.phase)],
+    ["Sự kiện", compactText(runtimePath?.eventName)],
+    ["Trạng thái", compactText(runtimePath?.status)],
+    ["Surface", compactText(runtimePath?.hostSurface, "Không")],
+    ["Tool đã thấy", toolGroupSummary(runtimePath?.observedTools)],
+    ["Tool bị chặn", toolGroupSummary(runtimePath?.suppressedTools)],
+    ["Preview", runtimePath?.previewRequired ? "Cần preview" : "Không"],
+    ["Apply", runtimePath?.approvalTokenPresent ? "Có approval evidence" : "Không"],
+    ["Nhận lúc", runtimePath?.receivedAtMs ? formatDateTime(new Date(runtimePath.receivedAtMs).toISOString()) : "Chưa có"],
+  ];
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(300px,380px)]">
+      <section className="rounded-lg border border-[var(--border)] bg-surface p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <Route size={16} className="text-text-secondary" aria-hidden="true" />
+          <h3 className="text-sm font-semibold text-text">Lượt runtime gần nhất</h3>
+        </div>
+        <dl className="grid gap-2 sm:grid-cols-2">
+          {rows.map(([label, value]) => (
+            <div key={label} className="min-w-0 rounded-md bg-surface-secondary px-3 py-2">
+              <dt className="text-xs text-text-tertiary">{label}</dt>
+              <dd className="mt-0.5 truncate text-sm font-medium text-text">{value}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+
+      <section className="rounded-lg border border-[var(--border)] bg-surface p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <Info size={16} className="text-text-secondary" aria-hidden="true" />
+          <h3 className="text-sm font-semibold text-text">Kỷ luật hiển thị</h3>
+        </div>
+        <ul className="space-y-2 text-sm text-text-secondary">
+          <li className="flex gap-2">
+            <CheckCircle2 size={16} className="mt-0.5 shrink-0 text-emerald-600" aria-hidden="true" />
+            Chỉ hiển thị snapshot đã sanitize từ runtime.
+          </li>
+          <li className="flex gap-2">
+            <CheckCircle2 size={16} className="mt-0.5 shrink-0 text-emerald-600" aria-hidden="true" />
+            Không hiển thị token, payload provider, raw document hay approval_token.
+          </li>
+          <li className="flex gap-2">
+            <XCircle size={16} className="mt-0.5 shrink-0 text-text-tertiary" aria-hidden="true" />
+            Adapter bên ngoài chưa được bật nếu chưa có vault/policy/gate.
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+export function WiiiConnectPage() {
+  const [activeTab, setActiveTab] = useState<ConnectTab>("connections");
+  const navigateToChat = useUIStore((state) => state.navigateToChat);
+  const connectionStatus = useConnectionStore((state) => state.status);
+  const serverVersion = useConnectionStore((state) => state.serverVersion);
+  const lastCheckedAt = useConnectionStore((state) => state.lastCheckedAt);
+  const errorMessage = useConnectionStore((state) => state.errorMessage);
+  const capabilities = useHostContextStore((state) => state.capabilities);
+  const currentContext = useHostContextStore((state) => state.currentContext);
+  const streamingLifecycleEvents = useChatStore(
+    (state) => state.streamingLifecycleEvents,
+  );
+  const lastCompletedLifecycleEvents = useChatStore(
+    (state) => state.lastCompletedLifecycleEvents,
+  );
+
+  const runtimePath = useMemo(
+    () =>
+      runtimePathFromLifecycleEvents(
+        streamingLifecycleEvents,
+        lastCompletedLifecycleEvents,
+      ),
+    [streamingLifecycleEvents, lastCompletedLifecycleEvents],
+  );
+  const snapshot = runtimePath?.wiiiConnect ?? null;
+  const stats = snapshotStats(snapshot);
+  const isEmbedded = isEmbeddedWindow();
+
+  const fallbackModel = useMemo(
+    () =>
+      buildCapabilityStatusViewModel({
+        connectionStatus,
+        capabilities,
+        currentContext,
+        isEmbedded,
+        serverVersion,
+        lastCheckedAt,
+        errorMessage,
+        runtimePath,
+      }),
+    [
+      connectionStatus,
+      capabilities,
+      currentContext,
+      isEmbedded,
+      serverVersion,
+      lastCheckedAt,
+      errorMessage,
+      runtimePath,
+    ],
+  );
+
+  const snapshotTone: CapabilityStatusTone =
+    !snapshot ? "pending" : stats.warningCount > 0 ? "warn" : stats.ready > 0 ? "ok" : "off";
+
+  return (
+    <FullPageView
+      title="Wiii Connect"
+      subtitle="Connection registry V0"
+      icon={<PlugZap size={18} />}
+      tabs={tabs}
+      activeTab={activeTab}
+      onTabChange={(id) => setActiveTab(id as ConnectTab)}
+      onClose={navigateToChat}
+    >
+      <div className="space-y-6" data-testid="wiii-connect-page">
+        <section>
+          <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h1 className="text-xl font-semibold text-text">Wiii Connect</h1>
+              <p className="mt-1 max-w-3xl text-sm text-text-secondary">
+                Trạng thái kết nối, capability và path policy đang được Wiii dùng trong lượt runtime gần nhất.
+              </p>
+            </div>
+            <StatusPill tone={snapshotTone}>
+              {snapshot ? `${stats.ready}/${stats.total} agent-ready` : "Chưa có snapshot"}
+            </StatusPill>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <SummaryMetric
+              icon={Database}
+              label="Kết nối"
+              value={snapshot ? `${stats.total}` : `${fallbackModel.items.length} local`}
+              tone={snapshot ? "ok" : "pending"}
+            />
+            <SummaryMetric
+              icon={CheckCircle2}
+              label="Agent-ready"
+              value={snapshot ? `${stats.ready}/${stats.total}` : fallbackModel.summary}
+              tone={snapshotTone}
+            />
+            <SummaryMetric
+              icon={Route}
+              label="Path policy"
+              value={snapshot ? `${stats.pathCount}` : "Đang chờ"}
+              tone={stats.pathCount > 0 ? "ok" : "pending"}
+            />
+            <SummaryMetric
+              icon={AlertTriangle}
+              label="Cảnh báo"
+              value={`${stats.warningCount}`}
+              tone={stats.warningCount > 0 ? "warn" : "ok"}
+            />
+          </div>
+        </section>
+
+        {activeTab === "connections" && (
+          <>
+            <ConnectionsGrid connections={snapshot?.connections ?? []} snapshot={snapshot} />
+            {!snapshot && <LocalRuntimeFallback sections={fallbackModel.sections} />}
+            <ProviderRoadmap />
+          </>
+        )}
+
+        {activeTab === "paths" && (
+          <PathPolicyTable paths={snapshot?.path_capabilities ?? []} />
+        )}
+
+        {activeTab === "runtime" && (
+          <RuntimeSection runtimePath={runtimePath} />
+        )}
+      </div>
+    </FullPageView>
+  );
+}

--- a/wiii-desktop/src/components/layout/AppShell.tsx
+++ b/wiii-desktop/src/components/layout/AppShell.tsx
@@ -67,6 +67,11 @@ const SoulBridgePanel = lazy(async () => {
   return { default: mod.SoulBridgePanel };
 });
 
+const WiiiConnectPage = lazy(async () => {
+  const mod = await import("@/components/connect/WiiiConnectPage");
+  return { default: mod.WiiiConnectPage };
+});
+
 const CodeStudioPanel = lazy(async () => {
   const mod = await import("./CodeStudioPanel");
   return { default: mod.CodeStudioPanel };
@@ -251,6 +256,7 @@ export function AppShell() {
               {activeView === "org-admin" && <OrgAdminView />}
               {activeView === "settings" && <SettingsView />}
               {activeView === "soul-bridge" && <SoulBridgePanel />}
+              {activeView === "wiii-connect" && <WiiiConnectPage />}
             </Suspense>
           )}
         </main>

--- a/wiii-desktop/src/components/layout/Sidebar.tsx
+++ b/wiii-desktop/src/components/layout/Sidebar.tsx
@@ -5,7 +5,7 @@
  */
 import { useState, useRef, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { Plus, Trash2, Settings, MessageSquare, Search, Pin, PinOff, Pencil, Shield, Building2, LogOut, User, Network, PanelLeftClose, PanelLeft, MoreHorizontal } from "lucide-react";
+import { Plus, Trash2, Settings, MessageSquare, Search, Pin, PinOff, Pencil, Shield, Building2, LogOut, User, Network, PlugZap, PanelLeftClose, PanelLeft, MoreHorizontal } from "lucide-react";
 import { useChatStore } from "@/stores/chat-store";
 import { useUIStore } from "@/stores/ui-store";
 import { useDomainStore } from "@/stores/domain-store";
@@ -39,7 +39,7 @@ export function Sidebar() {
     pinConversation,
     unpinConversation,
   } = useChatStore();
-  const { sidebarOpen, toggleSidebar, activeView, openSettings, openAdminPanel, openOrgManagerPanel, openSoulBridge, navigateToChat } = useUIStore();
+  const { sidebarOpen, toggleSidebar, activeView, openSettings, openAdminPanel, openOrgManagerPanel, openSoulBridge, openWiiiConnect, navigateToChat } = useUIStore();
   const { isSystemAdmin, isOrgAdmin } = useOrgStore();
   const { activeDomainId } = useDomainStore();
   const { activeOrgId } = useOrgStore();
@@ -218,6 +218,16 @@ export function Sidebar() {
           </button>
         )}
 
+        {/* Wiii Connect */}
+        <button
+          onClick={openWiiiConnect}
+          className={iconBtnClass(activeView === "wiii-connect")}
+          title="Wiii Connect"
+          aria-label="Mở Wiii Connect"
+        >
+          <PlugZap size={18} />
+        </button>
+
         {/* Sprint 216: Soul Bridge */}
         <button
           onClick={openSoulBridge}
@@ -348,6 +358,18 @@ export function Sidebar() {
 
       {/* Sprint 231h: User profile footer — click avatar → dropdown menu (Claude.ai pattern) */}
       <div className="px-2 py-2 border-t border-border relative">
+        <button
+          onClick={openWiiiConnect}
+          className={`mb-1 flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-sm transition-colors ${
+            activeView === "wiii-connect"
+              ? "bg-[var(--accent)]/10 text-[var(--accent)] font-medium"
+              : "text-text-secondary hover:bg-surface-tertiary hover:text-text"
+          }`}
+          aria-current={activeView === "wiii-connect" ? "page" : undefined}
+        >
+          <PlugZap size={15} />
+          <span className="truncate">Wiii Connect</span>
+        </button>
         {isAuthenticated && (
           <>
             <button
@@ -421,6 +443,14 @@ export function Sidebar() {
                           Quản lý tổ chức
                         </button>
                       )}
+                      <button
+                        onClick={() => { openWiiiConnect(); setUserMenuOpen(false); }}
+                        className="flex items-center gap-2.5 w-full px-3 py-2 text-sm text-text-secondary hover:bg-surface-tertiary transition-colors"
+                        role="menuitem"
+                      >
+                        <PlugZap size={15} />
+                        Wiii Connect
+                      </button>
                       <button
                         onClick={() => { openSoulBridge(); setUserMenuOpen(false); }}
                         className="flex items-center gap-2.5 w-full px-3 py-2 text-sm text-text-secondary hover:bg-surface-tertiary transition-colors"

--- a/wiii-desktop/src/hooks/useReducedMotion.ts
+++ b/wiii-desktop/src/hooks/useReducedMotion.ts
@@ -16,14 +16,25 @@ const QUERY = "(prefers-reduced-motion: reduce)";
 export function useReducedMotion(): boolean {
   const [reduced, setReduced] = useState(() => {
     if (typeof window === "undefined") return false;
+    if (typeof window.matchMedia !== "function") return false;
     return window.matchMedia(QUERY).matches;
   });
 
   useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
+    }
     const mql = window.matchMedia(QUERY);
     const handler = (e: MediaQueryListEvent) => setReduced(e.matches);
-    mql.addEventListener("change", handler);
-    return () => mql.removeEventListener("change", handler);
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", handler);
+      return () => mql.removeEventListener("change", handler);
+    }
+    mql.addListener(handler);
+    return () => mql.removeListener(handler);
   }, []);
 
   return reduced;

--- a/wiii-desktop/src/lib/capability-status.ts
+++ b/wiii-desktop/src/lib/capability-status.ts
@@ -1,8 +1,12 @@
 import type {
+  WiiiConnectRuntimeConnection,
+  WiiiConnectRuntimeSnapshot,
+  ChatLifecycleTelemetryEvent,
+} from "@/api/types";
+import type {
   HostCapabilities,
   HostContext,
 } from "@/stores/host-context-store";
-import type { WiiiConnectRuntimeConnection, WiiiConnectRuntimeSnapshot } from "@/api/types";
 
 export type RuntimeConnectionStatus =
   | "connected"
@@ -42,6 +46,46 @@ export interface RuntimePathSnapshot {
   applyAttempted?: boolean;
   wiiiConnect?: WiiiConnectRuntimeSnapshot | null;
   receivedAtMs?: number;
+}
+
+export function latestRuntimeLifecycleEvent(
+  streamingEvents: ChatLifecycleTelemetryEvent[],
+  completedEvents: ChatLifecycleTelemetryEvent[],
+): ChatLifecycleTelemetryEvent | null {
+  const source = streamingEvents.length > 0 ? streamingEvents : completedEvents;
+  for (let index = source.length - 1; index >= 0; index -= 1) {
+    const event = source[index];
+    if (event) return event;
+  }
+  return null;
+}
+
+export function runtimePathFromLifecycleEvents(
+  streamingEvents: ChatLifecycleTelemetryEvent[],
+  completedEvents: ChatLifecycleTelemetryEvent[],
+): RuntimePathSnapshot | null {
+  const event = latestRuntimeLifecycleEvent(streamingEvents, completedEvents);
+  if (!event) return null;
+  return {
+    lane: event.lane,
+    eventName: event.event_name,
+    phase: event.phase,
+    status: event.status,
+    message: event.message,
+    hostSurface: event.capabilities?.host_surface,
+    observedTools: event.capabilities?.observed_tools
+      ? [...event.capabilities.observed_tools]
+      : undefined,
+    suppressedTools: event.capabilities?.suppressed_tools
+      ? [...event.capabilities.suppressed_tools]
+      : undefined,
+    previewRequired: event.capabilities?.preview_required,
+    previewEmitted: event.capabilities?.preview_emitted,
+    approvalTokenPresent: event.capabilities?.approval_token_present,
+    applyAttempted: event.capabilities?.apply_attempted,
+    wiiiConnect: event.capabilities?.wiii_connect ?? null,
+    receivedAtMs: event.received_at_ms,
+  };
 }
 
 export interface CapabilityDashboardMetric {

--- a/wiii-desktop/src/stores/ui-store.ts
+++ b/wiii-desktop/src/stores/ui-store.ts
@@ -7,7 +7,13 @@ import { create } from "zustand";
 import type { ArtifactData } from "@/api/types";
 
 /** Sprint 192: Main content view — chat or full-page admin/settings */
-export type ActiveView = "chat" | "system-admin" | "org-admin" | "settings" | "soul-bridge";
+export type ActiveView =
+  | "chat"
+  | "system-admin"
+  | "org-admin"
+  | "settings"
+  | "soul-bridge"
+  | "wiii-connect";
 
 interface UIState {
   /** Sprint 192: Which view is displayed in the main content area */
@@ -63,6 +69,9 @@ interface UIState {
   /** Sprint 216: Soul Bridge panel */
   openSoulBridge: () => void;
   closeSoulBridge: () => void;
+  /** Wiii Connect capability page */
+  openWiiiConnect: () => void;
+  closeWiiiConnect: () => void;
   /** Code Studio panel actions */
   openCodeStudio: () => void;
   closeCodeStudio: () => void;
@@ -129,6 +138,8 @@ export const useUIStore = create<UIState>((set, get) => ({
   closeCodeStudio: () => set({ codeStudioPanelOpen: false }),
   openSoulBridge: () => set({ activeView: "soul-bridge" as ActiveView, commandPaletteOpen: false }),
   closeSoulBridge: () => set({ activeView: "chat" as ActiveView }),
+  openWiiiConnect: () => set({ activeView: "wiii-connect" as ActiveView, commandPaletteOpen: false }),
+  closeWiiiConnect: () => set({ activeView: "chat" as ActiveView }),
   navigateToChat: () => set({ activeView: "chat" as ActiveView, orgManagerTargetOrgId: null }),
   closeAll: () =>
     set({ activeView: "chat" as ActiveView, commandPaletteOpen: false, sourcesPanelOpen: false, characterPanelOpen: false, previewPanelOpen: false, selectedPreviewId: null, artifactPanelOpen: false, selectedArtifactId: null, _ephemeralArtifact: null, orgManagerTargetOrgId: null, codeStudioPanelOpen: false }),

--- a/wiii-desktop/src/stores/ui-store.ts
+++ b/wiii-desktop/src/stores/ui-store.ts
@@ -139,7 +139,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   openSoulBridge: () => set({ activeView: "soul-bridge" as ActiveView, commandPaletteOpen: false }),
   closeSoulBridge: () => set({ activeView: "chat" as ActiveView }),
   openWiiiConnect: () => set({ activeView: "wiii-connect" as ActiveView, commandPaletteOpen: false }),
-  closeWiiiConnect: () => set({ activeView: "chat" as ActiveView }),
+  closeWiiiConnect: () => set({ activeView: "chat" as ActiveView, commandPaletteOpen: false }),
   navigateToChat: () => set({ activeView: "chat" as ActiveView, orgManagerTargetOrgId: null }),
   closeAll: () =>
     set({ activeView: "chat" as ActiveView, commandPaletteOpen: false, sourcesPanelOpen: false, characterPanelOpen: false, previewPanelOpen: false, selectedPreviewId: null, artifactPanelOpen: false, selectedArtifactId: null, _ephemeralArtifact: null, orgManagerTargetOrgId: null, codeStudioPanelOpen: false }),


### PR DESCRIPTION
## Summary
Adds a first-class Wiii Connect page to the desktop shell so runtime connections, agent-ready state, local fallback state, disabled external provider adapters, and path policy can be inspected without reading logs.

Closes #726.

## Scope
- Add `wiii-connect` full-page view routing and navigation from Sidebar and Command Palette.
- Add `WiiiConnectPage` with connection cards, path policy table, runtime diagnostics, local fallback status, and disabled provider adapter rows for Composio/MCP/custom OAuth/workflow.
- Reuse the sanitized chat lifecycle Wiii Connect snapshot by moving runtime lifecycle snapshot extraction into `capability-status`.
- Harden `useReducedMotion` for jsdom/non-browser runtimes without `matchMedia`.
- Update Wiii Connect architecture/contract docs with the V0 desktop UX projection.

## Non-Scope
- No new OAuth flow, token vault, Composio adapter, MCP adapter, or external app action execution.
- No LMS mutation behavior changes.
- No backend snapshot contract changes.

## Verification
- `cd wiii-desktop; npx vitest run src/__tests__/wiii-connect-page.test.tsx src/__tests__/full-page-views.test.ts src/__tests__/capability-status-bar.test.tsx` -> 3 files / 34 tests passed.
- `cd wiii-desktop; npx tsc --noEmit` -> passed.
- `cd wiii-desktop; npm run build:embed` -> passed; existing Vite chunk-size and ineffective dynamic import warnings only.
- `git diff --check` -> passed; Git reported existing CRLF normalization warnings for touched frontend files.
- Browser smoke: `http://127.0.0.1:1420`, local-dev login, opened Wiii Connect from Sidebar; page showed Kết nối/Path policy/Runtime, local fallback, disabled provider adapters; console errors: 0. Local screenshot stored under ignored `artifacts/wiii-connect-page-smoke.png` for this run only.

## Risk
Frontend-visible observability change. Main risk is misleading capability state or exposing raw internals; the page summarizes capability counts and tool groups, and tests assert raw tool names/tokens do not render.

## Rollback
Revert this PR. Existing chat runtime dashboard and backend Wiii Connect snapshot behavior remain unchanged.

## Reviewer Focus
- `WiiiConnectPage` privacy boundaries: no raw provider payload, tool schema, document text, or token values.
- Routing/navigation consistency for `activeView=wiii-connect`.
- Whether disabled external provider rows are clear enough to avoid implying live Composio/MCP support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Wiii Connect" page accessible from the command palette and sidebar, displaying connection status, capabilities, path policies, and runtime diagnostics in a read-only, observability-focused interface.

* **Documentation**
  * Documented the desktop UX projection for the Wiii Connect page with specifications for sanitized snapshot display and external adapter visibility.

* **Tests**
  * Added comprehensive test coverage for the Wiii Connect page and navigation flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->