### PR TITLE
Add Wiii Connect durable storage contract

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -76,6 +76,13 @@ The provider adapter readiness and authorization URL contract lives in:
 maritime-ai-service/app/engine/wiii_connect/provider_adapters.py
 ```
 
+The durable storage contract and schema live in:
+
+```text
+maritime-ai-service/app/engine/wiii_connect/persistent_storage.py
+maritime-ai-service/alembic/versions/049_create_wiii_connect_storage.py
+```
+
 Current session/status API projections:
 
 ```text
@@ -209,6 +216,17 @@ must keep that provider disabled and non-agent-ready.
 - rejects adapter/provider-kind mismatch before any OAuth handoff;
 - direct session callers may not bypass adapter policy by passing a URL.
 
+`WiiiConnectPersistentStorage`
+
+- writes per-org, per-user connection records to `wiii_connect_connections`;
+- appends privacy-safe provider/session/callback/vault/execution events to
+  `wiii_connect_audit_ledger`;
+- requires explicit `organization_id` and `user_id` before writing;
+- stores only public vault-reference metadata, never raw vault paths or secret
+  material;
+- fails softly when the database or migration is unavailable, keeping providers
+  blocked instead of allowing un-audited execution.
+
 ## Lifecycle States
 
 Adapter V1 normalizes provider states into:
@@ -301,7 +319,10 @@ Before real Composio OAuth is enabled:
 - credential material must be stored in an encrypted vault or provider-managed
   backend secret store;
 - every session/callback/vault/execution decision must produce a privacy-safe
-  ledger record shape before durable persistence is added;
+  ledger record shape and be eligible for durable append before provider
+  execution is allowed;
+- durable persistence must bind every connection/audit write to a Wiii
+  organization and user boundary;
 - frontend may receive connect URLs and state labels, not tokens;
 - stale pending/error OAuth rows must be cleaned up or expired safely;
 - provider errors must be sanitized before reaching UI or chat.
@@ -322,7 +343,8 @@ approval tokens and provider payloads must remain outside chat lifecycle data.
 
 ## Next Slices
 
-1. Add durable audit ledger persistence and per-org connection records.
+1. Wire Wiii Connect status/authorization decisions to the durable store with a
+   controlled DB probe, not per-render UI guessing.
 2. Add encrypted vault integration or provider-managed secret reference storage.
 3. Add provider adapter implementation/configuration for one provider broker
    without enabling broad action execution.

