### PR TITLE
Add backend Wiii Connect disabled provider registry

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -39,6 +39,17 @@ The implemented backend contract lives in:
 maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
 ```
 
+The backend-owned provider catalog lives in:
+
+```text
+maritime-ai-service/app/engine/wiii_connect/provider_registry.py
+```
+
+Frontend surfaces should consume this registry/snapshot projection instead of
+inventing a separate external-provider source of truth. Until a provider has
+OAuth, vault, scoped action catalog, gateway, and audit support, the registry
+must keep that provider disabled and non-agent-ready.
+
 ## Core Entities
 
 `WiiiConnectProviderRegistryEntry`

--- a/docs/architecture/wiii-connect/README.md
+++ b/docs/architecture/wiii-connect/README.md
@@ -179,5 +179,8 @@ this repository.
    remains disabled until registry, vault, OAuth/session callback, scope
    policy, execution gateway, and audit ledger are implemented against that
    contract.
-6. Add a Composio adapter only after the native Wiii snapshot and Adapter V1
+6. Keep the backend `provider_registry.py` as the source of truth for disabled
+   external provider catalog entries; frontend catalog state should converge on
+   this projection.
+7. Add a Composio adapter only after the native Wiii snapshot and Adapter V1
    gateway are stable.

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -14,6 +14,12 @@ from .adapter_v1 import (
     is_connection_baseline_ready,
     normalize_connection_state,
 )
+from .provider_registry import (
+    WIII_CONNECT_PROVIDER_REGISTRY_VERSION,
+    get_wiii_connect_provider_entry,
+    list_wiii_connect_provider_registry,
+    provider_registry_public_metadata,
+)
 from .snapshot import (
     WIII_CONNECT_SNAPSHOT_VERSION,
     WiiiConnectionRecord,
@@ -33,6 +39,7 @@ __all__ = [
     "WiiiConnectRequiredField",
     "WiiiConnectScopeGrant",
     "WiiiConnectVaultSecretRef",
+    "WIII_CONNECT_PROVIDER_REGISTRY_VERSION",
     "WIII_CONNECT_SNAPSHOT_VERSION",
     "WiiiConnectionRecord",
     "WiiiConnectionScopes",
@@ -40,6 +47,9 @@ __all__ = [
     "WiiiPathCapabilityRecord",
     "build_wiii_connect_snapshot",
     "decide_external_execution",
+    "get_wiii_connect_provider_entry",
     "is_connection_baseline_ready",
+    "list_wiii_connect_provider_registry",
     "normalize_connection_state",
+    "provider_registry_public_metadata",
 ]

--- a/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
+++ b/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
@@ -114,8 +114,11 @@ class WiiiConnectProviderRegistryEntry:
     auth_mode: AuthMode
     enabled: bool = False
     agent_ready: bool = False
+    category: str = "integration"
+    description: str = ""
     allowed_paths: tuple[str, ...] = ("external_app_action",)
     action_allowlist: tuple[str, ...] = ()
+    requirements: tuple[str, ...] = ()
     required_fields: tuple[WiiiConnectRequiredField, ...] = ()
     default_scopes: WiiiConnectScopeGrant = field(default_factory=WiiiConnectScopeGrant)
     source: str = "wiii_connect_registry"
@@ -153,8 +156,11 @@ class WiiiConnectProviderRegistryEntry:
             "auth_mode": self.auth_mode,
             "enabled": self.enabled,
             "agent_ready": self.agent_ready,
+            "category": self.category,
+            "description": self.description,
             "allowed_paths": list(self.allowed_paths),
             "action_count": len(self.action_allowlist),
+            "requirements": list(self.requirements),
             "required_fields": [
                 field.to_public_metadata() for field in self.required_fields
             ],

--- a/maritime-ai-service/app/engine/wiii_connect/provider_registry.py
+++ b/maritime-ai-service/app/engine/wiii_connect/provider_registry.py
@@ -1,0 +1,162 @@
+"""Backend-owned Wiii Connect provider registry.
+
+This registry is the source of truth for external provider catalog entries that
+are visible to Wiii but not executable yet. Entries are deliberately disabled
+until provider-specific OAuth, vault, scope, gateway, and audit plumbing exists.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .adapter_v1 import (
+    WIII_CONNECT_ADAPTER_VERSION,
+    ProviderKind,
+    WiiiConnectProviderRegistryEntry,
+)
+
+
+WIII_CONNECT_PROVIDER_REGISTRY_VERSION = "wiii_connect_provider_registry.v1"
+
+
+_DISABLED_COMPOSIO_REQUIREMENTS = (
+    "oauth_or_connect_link",
+    "encrypted_vault_ref",
+    "scope_policy",
+    "curated_action_catalog",
+    "execution_gateway",
+    "audit_ledger",
+)
+
+
+_PROVIDER_REGISTRY: tuple[WiiiConnectProviderRegistryEntry, ...] = (
+    WiiiConnectProviderRegistryEntry(
+        slug="facebook",
+        label="Facebook",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        category="social",
+        description="Facebook Pages/content via a brokered OAuth adapter.",
+        requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        warnings=("adapter_disabled",),
+    ),
+    WiiiConnectProviderRegistryEntry(
+        slug="gmail",
+        label="Gmail",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        category="productivity",
+        description="Gmail read/write actions with explicit scope gates.",
+        requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        warnings=("adapter_disabled",),
+    ),
+    WiiiConnectProviderRegistryEntry(
+        slug="google_calendar",
+        label="Google Calendar",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        category="productivity",
+        description="Calendar lookup and event drafting through Composio.",
+        requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        warnings=("adapter_disabled",),
+    ),
+    WiiiConnectProviderRegistryEntry(
+        slug="google_drive",
+        label="Google Drive",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        category="productivity",
+        description="Drive file lookup and source reference workflows.",
+        requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        warnings=("adapter_disabled",),
+    ),
+    WiiiConnectProviderRegistryEntry(
+        slug="notion",
+        label="Notion",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        category="productivity",
+        description="Notion workspace search and page drafting.",
+        requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        warnings=("adapter_disabled",),
+    ),
+    WiiiConnectProviderRegistryEntry(
+        slug="slack",
+        label="Slack",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        category="chat",
+        description="Slack workspace/channel read and message drafting.",
+        requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        warnings=("adapter_disabled",),
+    ),
+    WiiiConnectProviderRegistryEntry(
+        slug="github",
+        label="GitHub",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        category="platform",
+        description="GitHub issue, PR, and repository workflows.",
+        requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        warnings=("adapter_disabled",),
+    ),
+    WiiiConnectProviderRegistryEntry(
+        slug="airtable",
+        label="Airtable",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        category="productivity",
+        description="Airtable base lookup and record drafting.",
+        requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        warnings=("adapter_disabled",),
+    ),
+    WiiiConnectProviderRegistryEntry(
+        slug="asana",
+        label="Asana",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        category="productivity",
+        description="Asana project/task lookup and task drafting.",
+        requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        warnings=("adapter_disabled",),
+    ),
+)
+
+
+def list_wiii_connect_provider_registry(
+    *,
+    provider_kind: ProviderKind | None = None,
+) -> tuple[WiiiConnectProviderRegistryEntry, ...]:
+    """Return provider registry entries filtered by optional provider kind."""
+
+    entries: Iterable[WiiiConnectProviderRegistryEntry] = _PROVIDER_REGISTRY
+    if provider_kind is not None:
+        entries = (entry for entry in entries if entry.provider_kind == provider_kind)
+    return tuple(sorted(entries, key=lambda entry: (entry.provider_kind, entry.slug)))
+
+
+def get_wiii_connect_provider_entry(
+    slug: str,
+) -> WiiiConnectProviderRegistryEntry | None:
+    """Return one provider registry entry by slug, if registered."""
+
+    key = slug.strip().lower().replace("-", "_")
+    if not key:
+        return None
+    for entry in _PROVIDER_REGISTRY:
+        if entry.slug == key:
+            return entry
+    return None
+
+
+def provider_registry_public_metadata() -> dict[str, object]:
+    """Return the privacy-safe provider catalog projection for UI/API use."""
+
+    return {
+        "version": WIII_CONNECT_PROVIDER_REGISTRY_VERSION,
+        "adapter_version": WIII_CONNECT_ADAPTER_VERSION,
+        "providers": [
+            entry.to_public_metadata()
+            for entry in list_wiii_connect_provider_registry()
+        ],
+    }

--- a/maritime-ai-service/app/engine/wiii_connect/snapshot.py
+++ b/maritime-ai-service/app/engine/wiii_connect/snapshot.py
@@ -16,6 +16,9 @@ from app.core.config import settings
 from app.engine.multi_agent.document_preview_contract import (
     lms_authoring_connection_status,
 )
+from app.engine.wiii_connect.provider_registry import (
+    list_wiii_connect_provider_registry,
+)
 
 
 WIII_CONNECT_SNAPSHOT_VERSION = "wiii_connect_snapshot.v0"
@@ -212,6 +215,7 @@ def build_wiii_connect_snapshot(
         _weather_connection(now),
         _visual_runtime_connection(now),
         _code_studio_connection(now),
+        *_external_provider_connections(now),
     )
     warnings = tuple(
         warning
@@ -479,6 +483,38 @@ def _code_studio_connection(now: str) -> WiiiConnectionRecord:
         reason="native_available",
         last_checked_at=now,
     )
+
+
+def _external_provider_connections(now: str) -> tuple[WiiiConnectionRecord, ...]:
+    records: list[WiiiConnectionRecord] = []
+    for entry in list_wiii_connect_provider_registry():
+        records.append(
+            WiiiConnectionRecord(
+                slug=entry.slug,
+                label=entry.label,
+                provider_kind=entry.provider_kind,
+                status="not_connected" if entry.enabled else "disabled",
+                agent_ready=False,
+                scopes=WiiiConnectionScopes(),
+                capabilities=(),
+                required_for_paths=tuple(entry.allowed_paths),
+                source="wiii_connect_provider_registry",
+                reason=(
+                    "provider_not_connected"
+                    if entry.enabled
+                    else "provider_adapter_disabled"
+                ),
+                last_checked_at=now,
+                warnings=tuple(entry.warnings),
+                details={
+                    "auth_mode": entry.auth_mode,
+                    "category": entry.category,
+                    "action_count": len(entry.action_allowlist),
+                    "requirement_count": len(entry.requirements),
+                },
+            )
+        )
+    return tuple(records)
 
 
 def _context_from_state(state: dict[str, Any] | None) -> dict[str, Any]:

--- a/maritime-ai-service/tests/unit/test_wiii_connect_provider_registry.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_provider_registry.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+
+
+def test_provider_registry_exposes_disabled_composio_catalog_without_secrets():
+    from app.engine.wiii_connect.provider_registry import (
+        provider_registry_public_metadata,
+    )
+
+    metadata = provider_registry_public_metadata()
+    providers = metadata["providers"]
+    by_slug = {item["slug"]: item for item in providers}
+
+    assert metadata["version"] == "wiii_connect_provider_registry.v1"
+    assert by_slug["facebook"]["provider_kind"] == "composio"
+    assert by_slug["gmail"]["enabled"] is False
+    assert by_slug["gmail"]["agent_ready"] is False
+    assert by_slug["github"]["requirements"] == [
+        "oauth_or_connect_link",
+        "encrypted_vault_ref",
+        "scope_policy",
+        "curated_action_catalog",
+        "execution_gateway",
+        "audit_ledger",
+    ]
+
+    serialized = json.dumps(metadata, sort_keys=True)
+    assert "access_token" not in serialized
+    assert "refresh_token" not in serialized
+    assert "api_key" not in serialized
+    assert "approval_token" not in serialized
+    assert "vault://" not in serialized
+
+
+def test_disabled_composio_registry_entries_remain_execution_denied():
+    from app.engine.wiii_connect.adapter_v1 import (
+        WiiiConnectConnectionRecordV1,
+        WiiiConnectExecutionRequest,
+        WiiiConnectScopeGrant,
+        decide_external_execution,
+    )
+    from app.engine.wiii_connect.provider_registry import (
+        get_wiii_connect_provider_entry,
+    )
+
+    entry = get_wiii_connect_provider_entry("facebook")
+    assert entry is not None
+
+    decision = decide_external_execution(
+        entry,
+        WiiiConnectConnectionRecordV1(
+            connection_id="conn_fake",
+            provider_slug="facebook",
+            state="connected",
+            scopes=WiiiConnectScopeGrant(read=True, write=True, apply=True),
+        ),
+        WiiiConnectExecutionRequest(
+            provider_slug="facebook",
+            action_slug="FACEBOOK_CREATE_POST",
+            path="external_app_action",
+            mutation="write",
+        ),
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "provider_disabled"
+
+
+def test_snapshot_projects_external_provider_registry_fail_closed(monkeypatch):
+    from app.engine.wiii_connect.snapshot import build_wiii_connect_snapshot, settings
+
+    monkeypatch.setattr(settings, "living_agent_enable_weather", False, raising=False)
+    monkeypatch.setattr(settings, "living_agent_weather_api_key", "", raising=False)
+
+    snapshot = build_wiii_connect_snapshot(state={"context": {}}, query="")
+    status = snapshot.connection_status_map()
+    metadata = snapshot.to_metadata()
+    facebook = next(item for item in metadata["connections"] if item["slug"] == "facebook")
+
+    assert status["facebook"]["active"] is False
+    assert status["facebook"]["status"] == "disabled"
+    assert status["facebook"]["reason"] == "provider_adapter_disabled"
+    assert status["facebook"]["agent_ready"] is False
+    assert facebook["provider_kind"] == "composio"
+    assert facebook["requirement_count"] == 6

--- a/specs/730-wiii-connect-adapter-v1/tasks.md
+++ b/specs/730-wiii-connect-adapter-v1/tasks.md
@@ -28,7 +28,9 @@
 ## Phase 4: Next Slices
 
 - [ ] T014 Add persistent provider registry API.
-- [ ] T015 Add OAuth start/callback routes for disabled Composio adapter.
-- [ ] T016 Add vault integration or provider-managed secret reference storage.
-- [ ] T017 Add frontend connection modal using Wiii backend routes.
-- [ ] T018 Add browser acceptance for connect, poll, disconnect, gated scope, and denied execute cases.
+- [x] T014 Add backend-owned static provider registry for disabled Composio catalog.
+- [ ] T015 Add persistent provider registry API.
+- [ ] T016 Add OAuth start/callback routes for disabled Composio adapter.
+- [ ] T017 Add vault integration or provider-managed secret reference storage.
+- [ ] T018 Add frontend connection modal using Wiii backend routes.
+- [ ] T019 Add browser acceptance for connect, poll, disconnect, gated scope, and denied execute cases.


### PR DESCRIPTION
## Summary
- adds a backend-owned Wiii Connect provider registry for disabled Composio catalog entries
- projects registry entries into the Wiii Connect snapshot as `disabled` and non-agent-ready
- extends Adapter V1 public metadata with category, description, and requirement fields

## Scope
- backend registry module only
- snapshot projection for disabled external providers
- focused tests for privacy-safe catalog metadata and fail-closed execution decisions

## Non-scope
- no real Composio OAuth endpoint
- no provider API calls
- no token/vault persistence
- no external action execution
- no frontend UI rewrite in this slice

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_snapshot.py tests/unit/test_wiii_connect_provider_registry.py -q --tb=short` -> 9 passed
- `cd maritime-ai-service; python -m ruff check app\engine\wiii_connect\adapter_v1.py app\engine\wiii_connect\provider_registry.py app\engine\wiii_connect\snapshot.py tests\unit\test_wiii_connect_adapter_v1.py tests\unit\test_wiii_connect_provider_registry.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
- Low runtime risk: providers are disabled and no provider calls are wired.
- Moderate UX/metadata risk: snapshot now includes external provider rows. They are explicitly disabled with `provider_adapter_disabled` so runtime and UI should remain fail-closed.

## Rollback
- Revert this PR. It adds no migrations, secrets, provider calls, or external mutations.

Closes #732