### PR TITLE
Add Wiii Connect Adapter V1 policy contract

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -1,0 +1,193 @@
+# Wiii Connect Adapter V1 Design
+
+Status: Draft contract implemented
+
+Owner: Architecture maintainers
+
+Created: 2026-05-28
+
+Related issue: #730
+
+## Purpose
+
+Adapter V1 is the policy layer between Wiii's path governor and any external
+integration provider such as Composio, MCP, custom OAuth, or workflow bridges.
+
+It exists to make external actions fail closed. A provider being connected does
+not mean the agent can use it. The gateway must verify provider state, user/org
+ownership, action curation, path policy, scope, preview evidence, approval
+evidence, and audit requirements first.
+
+## Contract Boundary
+
+Adapter V1 is not an OAuth client and not a provider SDK. It is the shared
+contract every provider implementation must satisfy.
+
+```text
+provider registry
+  -> OAuth/session/vault reconciliation
+  -> connection record
+  -> path-selected execution request
+  -> execution gateway decision
+  -> provider adapter call
+  -> audit ledger event
+```
+
+The implemented backend contract lives in:
+
+```text
+maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
+```
+
+## Core Entities
+
+`WiiiConnectProviderRegistryEntry`
+
+- provider slug, kind, auth mode, enabled state;
+- whether it is agent-ready;
+- path allowlist;
+- curated action allowlist;
+- provider-specific required fields;
+- default scopes and safe public metadata.
+
+`WiiiConnectVaultSecretRef`
+
+- opaque pointer to credentials;
+- never serializes secret values or vault paths to public metadata;
+- lets UI and runtime know that a vault reference exists without exposing it.
+
+`WiiiConnectConnectionRecordV1`
+
+- provider slug, connection ID, normalized lifecycle state;
+- granted scopes;
+- optional vault reference;
+- sanitized account label/reference only.
+
+`WiiiConnectExecutionRequest`
+
+- provider slug, action slug, product path, mutation class;
+- approval token presence flag, not token value;
+- preview evidence ID, not raw preview body;
+- argument key list for audit shape, not full provider payload.
+
+`WiiiConnectExecutionDecision`
+
+- allow/deny outcome;
+- reason code;
+- required scopes;
+- audit tags.
+
+`WiiiConnectAuditEvent`
+
+- privacy-safe event around request, deny, start, success, and failure stages.
+
+## Lifecycle States
+
+Adapter V1 normalizes provider states into:
+
+- `disconnected`
+- `authorizing`
+- `waiting`
+- `connected`
+- `expired`
+- `error`
+- `disabled`
+
+Composio-like statuses map as follows:
+
+| Provider status | Wiii state |
+|---|---|
+| `ACTIVE`, `CONNECTED` | `connected` |
+| `PENDING`, `INITIATED`, `INITIALIZING` | `waiting` |
+| `AUTHORIZING` | `authorizing` |
+| `EXPIRED` | `expired` |
+| `FAILED`, `ERROR` | `error` |
+| `DISABLED` | `disabled` |
+| unknown/empty | `disconnected` |
+
+## Agent-Ready Gate
+
+`connected` is only transport/auth state. `agent_ready` requires all of:
+
+1. provider registry entry is enabled;
+2. provider registry entry is marked agent-ready;
+3. live connection belongs to the same provider slug;
+4. live connection state is `connected`;
+5. runtime path and action are allowed by the gateway.
+
+This follows the useful OpenHuman pattern while keeping Wiii's stronger LMS,
+tenant, and host-action safety boundary.
+
+## Gateway Deny Reasons
+
+The gateway denies by default. Current reason codes:
+
+- `provider_disabled`
+- `provider_not_agent_ready`
+- `connection_missing`
+- `connection_provider_mismatch`
+- `connection_not_connected`
+- `path_not_allowed`
+- `action_not_allowed`
+- `missing_scope`
+- `missing_preview_evidence`
+- `missing_approval_token`
+
+The action is allowed only after all checks pass.
+
+## Composio Adapter Mapping
+
+Composio should enter Wiii through this contract:
+
+```text
+Composio toolkit catalog
+  -> Wiii registry entry
+Composio connect link / session authorize
+  -> Wiii OAuth/session handoff
+Composio connected account
+  -> Wiii connection record
+Composio tool/action schema
+  -> Wiii curated action allowlist
+Composio execute
+  -> Wiii execution gateway -> adapter call
+```
+
+Wiii must not expose Composio's broad meta-tools directly to normal chat. The
+path governor selects the product path first. Only then may a scoped integration
+agent receive curated action schemas for the selected provider.
+
+## OAuth And Vault Requirements
+
+Before real Composio OAuth is enabled:
+
+- Wiii backend must create authorization sessions with state and nonce;
+- callback/webhook handling must bind provider account to Wiii org/user;
+- credential material must be stored in an encrypted vault or provider-managed
+  backend secret store;
+- frontend may receive connect URLs and state labels, not tokens;
+- stale pending/error OAuth rows must be cleaned up or expired safely;
+- provider errors must be sanitized before reaching UI or chat.
+
+## Write And Apply Requirements
+
+External writes are never casual chat behavior. They require:
+
+- selected path allows external action;
+- action slug is curated;
+- user/org scope grants allow the mutation class;
+- preview evidence when the adapter marks it required;
+- approval token presence for apply-style mutations;
+- audit event before execution and after completion.
+
+The gateway stores only token presence and evidence IDs in public metadata. Raw
+approval tokens and provider payloads must remain outside chat lifecycle data.
+
+## Next Slices
+
+1. Persist provider registry and connection records behind backend API routes.
+2. Add OAuth session start/callback endpoints for a disabled Composio adapter.
+3. Add encrypted vault integration or provider-managed secret reference storage.
+4. Add frontend connection modal that uses Wiii backend routes only.
+5. Add browser acceptance for connect, poll, disconnect, gated scope, and denied
+   execute cases.
+6. Enable one low-risk read-only Composio action before any write action.

--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -2,9 +2,9 @@
 
 Status: Draft contract implemented
 
-Owner: Architecture maintainers
+Owner: Project leadership
 
-Created: 2026-05-28
+Created: 2026-05-27
 
 Related issue: #730
 