--- a/maritime-ai-service/alembic/versions/049_create_wiii_connect_storage.py
+++ b/maritime-ai-service/alembic/versions/049_create_wiii_connect_storage.py
@@ -1,0 +1,180 @@
+"""049: create Wiii Connect durable storage.
+
+Adds per-org connection records and an append-only audit ledger for future
+external provider adapters. The tables store sanitized control-plane metadata;
+raw OAuth tokens and provider secrets must remain in vault/provider-managed
+storage.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "049"
+down_revision = "048"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(conn, table_name: str) -> bool:
+    result = conn.execute(
+        sa.text(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = current_schema() "
+            "AND table_name = :table_name"
+        ),
+        {"table_name": table_name},
+    )
+    return result.fetchone() is not None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    if not _table_exists(conn, "wiii_connect_connections"):
+        op.create_table(
+            "wiii_connect_connections",
+            sa.Column("id", sa.Text(), nullable=False),
+            sa.Column("organization_id", sa.Text(), nullable=False),
+            sa.Column("user_id", sa.Text(), nullable=False),
+            sa.Column("provider_slug", sa.Text(), nullable=False),
+            sa.Column("provider_kind", sa.Text(), nullable=False),
+            sa.Column(
+                "state",
+                sa.Text(),
+                nullable=False,
+                server_default=sa.text("'disconnected'"),
+            ),
+            sa.Column(
+                "scopes",
+                postgresql.JSONB(astext_type=sa.Text()),
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            sa.Column(
+                "vault_ref",
+                postgresql.JSONB(astext_type=sa.Text()),
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            sa.Column("account_label", sa.Text(), nullable=True),
+            sa.Column("external_account_ref", sa.Text(), nullable=True),
+            sa.Column("reason", sa.Text(), nullable=True),
+            sa.Column(
+                "warnings",
+                postgresql.JSONB(astext_type=sa.Text()),
+                nullable=False,
+                server_default=sa.text("'[]'::jsonb"),
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("NOW()"),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("NOW()"),
+            ),
+            sa.Column("last_checked_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "ix_wiii_connect_connections_org_user_provider",
+            "wiii_connect_connections",
+            ["organization_id", "user_id", "provider_slug"],
+        )
+        op.create_index(
+            "ix_wiii_connect_connections_provider_state",
+            "wiii_connect_connections",
+            ["provider_slug", "state"],
+        )
+        op.create_index(
+            "ix_wiii_connect_connections_org_updated",
+            "wiii_connect_connections",
+            ["organization_id", "updated_at"],
+        )
+
+    if not _table_exists(conn, "wiii_connect_audit_ledger"):
+        op.create_table(
+            "wiii_connect_audit_ledger",
+            sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+            sa.Column("organization_id", sa.Text(), nullable=False),
+            sa.Column("user_id", sa.Text(), nullable=False),
+            sa.Column("provider_slug", sa.Text(), nullable=False),
+            sa.Column("event_kind", sa.Text(), nullable=False),
+            sa.Column("status", sa.Text(), nullable=False),
+            sa.Column("reason", sa.Text(), nullable=False),
+            sa.Column(
+                "surface",
+                sa.Text(),
+                nullable=False,
+                server_default=sa.text("'backend'"),
+            ),
+            sa.Column(
+                "metadata",
+                postgresql.JSONB(astext_type=sa.Text()),
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("NOW()"),
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "ix_wiii_connect_audit_org_created",
+            "wiii_connect_audit_ledger",
+            ["organization_id", "created_at"],
+        )
+        op.create_index(
+            "ix_wiii_connect_audit_provider_created",
+            "wiii_connect_audit_ledger",
+            ["provider_slug", "created_at"],
+        )
+        op.create_index(
+            "ix_wiii_connect_audit_kind_created",
+            "wiii_connect_audit_ledger",
+            ["event_kind", "created_at"],
+        )
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    if _table_exists(conn, "wiii_connect_audit_ledger"):
+        op.drop_index(
+            "ix_wiii_connect_audit_kind_created",
+            table_name="wiii_connect_audit_ledger",
+        )
+        op.drop_index(
+            "ix_wiii_connect_audit_provider_created",
+            table_name="wiii_connect_audit_ledger",
+        )
+        op.drop_index(
+            "ix_wiii_connect_audit_org_created",
+            table_name="wiii_connect_audit_ledger",
+        )
+        op.drop_table("wiii_connect_audit_ledger")
+
+    if _table_exists(conn, "wiii_connect_connections"):
+        op.drop_index(
+            "ix_wiii_connect_connections_org_updated",
+            table_name="wiii_connect_connections",
+        )
+        op.drop_index(
+            "ix_wiii_connect_connections_provider_state",
+            table_name="wiii_connect_connections",
+        )
+        op.drop_index(
+            "ix_wiii_connect_connections_org_user_provider",
+            table_name="wiii_connect_connections",
+        )
+        op.drop_table("wiii_connect_connections")

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -50,6 +50,13 @@ from .provider_adapters import (
     default_provider_adapter_capability,
     provider_adapter_status_public_metadata,
 )
+from .persistent_storage import (
+    WIII_CONNECT_PERSISTENT_STORAGE_VERSION,
+    WiiiConnectPersistentStorage,
+    WiiiConnectPersistentStorageStatus,
+    default_persistent_storage_status_metadata,
+    get_wiii_connect_persistent_storage,
+)
 from .vault import (
     WIII_CONNECT_VAULT_CONTRACT_VERSION,
     WiiiConnectVaultAuditEvent,
@@ -80,6 +87,7 @@ __all__ = [
     "WIII_CONNECT_AUDIT_LEDGER_VERSION",
     "WIII_CONNECT_CALLBACK_CONTRACT_VERSION",
     "WIII_CONNECT_PROVIDER_ADAPTER_VERSION",
+    "WIII_CONNECT_PERSISTENT_STORAGE_VERSION",
     "WIII_CONNECT_SESSION_CONTRACT_VERSION",
     "WIII_CONNECT_VAULT_CONTRACT_VERSION",
     "WiiiConnectAuthorizationUrlAuditEvent",
@@ -98,6 +106,8 @@ __all__ = [
     "WiiiConnectProviderAdapterCapability",
     "WiiiConnectProviderConnectionStatus",
     "WiiiConnectProviderRegistryEntry",
+    "WiiiConnectPersistentStorage",
+    "WiiiConnectPersistentStorageStatus",
     "WiiiConnectRequiredField",
     "WiiiConnectScopeGrant",
     "WiiiConnectSessionStartDecision",
@@ -121,8 +131,10 @@ __all__ = [
     "decide_authorization_url",
     "decide_vault_secret_write",
     "default_provider_adapter_capability",
+    "default_persistent_storage_status_metadata",
     "default_wiii_connect_vault_capability",
     "get_wiii_connect_provider_entry",
+    "get_wiii_connect_persistent_storage",
     "is_connection_baseline_ready",
     "list_wiii_connect_provider_registry",
     "normalize_connection_state",

--- a/maritime-ai-service/app/engine/wiii_connect/persistent_storage.py
+++ b/maritime-ai-service/app/engine/wiii_connect/persistent_storage.py
@@ -1,0 +1,306 @@
+"""Durable Wiii Connect connection and audit storage adapter.
+
+The adapter stores only privacy-safe control-plane metadata. It does not store
+OAuth codes, access tokens, refresh tokens, API keys, provider payloads, or raw
+vault paths.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Callable
+
+from sqlalchemy import text
+
+from .adapter_v1 import WiiiConnectConnectionRecordV1
+from .audit_ledger import WiiiConnectAuditLedgerRecord
+
+
+logger = logging.getLogger(__name__)
+
+WIII_CONNECT_PERSISTENT_STORAGE_VERSION = "wiii_connect_persistent_storage.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectPersistentStorageStatus:
+    """Readiness of the durable Wiii Connect storage boundary."""
+
+    enabled: bool = False
+    persistent: bool = False
+    backend: str = "postgres"
+    connection_table_ready: bool = False
+    audit_ledger_ready: bool = False
+    reason: str = "database_probe_not_requested"
+    warnings: tuple[str, ...] = ()
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_PERSISTENT_STORAGE_VERSION,
+            "enabled": self.enabled,
+            "persistent": self.persistent,
+            "backend": self.backend,
+            "connection_table_ready": self.connection_table_ready,
+            "audit_ledger_ready": self.audit_ledger_ready,
+            "reason": self.reason,
+            "warnings": list(self.warnings),
+        }
+
+
+class WiiiConnectPersistentStorage:
+    """Small repository for Wiii Connect durable control-plane records."""
+
+    CONNECTIONS_TABLE = "wiii_connect_connections"
+    AUDIT_TABLE = "wiii_connect_audit_ledger"
+
+    def __init__(self, session_factory: Callable[[], Any] | None = None) -> None:
+        self._session_factory = session_factory
+        self._initialized = session_factory is not None
+
+    def _ensure_initialized(self) -> None:
+        if self._initialized:
+            return
+        try:
+            from app.core.database import get_shared_session_factory
+
+            self._session_factory = get_shared_session_factory()
+            self._initialized = True
+        except Exception as exc:
+            logger.warning("Wiii Connect storage init failed: %s", exc)
+
+    def status(self, *, probe_database: bool = True) -> WiiiConnectPersistentStorageStatus:
+        """Return storage status without raising on DB/migration failures."""
+
+        if not probe_database:
+            return WiiiConnectPersistentStorageStatus()
+        self._ensure_initialized()
+        if self._session_factory is None:
+            return WiiiConnectPersistentStorageStatus(
+                reason="database_unavailable",
+                warnings=("session_factory_unavailable",),
+            )
+
+        try:
+            with self._session_factory() as session:
+                row = session.execute(
+                    text(
+                        "SELECT to_regclass(:connections_table), "
+                        "to_regclass(:audit_table)"
+                    ),
+                    {
+                        "connections_table": self.CONNECTIONS_TABLE,
+                        "audit_table": self.AUDIT_TABLE,
+                    },
+                ).fetchone()
+        except Exception as exc:
+            logger.warning("Wiii Connect storage status check failed: %s", exc)
+            return WiiiConnectPersistentStorageStatus(
+                reason="database_unavailable",
+                warnings=("status_probe_failed",),
+            )
+
+        connection_ready = bool(row and row[0])
+        audit_ready = bool(row and row[1])
+        ready = connection_ready and audit_ready
+        return WiiiConnectPersistentStorageStatus(
+            enabled=ready,
+            persistent=ready,
+            connection_table_ready=connection_ready,
+            audit_ledger_ready=audit_ready,
+            reason="ready" if ready else "migration_not_applied",
+        )
+
+    def append_audit_record(
+        self,
+        record: WiiiConnectAuditLedgerRecord,
+        *,
+        organization_id: str,
+        user_id: str,
+    ) -> bool:
+        """Append one sanitized audit record for a user/org boundary."""
+
+        owner = _normalize_owner(organization_id=organization_id, user_id=user_id)
+        if owner is None:
+            return False
+        payload = record.to_public_metadata()
+        metadata = payload.get("metadata") if isinstance(payload, dict) else {}
+        self._ensure_initialized()
+        if self._session_factory is None:
+            return False
+
+        try:
+            with self._session_factory() as session:
+                session.execute(
+                    text(
+                        f"INSERT INTO {self.AUDIT_TABLE} "
+                        f"(organization_id, user_id, provider_slug, event_kind, "
+                        f"status, reason, surface, metadata, created_at) "
+                        f"VALUES (:organization_id, :user_id, :provider_slug, "
+                        f":event_kind, :status, :reason, :surface, "
+                        f"CAST(:metadata AS jsonb), :created_at)"
+                    ),
+                    {
+                        "organization_id": owner["organization_id"],
+                        "user_id": owner["user_id"],
+                        "provider_slug": payload["provider_slug"],
+                        "event_kind": payload["event_kind"],
+                        "status": payload["status"],
+                        "reason": payload["reason"],
+                        "surface": payload["surface"],
+                        "metadata": _json_dumps(metadata),
+                        "created_at": _parse_datetime(payload.get("created_at")),
+                    },
+                )
+                session.commit()
+            return True
+        except Exception as exc:
+            if _is_missing_storage_table_error(exc):
+                logger.info("Wiii Connect audit storage unavailable; skipping append.")
+                return False
+            logger.warning("Wiii Connect audit append failed: %s", exc)
+            return False
+
+    def upsert_connection_record(
+        self,
+        connection: WiiiConnectConnectionRecordV1,
+        *,
+        organization_id: str,
+        user_id: str,
+        provider_kind: str = "unknown",
+    ) -> bool:
+        """Upsert one sanitized connection record for a user/org boundary."""
+
+        owner = _normalize_owner(organization_id=organization_id, user_id=user_id)
+        if owner is None or not connection.connection_id or not connection.provider_slug:
+            return False
+        metadata = connection.to_public_metadata()
+        self._ensure_initialized()
+        if self._session_factory is None:
+            return False
+
+        try:
+            with self._session_factory() as session:
+                session.execute(
+                    text(
+                        f"INSERT INTO {self.CONNECTIONS_TABLE} "
+                        f"(id, organization_id, user_id, provider_slug, "
+                        f"provider_kind, state, scopes, vault_ref, account_label, "
+                        f"external_account_ref, reason, warnings, updated_at, "
+                        f"last_checked_at, last_used_at) "
+                        f"VALUES (:id, :organization_id, :user_id, :provider_slug, "
+                        f":provider_kind, :state, CAST(:scopes AS jsonb), "
+                        f"CAST(:vault_ref AS jsonb), :account_label, "
+                        f":external_account_ref, :reason, CAST(:warnings AS jsonb), "
+                        f":updated_at, :last_checked_at, :last_used_at) "
+                        f"ON CONFLICT (id) DO UPDATE SET "
+                        f"organization_id = EXCLUDED.organization_id, "
+                        f"user_id = EXCLUDED.user_id, "
+                        f"provider_slug = EXCLUDED.provider_slug, "
+                        f"provider_kind = EXCLUDED.provider_kind, "
+                        f"state = EXCLUDED.state, "
+                        f"scopes = EXCLUDED.scopes, "
+                        f"vault_ref = EXCLUDED.vault_ref, "
+                        f"account_label = EXCLUDED.account_label, "
+                        f"external_account_ref = EXCLUDED.external_account_ref, "
+                        f"reason = EXCLUDED.reason, "
+                        f"warnings = EXCLUDED.warnings, "
+                        f"updated_at = EXCLUDED.updated_at, "
+                        f"last_checked_at = EXCLUDED.last_checked_at, "
+                        f"last_used_at = EXCLUDED.last_used_at"
+                    ),
+                    {
+                        "id": connection.connection_id,
+                        "organization_id": owner["organization_id"],
+                        "user_id": owner["user_id"],
+                        "provider_slug": connection.provider_slug,
+                        "provider_kind": str(provider_kind or "unknown").strip()
+                        or "unknown",
+                        "state": connection.state,
+                        "scopes": _json_dumps(metadata.get("scopes", {})),
+                        "vault_ref": _json_dumps(
+                            connection.vault_ref.to_public_metadata()
+                            if connection.vault_ref is not None
+                            else {}
+                        ),
+                        "account_label": metadata.get("account_label") or None,
+                        "external_account_ref": (
+                            metadata.get("external_account_ref") or None
+                        ),
+                        "reason": metadata.get("reason") or None,
+                        "warnings": _json_dumps(metadata.get("warnings", [])),
+                        "updated_at": datetime.now(UTC),
+                        "last_checked_at": _parse_datetime(
+                            metadata.get("last_checked_at")
+                        ),
+                        "last_used_at": datetime.now(UTC)
+                        if connection.active
+                        else None,
+                    },
+                )
+                session.commit()
+            return True
+        except Exception as exc:
+            if _is_missing_storage_table_error(exc):
+                logger.info("Wiii Connect connection storage unavailable; skipping upsert.")
+                return False
+            logger.warning("Wiii Connect connection upsert failed: %s", exc)
+            return False
+
+
+def default_persistent_storage_status_metadata() -> dict[str, Any]:
+    """Return default non-probed persistent storage status metadata."""
+
+    return WiiiConnectPersistentStorageStatus().to_public_metadata()
+
+
+def _normalize_owner(*, organization_id: str, user_id: str) -> dict[str, str] | None:
+    org = str(organization_id or "").strip()
+    user = str(user_id or "").strip()
+    if not org or not user:
+        return None
+    return {"organization_id": org, "user_id": user}
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value if value is not None else {}, ensure_ascii=False)
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
+    text_value = str(value or "").strip()
+    if not text_value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text_value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.astimezone(UTC) if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _is_missing_storage_table_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return "wiii_connect_" in message and (
+        "does not exist" in message or "undefinedtable" in message
+    )
+
+
+_persistent_storage: WiiiConnectPersistentStorage | None = None
+
+
+def get_wiii_connect_persistent_storage() -> WiiiConnectPersistentStorage:
+    global _persistent_storage
+    if _persistent_storage is None:
+        _persistent_storage = WiiiConnectPersistentStorage()
+    return _persistent_storage
+
+
+__all__ = [
+    "WIII_CONNECT_PERSISTENT_STORAGE_VERSION",
+    "WiiiConnectPersistentStorage",
+    "WiiiConnectPersistentStorageStatus",
+    "default_persistent_storage_status_metadata",
+    "get_wiii_connect_persistent_storage",
+]

