### PR TITLE
Add Wiii Connect session control contract

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -51,6 +51,19 @@ The read-only API projection lives at:
 GET /api/v1/wiii-connect/providers
 ```
 
+The connection-session control contract lives in:
+
+```text
+maritime-ai-service/app/engine/wiii_connect/connection_sessions.py
+```
+
+Current session/status API projections:
+
+```text
+GET  /api/v1/wiii-connect/providers/{slug}/status
+POST /api/v1/wiii-connect/providers/{slug}/sessions
+```
+
 Frontend surfaces should consume this registry/snapshot projection instead of
 inventing a separate external-provider source of truth. Until a provider has
 OAuth, vault, scoped action catalog, gateway, and audit support, the registry
@@ -97,6 +110,24 @@ must keep that provider disabled and non-agent-ready.
 `WiiiConnectAuditEvent`
 
 - privacy-safe event around request, deny, start, success, and failure stages.
+
+`WiiiConnectSessionStartRequest`
+
+- provider slug, UI surface, requested scope flags, and safe request-shape keys;
+- stores redirect URI presence only, not the URI value;
+- redacts sensitive request metadata keys before public/audit projection.
+
+`WiiiConnectProviderConnectionStatus`
+
+- provider authorization readiness for UI;
+- `can_start_authorization` remains false until registry, agent readiness,
+  provider adapter, vault, scope policy, execution gateway, and audit are ready.
+
+`WiiiConnectSessionStartDecision`
+
+- returns `blocked` or `ready`;
+- returns an authorization URL only when a provider adapter supplies one;
+- current Composio registry entries return `blocked/provider_disabled`.
 
 ## Lifecycle States
 
@@ -178,6 +209,9 @@ agent receive curated action schemas for the selected provider.
 Before real Composio OAuth is enabled:
 
 - Wiii backend must create authorization sessions with state and nonce;
+- session start must return a backend decision first, not let the frontend call
+  Composio directly;
+- disabled providers must return a blocked decision with missing requirements;
 - callback/webhook handling must bind provider account to Wiii org/user;
 - credential material must be stored in an encrypted vault or provider-managed
   backend secret store;
@@ -201,10 +235,11 @@ approval tokens and provider payloads must remain outside chat lifecycle data.
 
 ## Next Slices
 
-1. Persist provider registry and connection records behind backend API routes.
-2. Add OAuth session start/callback endpoints for a disabled Composio adapter.
-3. Add encrypted vault integration or provider-managed secret reference storage.
-4. Add frontend connection modal that uses Wiii backend routes only.
+1. Add OAuth callback/token-exchange placeholder that is still fail-closed until
+   vault storage exists.
+2. Add encrypted vault integration or provider-managed secret reference storage.
+3. Add frontend connection modal that uses Wiii backend routes only.
+4. Persist provider registry and connection records behind backend-owned storage.
 5. Add browser acceptance for connect, poll, disconnect, gated scope, and denied
    execute cases.
 6. Enable one low-risk read-only Composio action before any write action.

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -1,13 +1,34 @@
-"""Read-only Wiii Connect registry endpoints."""
+"""Wiii Connect registry and connection-session endpoints."""
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from typing import Any
 
-from app.engine.wiii_connect import provider_registry_public_metadata
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.engine.wiii_connect import (
+    WiiiConnectSessionStartRequest,
+    begin_connection_session,
+    get_wiii_connect_provider_entry,
+    provider_connection_status,
+    provider_registry_public_metadata,
+    scope_grant_from_mapping,
+)
 
 
 router = APIRouter(prefix="/wiii-connect", tags=["wiii-connect"])
+
+
+class WiiiConnectStartSessionBody(BaseModel):
+    """Safe request body for a provider authorization attempt."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    surface: str = "desktop"
+    redirect_uri: str | None = None
+    requested_scopes: dict[str, bool] = Field(default_factory=dict)
+    request_metadata: dict[str, Any] = Field(default_factory=dict)
 
 
 @router.get("/providers")
@@ -15,3 +36,39 @@ async def list_wiii_connect_providers() -> dict[str, object]:
     """Return the privacy-safe Wiii Connect provider catalog."""
 
     return provider_registry_public_metadata()
+
+
+@router.get("/providers/{slug}/status")
+async def get_wiii_connect_provider_connection_status(slug: str) -> dict[str, object]:
+    """Return fail-closed provider authorization readiness."""
+
+    status = provider_connection_status(slug)
+    if status is None:
+        raise HTTPException(status_code=404, detail="unknown_wiii_connect_provider")
+    return status.to_public_metadata()
+
+
+@router.post("/providers/{slug}/sessions")
+async def start_wiii_connect_provider_session(
+    slug: str,
+    body: WiiiConnectStartSessionBody | None = None,
+) -> dict[str, object]:
+    """Return the session-start decision for a provider.
+
+    This endpoint does not call Composio or any OAuth provider yet. It only
+    exposes the backend control-plane decision that the frontend can render.
+    """
+
+    entry = get_wiii_connect_provider_entry(slug)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="unknown_wiii_connect_provider")
+    body = body or WiiiConnectStartSessionBody()
+    request = WiiiConnectSessionStartRequest(
+        provider_slug=entry.slug,
+        surface=body.surface,
+        requested_scopes=scope_grant_from_mapping(body.requested_scopes),
+        redirect_uri_present=bool(body.redirect_uri),
+        request_metadata_keys=tuple(body.request_metadata.keys()),
+    )
+    decision = begin_connection_session(entry, request)
+    return decision.to_public_metadata()

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -14,6 +14,17 @@ from .adapter_v1 import (
     is_connection_baseline_ready,
     normalize_connection_state,
 )
+from .connection_sessions import (
+    WIII_CONNECT_SESSION_CONTRACT_VERSION,
+    WiiiConnectConnectionSessionAuditEvent,
+    WiiiConnectProviderConnectionStatus,
+    WiiiConnectSessionStartDecision,
+    WiiiConnectSessionStartRequest,
+    begin_connection_session,
+    provider_connection_status,
+    provider_connection_status_for_entry,
+    scope_grant_from_mapping,
+)
 from .provider_registry import (
     WIII_CONNECT_PROVIDER_REGISTRY_VERSION,
     get_wiii_connect_provider_entry,
@@ -31,13 +42,18 @@ from .snapshot import (
 
 __all__ = [
     "WIII_CONNECT_ADAPTER_VERSION",
+    "WIII_CONNECT_SESSION_CONTRACT_VERSION",
     "WiiiConnectAuditEvent",
+    "WiiiConnectConnectionSessionAuditEvent",
     "WiiiConnectConnectionRecordV1",
     "WiiiConnectExecutionDecision",
     "WiiiConnectExecutionRequest",
+    "WiiiConnectProviderConnectionStatus",
     "WiiiConnectProviderRegistryEntry",
     "WiiiConnectRequiredField",
     "WiiiConnectScopeGrant",
+    "WiiiConnectSessionStartDecision",
+    "WiiiConnectSessionStartRequest",
     "WiiiConnectVaultSecretRef",
     "WIII_CONNECT_PROVIDER_REGISTRY_VERSION",
     "WIII_CONNECT_SNAPSHOT_VERSION",
@@ -45,11 +61,15 @@ __all__ = [
     "WiiiConnectionScopes",
     "WiiiConnectionSnapshot",
     "WiiiPathCapabilityRecord",
+    "begin_connection_session",
     "build_wiii_connect_snapshot",
     "decide_external_execution",
     "get_wiii_connect_provider_entry",
     "is_connection_baseline_ready",
     "list_wiii_connect_provider_registry",
     "normalize_connection_state",
+    "provider_connection_status",
+    "provider_connection_status_for_entry",
     "provider_registry_public_metadata",
+    "scope_grant_from_mapping",
 ]

--- a/maritime-ai-service/app/engine/wiii_connect/connection_sessions.py
+++ b/maritime-ai-service/app/engine/wiii_connect/connection_sessions.py
@@ -1,0 +1,248 @@
+"""Wiii Connect connection-session control contract.
+
+This module owns the provider authorization/session boundary before any real
+OAuth broker, vault, or external execution adapter is allowed to run. It is
+intentionally network-free and fail-closed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from .adapter_v1 import (
+    WiiiConnectProviderRegistryEntry,
+    WiiiConnectScopeGrant,
+)
+from .provider_registry import get_wiii_connect_provider_entry
+
+
+WIII_CONNECT_SESSION_CONTRACT_VERSION = "wiii_connect_session.v1"
+
+SessionDecisionStatus = Literal["blocked", "ready"]
+SessionDecisionReason = Literal[
+    "provider_disabled",
+    "provider_not_agent_ready",
+    "missing_connect_prerequisites",
+    "provider_adapter_not_bound",
+    "authorization_url_issued",
+]
+SessionAuditStage = Literal["status_checked", "start_requested"]
+
+_SENSITIVE_KEY_MARKERS = ("token", "secret", "password", "credential", "key", "code")
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectSessionStartRequest:
+    """User request to begin a provider authorization session.
+
+    The request deliberately stores only safe control-plane metadata. Raw
+    request/provider values must not enter chat lifecycle or public API output.
+    """
+
+    provider_slug: str
+    surface: str = "desktop"
+    requested_scopes: WiiiConnectScopeGrant = field(default_factory=WiiiConnectScopeGrant)
+    redirect_uri_present: bool = False
+    request_metadata_keys: tuple[str, ...] = ()
+
+    def to_audit_metadata(self) -> dict[str, Any]:
+        return {
+            "provider_slug": self.provider_slug,
+            "surface": self.surface,
+            "requested_scopes": self.requested_scopes.to_metadata(),
+            "redirect_uri_present": self.redirect_uri_present,
+            "request_metadata_keys": [
+                _safe_metadata_key(key) for key in self.request_metadata_keys
+            ],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectConnectionSessionAuditEvent:
+    """Privacy-safe audit event for connection-session control-plane decisions."""
+
+    stage: SessionAuditStage
+    reason: SessionDecisionReason
+    request: WiiiConnectSessionStartRequest
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_SESSION_CONTRACT_VERSION,
+            "stage": self.stage,
+            "reason": self.reason,
+            "created_at": self.created_at,
+            "request": self.request.to_audit_metadata(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectProviderConnectionStatus:
+    """Provider authorization readiness projected to UI/API surfaces."""
+
+    provider_slug: str
+    label: str
+    provider_kind: str
+    auth_mode: str
+    enabled: bool
+    agent_ready: bool
+    can_start_authorization: bool
+    reason: SessionDecisionReason
+    missing_requirements: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_SESSION_CONTRACT_VERSION,
+            "provider_slug": self.provider_slug,
+            "label": self.label,
+            "provider_kind": self.provider_kind,
+            "auth_mode": self.auth_mode,
+            "enabled": self.enabled,
+            "agent_ready": self.agent_ready,
+            "can_start_authorization": self.can_start_authorization,
+            "reason": self.reason,
+            "missing_requirements": list(self.missing_requirements),
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectSessionStartDecision:
+    """Decision returned after a session-start attempt."""
+
+    status: SessionDecisionStatus
+    reason: SessionDecisionReason
+    provider_slug: str
+    label: str
+    provider_kind: str
+    auth_mode: str
+    authorization_url: str = ""
+    required_next: tuple[str, ...] = ()
+    audit_event: WiiiConnectConnectionSessionAuditEvent | None = None
+
+    @property
+    def ready(self) -> bool:
+        return self.status == "ready"
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_SESSION_CONTRACT_VERSION,
+            "status": self.status,
+            "reason": self.reason,
+            "provider_slug": self.provider_slug,
+            "label": self.label,
+            "provider_kind": self.provider_kind,
+            "auth_mode": self.auth_mode,
+            "authorization_url": self.authorization_url,
+            "required_next": list(self.required_next),
+            "audit_event": (
+                self.audit_event.to_metadata() if self.audit_event is not None else None
+            ),
+        }
+
+
+def provider_connection_status(
+    slug: str,
+) -> WiiiConnectProviderConnectionStatus | None:
+    """Return the current authorization-readiness status for a provider."""
+
+    entry = get_wiii_connect_provider_entry(slug)
+    if entry is None:
+        return None
+    return provider_connection_status_for_entry(entry)
+
+
+def provider_connection_status_for_entry(
+    entry: WiiiConnectProviderRegistryEntry,
+) -> WiiiConnectProviderConnectionStatus:
+    """Project one registry entry into connection-session readiness metadata."""
+
+    missing_requirements = tuple(entry.requirements)
+    reason = _session_block_reason(entry, missing_requirements)
+    if reason == "authorization_url_issued":
+        reason = "provider_adapter_not_bound"
+    can_start = False
+    return WiiiConnectProviderConnectionStatus(
+        provider_slug=entry.slug,
+        label=entry.label,
+        provider_kind=entry.provider_kind,
+        auth_mode=entry.auth_mode,
+        enabled=entry.enabled,
+        agent_ready=entry.agent_ready,
+        can_start_authorization=can_start,
+        reason=reason,
+        missing_requirements=missing_requirements,
+        warnings=entry.warnings,
+    )
+
+
+def begin_connection_session(
+    entry: WiiiConnectProviderRegistryEntry,
+    request: WiiiConnectSessionStartRequest,
+    *,
+    authorization_url: str | None = None,
+) -> WiiiConnectSessionStartDecision:
+    """Decide whether Wiii may start provider authorization for this request."""
+
+    missing_requirements = tuple(entry.requirements)
+    reason = _session_block_reason(entry, missing_requirements)
+    if reason == "authorization_url_issued" and not authorization_url:
+        reason = "provider_adapter_not_bound"
+
+    status: SessionDecisionStatus = (
+        "ready" if reason == "authorization_url_issued" and authorization_url else "blocked"
+    )
+    audit_event = WiiiConnectConnectionSessionAuditEvent(
+        stage="start_requested",
+        reason=reason,
+        request=request,
+    )
+    return WiiiConnectSessionStartDecision(
+        status=status,
+        reason=reason,
+        provider_slug=entry.slug,
+        label=entry.label,
+        provider_kind=entry.provider_kind,
+        auth_mode=entry.auth_mode,
+        authorization_url=authorization_url if status == "ready" else "",
+        required_next=missing_requirements,
+        audit_event=audit_event,
+    )
+
+
+def scope_grant_from_mapping(value: dict[str, Any] | None) -> WiiiConnectScopeGrant:
+    """Normalize user-requested scopes and ignore unknown fields."""
+
+    scopes = value or {}
+    return WiiiConnectScopeGrant(
+        read=bool(scopes.get("read", False)),
+        preview=bool(scopes.get("preview", False)),
+        write=bool(scopes.get("write", False)),
+        apply=bool(scopes.get("apply", False)),
+        admin=bool(scopes.get("admin", False)),
+    )
+
+
+def _session_block_reason(
+    entry: WiiiConnectProviderRegistryEntry,
+    missing_requirements: tuple[str, ...],
+) -> SessionDecisionReason:
+    if not entry.enabled:
+        return "provider_disabled"
+    if not entry.agent_ready:
+        return "provider_not_agent_ready"
+    if missing_requirements:
+        return "missing_connect_prerequisites"
+    return "authorization_url_issued"
+
+
+def _safe_metadata_key(key: str) -> str:
+    normalized = str(key).strip().lower()
+    if not normalized:
+        return "empty"
+    if any(marker in normalized for marker in _SENSITIVE_KEY_MARKERS):
+        return "redacted_sensitive_field"
+    return normalized[:80]

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -43,3 +43,69 @@ async def test_wiii_connect_provider_registry_api_is_privacy_safe(app):
     assert "api_key" not in serialized
     assert "approval_token" not in serialized
     assert "vault://" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_provider_status_api_is_fail_closed(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/wiii-connect/providers/facebook/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["version"] == "wiii_connect_session.v1"
+    assert payload["provider_slug"] == "facebook"
+    assert payload["can_start_authorization"] is False
+    assert payload["reason"] == "provider_disabled"
+    assert "execution_gateway" in payload["missing_requirements"]
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_session_start_api_blocks_without_leaking_secrets(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/wiii-connect/providers/facebook/sessions",
+            json={
+                "surface": "desktop",
+                "redirect_uri": "https://wiii.example.test/callback",
+                "requested_scopes": {"read": True, "write": True},
+                "request_metadata": {
+                    "access_token": "secret-value",
+                    "client_secret": "secret-value",
+                    "workspace_id": "workspace_1",
+                },
+                "refresh_token": "secret-value",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    serialized = json.dumps(payload, sort_keys=True)
+    assert payload["version"] == "wiii_connect_session.v1"
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "provider_disabled"
+    assert payload["authorization_url"] == ""
+    assert payload["audit_event"]["request"]["requested_scopes"]["write"] is True
+    assert "redacted_sensitive_field" in serialized
+    assert "workspace_id" in serialized
+    assert "access_token" not in serialized
+    assert "refresh_token" not in serialized
+    assert "client_secret" not in serialized
+    assert "secret-value" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_session_api_404_for_unknown_provider(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post("/wiii-connect/providers/not-real/sessions")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "unknown_wiii_connect_provider"

--- a/maritime-ai-service/tests/unit/test_wiii_connect_connection_sessions.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_connection_sessions.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+
+
+def test_disabled_provider_status_is_fail_closed_and_privacy_safe():
+    from app.engine.wiii_connect.connection_sessions import provider_connection_status
+
+    status = provider_connection_status("facebook")
+    assert status is not None
+
+    metadata = status.to_public_metadata()
+    assert metadata["version"] == "wiii_connect_session.v1"
+    assert metadata["provider_slug"] == "facebook"
+    assert metadata["can_start_authorization"] is False
+    assert metadata["reason"] == "provider_disabled"
+    assert "encrypted_vault_ref" in metadata["missing_requirements"]
+
+    serialized = json.dumps(metadata, sort_keys=True)
+    assert "access_token" not in serialized
+    assert "refresh_token" not in serialized
+    assert "client_secret" not in serialized
+    assert "approval_token" not in serialized
+
+
+def test_session_start_redacts_sensitive_request_metadata_keys():
+    from app.engine.wiii_connect.connection_sessions import (
+        WiiiConnectSessionStartRequest,
+        begin_connection_session,
+        scope_grant_from_mapping,
+    )
+    from app.engine.wiii_connect.provider_registry import get_wiii_connect_provider_entry
+
+    entry = get_wiii_connect_provider_entry("facebook")
+    assert entry is not None
+
+    request = WiiiConnectSessionStartRequest(
+        provider_slug="facebook",
+        requested_scopes=scope_grant_from_mapping({"read": True, "write": True}),
+        redirect_uri_present=True,
+        request_metadata_keys=("access_token", "client_secret", "workspace_id"),
+    )
+    decision = begin_connection_session(entry, request)
+    metadata = decision.to_public_metadata()
+    serialized = json.dumps(metadata, sort_keys=True)
+
+    assert decision.ready is False
+    assert metadata["status"] == "blocked"
+    assert metadata["reason"] == "provider_disabled"
+    assert metadata["authorization_url"] == ""
+    assert metadata["audit_event"]["request"]["redirect_uri_present"] is True
+    assert "redacted_sensitive_field" in serialized
+    assert "workspace_id" in serialized
+    assert "access_token" not in serialized
+    assert "client_secret" not in serialized
+    assert "secret-value" not in serialized
+
+
+def test_ready_session_requires_adapter_authorization_url_even_when_entry_enabled():
+    from app.engine.wiii_connect.adapter_v1 import WiiiConnectProviderRegistryEntry
+    from app.engine.wiii_connect.connection_sessions import (
+        WiiiConnectSessionStartRequest,
+        begin_connection_session,
+        provider_connection_status_for_entry,
+    )
+
+    entry = WiiiConnectProviderRegistryEntry(
+        slug="internal_test",
+        label="Internal Test",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        enabled=True,
+        agent_ready=True,
+        requirements=(),
+    )
+
+    status = provider_connection_status_for_entry(entry)
+    blocked = begin_connection_session(
+        entry,
+        WiiiConnectSessionStartRequest(provider_slug="internal_test"),
+    )
+    ready = begin_connection_session(
+        entry,
+        WiiiConnectSessionStartRequest(provider_slug="internal_test"),
+        authorization_url="https://connect.example.test/session/123",
+    )
+
+    assert status.can_start_authorization is False
+    assert status.reason == "provider_adapter_not_bound"
+    assert blocked.ready is False
+    assert blocked.reason == "provider_adapter_not_bound"
+    assert ready.ready is True
+    assert ready.reason == "authorization_url_issued"
+    assert ready.authorization_url == "https://connect.example.test/session/123"


### PR DESCRIPTION
Closes #738

## Summary
- Add a typed Wiii Connect connection-session control contract that stays network-free and fail-closed.
- Add provider status and session-start decision endpoints under `/api/v1/wiii-connect`.
- Redact sensitive request metadata keys and return only safe control-plane metadata/audit events.
- Update Adapter V1 design notes with the session/status boundary.

## Scope
- Backend Wiii Connect session contract.
- Wiii Connect status/session API endpoints.
- Focused privacy/fail-closed unit tests.
- Adapter V1 design documentation.

## Non-Scope
- No real Composio API calls.
- No OAuth callback/token exchange.
- No encrypted vault persistence.
- No external tool execution.
- No frontend connection modal wiring in this PR.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/api/test_wiii_connect_api.py -q --tb=short` passed: 14 tests
- `cd maritime-ai-service; python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7` passed
- `git diff --check` passed

## Risk
- Low runtime risk: the new session endpoint does not call external providers and currently returns blocked decisions for disabled Composio registry entries.
- Security-sensitive surface: this adds the future OAuth boundary, so metadata is explicitly redacted and tests assert no token/secret values are returned.

## Rollback
- Revert this PR to remove the session/status endpoints and return Wiii Connect to provider-registry-only behavior.