### PR TITLE
Add Wiii Connect callback vault boundary

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -57,11 +57,18 @@ The connection-session control contract lives in:
 maritime-ai-service/app/engine/wiii_connect/connection_sessions.py
 ```
 
+The OAuth callback/vault boundary contract lives in:
+
+```text
+maritime-ai-service/app/engine/wiii_connect/callback_boundary.py
+```
+
 Current session/status API projections:
 
 ```text
 GET  /api/v1/wiii-connect/providers/{slug}/status
 POST /api/v1/wiii-connect/providers/{slug}/sessions
+GET  /api/v1/wiii-connect/providers/{slug}/callback
 ```
 
 Frontend surfaces should consume this registry/snapshot projection instead of
@@ -128,6 +135,19 @@ must keep that provider disabled and non-agent-ready.
 - returns `blocked` or `ready`;
 - returns an authorization URL only when a provider adapter supplies one;
 - current Composio registry entries return `blocked/provider_disabled`.
+
+`WiiiConnectCallbackRequest`
+
+- records only callback shape: state/code/error presence and sanitized key names;
+- never returns OAuth code, state value, token, client secret, or raw provider
+  payload.
+
+`WiiiConnectCallbackDecision`
+
+- returns `blocked` or `accepted`;
+- blocks disabled providers, provider errors, missing state, missing code, missing
+  vault, or missing provider adapter;
+- issues a vault reference only after vault and provider adapter are both ready.
 
 ## Lifecycle States
 
@@ -212,6 +232,8 @@ Before real Composio OAuth is enabled:
 - session start must return a backend decision first, not let the frontend call
   Composio directly;
 - disabled providers must return a blocked decision with missing requirements;
+- callback handling must stay blocked until state/code validation, vault storage,
+  and provider adapter exchange are ready;
 - callback/webhook handling must bind provider account to Wiii org/user;
 - credential material must be stored in an encrypted vault or provider-managed
   backend secret store;
@@ -235,9 +257,9 @@ approval tokens and provider payloads must remain outside chat lifecycle data.
 
 ## Next Slices
 
-1. Add OAuth callback/token-exchange placeholder that is still fail-closed until
-   vault storage exists.
-2. Add encrypted vault integration or provider-managed secret reference storage.
+1. Add encrypted vault integration or provider-managed secret reference storage.
+2. Add provider adapter abstraction that can supply authorization URLs and token
+   exchange only behind vault policy.
 3. Add frontend connection modal that uses Wiii backend routes only.
 4. Persist provider registry and connection records behind backend-owned storage.
 5. Add browser acceptance for connect, poll, disconnect, gated scope, and denied

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.engine.wiii_connect import (
+    WiiiConnectCallbackRequest,
     WiiiConnectSessionStartRequest,
     begin_connection_session,
     get_wiii_connect_provider_entry,
+    provider_callback_decision,
     provider_connection_status,
     provider_registry_public_metadata,
     scope_grant_from_mapping,
@@ -71,4 +73,29 @@ async def start_wiii_connect_provider_session(
         request_metadata_keys=tuple(body.request_metadata.keys()),
     )
     decision = begin_connection_session(entry, request)
+    return decision.to_public_metadata()
+
+
+@router.get("/providers/{slug}/callback")
+async def receive_wiii_connect_provider_callback(
+    slug: str,
+    request: Request,
+    state: str | None = None,
+    code: str | None = None,
+    error: str | None = None,
+    surface: str = "desktop",
+) -> dict[str, object]:
+    """Return a fail-closed callback decision without exchanging credentials."""
+
+    callback_request = WiiiConnectCallbackRequest(
+        provider_slug=slug.strip().lower().replace("-", "_"),
+        surface=surface,
+        state_present=bool(state),
+        code_present=bool(code),
+        error_present=bool(error),
+        request_metadata_keys=tuple(request.query_params.keys()),
+    )
+    decision = provider_callback_decision(slug, callback_request)
+    if decision is None:
+        raise HTTPException(status_code=404, detail="unknown_wiii_connect_provider")
     return decision.to_public_metadata()

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -14,6 +14,14 @@ from .adapter_v1 import (
     is_connection_baseline_ready,
     normalize_connection_state,
 )
+from .callback_boundary import (
+    WIII_CONNECT_CALLBACK_CONTRACT_VERSION,
+    WiiiConnectCallbackAuditEvent,
+    WiiiConnectCallbackDecision,
+    WiiiConnectCallbackRequest,
+    provider_callback_decision,
+    provider_callback_decision_for_entry,
+)
 from .connection_sessions import (
     WIII_CONNECT_SESSION_CONTRACT_VERSION,
     WiiiConnectConnectionSessionAuditEvent,
@@ -42,8 +50,12 @@ from .snapshot import (
 
 __all__ = [
     "WIII_CONNECT_ADAPTER_VERSION",
+    "WIII_CONNECT_CALLBACK_CONTRACT_VERSION",
     "WIII_CONNECT_SESSION_CONTRACT_VERSION",
     "WiiiConnectAuditEvent",
+    "WiiiConnectCallbackAuditEvent",
+    "WiiiConnectCallbackDecision",
+    "WiiiConnectCallbackRequest",
     "WiiiConnectConnectionSessionAuditEvent",
     "WiiiConnectConnectionRecordV1",
     "WiiiConnectExecutionDecision",
@@ -68,6 +80,8 @@ __all__ = [
     "is_connection_baseline_ready",
     "list_wiii_connect_provider_registry",
     "normalize_connection_state",
+    "provider_callback_decision",
+    "provider_callback_decision_for_entry",
     "provider_connection_status",
     "provider_connection_status_for_entry",
     "provider_registry_public_metadata",

--- a/maritime-ai-service/app/engine/wiii_connect/callback_boundary.py
+++ b/maritime-ai-service/app/engine/wiii_connect/callback_boundary.py
@@ -1,0 +1,189 @@
+"""Wiii Connect OAuth callback and vault boundary contract.
+
+The real OAuth callback path must never exchange or store credentials until the
+provider adapter and vault are explicitly ready. This module models that
+decision without making network calls or persisting secrets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from .adapter_v1 import WiiiConnectProviderRegistryEntry
+from .provider_registry import get_wiii_connect_provider_entry
+
+
+WIII_CONNECT_CALLBACK_CONTRACT_VERSION = "wiii_connect_callback.v1"
+
+CallbackDecisionStatus = Literal["blocked", "accepted"]
+CallbackDecisionReason = Literal[
+    "provider_disabled",
+    "provider_error",
+    "missing_state",
+    "missing_code",
+    "vault_not_configured",
+    "provider_adapter_not_bound",
+    "accepted",
+]
+
+_SENSITIVE_KEY_MARKERS = ("token", "secret", "password", "credential", "key", "code")
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectCallbackRequest:
+    """Sanitized shape of an OAuth callback request."""
+
+    provider_slug: str
+    surface: str = "desktop"
+    state_present: bool = False
+    code_present: bool = False
+    error_present: bool = False
+    request_metadata_keys: tuple[str, ...] = ()
+
+    def to_audit_metadata(self) -> dict[str, Any]:
+        return {
+            "provider_slug": self.provider_slug,
+            "surface": self.surface,
+            "state_present": self.state_present,
+            "code_present": self.code_present,
+            "error_present": self.error_present,
+            "request_metadata_keys": [
+                _safe_metadata_key(key) for key in self.request_metadata_keys
+            ],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectCallbackAuditEvent:
+    """Privacy-safe audit event around a callback decision."""
+
+    reason: CallbackDecisionReason
+    request: WiiiConnectCallbackRequest
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_CALLBACK_CONTRACT_VERSION,
+            "stage": "callback_received",
+            "reason": self.reason,
+            "created_at": self.created_at,
+            "request": self.request.to_audit_metadata(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectCallbackDecision:
+    """Decision returned after an OAuth callback reaches Wiii."""
+
+    status: CallbackDecisionStatus
+    reason: CallbackDecisionReason
+    provider_slug: str
+    label: str
+    provider_kind: str
+    auth_mode: str
+    vault_ref_issued: bool = False
+    connection_id: str = ""
+    audit_event: WiiiConnectCallbackAuditEvent | None = None
+
+    @property
+    def accepted(self) -> bool:
+        return self.status == "accepted"
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_CALLBACK_CONTRACT_VERSION,
+            "status": self.status,
+            "reason": self.reason,
+            "provider_slug": self.provider_slug,
+            "label": self.label,
+            "provider_kind": self.provider_kind,
+            "auth_mode": self.auth_mode,
+            "vault_ref_issued": self.vault_ref_issued,
+            "connection_id": self.connection_id,
+            "audit_event": (
+                self.audit_event.to_metadata() if self.audit_event is not None else None
+            ),
+        }
+
+
+def provider_callback_decision(
+    slug: str,
+    request: WiiiConnectCallbackRequest,
+    *,
+    vault_ready: bool = False,
+    provider_adapter_bound: bool = False,
+) -> WiiiConnectCallbackDecision | None:
+    """Return a callback decision for a registry provider slug."""
+
+    entry = get_wiii_connect_provider_entry(slug)
+    if entry is None:
+        return None
+    return provider_callback_decision_for_entry(
+        entry,
+        request,
+        vault_ready=vault_ready,
+        provider_adapter_bound=provider_adapter_bound,
+    )
+
+
+def provider_callback_decision_for_entry(
+    entry: WiiiConnectProviderRegistryEntry,
+    request: WiiiConnectCallbackRequest,
+    *,
+    vault_ready: bool = False,
+    provider_adapter_bound: bool = False,
+) -> WiiiConnectCallbackDecision:
+    """Decide whether a callback may be exchanged and persisted."""
+
+    reason = _callback_reason(
+        entry,
+        request,
+        vault_ready=vault_ready,
+        provider_adapter_bound=provider_adapter_bound,
+    )
+    status: CallbackDecisionStatus = "accepted" if reason == "accepted" else "blocked"
+    audit_event = WiiiConnectCallbackAuditEvent(reason=reason, request=request)
+    return WiiiConnectCallbackDecision(
+        status=status,
+        reason=reason,
+        provider_slug=entry.slug,
+        label=entry.label,
+        provider_kind=entry.provider_kind,
+        auth_mode=entry.auth_mode,
+        vault_ref_issued=status == "accepted",
+        connection_id="pending_connection_ref" if status == "accepted" else "",
+        audit_event=audit_event,
+    )
+
+
+def _callback_reason(
+    entry: WiiiConnectProviderRegistryEntry,
+    request: WiiiConnectCallbackRequest,
+    *,
+    vault_ready: bool,
+    provider_adapter_bound: bool,
+) -> CallbackDecisionReason:
+    if not entry.enabled:
+        return "provider_disabled"
+    if request.error_present:
+        return "provider_error"
+    if not request.state_present:
+        return "missing_state"
+    if not request.code_present:
+        return "missing_code"
+    if not vault_ready:
+        return "vault_not_configured"
+    if not provider_adapter_bound:
+        return "provider_adapter_not_bound"
+    return "accepted"
+
+
+def _safe_metadata_key(key: str) -> str:
+    normalized = str(key).strip().lower()
+    if not normalized:
+        return "empty"
+    if any(marker in normalized for marker in _SENSITIVE_KEY_MARKERS):
+        return "redacted_sensitive_field"
+    return normalized[:80]

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -109,3 +109,46 @@ async def test_wiii_connect_session_api_404_for_unknown_provider(app):
 
     assert response.status_code == 404
     assert response.json()["detail"] == "unknown_wiii_connect_provider"
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_callback_api_blocks_and_redacts_oauth_values(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/wiii-connect/providers/facebook/callback",
+            params={
+                "state": "secret-state-value",
+                "code": "oauth-code-value",
+                "client_secret": "secret-value",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    serialized = json.dumps(payload, sort_keys=True)
+    assert payload["version"] == "wiii_connect_callback.v1"
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "provider_disabled"
+    assert payload["vault_ref_issued"] is False
+    assert payload["audit_event"]["request"]["state_present"] is True
+    assert payload["audit_event"]["request"]["code_present"] is True
+    assert "redacted_sensitive_field" in serialized
+    assert "secret-state-value" not in serialized
+    assert "oauth-code-value" not in serialized
+    assert "client_secret" not in serialized
+    assert "secret-value" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_callback_api_404_for_unknown_provider(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/wiii-connect/providers/not-real/callback")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "unknown_wiii_connect_provider"

--- a/maritime-ai-service/tests/unit/test_wiii_connect_callback_boundary.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_callback_boundary.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+
+
+def test_disabled_provider_callback_is_blocked_and_redacted():
+    from app.engine.wiii_connect.callback_boundary import (
+        WiiiConnectCallbackRequest,
+        provider_callback_decision,
+    )
+
+    decision = provider_callback_decision(
+        "facebook",
+        WiiiConnectCallbackRequest(
+            provider_slug="facebook",
+            state_present=True,
+            code_present=True,
+            request_metadata_keys=("state", "code", "client_secret"),
+        ),
+    )
+    assert decision is not None
+
+    metadata = decision.to_public_metadata()
+    serialized = json.dumps(metadata, sort_keys=True)
+
+    assert metadata["version"] == "wiii_connect_callback.v1"
+    assert metadata["status"] == "blocked"
+    assert metadata["reason"] == "provider_disabled"
+    assert metadata["vault_ref_issued"] is False
+    assert "redacted_sensitive_field" in serialized
+    assert "client_secret" not in serialized
+    assert "oauth-code-value" not in serialized
+    assert "access_token" not in serialized
+
+
+def test_callback_requires_state_code_vault_and_adapter_before_accepting():
+    from app.engine.wiii_connect.adapter_v1 import WiiiConnectProviderRegistryEntry
+    from app.engine.wiii_connect.callback_boundary import (
+        WiiiConnectCallbackRequest,
+        provider_callback_decision_for_entry,
+    )
+
+    entry = WiiiConnectProviderRegistryEntry(
+        slug="internal_test",
+        label="Internal Test",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        enabled=True,
+        agent_ready=True,
+        requirements=(),
+    )
+
+    missing_state = provider_callback_decision_for_entry(
+        entry,
+        WiiiConnectCallbackRequest(provider_slug="internal_test", code_present=True),
+    )
+    missing_code = provider_callback_decision_for_entry(
+        entry,
+        WiiiConnectCallbackRequest(provider_slug="internal_test", state_present=True),
+    )
+    missing_vault = provider_callback_decision_for_entry(
+        entry,
+        WiiiConnectCallbackRequest(
+            provider_slug="internal_test",
+            state_present=True,
+            code_present=True,
+        ),
+    )
+    missing_adapter = provider_callback_decision_for_entry(
+        entry,
+        WiiiConnectCallbackRequest(
+            provider_slug="internal_test",
+            state_present=True,
+            code_present=True,
+        ),
+        vault_ready=True,
+    )
+    accepted = provider_callback_decision_for_entry(
+        entry,
+        WiiiConnectCallbackRequest(
+            provider_slug="internal_test",
+            state_present=True,
+            code_present=True,
+        ),
+        vault_ready=True,
+        provider_adapter_bound=True,
+    )
+
+    assert missing_state.reason == "missing_state"
+    assert missing_code.reason == "missing_code"
+    assert missing_vault.reason == "vault_not_configured"
+    assert missing_adapter.reason == "provider_adapter_not_bound"
+    assert accepted.accepted is True
+    assert accepted.vault_ref_issued is True
+    assert accepted.connection_id == "pending_connection_ref"


### PR DESCRIPTION
Closes #742

## Summary
- Add a Wiii Connect OAuth callback/vault boundary contract that never exchanges or stores credentials until vault and adapter gates are ready.
- Add a callback decision endpoint under `/api/v1/wiii-connect/providers/{slug}/callback`.
- Redact OAuth code/state/client-secret values and sensitive metadata keys from public/audit output.
- Update Adapter V1 design notes with the callback/vault boundary.

## Scope
- Backend callback decision contract.
- Wiii Connect callback API endpoint.
- Focused fail-closed/redaction tests.
- Wiii Connect architecture docs.

## Non-Scope
- No real Composio API calls.
- No token exchange.
- No encrypted vault persistence.
- No external tool execution.
- No frontend callback UX.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/api/test_wiii_connect_api.py -q --tb=short` passed: 18 tests
- `cd maritime-ai-service; python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7` passed
- `git diff --check` passed

## Risk
- Low runtime risk: the callback endpoint is fail-closed and does not exchange credentials.
- Security-sensitive surface: redaction tests assert OAuth state/code/client-secret values are not returned.

## Rollback
- Revert this PR to remove the callback endpoint and callback/vault contract.