--- a/maritime-ai-service/tests/unit/test_wiii_connect_persistent_storage.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_persistent_storage.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+
+
+class _FakeResult:
+    def __init__(self, row=None):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class _FakeSession:
+    def __init__(self, row=None):
+        self.row = row
+        self.executions = []
+        self.commits = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, statement, params=None):
+        self.executions.append(
+            {
+                "statement": str(statement),
+                "params": dict(params or {}),
+            }
+        )
+        return _FakeResult(self.row)
+
+    def commit(self):
+        self.commits += 1
+
+
+def test_persistent_storage_status_reports_ready_when_tables_exist():
+    from app.engine.wiii_connect.persistent_storage import WiiiConnectPersistentStorage
+
+    session = _FakeSession(
+        row=("wiii_connect_connections", "wiii_connect_audit_ledger"),
+    )
+    storage = WiiiConnectPersistentStorage(session_factory=lambda: session)
+
+    status = storage.status()
+    metadata = status.to_public_metadata()
+
+    assert metadata["version"] == "wiii_connect_persistent_storage.v1"
+    assert metadata["persistent"] is True
+    assert metadata["connection_table_ready"] is True
+    assert metadata["audit_ledger_ready"] is True
+    assert metadata["reason"] == "ready"
+
+
+def test_persistent_audit_append_stores_redacted_metadata_only():
+    from app.engine.wiii_connect.audit_ledger import build_audit_ledger_record
+    from app.engine.wiii_connect.persistent_storage import WiiiConnectPersistentStorage
+
+    session = _FakeSession()
+    storage = WiiiConnectPersistentStorage(session_factory=lambda: session)
+    record = build_audit_ledger_record(
+        event_kind="provider",
+        provider_slug="facebook",
+        status="blocked",
+        reason="provider_disabled",
+        surface="desktop",
+        metadata={
+            "account_id": "page_1",
+            "access_token": "secret-value",
+            "nested": {"client_secret": "secret-value", "safe": "ok"},
+        },
+    )
+
+    assert storage.append_audit_record(
+        record,
+        organization_id="org_1",
+        user_id="user_1",
+    )
+    params = session.executions[-1]["params"]
+    metadata = json.loads(params["metadata"])
+    serialized = json.dumps(params, sort_keys=True, default=str)
+
+    assert params["organization_id"] == "org_1"
+    assert params["user_id"] == "user_1"
+    assert params["provider_slug"] == "facebook"
+    assert metadata["account_id"] == "page_1"
+    assert metadata["nested"]["safe"] == "ok"
+    assert "redacted_sensitive_field" in serialized
+    assert "access_token" not in serialized
+    assert "client_secret" not in serialized
+    assert "secret-value" not in serialized
+    assert session.commits == 1
+
+
+def test_connection_upsert_stores_only_public_vault_ref_metadata():
+    from app.engine.wiii_connect.adapter_v1 import (
+        WiiiConnectConnectionRecordV1,
+        WiiiConnectScopeGrant,
+        WiiiConnectVaultSecretRef,
+    )
+    from app.engine.wiii_connect.persistent_storage import WiiiConnectPersistentStorage
+
+    session = _FakeSession()
+    storage = WiiiConnectPersistentStorage(session_factory=lambda: session)
+    connection = WiiiConnectConnectionRecordV1(
+        connection_id="conn_1",
+        provider_slug="facebook",
+        state="connected",
+        scopes=WiiiConnectScopeGrant(read=True, write=True),
+        vault_ref=WiiiConnectVaultSecretRef(
+            provider_slug="facebook",
+            connection_id="conn_1",
+            vault_key_id="vault://tenant/private/oauth-token-secret",
+            secret_version="v1",
+        ),
+        account_label="Wiii Page",
+        external_account_ref="page_1",
+    )
+
+    assert storage.upsert_connection_record(
+        connection,
+        organization_id="org_1",
+        user_id="user_1",
+        provider_kind="composio",
+    )
+    params = session.executions[-1]["params"]
+    vault_ref = json.loads(params["vault_ref"])
+    scopes = json.loads(params["scopes"])
+    serialized = json.dumps(params, sort_keys=True, default=str)
+
+    assert params["organization_id"] == "org_1"
+    assert params["user_id"] == "user_1"
+    assert params["provider_kind"] == "composio"
+    assert params["state"] == "connected"
+    assert scopes["read"] is True
+    assert scopes["write"] is True
+    assert vault_ref["vault_ref_present"] is True
+    assert vault_ref["secret_version"] == "v1"
+    assert "oauth-token-secret" not in serialized
+    assert "vault://tenant/private" not in serialized
+    assert session.commits == 1
+
+
+def test_persistent_storage_rejects_missing_owner_boundary():
+    from app.engine.wiii_connect.audit_ledger import build_audit_ledger_record
+    from app.engine.wiii_connect.persistent_storage import WiiiConnectPersistentStorage
+
+    session = _FakeSession()
+    storage = WiiiConnectPersistentStorage(session_factory=lambda: session)
+    record = build_audit_ledger_record(
+        event_kind="provider",
+        provider_slug="facebook",
+        status="blocked",
+        reason="provider_disabled",
+    )
+
+    assert storage.append_audit_record(record, organization_id="", user_id="user_1") is False
+    assert session.executions == []