--- a/docs/architecture/wiii-connect/README.md
+++ b/docs/architecture/wiii-connect/README.md
@@ -175,4 +175,9 @@ this repository.
    it read-only until real provider adapters exist.
 4. Add tests proving that LMS apply, Pointy, web/weather, document-grounded
    chat, and visual/Code Studio paths bind only the right tools.
-5. Add a Composio adapter only after the native Wiii snapshot is stable.
+5. Use `ADAPTER_V1_DESIGN.md` as the contract for external providers. Composio
+   remains disabled until registry, vault, OAuth/session callback, scope
+   policy, execution gateway, and audit ledger are implemented against that
+   contract.
+6. Add a Composio adapter only after the native Wiii snapshot and Adapter V1
+   gateway are stable.

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -2,9 +2,9 @@
 
 Status: Active reference audit
 
-Owner: Architecture maintainers
+Owner: Project leadership
 
-Created: 2026-05-28
+Created: 2026-05-27
 
 Related issue: #730
 

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -1,0 +1,138 @@
+# Wiii OpenHuman Composio Source Audit
+
+Status: Active reference audit
+
+Owner: Architecture maintainers
+
+Created: 2026-05-28
+
+Related issue: #730
+
+## Scope
+
+This audit records the OpenHuman and Composio patterns Wiii should adopt before
+enabling real third-party actions through Wiii Connect.
+
+It does not mean Wiii has enabled Composio. Wiii currently has a read-only
+catalog and runtime status surface. Real OAuth and provider execution must wait
+for the Adapter V1 gateway, vault, scope policy, and audit ledger.
+
+## Official Composio Runtime Model
+
+Current Composio docs describe a session-based model:
+
+- a session is scoped to a user ID, tool access, authentication, and execution
+  state;
+- connected accounts are stored under the app's user ID, so executions use the
+  right user's account;
+- Connect Links or `session.authorize()` initiate authentication;
+- connected account responses mask sensitive credential fields by default;
+- sessions can be configured with allowed toolkits, auth configs, connected
+  accounts, and optionally a workbench;
+- Composio Connect also exposes meta tools for search, schema fetch, multi
+  execute, connection management, wait-for-connection, and remote workbench.
+
+Sources:
+
+- https://docs.composio.dev/docs/how-composio-works
+- https://docs.composio.dev/docs/configuring-sessions
+- https://docs.composio.dev/docs/auth-configuration/connected-accounts
+- https://docs.composio.dev/docs/composio-connect
+- https://docs.composio.dev/reference/changelog
+
+## OpenHuman Source Findings
+
+Audited local reference clone:
+
+```text
+.Codex/external/reference-systems/openhuman
+```
+
+Important source files:
+
+```text
+app/src/lib/composio/composioApi.ts
+app/src/lib/composio/hooks.ts
+app/src/components/composio/ComposioConnectModal.tsx
+app/src/components/composio/toolkitRequiredFields.ts
+src/openhuman/composio/client.rs
+src/openhuman/composio/ops.rs
+src/openhuman/composio/oauth_handoff.rs
+src/openhuman/composio/action_tool.rs
+```
+
+Key behaviors:
+
+1. Frontend never talks to Composio directly in backend mode. It calls core
+   JSON-RPC methods such as `openhuman.composio_authorize`,
+   `openhuman.composio_list_connections`, and `openhuman.composio_execute`.
+2. The core proxies through authenticated backend integration routes, so the UI
+   does not receive Composio API keys or raw tokens.
+3. The connection UI is a state machine: idle, needs-fields, authorizing,
+   waiting, connected, expired, disconnecting, and error.
+4. OAuth completion is observed by polling `listConnections()` every few
+   seconds and by refreshing on configuration-change events.
+5. Provider-specific required fields live in a registry, not in scattered modal
+   branches.
+6. `connected` is not the same as `agent-ready`. OpenHuman has a separate
+   agent-ready toolkit set so connected but uncurated providers do not enter
+   the agent tool loop.
+7. User scope preferences gate read, write, and admin action visibility.
+8. Actions hidden by scope are reported as gated capabilities with UI unlock
+   paths; the model cannot elevate scopes by itself.
+9. The integration agent receives toolkit-scoped action schemas only after the
+   toolkit is selected and verified.
+10. Execution paths include retry handling for the post-OAuth readiness gap.
+11. Meta OAuth flows clean up stale pending/error rows and back off on 429-like
+    failures.
+12. Error messages and sync logs are sanitized to avoid leaking provider URLs,
+    JSON payloads, message bodies, or PII.
+
+## What Wiii Should Adopt
+
+Wiii should adopt these rules:
+
+- frontend talks to Wiii backend only;
+- backend owns provider registry, OAuth/session reconciliation, and execution
+  policy;
+- UI shows state and starts OAuth, but cannot grant itself execution rights;
+- connection status is separate from agent-ready status;
+- main chat sees only path/capability summaries, not a broad action catalog;
+- integration-specific agents get narrowed action schemas after path and
+  provider selection;
+- write/apply operations require scope and evidence;
+- action attempts are audited before and after provider execution.
+
+## What Wiii Should Not Copy Blindly
+
+Wiii should not expose direct BYO Composio API key mode as the first product
+path. That mode is useful for a personal desktop agent, but Wiii has LMS,
+organization, host action, tenant, and audit requirements. Wiii should start
+with a server-side adapter and vault-backed secret references.
+
+Wiii should not treat Composio meta tools as general chat tools. Composio's
+meta-tool model is powerful, but Wiii must keep path governance first: choose
+the product path, verify the connection, narrow the action catalog, then
+execute through Wiii's gateway.
+
+## Adapter V1 Requirements
+
+Before Wiii enables Composio:
+
+- `connected` must mean only OAuth/session state;
+- `agent_ready` must require enabled provider adapter, curated action catalog,
+  path policy, user/org scope grant, and gateway support;
+- vault records must be opaque references, never frontend tokens;
+- OAuth callbacks must validate state/nonce and bind to org/user context;
+- execution requests must pass through a single gateway;
+- writes must require scope and preview/approval evidence when applicable;
+- audit events must record requested, denied, started, succeeded, and failed
+  states without raw request/response bodies;
+- external provider failures must be surfaced as sanitized reason codes.
+
+## Current Wiii Position
+
+Wiii now has a V0 snapshot/dashboard and a V1 policy contract. It still needs
+provider persistence, OAuth endpoints, vault integration, provider-specific
+adapter clients, and end-to-end browser acceptance before Composio can be
+enabled for real users.

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -1,5 +1,19 @@
 """Wiii Connect contract helpers."""
 
