### PR TITLE
Expose Wiii Connect provider registry API

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -45,6 +45,12 @@ The backend-owned provider catalog lives in:
 maritime-ai-service/app/engine/wiii_connect/provider_registry.py
 ```
 
+The read-only API projection lives at:
+
+```text
+GET /api/v1/wiii-connect/providers
+```
+
 Frontend surfaces should consume this registry/snapshot projection instead of
 inventing a separate external-provider source of truth. Until a provider has
 OAuth, vault, scoped action catalog, gateway, and audit support, the registry

--- a/maritime-ai-service/app/api/v1/__init__.py
+++ b/maritime-ai-service/app/api/v1/__init__.py
@@ -66,6 +66,7 @@ def _build_router() -> APIRouter:
         ("app.api.v1.llm_status.router", "LLM Status"),
         ("app.api.v1.document_context.router", "Document Context"),
         ("app.api.v1.host_actions.router", "Host Action Audit"),
+        ("app.api.v1.wiii_connect.router", "Wiii Connect"),
         ("app.api.v1.voice.router", "Voice"),
         ("app.api.v1.soul_bridge.router", "Soul Bridge"),
         ("app.api.v1.living_agent.router", "Living Agent"),

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -1,0 +1,17 @@
+"""Read-only Wiii Connect registry endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.engine.wiii_connect import provider_registry_public_metadata
+
+
+router = APIRouter(prefix="/wiii-connect", tags=["wiii-connect"])
+
+
+@router.get("/providers")
+async def list_wiii_connect_providers() -> dict[str, object]:
+    """Return the privacy-safe Wiii Connect provider catalog."""
+
+    return provider_registry_public_metadata()

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from app.api.v1.wiii_connect import router as wiii_connect_router
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(wiii_connect_router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_provider_registry_api_is_privacy_safe(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/wiii-connect/providers")
+
+    assert response.status_code == 200
+    payload = response.json()
+    providers = payload["providers"]
+    by_slug = {provider["slug"]: provider for provider in providers}
+
+    assert payload["version"] == "wiii_connect_provider_registry.v1"
+    assert payload["adapter_version"] == "wiii_connect_adapter.v1"
+    assert by_slug["facebook"]["provider_kind"] == "composio"
+    assert by_slug["facebook"]["enabled"] is False
+    assert by_slug["facebook"]["agent_ready"] is False
+    assert by_slug["facebook"]["action_count"] == 0
+    assert "execution_gateway" in by_slug["facebook"]["requirements"]
+
+    serialized = json.dumps(payload, sort_keys=True)
+    assert "access_token" not in serialized
+    assert "refresh_token" not in serialized
+    assert "api_key" not in serialized
+    assert "approval_token" not in serialized
+    assert "vault://" not in serialized

--- a/specs/730-wiii-connect-adapter-v1/tasks.md
+++ b/specs/730-wiii-connect-adapter-v1/tasks.md
@@ -29,8 +29,9 @@
 
 - [ ] T014 Add persistent provider registry API.
 - [x] T014 Add backend-owned static provider registry for disabled Composio catalog.
-- [ ] T015 Add persistent provider registry API.
-- [ ] T016 Add OAuth start/callback routes for disabled Composio adapter.
-- [ ] T017 Add vault integration or provider-managed secret reference storage.
-- [ ] T018 Add frontend connection modal using Wiii backend routes.
-- [ ] T019 Add browser acceptance for connect, poll, disconnect, gated scope, and denied execute cases.
+- [x] T015 Add read-only provider registry API.
+- [ ] T016 Add persistent provider registry API.
+- [ ] T017 Add OAuth start/callback routes for disabled Composio adapter.
+- [ ] T018 Add vault integration or provider-managed secret reference storage.
+- [ ] T019 Add frontend connection modal using Wiii backend routes.
+- [ ] T020 Add browser acceptance for connect, poll, disconnect, gated scope, and denied execute cases.


### PR DESCRIPTION
## Summary
- adds read-only `GET /api/v1/wiii-connect/providers`
- registers the Wiii Connect API router under v1
- adds API tests proving disabled Composio catalog metadata is privacy-safe

## Scope
- backend API only
- read-only provider registry projection
- focused API/registry tests

## Non-scope
- no OAuth start/callback route
- no provider API calls
- no token/vault persistence
- no external action execution
- no frontend rewrite in this slice

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/api/test_wiii_connect_api.py tests/unit/test_wiii_connect_provider_registry.py -q --tb=short` -> 4 passed
- `cd maritime-ai-service; python -m pytest tests/unit/api/test_wiii_connect_api.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_snapshot.py tests/unit/test_wiii_connect_provider_registry.py -q --tb=short` -> 10 passed
- `cd maritime-ai-service; python -m ruff check app\api\v1\wiii_connect.py app\api\v1\__init__.py tests\unit\api\test_wiii_connect_api.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
- Low runtime risk: read-only endpoint returns already privacy-safe static metadata.
- Security boundary: no auth because response is catalog metadata only; future stateful connection/OAuth routes must add auth/org checks.

## Rollback
- Revert this PR. It adds no migrations, secrets, provider calls, or external mutations.

Closes #734