### PR DESCRIPTION
## Summary
- Adds durable Wiii Connect tables for per-org connection records and append-only audit ledger records.
- Adds a fail-soft persistent storage adapter that writes only sanitized control-plane metadata.
- Exports storage contract metadata and updates the Wiii Connect adapter design doc.

## Scope
- Alembic migration `049_create_wiii_connect_storage.py`.
- Backend `WiiiConnectPersistentStorage` repository for storage readiness, audit appends, and connection upserts.
- Unit coverage with fake sessions so local Postgres/Docker is not required.
- Documentation updates for storage boundary and next slices.

## Non-scope
- No Composio provider is enabled.
- No OAuth token, refresh token, API key, provider payload, or raw vault path is stored.
- No frontend/UI changes.
- No automatic database probe on normal Wiii Connect UI status calls.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/api/test_wiii_connect_api.py -q --tb=short` -> 34 passed
- `cd maritime-ai-service; python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/api/test_wiii_connect_api.py alembic/versions/049_create_wiii_connect_storage.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
Connector persistence is high-risk because it stores user/org-scoped integration state. This PR keeps writes fail-soft, requires explicit `organization_id` and `user_id`, and stores only redacted ledger metadata plus public vault-reference metadata.

## Rollback
Before deployment: revert this PR. After migration: drop `wiii_connect_audit_ledger` and `wiii_connect_connections` if unused, then revert code/docs.

Closes #748