+from .adapter_v1 import (
+    WIII_CONNECT_ADAPTER_VERSION,
+    WiiiConnectAuditEvent,
+    WiiiConnectConnectionRecordV1,
+    WiiiConnectExecutionDecision,
+    WiiiConnectExecutionRequest,
+    WiiiConnectProviderRegistryEntry,
+    WiiiConnectRequiredField,
+    WiiiConnectScopeGrant,
+    WiiiConnectVaultSecretRef,
+    decide_external_execution,
+    is_connection_agent_ready,
+    normalize_connection_state,
+)
 from .snapshot import (
     WIII_CONNECT_SNAPSHOT_VERSION,
     WiiiConnectionRecord,
@@ -10,10 +24,22 @@ from .snapshot import (
 )
 
 __all__ = [
+    "WIII_CONNECT_ADAPTER_VERSION",
+    "WiiiConnectAuditEvent",
+    "WiiiConnectConnectionRecordV1",
+    "WiiiConnectExecutionDecision",
+    "WiiiConnectExecutionRequest",
+    "WiiiConnectProviderRegistryEntry",
+    "WiiiConnectRequiredField",
+    "WiiiConnectScopeGrant",
+    "WiiiConnectVaultSecretRef",
     "WIII_CONNECT_SNAPSHOT_VERSION",
     "WiiiConnectionRecord",
     "WiiiConnectionScopes",
     "WiiiConnectionSnapshot",
     "WiiiPathCapabilityRecord",
     "build_wiii_connect_snapshot",
+    "decide_external_execution",
+    "is_connection_agent_ready",
+    "normalize_connection_state",
 ]

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -11,7 +11,7 @@ from .adapter_v1 import (
     WiiiConnectScopeGrant,
     WiiiConnectVaultSecretRef,
     decide_external_execution,
-    is_connection_agent_ready,
+    is_connection_baseline_ready,
     normalize_connection_state,
 )
 from .snapshot import (
@@ -40,6 +40,6 @@ __all__ = [
     "WiiiPathCapabilityRecord",
     "build_wiii_connect_snapshot",
     "decide_external_execution",
-    "is_connection_agent_ready",
+    "is_connection_baseline_ready",
     "normalize_connection_state",
 ]

--- a/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
+++ b/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
@@ -135,8 +135,11 @@ class WiiiConnectProviderRegistryEntry:
             normalized = pattern.strip().upper()
             if not normalized:
                 continue
-            if normalized.endswith("*") and action.startswith(normalized[:-1]):
-                return True
+            if normalized.endswith("*"):
+                prefix = normalized[:-1]
+                if prefix and action.startswith(prefix):
+                    return True
+                continue
             if action == normalized:
                 return True
         return False
@@ -309,11 +312,16 @@ def normalize_connection_state(status: str | None) -> ConnectionLifecycleState:
     return "disconnected"
 
 
-def is_connection_agent_ready(
+def is_connection_baseline_ready(
     entry: WiiiConnectProviderRegistryEntry,
     connection: WiiiConnectConnectionRecordV1 | None,
 ) -> bool:
-    """Return true only when registry and live connection both permit agents."""
+    """Return true when registry and live connection pass baseline readiness.
+
+    This is not a final execution decision. Call ``decide_external_execution``
+    with the active path/action request before exposing a provider action to an
+    agent.
+    """
 
     return bool(
         entry.enabled

--- a/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
+++ b/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
@@ -1,0 +1,413 @@
+"""Wiii Connect Adapter V1 policy contract.
+
+This module defines the backend-side contract Wiii must enforce before any
+external connector such as Composio can execute on behalf of a user. It is
+intentionally provider-neutral and performs no network calls.
+
+The execution gateway is fail-closed: connected account state is not enough.
+The provider must be enabled, agent-ready, path-allowed, action-curated, scoped,
+and carrying the required approval evidence before execution can proceed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+
+WIII_CONNECT_ADAPTER_VERSION = "wiii_connect_adapter.v1"
+
+ProviderKind = Literal[
+    "wiii_native",
+    "composio",
+    "mcp",
+    "custom_oauth",
+    "workflow",
+]
+AuthMode = Literal["none", "oauth2", "api_key", "mcp", "delegated"]
+ConnectionLifecycleState = Literal[
+    "disconnected",
+    "authorizing",
+    "waiting",
+    "connected",
+    "expired",
+    "error",
+    "disabled",
+]
+ScopeName = Literal["read", "preview", "write", "apply", "admin"]
+ActionMutation = Literal["read", "preview", "write", "apply", "admin"]
+DecisionOutcome = Literal["allowed", "denied"]
+ExecutionDenyReason = Literal[
+    "allowed",
+    "provider_disabled",
+    "provider_not_agent_ready",
+    "connection_missing",
+    "connection_provider_mismatch",
+    "connection_not_connected",
+    "path_not_allowed",
+    "action_not_allowed",
+    "missing_scope",
+    "missing_preview_evidence",
+    "missing_approval_token",
+]
+AuditEventStage = Literal["requested", "denied", "started", "succeeded", "failed"]
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectScopeGrant:
+    """User-approved scope gates for a connected provider account."""
+
+    read: bool = False
+    preview: bool = False
+    write: bool = False
+    apply: bool = False
+    admin: bool = False
+
+    def allows(self, scope: ScopeName) -> bool:
+        return bool(getattr(self, scope))
+
+    def enabled_scopes(self) -> tuple[ScopeName, ...]:
+        scopes: list[ScopeName] = []
+        for scope in ("read", "preview", "write", "apply", "admin"):
+            if self.allows(scope):
+                scopes.append(scope)
+        return tuple(scopes)
+
+    def to_metadata(self) -> dict[str, bool]:
+        return {
+            "read": self.read,
+            "preview": self.preview,
+            "write": self.write,
+            "apply": self.apply,
+            "admin": self.admin,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectRequiredField:
+    """One provider-specific input required before starting authorization."""
+
+    key: str
+    label: str
+    required: bool = True
+    secret: bool = False
+    help_text: str = ""
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "label": self.label,
+            "required": self.required,
+            "secret": self.secret,
+            "help_text": self.help_text,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectProviderRegistryEntry:
+    """Static provider registration exposed to UI and runtime policy."""
+
+    slug: str
+    label: str
+    provider_kind: ProviderKind
+    auth_mode: AuthMode
+    enabled: bool = False
+    agent_ready: bool = False
+    allowed_paths: tuple[str, ...] = ("external_app_action",)
+    action_allowlist: tuple[str, ...] = ()
+    required_fields: tuple[WiiiConnectRequiredField, ...] = ()
+    default_scopes: WiiiConnectScopeGrant = field(default_factory=WiiiConnectScopeGrant)
+    source: str = "wiii_connect_registry"
+    warnings: tuple[str, ...] = ()
+
+    def allows_action(self, action_slug: str) -> bool:
+        """Return true when an action is in the curated allowlist.
+
+        Patterns ending in ``*`` are treated as conservative prefix grants. An
+        empty allowlist allows nothing.
+        """
+
+        action = action_slug.strip().upper()
+        if not action:
+            return False
+        for pattern in self.action_allowlist:
+            normalized = pattern.strip().upper()
+            if not normalized:
+                continue
+            if normalized.endswith("*") and action.startswith(normalized[:-1]):
+                return True
+            if action == normalized:
+                return True
+        return False
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_ADAPTER_VERSION,
+            "slug": self.slug,
+            "label": self.label,
+            "provider_kind": self.provider_kind,
+            "auth_mode": self.auth_mode,
+            "enabled": self.enabled,
+            "agent_ready": self.agent_ready,
+            "allowed_paths": list(self.allowed_paths),
+            "action_count": len(self.action_allowlist),
+            "required_fields": [
+                field.to_public_metadata() for field in self.required_fields
+            ],
+            "default_scopes": self.default_scopes.to_metadata(),
+            "source": self.source,
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectVaultSecretRef:
+    """Opaque reference to credentials held outside chat/runtime metadata."""
+
+    provider_slug: str
+    connection_id: str
+    vault_key_id: str
+    secret_version: str = ""
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "provider_slug": self.provider_slug,
+            "connection_id": self.connection_id,
+            "vault_ref_present": bool(self.vault_key_id),
+            "secret_version": self.secret_version,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectConnectionRecordV1:
+    """One resolved connection row after OAuth/session reconciliation."""
+
+    connection_id: str
+    provider_slug: str
+    state: ConnectionLifecycleState = "disconnected"
+    scopes: WiiiConnectScopeGrant = field(default_factory=WiiiConnectScopeGrant)
+    vault_ref: WiiiConnectVaultSecretRef | None = None
+    account_label: str = ""
+    external_account_ref: str = ""
+    last_checked_at: str | None = None
+    reason: str = ""
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def active(self) -> bool:
+        return self.state == "connected"
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_ADAPTER_VERSION,
+            "connection_id": self.connection_id,
+            "provider_slug": self.provider_slug,
+            "state": self.state,
+            "active": self.active,
+            "scopes": self.scopes.to_metadata(),
+            "vault_ref_present": self.vault_ref is not None,
+            "account_label": self.account_label,
+            "external_account_ref": self.external_account_ref,
+            "last_checked_at": self.last_checked_at,
+            "reason": self.reason,
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectExecutionRequest:
+    """Runtime request entering the Wiii Connect execution gateway."""
+
+    provider_slug: str
+    action_slug: str
+    path: str
+    mutation: ActionMutation = "read"
+    approval_token_present: bool = False
+    preview_evidence_id: str | None = None
+    preview_evidence_required: bool = False
+    argument_keys: tuple[str, ...] = ()
+
+    def to_audit_metadata(self) -> dict[str, Any]:
+        return {
+            "provider_slug": self.provider_slug,
+            "action_slug": self.action_slug,
+            "path": self.path,
+            "mutation": self.mutation,
+            "approval_token_present": self.approval_token_present,
+            "preview_evidence_present": bool(self.preview_evidence_id),
+            "argument_keys": list(self.argument_keys),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectExecutionDecision:
+    """Fail-closed decision returned before a provider action can run."""
+
+    outcome: DecisionOutcome
+    reason: ExecutionDenyReason
+    provider_slug: str
+    action_slug: str
+    path: str
+    required_scopes: tuple[ScopeName, ...] = ()
+    audit_tags: tuple[str, ...] = ()
+
+    @property
+    def allowed(self) -> bool:
+        return self.outcome == "allowed"
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_ADAPTER_VERSION,
+            "outcome": self.outcome,
+            "reason": self.reason,
+            "provider_slug": self.provider_slug,
+            "action_slug": self.action_slug,
+            "path": self.path,
+            "required_scopes": list(self.required_scopes),
+            "audit_tags": list(self.audit_tags),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectAuditEvent:
+    """Privacy-safe ledger event around a provider execution attempt."""
+
+    stage: AuditEventStage
+    request: WiiiConnectExecutionRequest
+    decision: WiiiConnectExecutionDecision
+    connection_id: str = ""
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_ADAPTER_VERSION,
+            "stage": self.stage,
+            "created_at": self.created_at,
+            "connection_id": self.connection_id,
+            "request": self.request.to_audit_metadata(),
+            "decision": self.decision.to_metadata(),
+        }
+
+
+def normalize_connection_state(status: str | None) -> ConnectionLifecycleState:
+    """Normalize provider-specific connection statuses into Wiii states."""
+
+    normalized = str(status or "").strip().upper()
+    if normalized in {"ACTIVE", "CONNECTED"}:
+        return "connected"
+    if normalized in {"AUTHORIZING"}:
+        return "authorizing"
+    if normalized in {"PENDING", "INITIATED", "INITIALIZING"}:
+        return "waiting"
+    if normalized == "EXPIRED":
+        return "expired"
+    if normalized in {"FAILED", "ERROR"}:
+        return "error"
+    if normalized == "DISABLED":
+        return "disabled"
+    return "disconnected"
+
+
+def is_connection_agent_ready(
+    entry: WiiiConnectProviderRegistryEntry,
+    connection: WiiiConnectConnectionRecordV1 | None,
+) -> bool:
+    """Return true only when registry and live connection both permit agents."""
+
+    return bool(
+        entry.enabled
+        and entry.agent_ready
+        and connection is not None
+        and connection.provider_slug == entry.slug
+        and connection.active
+    )
+
+
+def decide_external_execution(
+    entry: WiiiConnectProviderRegistryEntry,
+    connection: WiiiConnectConnectionRecordV1 | None,
+    request: WiiiConnectExecutionRequest,
+) -> WiiiConnectExecutionDecision:
+    """Decide whether Wiii may execute one external provider action."""
+
+    if not entry.enabled:
+        return _deny(entry, request, "provider_disabled")
+    if not entry.agent_ready:
+        return _deny(entry, request, "provider_not_agent_ready")
+    if connection is None:
+        return _deny(entry, request, "connection_missing")
+    if connection.provider_slug != entry.slug or request.provider_slug != entry.slug:
+        return _deny(entry, request, "connection_provider_mismatch")
+    if not connection.active:
+        return _deny(entry, request, "connection_not_connected")
+    if request.path not in entry.allowed_paths:
+        return _deny(entry, request, "path_not_allowed")
+    if not entry.allows_action(request.action_slug):
+        return _deny(entry, request, "action_not_allowed")
+
+    required_scope = _required_scope_for_mutation(request.mutation)
+    if not connection.scopes.allows(required_scope):
+        return _deny(
+            entry,
+            request,
+            "missing_scope",
+            required_scopes=(required_scope,),
+        )
+    if request.preview_evidence_required and not request.preview_evidence_id:
+        return _deny(entry, request, "missing_preview_evidence")
+    if request.mutation == "apply" and not request.approval_token_present:
+        return _deny(
+            entry,
+            request,
+            "missing_approval_token",
+            required_scopes=("apply",),
+        )
+
+    return WiiiConnectExecutionDecision(
+        outcome="allowed",
+        reason="allowed",
+        provider_slug=entry.slug,
+        action_slug=request.action_slug,
+        path=request.path,
+        required_scopes=(required_scope,),
+        audit_tags=(
+            f"provider:{entry.provider_kind}",
+            f"auth:{entry.auth_mode}",
+            f"mutation:{request.mutation}",
+        ),
+    )
+
+
+def _required_scope_for_mutation(mutation: ActionMutation) -> ScopeName:
+    if mutation == "admin":
+        return "admin"
+    if mutation == "apply":
+        return "apply"
+    if mutation == "write":
+        return "write"
+    if mutation == "preview":
+        return "preview"
+    return "read"
+
+
+def _deny(
+    entry: WiiiConnectProviderRegistryEntry,
+    request: WiiiConnectExecutionRequest,
+    reason: ExecutionDenyReason,
+    *,
+    required_scopes: tuple[ScopeName, ...] = (),
+) -> WiiiConnectExecutionDecision:
+    return WiiiConnectExecutionDecision(
+        outcome="denied",
+        reason=reason,
+        provider_slug=entry.slug,
+        action_slug=request.action_slug,
+        path=request.path,
+        required_scopes=required_scopes,
+        audit_tags=(
+            f"provider:{entry.provider_kind}",
+            f"auth:{entry.auth_mode}",
+            f"deny:{reason}",
+        ),
+    )

--- a/maritime-ai-service/tests/unit/test_wiii_connect_adapter_v1.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_adapter_v1.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import json
 
-def test_composio_connection_state_normalization_and_agent_ready_gate():
+
+def test_composio_connection_state_normalization_and_baseline_gate():
     from app.engine.wiii_connect.adapter_v1 import (
         WiiiConnectConnectionRecordV1,
         WiiiConnectProviderRegistryEntry,
-        is_connection_agent_ready,
+        is_connection_baseline_ready,
         normalize_connection_state,
     )
 
@@ -28,7 +30,7 @@ def test_composio_connection_state_normalization_and_agent_ready_gate():
     assert pending.state == "waiting"
     assert normalize_connection_state("ACTIVE") == "connected"
     assert normalize_connection_state("FAILED") == "error"
-    assert is_connection_agent_ready(entry, pending) is False
+    assert is_connection_baseline_ready(entry, pending) is False
 
 
 def test_external_execute_requires_connection_action_path_scope_and_approval():
@@ -83,6 +85,26 @@ def test_external_execute_requires_connection_action_path_scope_and_approval():
     assert wrong_path.allowed is False
     assert wrong_path.reason == "path_not_allowed"
 
+    missing_scope_connection = WiiiConnectConnectionRecordV1(
+        connection_id="conn_2",
+        provider_slug="facebook",
+        state="connected",
+        scopes=WiiiConnectScopeGrant(read=True, write=False, apply=False),
+    )
+    missing_scope = decide_external_execution(
+        entry,
+        missing_scope_connection,
+        WiiiConnectExecutionRequest(
+            provider_slug="facebook",
+            action_slug="FACEBOOK_CREATE_POST",
+            path="external_app_action",
+            mutation="apply",
+        ),
+    )
+    assert missing_scope.allowed is False
+    assert missing_scope.reason == "missing_scope"
+    assert missing_scope.required_scopes == ("apply",)
+
     missing_approval = decide_external_execution(
         entry,
         connection,
@@ -113,6 +135,23 @@ def test_external_execute_requires_connection_action_path_scope_and_approval():
     )
     assert allowed.allowed is True
     assert allowed.reason == "allowed"
+
+
+def test_wildcard_only_action_allowlist_stays_fail_closed():
+    from app.engine.wiii_connect.adapter_v1 import WiiiConnectProviderRegistryEntry
+
+    entry = WiiiConnectProviderRegistryEntry(
+        slug="github",
+        label="GitHub",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        enabled=True,
+        agent_ready=True,
+        action_allowlist=("*", "GITHUB_GET_*"),
+    )
+
+    assert entry.allows_action("GITHUB_GET_REPO") is True
+    assert entry.allows_action("SLACK_SEND_MESSAGE") is False
 
 
 def test_public_metadata_does_not_expose_vault_key_or_raw_secret_values():
@@ -150,15 +189,15 @@ def test_public_metadata_does_not_expose_vault_key_or_raw_secret_values():
         ),
     )
 
-    serialized = str(
-        {
-            "entry": entry.to_public_metadata(),
-            "connection": connection.to_public_metadata(),
-            "vault": connection.vault_ref.to_public_metadata(),
-        }
-    )
+    metadata = {
+        "entry": entry.to_public_metadata(),
+        "connection": connection.to_public_metadata(),
+        "vault": connection.vault_ref.to_public_metadata(),
+    }
+    serialized = json.dumps(metadata, sort_keys=True)
 
+    assert metadata["connection"]["vault_ref_present"] is True
+    assert metadata["vault"]["vault_ref_present"] is True
+    assert metadata["entry"]["required_fields"][0]["key"] == "client_secret"
     assert "oauth-token-secret" not in serialized
     assert "vault://tenant/private" not in serialized
-    assert "vault_ref_present" in serialized
-    assert "client_secret" in serialized

--- a/maritime-ai-service/tests/unit/test_wiii_connect_adapter_v1.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_adapter_v1.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+
+def test_composio_connection_state_normalization_and_agent_ready_gate():
+    from app.engine.wiii_connect.adapter_v1 import (
+        WiiiConnectConnectionRecordV1,
+        WiiiConnectProviderRegistryEntry,
+        is_connection_agent_ready,
+        normalize_connection_state,
+    )
+
+    entry = WiiiConnectProviderRegistryEntry(
+        slug="facebook",
+        label="Facebook",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        enabled=True,
+        agent_ready=True,
+        action_allowlist=("FACEBOOK_CREATE_POST",),
+    )
+
+    pending = WiiiConnectConnectionRecordV1(
+        connection_id="conn_1",
+        provider_slug="facebook",
+        state=normalize_connection_state("PENDING"),
+    )
+
+    assert pending.state == "waiting"
+    assert normalize_connection_state("ACTIVE") == "connected"
+    assert normalize_connection_state("FAILED") == "error"
+    assert is_connection_agent_ready(entry, pending) is False
+
+
+def test_external_execute_requires_connection_action_path_scope_and_approval():
+    from app.engine.wiii_connect.adapter_v1 import (
+        WiiiConnectConnectionRecordV1,
+        WiiiConnectExecutionRequest,
+        WiiiConnectProviderRegistryEntry,
+        WiiiConnectScopeGrant,
+        decide_external_execution,
+    )
+
+    entry = WiiiConnectProviderRegistryEntry(
+        slug="facebook",
+        label="Facebook",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        enabled=True,
+        agent_ready=True,
+        allowed_paths=("external_app_action",),
+        action_allowlist=("FACEBOOK_CREATE_POST",),
+    )
+    connection = WiiiConnectConnectionRecordV1(
+        connection_id="conn_1",
+        provider_slug="facebook",
+        state="connected",
+        scopes=WiiiConnectScopeGrant(read=True, write=True, apply=True),
+    )
+
+    uncurated = decide_external_execution(
+        entry,
+        connection,
+        WiiiConnectExecutionRequest(
+            provider_slug="facebook",
+            action_slug="FACEBOOK_DELETE_PAGE",
+            path="external_app_action",
+            mutation="write",
+        ),
+    )
+    assert uncurated.allowed is False
+    assert uncurated.reason == "action_not_allowed"
+
+    wrong_path = decide_external_execution(
+        entry,
+        connection,
+        WiiiConnectExecutionRequest(
+            provider_slug="facebook",
+            action_slug="FACEBOOK_CREATE_POST",
+            path="casual_chat",
+            mutation="write",
+        ),
+    )
+    assert wrong_path.allowed is False
+    assert wrong_path.reason == "path_not_allowed"
+
+    missing_approval = decide_external_execution(
+        entry,
+        connection,
+        WiiiConnectExecutionRequest(
+            provider_slug="facebook",
+            action_slug="FACEBOOK_CREATE_POST",
+            path="external_app_action",
+            mutation="apply",
+            preview_evidence_required=True,
+            preview_evidence_id="preview_1",
+        ),
+    )
+    assert missing_approval.allowed is False
+    assert missing_approval.reason == "missing_approval_token"
+
+    allowed = decide_external_execution(
+        entry,
+        connection,
+        WiiiConnectExecutionRequest(
+            provider_slug="facebook",
+            action_slug="FACEBOOK_CREATE_POST",
+            path="external_app_action",
+            mutation="apply",
+            preview_evidence_required=True,
+            preview_evidence_id="preview_1",
+            approval_token_present=True,
+        ),
+    )
+    assert allowed.allowed is True
+    assert allowed.reason == "allowed"
+
+
+def test_public_metadata_does_not_expose_vault_key_or_raw_secret_values():
+    from app.engine.wiii_connect.adapter_v1 import (
+        WiiiConnectConnectionRecordV1,
+        WiiiConnectProviderRegistryEntry,
+        WiiiConnectRequiredField,
+        WiiiConnectVaultSecretRef,
+    )
+
+    entry = WiiiConnectProviderRegistryEntry(
+        slug="gmail",
+        label="Gmail",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        enabled=False,
+        agent_ready=False,
+        required_fields=(
+            WiiiConnectRequiredField(
+                key="client_secret",
+                label="Client secret",
+                secret=True,
+            ),
+        ),
+    )
+    connection = WiiiConnectConnectionRecordV1(
+        connection_id="conn_1",
+        provider_slug="gmail",
+        state="connected",
+        vault_ref=WiiiConnectVaultSecretRef(
+            provider_slug="gmail",
+            connection_id="conn_1",
+            vault_key_id="vault://tenant/private/oauth-token-secret",
+            secret_version="v1",
+        ),
+    )
+
+    serialized = str(
+        {
+            "entry": entry.to_public_metadata(),
+            "connection": connection.to_public_metadata(),
+            "vault": connection.vault_ref.to_public_metadata(),
+        }
+    )
+
+    assert "oauth-token-secret" not in serialized
+    assert "vault://tenant/private" not in serialized
+    assert "vault_ref_present" in serialized
+    assert "client_secret" in serialized

--- a/specs/730-wiii-connect-adapter-v1/plan.md
+++ b/specs/730-wiii-connect-adapter-v1/plan.md
@@ -1,0 +1,58 @@
+# Implementation Plan: Wiii Connect Adapter V1
+
+**Branch**: `codex/730-audit-wiii-connect-adapter-v1` | **Date**: 2026-05-28 | **Spec**: `specs/730-wiii-connect-adapter-v1/spec.md`
+**Input**: Feature specification from `specs/730-wiii-connect-adapter-v1/spec.md`
+
+## Summary
+
+Audit OpenHuman's Composio connection architecture and implement the first Wiii
+Connect Adapter V1 contract. This slice adds deterministic policy objects and
+unit tests, while keeping real Composio OAuth/execution disabled until vault and
+runtime endpoints exist.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+
+**Primary Dependencies**: FastAPI backend codebase, dataclasses, pytest
+**Storage**: None in this slice; future slices need persistent registry,
+connection records, vault references, and audit ledger.
+**Testing**: pytest unit tests
+**Target Platform**: Wiii backend service
+**Project Type**: backend contract and architecture docs
+**Performance Goals**: Gateway decision is in-process and deterministic.
+**Constraints**: No secrets, no provider payloads, no raw approval tokens in
+public metadata.
+**Scale/Scope**: One contract module plus docs/tests. No real provider calls.
+
+## Constitution Check
+
+- Preserve tenant/auth safety: pass, no provider calls or persistence added.
+- Fail closed on external actions: pass, gateway denies by default.
+- Keep changes scoped: pass, backend contract plus docs/tests only.
+- No secrets committed: pass, tests use fake opaque strings only.
+- Vietnamese-first UI: not applicable, no user-facing UI copy in this slice.
+
+## Project Structure
+
+```text
+docs/
+  architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+  operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+maritime-ai-service/
+  app/engine/wiii_connect/adapter_v1.py
+  tests/unit/test_wiii_connect_adapter_v1.py
+specs/
+  730-wiii-connect-adapter-v1/
+    spec.md
+    plan.md
+    tasks.md
+```
+
+**Structure Decision**: Keep Adapter V1 inside the monorepo until Wiii-native
+and at least one external provider prove the contract.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | N/A |

--- a/specs/730-wiii-connect-adapter-v1/plan.md
+++ b/specs/730-wiii-connect-adapter-v1/plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: Wiii Connect Adapter V1
 
-**Branch**: `codex/730-audit-wiii-connect-adapter-v1` | **Date**: 2026-05-28 | **Spec**: `specs/730-wiii-connect-adapter-v1/spec.md`
+**Branch**: `codex/730-audit-wiii-connect-adapter-v1` | **Date**: 2026-05-27 | **Spec**: `specs/730-wiii-connect-adapter-v1/spec.md`
 **Input**: Feature specification from `specs/730-wiii-connect-adapter-v1/spec.md`
 
 ## Summary

--- a/specs/730-wiii-connect-adapter-v1/spec.md
+++ b/specs/730-wiii-connect-adapter-v1/spec.md
@@ -1,0 +1,125 @@
+# Feature Specification: Wiii Connect Adapter V1
+
+**Feature Branch**: `codex/730-audit-wiii-connect-adapter-v1`
+**Created**: 2026-05-28
+**Status**: Draft
+**Input**: User request to audit OpenHuman Connections/Composio and design Wiii
+Connect Adapter V1 before enabling real Composio execution.
+
+## User Scenarios & Testing
+
+### User Story 1 - Safe Connection State (Priority: P1)
+
+As a Wiii user, I can see whether a provider is connected without Wiii implying
+the agent can already act through it.
+
+**Why this priority**: This prevents false confidence and prevents connected
+OAuth state from becoming accidental execution permission.
+
+**Independent Test**: Unit tests normalize provider statuses and prove pending
+connections are not agent-ready.
+
+**Acceptance Scenarios**:
+
+1. Given a Composio-style `PENDING` connection, when Wiii normalizes it, then
+   the state is `waiting` and agent-ready is false.
+2. Given an `ACTIVE` connection for an enabled provider, when Wiii normalizes it,
+   then the state is `connected` but gateway checks still decide execution.
+
+### User Story 2 - Fail-Closed Execution Gateway (Priority: P1)
+
+As Wiii runtime, I can reject external actions unless provider, path, action,
+scope, and approval evidence all pass.
+
+**Why this priority**: External tools can read or mutate real user accounts.
+Gateway policy must be deterministic before provider calls exist.
+
+**Independent Test**: Unit tests call the gateway with wrong path, uncurated
+action, missing approval, and allowed cases.
+
+**Acceptance Scenarios**:
+
+1. Given a connected provider, when the requested action is not curated, then
+   execution is denied.
+2. Given a curated apply action without approval evidence, when the gateway runs,
+   then execution is denied.
+3. Given connected provider, curated action, allowed path, required scope, and
+   approval evidence, when the gateway runs, then execution is allowed.
+
+### User Story 3 - Privacy-Safe Metadata (Priority: P2)
+
+As a maintainer, I can inspect registry and connection metadata without exposing
+tokens, API keys, provider payloads, or approval tokens.
+
+**Why this priority**: Wiii needs observability, but connection metadata can be
+sensitive.
+
+**Independent Test**: Unit tests serialize public metadata and assert vault
+paths and secret-like values are absent.
+
+**Acceptance Scenarios**:
+
+1. Given a vault secret reference, when public metadata is serialized, then only
+   `vault_ref_present` is visible.
+2. Given a provider required secret field, when public metadata is serialized,
+   then the field key is visible but no secret value exists.
+
+### Edge Cases
+
+- OAuth state is pending or stale after a browser flow.
+- Provider is connected but has no curated agent action catalog.
+- User has read scope but asks Wiii to write or apply.
+- Action belongs to a connected provider but the active product path is casual
+  chat.
+- Provider returns raw URLs or provider payloads in errors.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST distinguish connection state from agent-ready state.
+- **FR-002**: System MUST normalize provider statuses into a provider-neutral
+  lifecycle state.
+- **FR-003**: System MUST define a registry entry for external provider
+  adapters.
+- **FR-004**: System MUST keep vault references opaque in public metadata.
+- **FR-005**: System MUST deny external execution by default.
+- **FR-006**: System MUST require provider enabled state, agent-ready state,
+  matching live connection, allowed path, curated action, and required scope.
+- **FR-007**: System MUST require approval evidence for apply-style external
+  mutations.
+- **FR-008**: System MUST produce privacy-safe audit event metadata.
+- **FR-009**: System MUST document OpenHuman/Composio source findings before
+  enabling Composio.
+
+### Key Entities
+
+- **Provider Registry Entry**: Declares provider kind, auth mode, enabled state,
+  path allowlist, curated actions, and required fields.
+- **Vault Secret Reference**: Opaque pointer to credential material.
+- **Connection Record**: Live connection state and scope grants.
+- **Execution Request**: Provider action request after path selection.
+- **Execution Decision**: Deterministic allow/deny result.
+- **Audit Event**: Privacy-safe ledger record around action execution.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Unit tests prove pending/error provider states do not become
+  agent-ready.
+- **SC-002**: Unit tests prove gateway denies uncurated action, wrong path, and
+  missing approval.
+- **SC-003**: Unit tests prove public metadata omits vault paths and raw secret
+  values.
+- **SC-004**: Architecture docs explicitly state Composio is not enabled until
+  vault, OAuth callback, scope policy, gateway, and audit ledger are in place.
+
+## Assumptions
+
+- Wiii will start with a server-side Composio adapter, not direct frontend API
+  key mode.
+- Existing Wiii auth/org boundaries remain the source of user and tenant
+  identity.
+- Composio is an adapter behind Wiii Connect, not the foundation of Wiii
+  Connect.

--- a/specs/730-wiii-connect-adapter-v1/spec.md
+++ b/specs/730-wiii-connect-adapter-v1/spec.md
@@ -1,7 +1,7 @@
 # Feature Specification: Wiii Connect Adapter V1
 
 **Feature Branch**: `codex/730-audit-wiii-connect-adapter-v1`
-**Created**: 2026-05-28
+**Created**: 2026-05-27
 **Status**: Draft
 **Input**: User request to audit OpenHuman Connections/Composio and design Wiii
 Connect Adapter V1 before enabling real Composio execution.
@@ -17,12 +17,12 @@ the agent can already act through it.
 OAuth state from becoming accidental execution permission.
 
 **Independent Test**: Unit tests normalize provider statuses and prove pending
-connections are not agent-ready.
+connections are not baseline-ready.
 
 **Acceptance Scenarios**:
 
 1. Given a Composio-style `PENDING` connection, when Wiii normalizes it, then
-   the state is `waiting` and agent-ready is false.
+   the state is `waiting` and baseline-ready is false.
 2. Given an `ACTIVE` connection for an enabled provider, when Wiii normalizes it,
    then the state is `connected` but gateway checks still decide execution.
 

--- a/specs/730-wiii-connect-adapter-v1/tasks.md
+++ b/specs/730-wiii-connect-adapter-v1/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: Wiii Connect Adapter V1
+
+**Input**: Design documents from `specs/730-wiii-connect-adapter-v1/`
+**Prerequisites**: `plan.md`, `spec.md`
+
+## Phase 1: Audit And Design
+
+- [x] T001 Read repository governance and Wiii Connect V0 docs.
+- [x] T002 Audit OpenHuman frontend Composio RPC, hooks, modal, required-field registry.
+- [x] T003 Audit OpenHuman core Composio client, ops, OAuth handoff, and action tool policy.
+- [x] T004 Review current Composio docs for sessions, connected accounts, connect links, and meta tools.
+- [x] T005 Write source audit doc in `docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md`.
+
+## Phase 2: Contract Implementation
+
+- [x] T006 Add Adapter V1 dataclasses and gateway decision helper in `maritime-ai-service/app/engine/wiii_connect/adapter_v1.py`.
+- [x] T007 Export Adapter V1 helpers from `maritime-ai-service/app/engine/wiii_connect/__init__.py`.
+- [x] T008 Document Adapter V1 architecture in `docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md`.
+
+## Phase 3: Verification
+
+- [x] T009 Add unit tests for state normalization and agent-ready gating.
+- [x] T010 Add unit tests for fail-closed gateway decisions.
+- [x] T011 Add unit tests for public metadata redaction.
+- [x] T012 Run focused pytest and ruff checks.
+- [x] T013 Run `git diff --check` and inspect worktree.
+
+## Phase 4: Next Slices
+
+- [ ] T014 Add persistent provider registry API.
+- [ ] T015 Add OAuth start/callback routes for disabled Composio adapter.
+- [ ] T016 Add vault integration or provider-managed secret reference storage.
+- [ ] T017 Add frontend connection modal using Wiii backend routes.
+- [ ] T018 Add browser acceptance for connect, poll, disconnect, gated scope, and denied execute cases.


### PR DESCRIPTION
## Summary
- audited OpenHuman's Composio connection flow and current Composio session/connected-account model
- added Wiii Connect Adapter V1 policy contract for registry entries, opaque vault refs, connection records, execution requests/decisions, and audit events
- documented why Composio remains disabled until Wiii has vault, OAuth callback, scope policy, execution gateway, and audit ledger

## Scope
- backend contract only: `maritime-ai-service/app/engine/wiii_connect/adapter_v1.py`
- architecture/operations/spec docs for Adapter V1 and OpenHuman/Composio audit
- focused unit tests for state normalization, fail-closed gateway decisions, and metadata redaction

## Non-scope
- no real Composio OAuth endpoints
- no provider API calls
- no frontend connection modal changes
- no token/vault persistence or LMS mutation behavior changes

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_adapter_v1.py -q --tb=short` -> 3 passed
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_snapshot.py tests/unit/test_wiii_connect_adapter_v1.py -q --tb=short` -> 5 passed
- `cd maritime-ai-service; python -m ruff check app\engine\wiii_connect\adapter_v1.py tests\unit\test_wiii_connect_adapter_v1.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
- Low runtime risk: this adds a contract module and docs/tests; no active provider calls are wired into runtime.
- Main risk is future misuse: teams could treat `connected` as sufficient. The contract/docs/tests explicitly require `agent_ready` and gateway decision checks.

## Rollback
- Revert this PR. It does not add migrations, external services, secrets, or runtime provider execution paths.

Closes #730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Wiii Connect Adapter V1 architecture and design specification.
  * Updated implementation roadmap with refined integration phases.
  * Created audit reference documenting OpenHuman and Composio integration patterns and adoption guidelines.

* **Tests**
  * Added unit tests validating Adapter V1 contract enforcement (connection state, execution authorization, metadata privacy).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->