### PR TITLE
Add Wiii Connect vault and audit ledger contracts

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -63,12 +63,21 @@ The OAuth callback/vault boundary contract lives in:
 maritime-ai-service/app/engine/wiii_connect/callback_boundary.py
 ```
 
+The vault policy and audit ledger contracts live in:
+
+```text
+maritime-ai-service/app/engine/wiii_connect/vault.py
+maritime-ai-service/app/engine/wiii_connect/audit_ledger.py
+```
+
 Current session/status API projections:
 
 ```text
 GET  /api/v1/wiii-connect/providers/{slug}/status
 POST /api/v1/wiii-connect/providers/{slug}/sessions
 GET  /api/v1/wiii-connect/providers/{slug}/callback
+GET  /api/v1/wiii-connect/vault/status
+GET  /api/v1/wiii-connect/audit-ledger/status
 ```
 
 Frontend surfaces should consume this registry/snapshot projection instead of
@@ -148,6 +157,26 @@ must keep that provider disabled and non-agent-ready.
 - blocks disabled providers, provider errors, missing state, missing code, missing
   vault, or missing provider adapter;
 - issues a vault reference only after vault and provider adapter are both ready.
+
+`WiiiConnectVaultCapability`
+
+- reports whether a vault backend is enabled and can accept external secrets;
+- default status is disabled/fail-closed;
+- public metadata never exposes vault namespaces, key IDs, or secret material.
+
+`WiiiConnectVaultSecretWriteDecision`
+
+- decides whether OAuth/API/provider secret material may enter a vault adapter;
+- blocks disabled providers, disabled vaults, missing secret material, unsupported
+  secret kinds, and non-accepting vault backends;
+- returns only an opaque `WiiiConnectVaultSecretRef` when ready.
+
+`WiiiConnectAuditLedgerRecord`
+
+- normalizes session, callback, vault, provider, and execution audit events;
+- recursively redacts sensitive keys before public projection;
+- current contract is storage-agnostic and reports persistent storage as not yet
+  configured.
 
 ## Lifecycle States
 
@@ -237,6 +266,8 @@ Before real Composio OAuth is enabled:
 - callback/webhook handling must bind provider account to Wiii org/user;
 - credential material must be stored in an encrypted vault or provider-managed
   backend secret store;
+- every session/callback/vault/execution decision must produce a privacy-safe
+  ledger record shape before durable persistence is added;
 - frontend may receive connect URLs and state labels, not tokens;
 - stale pending/error OAuth rows must be cleaned up or expired safely;
 - provider errors must be sanitized before reaching UI or chat.
@@ -257,11 +288,12 @@ approval tokens and provider payloads must remain outside chat lifecycle data.
 
 ## Next Slices
 
-1. Add encrypted vault integration or provider-managed secret reference storage.
-2. Add provider adapter abstraction that can supply authorization URLs and token
+1. Add durable audit ledger persistence and per-org connection records.
+2. Add encrypted vault integration or provider-managed secret reference storage.
+3. Add provider adapter abstraction that can supply authorization URLs and token
    exchange only behind vault policy.
-3. Add frontend connection modal that uses Wiii backend routes only.
-4. Persist provider registry and connection records behind backend-owned storage.
-5. Add browser acceptance for connect, poll, disconnect, gated scope, and denied
+4. Add frontend connection modal that uses Wiii backend routes only.
+5. Persist provider registry and connection records behind backend-owned storage.
+6. Add browser acceptance for connect, poll, disconnect, gated scope, and denied
    execute cases.
-6. Enable one low-risk read-only Composio action before any write action.
+7. Enable one low-risk read-only Composio action before any write action.

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -10,12 +10,14 @@ from pydantic import BaseModel, ConfigDict, Field
 from app.engine.wiii_connect import (
     WiiiConnectCallbackRequest,
     WiiiConnectSessionStartRequest,
+    audit_ledger_status_public_metadata,
     begin_connection_session,
     get_wiii_connect_provider_entry,
     provider_callback_decision,
     provider_connection_status,
     provider_registry_public_metadata,
     scope_grant_from_mapping,
+    vault_status_public_metadata,
 )
 
 
@@ -38,6 +40,20 @@ async def list_wiii_connect_providers() -> dict[str, object]:
     """Return the privacy-safe Wiii Connect provider catalog."""
 
     return provider_registry_public_metadata()
+
+
+@router.get("/vault/status")
+async def get_wiii_connect_vault_status() -> dict[str, object]:
+    """Return privacy-safe Wiii Connect vault readiness metadata."""
+
+    return vault_status_public_metadata()
+
+
+@router.get("/audit-ledger/status")
+async def get_wiii_connect_audit_ledger_status() -> dict[str, object]:
+    """Return privacy-safe Wiii Connect audit ledger readiness metadata."""
+
+    return audit_ledger_status_public_metadata()
 
 
 @router.get("/providers/{slug}/status")

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -14,6 +14,13 @@ from .adapter_v1 import (
     is_connection_baseline_ready,
     normalize_connection_state,
 )
+from .audit_ledger import (
+    WIII_CONNECT_AUDIT_LEDGER_VERSION,
+    WiiiConnectAuditLedgerRecord,
+    WiiiConnectInMemoryAuditLedger,
+    audit_ledger_status_public_metadata,
+    build_audit_ledger_record,
+)
 from .callback_boundary import (
     WIII_CONNECT_CALLBACK_CONTRACT_VERSION,
     WiiiConnectCallbackAuditEvent,
@@ -33,6 +40,16 @@ from .connection_sessions import (
     provider_connection_status_for_entry,
     scope_grant_from_mapping,
 )
+from .vault import (
+    WIII_CONNECT_VAULT_CONTRACT_VERSION,
+    WiiiConnectVaultAuditEvent,
+    WiiiConnectVaultCapability,
+    WiiiConnectVaultSecretWriteDecision,
+    WiiiConnectVaultSecretWriteRequest,
+    decide_vault_secret_write,
+    default_wiii_connect_vault_capability,
+    vault_status_public_metadata,
+)
 from .provider_registry import (
     WIII_CONNECT_PROVIDER_REGISTRY_VERSION,
     get_wiii_connect_provider_entry,
@@ -50,9 +67,12 @@ from .snapshot import (
 
 __all__ = [
     "WIII_CONNECT_ADAPTER_VERSION",
+    "WIII_CONNECT_AUDIT_LEDGER_VERSION",
     "WIII_CONNECT_CALLBACK_CONTRACT_VERSION",
     "WIII_CONNECT_SESSION_CONTRACT_VERSION",
+    "WIII_CONNECT_VAULT_CONTRACT_VERSION",
     "WiiiConnectAuditEvent",
+    "WiiiConnectAuditLedgerRecord",
     "WiiiConnectCallbackAuditEvent",
     "WiiiConnectCallbackDecision",
     "WiiiConnectCallbackRequest",
@@ -60,22 +80,31 @@ __all__ = [
     "WiiiConnectConnectionRecordV1",
     "WiiiConnectExecutionDecision",
     "WiiiConnectExecutionRequest",
+    "WiiiConnectInMemoryAuditLedger",
     "WiiiConnectProviderConnectionStatus",
     "WiiiConnectProviderRegistryEntry",
     "WiiiConnectRequiredField",
     "WiiiConnectScopeGrant",
     "WiiiConnectSessionStartDecision",
     "WiiiConnectSessionStartRequest",
+    "WiiiConnectVaultAuditEvent",
+    "WiiiConnectVaultCapability",
     "WiiiConnectVaultSecretRef",
+    "WiiiConnectVaultSecretWriteDecision",
+    "WiiiConnectVaultSecretWriteRequest",
     "WIII_CONNECT_PROVIDER_REGISTRY_VERSION",
     "WIII_CONNECT_SNAPSHOT_VERSION",
     "WiiiConnectionRecord",
     "WiiiConnectionScopes",
     "WiiiConnectionSnapshot",
     "WiiiPathCapabilityRecord",
+    "audit_ledger_status_public_metadata",
     "begin_connection_session",
     "build_wiii_connect_snapshot",
+    "build_audit_ledger_record",
     "decide_external_execution",
+    "decide_vault_secret_write",
+    "default_wiii_connect_vault_capability",
     "get_wiii_connect_provider_entry",
     "is_connection_baseline_ready",
     "list_wiii_connect_provider_registry",
@@ -86,4 +115,5 @@ __all__ = [
     "provider_connection_status_for_entry",
     "provider_registry_public_metadata",
     "scope_grant_from_mapping",
+    "vault_status_public_metadata",
 ]

--- a/maritime-ai-service/app/engine/wiii_connect/audit_ledger.py
+++ b/maritime-ai-service/app/engine/wiii_connect/audit_ledger.py
@@ -1,0 +1,120 @@
+"""Privacy-safe Wiii Connect audit ledger contract.
+
+The ledger contract normalizes audit records from registry/session/callback,
+vault, and execution decisions. This module is intentionally storage-agnostic;
+database persistence can be added behind this shape without changing public
+metadata or agent-facing contracts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+
+WIII_CONNECT_AUDIT_LEDGER_VERSION = "wiii_connect_audit_ledger.v1"
+
+AuditRecordKind = Literal["session", "callback", "vault", "execution", "provider"]
+
+_SENSITIVE_KEY_MARKERS = ("token", "secret", "password", "credential", "key", "code")
+_REDACTED = "[redacted]"
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectAuditLedgerRecord:
+    """One privacy-safe audit ledger record."""
+
+    event_kind: AuditRecordKind
+    provider_slug: str
+    status: str
+    reason: str
+    surface: str = "backend"
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_AUDIT_LEDGER_VERSION,
+            "event_kind": self.event_kind,
+            "provider_slug": self.provider_slug,
+            "status": self.status,
+            "reason": self.reason,
+            "surface": self.surface,
+            "created_at": self.created_at,
+            "metadata": _sanitize_metadata(self.metadata),
+        }
+
+
+@dataclass(slots=True)
+class WiiiConnectInMemoryAuditLedger:
+    """Small storage-agnostic collector used by tests and future adapters."""
+
+    records: list[WiiiConnectAuditLedgerRecord] = field(default_factory=list)
+
+    def append(self, record: WiiiConnectAuditLedgerRecord) -> WiiiConnectAuditLedgerRecord:
+        self.records.append(record)
+        return record
+
+    def recent_public_metadata(self, limit: int = 50) -> list[dict[str, Any]]:
+        safe_limit = max(0, min(limit, 200))
+        return [record.to_public_metadata() for record in self.records[-safe_limit:]]
+
+
+def build_audit_ledger_record(
+    *,
+    event_kind: AuditRecordKind,
+    provider_slug: str,
+    status: str,
+    reason: str,
+    surface: str = "backend",
+    metadata: dict[str, Any] | None = None,
+) -> WiiiConnectAuditLedgerRecord:
+    """Build a ledger record from already-sanitized or raw-ish metadata."""
+
+    return WiiiConnectAuditLedgerRecord(
+        event_kind=event_kind,
+        provider_slug=provider_slug,
+        status=status,
+        reason=reason,
+        surface=surface,
+        metadata=metadata or {},
+    )
+
+
+def audit_ledger_status_public_metadata(
+    *,
+    persistent: bool = False,
+    backend: str = "memory_contract",
+) -> dict[str, Any]:
+    """Return privacy-safe metadata describing current ledger readiness."""
+
+    return {
+        "version": WIII_CONNECT_AUDIT_LEDGER_VERSION,
+        "enabled": True,
+        "persistent": persistent,
+        "backend": backend,
+        "reason": "persistent_store_not_configured" if not persistent else "ready",
+    }
+
+
+def _sanitize_metadata(value: Any) -> Any:
+    if isinstance(value, dict):
+        sanitized: dict[str, Any] = {}
+        for raw_key, raw_value in value.items():
+            key = str(raw_key)
+            if _is_sensitive_key(key):
+                sanitized["redacted_sensitive_field"] = _REDACTED
+                continue
+            sanitized[key] = _sanitize_metadata(raw_value)
+        return sanitized
+    if isinstance(value, list):
+        return [_sanitize_metadata(item) for item in value]
+    if isinstance(value, tuple):
+        return [_sanitize_metadata(item) for item in value]
+    return value
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = key.strip().lower()
+    return any(marker in normalized for marker in _SENSITIVE_KEY_MARKERS)

--- a/maritime-ai-service/app/engine/wiii_connect/callback_boundary.py
+++ b/maritime-ai-service/app/engine/wiii_connect/callback_boundary.py
@@ -13,6 +13,7 @@ from typing import Any, Literal
 
 from .adapter_v1 import WiiiConnectProviderRegistryEntry
 from .provider_registry import get_wiii_connect_provider_entry
+from .vault import WiiiConnectVaultCapability
 
 
 WIII_CONNECT_CALLBACK_CONTRACT_VERSION = "wiii_connect_callback.v1"
@@ -113,6 +114,7 @@ def provider_callback_decision(
     request: WiiiConnectCallbackRequest,
     *,
     vault_ready: bool = False,
+    vault_capability: WiiiConnectVaultCapability | None = None,
     provider_adapter_bound: bool = False,
 ) -> WiiiConnectCallbackDecision | None:
     """Return a callback decision for a registry provider slug."""
@@ -124,6 +126,7 @@ def provider_callback_decision(
         entry,
         request,
         vault_ready=vault_ready,
+        vault_capability=vault_capability,
         provider_adapter_bound=provider_adapter_bound,
     )
 
@@ -133,6 +136,7 @@ def provider_callback_decision_for_entry(
     request: WiiiConnectCallbackRequest,
     *,
     vault_ready: bool = False,
+    vault_capability: WiiiConnectVaultCapability | None = None,
     provider_adapter_bound: bool = False,
 ) -> WiiiConnectCallbackDecision:
     """Decide whether a callback may be exchanged and persisted."""
@@ -140,7 +144,7 @@ def provider_callback_decision_for_entry(
     reason = _callback_reason(
         entry,
         request,
-        vault_ready=vault_ready,
+        vault_ready=_resolved_vault_ready(vault_ready, vault_capability),
         provider_adapter_bound=provider_adapter_bound,
     )
     status: CallbackDecisionStatus = "accepted" if reason == "accepted" else "blocked"
@@ -178,6 +182,13 @@ def _callback_reason(
     if not provider_adapter_bound:
         return "provider_adapter_not_bound"
     return "accepted"
+
+
+def _resolved_vault_ready(
+    vault_ready: bool,
+    vault_capability: WiiiConnectVaultCapability | None,
+) -> bool:
+    return bool(vault_ready or (vault_capability and vault_capability.can_store_external_secret))
 
 
 def _safe_metadata_key(key: str) -> str:

--- a/maritime-ai-service/app/engine/wiii_connect/vault.py
+++ b/maritime-ai-service/app/engine/wiii_connect/vault.py
@@ -1,0 +1,232 @@
+"""Wiii Connect vault policy and secret-write decision contract.
+
+This module is the safety boundary between OAuth/provider callbacks and any
+credential storage. It does not persist secrets. It decides whether a future
+vault adapter is allowed to store secret material and returns only opaque vault
+references in public metadata.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from .adapter_v1 import (
+    WiiiConnectProviderRegistryEntry,
+    WiiiConnectVaultSecretRef,
+)
+
+
+WIII_CONNECT_VAULT_CONTRACT_VERSION = "wiii_connect_vault.v1"
+
+VaultBackendKind = Literal["disabled", "provider_managed", "external_kms"]
+VaultDecisionStatus = Literal["blocked", "ready"]
+VaultDecisionReason = Literal[
+    "vault_disabled",
+    "provider_disabled",
+    "missing_secret_material",
+    "unsupported_secret_kind",
+    "secret_material_not_accepted",
+    "ready_to_store",
+]
+SecretKind = Literal["oauth_token", "api_key", "provider_session", "webhook_secret"]
+
+_SENSITIVE_KEY_MARKERS = ("token", "secret", "password", "credential", "key", "code")
+_SUPPORTED_SECRET_KINDS: tuple[SecretKind, ...] = (
+    "oauth_token",
+    "api_key",
+    "provider_session",
+    "webhook_secret",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectVaultCapability:
+    """Runtime capability of the configured vault backend."""
+
+    enabled: bool = False
+    backend: VaultBackendKind = "disabled"
+    accepts_secret_material: bool = False
+    provider_managed: bool = False
+    key_namespace: str = ""
+    reason: str = "vault_disabled"
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def can_store_external_secret(self) -> bool:
+        return bool(self.enabled and self.accepts_secret_material)
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_VAULT_CONTRACT_VERSION,
+            "enabled": self.enabled,
+            "backend": self.backend,
+            "provider_managed": self.provider_managed,
+            "can_store_external_secret": self.can_store_external_secret,
+            "reason": self.reason,
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectVaultSecretWriteRequest:
+    """Sanitized request to store provider credential material."""
+
+    provider_slug: str
+    connection_id: str
+    secret_kind: str
+    secret_material_present: bool = False
+    metadata_keys: tuple[str, ...] = ()
+
+    def to_audit_metadata(self) -> dict[str, Any]:
+        return {
+            "provider_slug": self.provider_slug,
+            "connection_id": self.connection_id,
+            "secret_kind": self.secret_kind,
+            "secret_material_present": self.secret_material_present,
+            "metadata_keys": [_safe_metadata_key(key) for key in self.metadata_keys],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectVaultAuditEvent:
+    """Privacy-safe audit event for a vault decision."""
+
+    reason: VaultDecisionReason
+    request: WiiiConnectVaultSecretWriteRequest
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_VAULT_CONTRACT_VERSION,
+            "stage": "vault_write_decided",
+            "reason": self.reason,
+            "created_at": self.created_at,
+            "request": self.request.to_audit_metadata(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectVaultSecretWriteDecision:
+    """Decision returned before secret material can enter a vault adapter."""
+
+    status: VaultDecisionStatus
+    reason: VaultDecisionReason
+    provider_slug: str
+    connection_id: str
+    secret_kind: str
+    vault_ref: WiiiConnectVaultSecretRef | None = None
+    audit_event: WiiiConnectVaultAuditEvent | None = None
+
+    @property
+    def ready(self) -> bool:
+        return self.status == "ready"
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_VAULT_CONTRACT_VERSION,
+            "status": self.status,
+            "reason": self.reason,
+            "provider_slug": self.provider_slug,
+            "connection_id": self.connection_id,
+            "secret_kind": self.secret_kind,
+            "vault_ref": (
+                self.vault_ref.to_public_metadata() if self.vault_ref is not None else None
+            ),
+            "audit_event": (
+                self.audit_event.to_metadata() if self.audit_event is not None else None
+            ),
+        }
+
+
+def default_wiii_connect_vault_capability() -> WiiiConnectVaultCapability:
+    """Return the default fail-closed vault capability."""
+
+    return WiiiConnectVaultCapability(
+        enabled=False,
+        backend="disabled",
+        accepts_secret_material=False,
+        provider_managed=False,
+        reason="vault_disabled",
+    )
+
+
+def decide_vault_secret_write(
+    entry: WiiiConnectProviderRegistryEntry,
+    request: WiiiConnectVaultSecretWriteRequest,
+    capability: WiiiConnectVaultCapability | None = None,
+) -> WiiiConnectVaultSecretWriteDecision:
+    """Decide whether a provider secret can be stored by Wiii Connect."""
+
+    capability = capability or default_wiii_connect_vault_capability()
+    reason = _vault_decision_reason(entry, request, capability)
+    status: VaultDecisionStatus = "ready" if reason == "ready_to_store" else "blocked"
+    vault_ref = (
+        _build_vault_ref(entry, request, capability)
+        if status == "ready"
+        else None
+    )
+    audit_event = WiiiConnectVaultAuditEvent(reason=reason, request=request)
+    return WiiiConnectVaultSecretWriteDecision(
+        status=status,
+        reason=reason,
+        provider_slug=entry.slug,
+        connection_id=request.connection_id,
+        secret_kind=request.secret_kind,
+        vault_ref=vault_ref,
+        audit_event=audit_event,
+    )
+
+
+def vault_status_public_metadata(
+    capability: WiiiConnectVaultCapability | None = None,
+) -> dict[str, Any]:
+    """Return privacy-safe vault readiness metadata for UI/API."""
+
+    return (capability or default_wiii_connect_vault_capability()).to_public_metadata()
+
+
+def _vault_decision_reason(
+    entry: WiiiConnectProviderRegistryEntry,
+    request: WiiiConnectVaultSecretWriteRequest,
+    capability: WiiiConnectVaultCapability,
+) -> VaultDecisionReason:
+    if not entry.enabled:
+        return "provider_disabled"
+    if not capability.enabled:
+        return "vault_disabled"
+    if request.secret_kind not in _SUPPORTED_SECRET_KINDS:
+        return "unsupported_secret_kind"
+    if not request.secret_material_present:
+        return "missing_secret_material"
+    if not capability.accepts_secret_material:
+        return "secret_material_not_accepted"
+    return "ready_to_store"
+
+
+def _build_vault_ref(
+    entry: WiiiConnectProviderRegistryEntry,
+    request: WiiiConnectVaultSecretWriteRequest,
+    capability: WiiiConnectVaultCapability,
+) -> WiiiConnectVaultSecretRef:
+    namespace = capability.key_namespace or "wiii_connect"
+    vault_key_id = (
+        f"{namespace}/{entry.provider_kind}/{entry.slug}/{request.connection_id}/"
+        f"{request.secret_kind}"
+    )
+    return WiiiConnectVaultSecretRef(
+        provider_slug=entry.slug,
+        connection_id=request.connection_id,
+        vault_key_id=vault_key_id,
+        secret_version="pending",
+    )
+
+
+def _safe_metadata_key(key: str) -> str:
+    normalized = str(key).strip().lower()
+    if not normalized:
+        return "empty"
+    if any(marker in normalized for marker in _SENSITIVE_KEY_MARKERS):
+        return "redacted_sensitive_field"
+    return normalized[:80]

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -46,6 +46,35 @@ async def test_wiii_connect_provider_registry_api_is_privacy_safe(app):
 
 
 @pytest.mark.asyncio
+async def test_wiii_connect_vault_and_audit_status_apis_are_privacy_safe(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        vault_response = await client.get("/wiii-connect/vault/status")
+        audit_response = await client.get("/wiii-connect/audit-ledger/status")
+
+    assert vault_response.status_code == 200
+    assert audit_response.status_code == 200
+    vault_payload = vault_response.json()
+    audit_payload = audit_response.json()
+    serialized = json.dumps(
+        {"vault": vault_payload, "audit": audit_payload},
+        sort_keys=True,
+    )
+
+    assert vault_payload["version"] == "wiii_connect_vault.v1"
+    assert vault_payload["enabled"] is False
+    assert vault_payload["can_store_external_secret"] is False
+    assert audit_payload["version"] == "wiii_connect_audit_ledger.v1"
+    assert audit_payload["enabled"] is True
+    assert audit_payload["persistent"] is False
+    assert "access_token" not in serialized
+    assert "refresh_token" not in serialized
+    assert "client_secret" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_wiii_connect_provider_status_api_is_fail_closed(app):
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app),

--- a/maritime-ai-service/tests/unit/test_wiii_connect_callback_boundary.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_callback_boundary.py
@@ -93,3 +93,41 @@ def test_callback_requires_state_code_vault_and_adapter_before_accepting():
     assert accepted.accepted is True
     assert accepted.vault_ref_issued is True
     assert accepted.connection_id == "pending_connection_ref"
+
+
+def test_callback_accepts_vault_capability_without_boolean_override():
+    from app.engine.wiii_connect.adapter_v1 import WiiiConnectProviderRegistryEntry
+    from app.engine.wiii_connect.callback_boundary import (
+        WiiiConnectCallbackRequest,
+        provider_callback_decision_for_entry,
+    )
+    from app.engine.wiii_connect.vault import WiiiConnectVaultCapability
+
+    entry = WiiiConnectProviderRegistryEntry(
+        slug="internal_test",
+        label="Internal Test",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        enabled=True,
+        agent_ready=True,
+        requirements=(),
+    )
+    decision = provider_callback_decision_for_entry(
+        entry,
+        WiiiConnectCallbackRequest(
+            provider_slug="internal_test",
+            state_present=True,
+            code_present=True,
+        ),
+        vault_capability=WiiiConnectVaultCapability(
+            enabled=True,
+            backend="provider_managed",
+            accepts_secret_material=True,
+            provider_managed=True,
+            reason="ready",
+        ),
+        provider_adapter_bound=True,
+    )
+
+    assert decision.accepted is True
+    assert decision.reason == "accepted"

--- a/maritime-ai-service/tests/unit/test_wiii_connect_vault_audit.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_vault_audit.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+
+
+def test_default_vault_status_is_disabled_and_secret_free():
+    from app.engine.wiii_connect.vault import vault_status_public_metadata
+
+    metadata = vault_status_public_metadata()
+    serialized = json.dumps(metadata, sort_keys=True)
+
+    assert metadata["version"] == "wiii_connect_vault.v1"
+    assert metadata["enabled"] is False
+    assert metadata["can_store_external_secret"] is False
+    assert metadata["reason"] == "vault_disabled"
+    assert "access_token" not in serialized
+    assert "refresh_token" not in serialized
+    assert "client_secret" not in serialized
+
+
+def test_vault_write_decision_blocks_disabled_provider_and_redacts_keys():
+    from app.engine.wiii_connect.provider_registry import get_wiii_connect_provider_entry
+    from app.engine.wiii_connect.vault import (
+        WiiiConnectVaultCapability,
+        WiiiConnectVaultSecretWriteRequest,
+        decide_vault_secret_write,
+    )
+
+    entry = get_wiii_connect_provider_entry("facebook")
+    assert entry is not None
+    decision = decide_vault_secret_write(
+        entry,
+        WiiiConnectVaultSecretWriteRequest(
+            provider_slug="facebook",
+            connection_id="conn_1",
+            secret_kind="oauth_token",
+            secret_material_present=True,
+            metadata_keys=("access_token", "refresh_token", "account_id"),
+        ),
+        WiiiConnectVaultCapability(
+            enabled=True,
+            backend="provider_managed",
+            accepts_secret_material=True,
+            provider_managed=True,
+            key_namespace="wiii_test",
+            reason="ready",
+        ),
+    )
+    metadata = decision.to_public_metadata()
+    serialized = json.dumps(metadata, sort_keys=True)
+
+    assert decision.ready is False
+    assert metadata["reason"] == "provider_disabled"
+    assert metadata["vault_ref"] is None
+    assert "redacted_sensitive_field" in serialized
+    assert "account_id" in serialized
+    assert "access_token" not in serialized
+    assert "refresh_token" not in serialized
+    assert "secret-value" not in serialized
+
+
+def test_vault_write_decision_issues_only_opaque_ref_when_ready():
+    from app.engine.wiii_connect.adapter_v1 import WiiiConnectProviderRegistryEntry
+    from app.engine.wiii_connect.vault import (
+        WiiiConnectVaultCapability,
+        WiiiConnectVaultSecretWriteRequest,
+        decide_vault_secret_write,
+    )
+
+    entry = WiiiConnectProviderRegistryEntry(
+        slug="internal_test",
+        label="Internal Test",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        enabled=True,
+        agent_ready=True,
+    )
+    decision = decide_vault_secret_write(
+        entry,
+        WiiiConnectVaultSecretWriteRequest(
+            provider_slug="internal_test",
+            connection_id="conn_1",
+            secret_kind="oauth_token",
+            secret_material_present=True,
+            metadata_keys=("account_id",),
+        ),
+        WiiiConnectVaultCapability(
+            enabled=True,
+            backend="external_kms",
+            accepts_secret_material=True,
+            key_namespace="tenant_1",
+            reason="ready",
+        ),
+    )
+    metadata = decision.to_public_metadata()
+    serialized = json.dumps(metadata, sort_keys=True)
+
+    assert decision.ready is True
+    assert metadata["reason"] == "ready_to_store"
+    assert metadata["vault_ref"]["vault_ref_present"] is True
+    assert metadata["vault_ref"]["secret_version"] == "pending"
+    assert "tenant_1/composio/internal_test/conn_1/oauth_token" not in serialized
+
+
+def test_audit_ledger_sanitizes_sensitive_metadata_recursively():
+    from app.engine.wiii_connect.audit_ledger import (
+        WiiiConnectInMemoryAuditLedger,
+        build_audit_ledger_record,
+    )
+
+    ledger = WiiiConnectInMemoryAuditLedger()
+    ledger.append(
+        build_audit_ledger_record(
+            event_kind="vault",
+            provider_slug="facebook",
+            status="blocked",
+            reason="provider_disabled",
+            metadata={
+                "account_id": "page_1",
+                "access_token": "secret-value",
+                "nested": {"client_secret": "secret-value", "safe": "ok"},
+            },
+        ),
+    )
+
+    metadata = ledger.recent_public_metadata()
+    serialized = json.dumps(metadata, sort_keys=True)
+
+    assert metadata[0]["version"] == "wiii_connect_audit_ledger.v1"
+    assert metadata[0]["metadata"]["account_id"] == "page_1"
+    assert metadata[0]["metadata"]["nested"]["safe"] == "ok"
+    assert "redacted_sensitive_field" in serialized
+    assert "access_token" not in serialized
+    assert "client_secret" not in serialized
+    assert "secret-value" not in serialized


### PR DESCRIPTION
Closes #744

## Summary
- Add a Wiii Connect vault policy and secret-write decision contract that defaults to disabled/fail-closed.
- Add a privacy-safe audit ledger record/collector contract for session/callback/vault/execution events.
- Expose read-only vault and audit-ledger readiness endpoints.
- Let callback decisions consume a typed vault capability instead of only a raw boolean.
- Update Adapter V1 design notes and focused tests.

## Scope
- `maritime-ai-service/app/engine/wiii_connect/vault.py`
- `maritime-ai-service/app/engine/wiii_connect/audit_ledger.py`
- Wiii Connect API status endpoints for vault and ledger readiness.
- Callback boundary compatibility with vault capability.
- Focused Wiii Connect backend tests and docs.

## Non-Scope
- No real secret persistence.
- No token exchange.
- No Composio network calls.
- No external tool execution.
- No database migration in this slice; the ledger contract reports persistent storage as not configured.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/api/test_wiii_connect_api.py -q --tb=short` passed: 24 tests
- `cd maritime-ai-service; python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7` passed
- `git diff --check` passed

## Risk
- Low runtime risk: new endpoints are read-only status projections and vault decisions do not persist secrets.
- Security-sensitive surface: tests assert token/client-secret metadata is redacted and vault refs do not expose key IDs.

## Rollback
- Revert this PR to remove the vault/ledger contracts and status endpoints; callback behavior can fall back to the previous boolean vault readiness gate.