### PR TITLE
Wire Wiii Connect controlled storage probes

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -91,6 +91,7 @@ POST /api/v1/wiii-connect/providers/{slug}/sessions
 POST /api/v1/wiii-connect/providers/{slug}/authorization-url
 GET  /api/v1/wiii-connect/providers/{slug}/callback
 GET  /api/v1/wiii-connect/provider-adapters/status
+GET  /api/v1/wiii-connect/storage/status
 GET  /api/v1/wiii-connect/vault/status
 GET  /api/v1/wiii-connect/audit-ledger/status
 ```
@@ -226,6 +227,8 @@ must keep that provider disabled and non-agent-ready.
   material;
 - fails softly when the database or migration is unavailable, keeping providers
   blocked instead of allowing un-audited execution.
+- is exposed through controlled status/probe APIs with database probing disabled
+  by default, so normal UI renders do not block on storage connectivity.
 
 ## Lifecycle States
 
@@ -312,6 +315,9 @@ Before real Composio OAuth is enabled:
   Composio directly;
 - authorization URLs must come from a bound provider adapter decision, not from
   raw frontend input or ad hoc session arguments;
+- authorization URL decisions may consume durable audit readiness only from an
+  explicit storage probe or backend-controlled storage status, never from
+  frontend claims;
 - disabled providers must return a blocked decision with missing requirements;
 - callback handling must stay blocked until state/code validation, vault storage,
   and provider adapter exchange are ready;
@@ -343,13 +349,11 @@ approval tokens and provider payloads must remain outside chat lifecycle data.
 
 ## Next Slices
 
-1. Wire Wiii Connect status/authorization decisions to the durable store with a
-   controlled DB probe, not per-render UI guessing.
-2. Add encrypted vault integration or provider-managed secret reference storage.
-3. Add provider adapter implementation/configuration for one provider broker
+1. Add encrypted vault integration or provider-managed secret reference storage.
+2. Add provider adapter implementation/configuration for one provider broker
    without enabling broad action execution.
-4. Add frontend connection modal that uses Wiii backend routes only.
-5. Persist provider registry and connection records behind backend-owned storage.
-6. Add browser acceptance for connect, poll, disconnect, gated scope, and denied
+3. Add frontend connection modal that uses Wiii backend routes only.
+4. Persist provider registry and connection records behind backend-owned storage.
+5. Add browser acceptance for connect, poll, disconnect, gated scope, and denied
    execute cases.
-7. Enable one low-risk read-only Composio action before any write action.
+6. Enable one low-risk read-only Composio action before any write action.

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -14,7 +14,9 @@ from app.engine.wiii_connect import (
     audit_ledger_status_public_metadata,
     begin_connection_session,
     decide_authorization_url,
+    default_persistent_storage_status_metadata,
     get_wiii_connect_provider_entry,
+    get_wiii_connect_persistent_storage,
     provider_adapter_status_public_metadata,
     provider_callback_decision,
     provider_connection_status,
@@ -35,6 +37,7 @@ class WiiiConnectStartSessionBody(BaseModel):
     surface: str = "desktop"
     redirect_uri: str | None = None
     state_present: bool = False
+    probe_database: bool = False
     requested_scopes: dict[str, bool] = Field(default_factory=dict)
     request_metadata: dict[str, Any] = Field(default_factory=dict)
 
@@ -54,10 +57,34 @@ async def get_wiii_connect_vault_status() -> dict[str, object]:
 
 
 @router.get("/audit-ledger/status")
-async def get_wiii_connect_audit_ledger_status() -> dict[str, object]:
+async def get_wiii_connect_audit_ledger_status(
+    probe_database: bool = False,
+) -> dict[str, object]:
     """Return privacy-safe Wiii Connect audit ledger readiness metadata."""
 
-    return audit_ledger_status_public_metadata()
+    storage = _wiii_connect_storage_status_metadata(probe_database=probe_database)
+    persistent = bool(storage.get("persistent") and storage.get("audit_ledger_ready"))
+    metadata = audit_ledger_status_public_metadata(
+        persistent=persistent,
+        backend=str(storage.get("backend") or "memory_contract")
+        if probe_database
+        else "memory_contract",
+    )
+    metadata["storage"] = storage
+    return metadata
+
+
+@router.get("/storage/status")
+async def get_wiii_connect_storage_status(
+    probe_database: bool = False,
+) -> dict[str, object]:
+    """Return Wiii Connect durable storage status.
+
+    Database probing is opt-in so normal UI renders do not block on local or
+    production database connectivity checks.
+    """
+
+    return _wiii_connect_storage_status_metadata(probe_database=probe_database)
 
 
 @router.get("/provider-adapters/status")
@@ -122,7 +149,18 @@ async def create_wiii_connect_provider_authorization_url(
         redirect_uri_present=bool(body.redirect_uri),
         request_metadata_keys=tuple(body.request_metadata.keys()),
     )
-    decision = decide_authorization_url(entry, request)
+    storage = _wiii_connect_storage_status_metadata(
+        probe_database=body.probe_database,
+    )
+    decision = decide_authorization_url(
+        entry,
+        request,
+        audit_ledger_metadata={
+            "persistent": bool(
+                storage.get("persistent") and storage.get("audit_ledger_ready")
+            )
+        },
+    )
     return decision.to_public_metadata()
 
 
@@ -149,3 +187,16 @@ async def receive_wiii_connect_provider_callback(
     if decision is None:
         raise HTTPException(status_code=404, detail="unknown_wiii_connect_provider")
     return decision.to_public_metadata()
+
+
+def _wiii_connect_storage_status_metadata(
+    *,
+    probe_database: bool,
+) -> dict[str, Any]:
+    if not probe_database:
+        return default_persistent_storage_status_metadata()
+    return (
+        get_wiii_connect_persistent_storage()
+        .status(probe_database=True)
+        .to_public_metadata()
+    )

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -75,6 +75,121 @@ async def test_wiii_connect_vault_and_audit_status_apis_are_privacy_safe(app):
 
 
 @pytest.mark.asyncio
+async def test_wiii_connect_storage_status_api_does_not_probe_by_default(
+    app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+
+    def _raise_if_called():
+        raise AssertionError("storage probe should be opt-in")
+
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        _raise_if_called,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/wiii-connect/storage/status")
+        audit_response = await client.get("/wiii-connect/audit-ledger/status")
+
+    assert response.status_code == 200
+    assert audit_response.status_code == 200
+    payload = response.json()
+    audit_payload = audit_response.json()
+
+    assert payload["version"] == "wiii_connect_persistent_storage.v1"
+    assert payload["persistent"] is False
+    assert payload["reason"] == "database_probe_not_requested"
+    assert audit_payload["persistent"] is False
+    assert audit_payload["storage"]["reason"] == "database_probe_not_requested"
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_storage_probe_is_explicit_and_privacy_safe(
+    app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+    from app.engine.wiii_connect.persistent_storage import (
+        WiiiConnectPersistentStorageStatus,
+    )
+
+    class FakeStorage:
+        calls = 0
+
+        def status(self, *, probe_database: bool = True):
+            self.calls += 1
+            assert probe_database is True
+            return WiiiConnectPersistentStorageStatus(
+                enabled=True,
+                persistent=True,
+                connection_table_ready=True,
+                audit_ledger_ready=True,
+                reason="ready",
+            )
+
+    fake_storage = FakeStorage()
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        lambda: fake_storage,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        storage_response = await client.get(
+            "/wiii-connect/storage/status",
+            params={"probe_database": "true"},
+        )
+        audit_response = await client.get(
+            "/wiii-connect/audit-ledger/status",
+            params={"probe_database": "true"},
+        )
+        authorization_response = await client.post(
+            "/wiii-connect/providers/facebook/authorization-url",
+            json={
+                "surface": "desktop",
+                "redirect_uri": "https://wiii.example.test/callback",
+                "state_present": True,
+                "probe_database": True,
+            },
+        )
+
+    assert storage_response.status_code == 200
+    assert audit_response.status_code == 200
+    assert authorization_response.status_code == 200
+    assert fake_storage.calls == 3
+
+    storage_payload = storage_response.json()
+    audit_payload = audit_response.json()
+    authorization_payload = authorization_response.json()
+    serialized = json.dumps(
+        {
+            "storage": storage_payload,
+            "audit": audit_payload,
+            "authorization": authorization_payload,
+        },
+        sort_keys=True,
+    )
+
+    assert storage_payload["persistent"] is True
+    assert storage_payload["reason"] == "ready"
+    assert audit_payload["persistent"] is True
+    assert audit_payload["storage"]["audit_ledger_ready"] is True
+    assert authorization_payload["reason"] == "provider_disabled"
+    assert "access_token" not in serialized
+    assert "refresh_token" not in serialized
+    assert "client_secret" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_wiii_connect_provider_adapter_status_api_is_fail_closed(app):
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app),


### PR DESCRIPTION
## Summary
- Adds opt-in Wiii Connect durable storage status APIs.
- Wires authorization URL decisions to consume durable audit readiness only from backend-controlled storage probes.
- Keeps default Wiii Connect status paths non-blocking and fail-closed.
- Updates the Wiii Connect design doc for controlled storage probing.

## Scope
- `GET /wiii-connect/storage/status?probe_database=false|true`
- `GET /wiii-connect/audit-ledger/status?probe_database=false|true`
- `POST /wiii-connect/providers/{slug}/authorization-url` can request `probe_database: true` in the safe request body.
- API tests for no-probe default and explicit fake-storage probe.

## Non-scope
- No Composio provider enablement.
- No real OAuth/token exchange.
- No provider SDK or network calls.
- No frontend UI changes.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/api/test_wiii_connect_api.py -q --tb=short` -> 36 passed
- `cd maritime-ai-service; python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/api/test_wiii_connect_api.py alembic/versions/049_create_wiii_connect_storage.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
Storage probing can introduce latency or bad fail-open assumptions. This PR keeps probes opt-in and only treats audit as persistent when backend storage reports both persistent and audit table readiness.

## Rollback
Revert this PR. Durable storage remains available but unused by authorization-url decisions.

Closes #750