### PR TITLE
Add Wiii Connect Composio config status

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -74,6 +74,7 @@ The provider adapter readiness and authorization URL contract lives in:
 
 ```text
 maritime-ai-service/app/engine/wiii_connect/provider_adapters.py
+maritime-ai-service/app/engine/wiii_connect/composio_adapter.py
 ```
 
 The durable storage contract and schema live in:
@@ -201,6 +202,14 @@ must keep that provider disabled and non-agent-ready.
   exchange, and action execution;
 - defaults every external provider kind to unbound and not authorization-ready.
 
+`WiiiConnectComposioAdapterConfig`
+
+- reads backend-only Composio settings without exposing `composio_api_key`;
+- supports provider-to-`auth_config_id` maps via JSON or comma-separated text;
+- reports disabled, missing API key, missing auth config map, or configured
+  status as provider adapter capability metadata;
+- still keeps action execution disabled until gateway/curated-action enablement.
+
 `WiiiConnectAuthorizationUrlRequest`
 
 - records only safe authorization request shape: state presence, redirect URI
@@ -310,6 +319,8 @@ agent receive curated action schemas for the selected provider.
 
 Before real Composio OAuth is enabled:
 
+- backend settings must explicitly set `enable_wiii_connect_composio`, provide a
+  Composio project API key, and map provider slugs to Composio auth config IDs;
 - Wiii backend must create authorization sessions with state and nonce;
 - session start must return a backend decision first, not let the frontend call
   Composio directly;

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -132,7 +132,9 @@ Before Wiii enables Composio:
 
 ## Current Wiii Position
 
-Wiii now has a V0 snapshot/dashboard and a V1 policy contract. It still needs
-provider persistence, OAuth endpoints, vault integration, provider-specific
-adapter clients, and end-to-end browser acceptance before Composio can be
-enabled for real users.
+Wiii now has a V0 snapshot/dashboard, V1 policy contract, provider registry,
+callback/vault boundary, durable connection/audit storage, controlled storage
+probe, and Composio adapter configuration status. It still needs real OAuth
+endpoint implementation, vault/provider-managed secret reference integration,
+provider-specific adapter clients, and end-to-end browser acceptance before
+Composio can be enabled for real users.

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -12,6 +12,7 @@ from app.engine.wiii_connect import (
     WiiiConnectCallbackRequest,
     WiiiConnectSessionStartRequest,
     audit_ledger_status_public_metadata,
+    build_composio_provider_adapter_capability,
     begin_connection_session,
     decide_authorization_url,
     default_persistent_storage_status_metadata,
@@ -91,7 +92,9 @@ async def get_wiii_connect_storage_status(
 async def get_wiii_connect_provider_adapter_status() -> dict[str, object]:
     """Return privacy-safe Wiii Connect provider adapter readiness metadata."""
 
-    return provider_adapter_status_public_metadata()
+    return provider_adapter_status_public_metadata(
+        adapter_capabilities=(build_composio_provider_adapter_capability(),),
+    )
 
 
 @router.get("/providers/{slug}/status")

--- a/maritime-ai-service/app/core/config/_settings_feature_fields.py
+++ b/maritime-ai-service/app/core/config/_settings_feature_fields.py
@@ -391,6 +391,31 @@ class FeatureSettingsMixin:
         ),
     )
 
+    # Wiii Connect external provider adapters
+    enable_wiii_connect_composio: bool = Field(
+        default=False,
+        description="Enable the Wiii-owned Composio provider adapter configuration path",
+    )
+    composio_api_key: Optional[str] = Field(
+        default=None,
+        description="Composio project API key for backend-only adapter calls",
+        repr=False,
+    )
+    composio_base_url: str = Field(
+        default="https://backend.composio.dev",
+        description="Composio backend base URL",
+    )
+    composio_api_version: str = Field(
+        default="v3.1",
+        description="Composio backend API version used by connect-link calls",
+    )
+    composio_auth_config_map: str = Field(
+        default="",
+        description=(
+            "JSON object or comma list mapping provider slug to Composio auth_config_id"
+        ),
+    )
+
     # SoulBridge (Sprint 213)
     enable_soul_bridge: bool = Field(default=False, description="Enable cross-service soul-to-soul communication bridge (WebSocket + HTTP)")
     soul_bridge_peers: str = Field(default="", description="Comma-separated peer entries: 'peer_id=url' or 'url' (e.g., 'bro=http://localhost:8001')")

--- a/maritime-ai-service/app/core/feature_tiers.py
+++ b/maritime-ai-service/app/core/feature_tiers.py
@@ -184,6 +184,7 @@ FEATURE_TIER_GROUPS: Final[dict[FeatureTier, frozenset[str]]] = {
             "enable_visual_page_capture",
             "enable_visual_product_search",
             "enable_visual_rag",
+            "enable_wiii_connect_composio",
             "living_agent_enable_autonomy_graduation",
             "living_agent_enable_briefing",
             "living_agent_enable_dynamic_goals",

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -29,6 +29,13 @@ from .callback_boundary import (
     provider_callback_decision,
     provider_callback_decision_for_entry,
 )
+from .composio_adapter import (
+    WIII_CONNECT_COMPOSIO_ADAPTER_VERSION,
+    WiiiConnectComposioAdapterConfig,
+    build_composio_adapter_config,
+    build_composio_provider_adapter_capability,
+    parse_composio_auth_config_map,
+)
 from .connection_sessions import (
     WIII_CONNECT_SESSION_CONTRACT_VERSION,
     WiiiConnectConnectionSessionAuditEvent,
@@ -86,6 +93,7 @@ __all__ = [
     "WIII_CONNECT_ADAPTER_VERSION",
     "WIII_CONNECT_AUDIT_LEDGER_VERSION",
     "WIII_CONNECT_CALLBACK_CONTRACT_VERSION",
+    "WIII_CONNECT_COMPOSIO_ADAPTER_VERSION",
     "WIII_CONNECT_PROVIDER_ADAPTER_VERSION",
     "WIII_CONNECT_PERSISTENT_STORAGE_VERSION",
     "WIII_CONNECT_SESSION_CONTRACT_VERSION",
@@ -98,6 +106,7 @@ __all__ = [
     "WiiiConnectCallbackAuditEvent",
     "WiiiConnectCallbackDecision",
     "WiiiConnectCallbackRequest",
+    "WiiiConnectComposioAdapterConfig",
     "WiiiConnectConnectionSessionAuditEvent",
     "WiiiConnectConnectionRecordV1",
     "WiiiConnectExecutionDecision",
@@ -125,6 +134,8 @@ __all__ = [
     "WiiiPathCapabilityRecord",
     "audit_ledger_status_public_metadata",
     "begin_connection_session",
+    "build_composio_adapter_config",
+    "build_composio_provider_adapter_capability",
     "build_wiii_connect_snapshot",
     "build_audit_ledger_record",
     "decide_external_execution",
@@ -138,6 +149,7 @@ __all__ = [
     "is_connection_baseline_ready",
     "list_wiii_connect_provider_registry",
     "normalize_connection_state",
+    "parse_composio_auth_config_map",
     "provider_adapter_status_public_metadata",
     "provider_callback_decision",
     "provider_callback_decision_for_entry",

--- a/maritime-ai-service/app/engine/wiii_connect/composio_adapter.py
+++ b/maritime-ai-service/app/engine/wiii_connect/composio_adapter.py
@@ -1,0 +1,182 @@
+"""Composio adapter configuration status for Wiii Connect.
+
+This module does not call Composio. It turns backend settings into a
+privacy-safe provider adapter capability so operators can see whether Wiii is
+configured enough to attempt a future Connect Link flow.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .provider_adapters import WiiiConnectProviderAdapterCapability
+
+
+WIII_CONNECT_COMPOSIO_ADAPTER_VERSION = "wiii_connect_composio_adapter.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectComposioAdapterConfig:
+    """Sanitized Composio adapter configuration state."""
+
+    enabled: bool = False
+    api_key_present: bool = False
+    base_url: str = "https://backend.composio.dev"
+    api_version: str = "v3.1"
+    auth_config_by_provider: dict[str, str] | None = None
+
+    @property
+    def auth_config_count(self) -> int:
+        return len(self.auth_config_by_provider or {})
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_COMPOSIO_ADAPTER_VERSION,
+            "enabled": self.enabled,
+            "api_key_present": self.api_key_present,
+            "base_url": self.base_url,
+            "api_version": self.api_version,
+            "auth_config_count": self.auth_config_count,
+            "provider_slugs": sorted((self.auth_config_by_provider or {}).keys()),
+        }
+
+
+def parse_composio_auth_config_map(raw_value: Any) -> dict[str, str]:
+    """Parse provider->auth_config_id mappings from JSON or comma text."""
+
+    if isinstance(raw_value, Mapping):
+        return _normalize_mapping(raw_value)
+    text = str(raw_value or "").strip()
+    if not text:
+        return {}
+    if text.startswith("{"):
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, Mapping):
+            return _normalize_mapping(parsed)
+        return {}
+
+    result: dict[str, str] = {}
+    for item in text.split(","):
+        pair = item.strip()
+        if not pair:
+            continue
+        if "=" in pair:
+            provider, auth_config = pair.split("=", 1)
+        elif ":" in pair:
+            provider, auth_config = pair.split(":", 1)
+        else:
+            continue
+        provider_slug = _normalize_provider_slug(provider)
+        auth_config_id = str(auth_config or "").strip()
+        if provider_slug and auth_config_id:
+            result[provider_slug] = auth_config_id
+    return result
+
+
+def build_composio_adapter_config(
+    settings_obj: Any | None = None,
+) -> WiiiConnectComposioAdapterConfig:
+    """Build sanitized Composio adapter config from backend settings."""
+
+    if settings_obj is None:
+        from app.core.config import settings as settings_obj
+
+    auth_config_map = parse_composio_auth_config_map(
+        getattr(settings_obj, "composio_auth_config_map", ""),
+    )
+    return WiiiConnectComposioAdapterConfig(
+        enabled=bool(getattr(settings_obj, "enable_wiii_connect_composio", False)),
+        api_key_present=bool(str(getattr(settings_obj, "composio_api_key", "") or "").strip()),
+        base_url=str(
+            getattr(settings_obj, "composio_base_url", "https://backend.composio.dev")
+            or "https://backend.composio.dev"
+        ).rstrip("/"),
+        api_version=str(getattr(settings_obj, "composio_api_version", "v3.1") or "v3.1").strip(),
+        auth_config_by_provider=auth_config_map,
+    )
+
+
+def build_composio_provider_adapter_capability(
+    config: WiiiConnectComposioAdapterConfig | None = None,
+    *,
+    settings_obj: Any | None = None,
+) -> WiiiConnectProviderAdapterCapability:
+    """Return privacy-safe Composio adapter capability metadata."""
+
+    resolved = config or build_composio_adapter_config(settings_obj)
+    if not resolved.enabled:
+        return WiiiConnectProviderAdapterCapability(
+            provider_kind="composio",
+            adapter_name="composio_adapter",
+            bound=False,
+            configured=False,
+            can_create_authorization_url=False,
+            can_exchange_callback=False,
+            can_execute_actions=False,
+            reason="provider_adapter_not_bound",
+            warnings=("composio_disabled",),
+        )
+    if not resolved.api_key_present:
+        return WiiiConnectProviderAdapterCapability(
+            provider_kind="composio",
+            adapter_name="composio_adapter",
+            bound=True,
+            configured=False,
+            can_create_authorization_url=False,
+            can_exchange_callback=False,
+            can_execute_actions=False,
+            reason="provider_adapter_not_configured",
+            warnings=("missing_composio_api_key",),
+        )
+    if resolved.auth_config_count <= 0:
+        return WiiiConnectProviderAdapterCapability(
+            provider_kind="composio",
+            adapter_name="composio_adapter",
+            bound=True,
+            configured=False,
+            can_create_authorization_url=False,
+            can_exchange_callback=False,
+            can_execute_actions=False,
+            reason="provider_adapter_not_configured",
+            warnings=("missing_composio_auth_config_map",),
+        )
+
+    return WiiiConnectProviderAdapterCapability(
+        provider_kind="composio",
+        adapter_name="composio_adapter",
+        bound=True,
+        configured=True,
+        can_create_authorization_url=True,
+        can_exchange_callback=True,
+        can_execute_actions=False,
+        reason="ready",
+        warnings=("action_execution_disabled_until_gateway_enablement",),
+    )
+
+
+def _normalize_mapping(value: Mapping[Any, Any]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for raw_provider, raw_auth_config in value.items():
+        provider = _normalize_provider_slug(raw_provider)
+        auth_config = str(raw_auth_config or "").strip()
+        if provider and auth_config:
+            result[provider] = auth_config
+    return result
+
+
+def _normalize_provider_slug(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_")
+
+
+__all__ = [
+    "WIII_CONNECT_COMPOSIO_ADAPTER_VERSION",
+    "WiiiConnectComposioAdapterConfig",
+    "build_composio_adapter_config",
+    "build_composio_provider_adapter_capability",
+    "parse_composio_auth_config_map",
+]

--- a/maritime-ai-service/app/engine/wiii_connect/provider_adapters.py
+++ b/maritime-ai-service/app/engine/wiii_connect/provider_adapters.py
@@ -187,14 +187,19 @@ def default_provider_adapter_capability(
 
 def provider_adapter_status_public_metadata(
     provider_kinds: Iterable[ProviderKind] | None = None,
+    adapter_capabilities: Iterable[WiiiConnectProviderAdapterCapability] | None = None,
 ) -> dict[str, Any]:
     """Return privacy-safe adapter readiness metadata for UI/API."""
 
     kinds = tuple(provider_kinds or _DEFAULT_PROVIDER_KINDS)
+    overrides = {
+        capability.provider_kind: capability
+        for capability in (adapter_capabilities or ())
+    }
     return {
         "version": WIII_CONNECT_PROVIDER_ADAPTER_VERSION,
         "adapters": [
-            default_provider_adapter_capability(kind).to_public_metadata()
+            overrides.get(kind, default_provider_adapter_capability(kind)).to_public_metadata()
             for kind in kinds
         ],
     }

--- a/maritime-ai-service/tests/unit/test_wiii_connect_provider_adapters.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_provider_adapters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 
 def test_default_provider_adapter_status_is_unbound_and_secret_free():
@@ -20,6 +21,110 @@ def test_default_provider_adapter_status_is_unbound_and_secret_free():
     assert "access_token" not in serialized
     assert "refresh_token" not in serialized
     assert "client_secret" not in serialized
+
+
+def test_composio_adapter_config_parses_without_exposing_secret_values():
+    from app.engine.wiii_connect.composio_adapter import (
+        build_composio_adapter_config,
+        build_composio_provider_adapter_capability,
+        parse_composio_auth_config_map,
+    )
+
+    parsed_json = parse_composio_auth_config_map(
+        '{"facebook": "authcfg_fb", "google-drive": "authcfg_drive"}',
+    )
+    parsed_text = parse_composio_auth_config_map(
+        "facebook=authcfg_fb,gmail:authcfg_gmail",
+    )
+    disabled = build_composio_provider_adapter_capability(
+        settings_obj=SimpleNamespace(
+            enable_wiii_connect_composio=False,
+            composio_api_key="secret-value",
+            composio_auth_config_map='{"facebook": "authcfg_fb"}',
+        ),
+    )
+    missing_key = build_composio_provider_adapter_capability(
+        settings_obj=SimpleNamespace(
+            enable_wiii_connect_composio=True,
+            composio_api_key="",
+            composio_auth_config_map='{"facebook": "authcfg_fb"}',
+        ),
+    )
+    missing_auth_config = build_composio_provider_adapter_capability(
+        settings_obj=SimpleNamespace(
+            enable_wiii_connect_composio=True,
+            composio_api_key="secret-value",
+            composio_auth_config_map="",
+        ),
+    )
+    configured_settings = SimpleNamespace(
+        enable_wiii_connect_composio=True,
+        composio_api_key="secret-value",
+        composio_base_url="https://backend.composio.dev/",
+        composio_api_version="v3.1",
+        composio_auth_config_map='{"facebook": "authcfg_fb"}',
+    )
+    config = build_composio_adapter_config(configured_settings)
+    configured = build_composio_provider_adapter_capability(config)
+    metadata = {
+        "config": config.to_public_metadata(),
+        "disabled": disabled.to_public_metadata(),
+        "missing_key": missing_key.to_public_metadata(),
+        "missing_auth_config": missing_auth_config.to_public_metadata(),
+        "configured": configured.to_public_metadata(),
+    }
+    serialized = json.dumps(metadata, sort_keys=True)
+
+    assert parsed_json == {
+        "facebook": "authcfg_fb",
+        "google_drive": "authcfg_drive",
+    }
+    assert parsed_text == {
+        "facebook": "authcfg_fb",
+        "gmail": "authcfg_gmail",
+    }
+    assert disabled.bound is False
+    assert disabled.reason == "provider_adapter_not_bound"
+    assert missing_key.bound is True
+    assert missing_key.configured is False
+    assert "missing_composio_api_key" in missing_key.warnings
+    assert missing_auth_config.configured is False
+    assert "missing_composio_auth_config_map" in missing_auth_config.warnings
+    assert configured.bound is True
+    assert configured.configured is True
+    assert configured.can_create_authorization_url is True
+    assert configured.can_exchange_callback is True
+    assert configured.can_execute_actions is False
+    assert metadata["config"]["auth_config_count"] == 1
+    assert metadata["config"]["provider_slugs"] == ["facebook"]
+    assert "secret-value" not in serialized
+
+
+def test_provider_adapter_status_accepts_backend_capability_override():
+    from app.engine.wiii_connect.provider_adapters import (
+        WiiiConnectProviderAdapterCapability,
+        provider_adapter_status_public_metadata,
+    )
+
+    metadata = provider_adapter_status_public_metadata(
+        adapter_capabilities=(
+            WiiiConnectProviderAdapterCapability(
+                provider_kind="composio",
+                adapter_name="composio_adapter",
+                bound=True,
+                configured=True,
+                can_create_authorization_url=True,
+                can_exchange_callback=True,
+                reason="ready",
+            ),
+        ),
+    )
+    by_kind = {adapter["provider_kind"]: adapter for adapter in metadata["adapters"]}
+
+    assert by_kind["composio"]["bound"] is True
+    assert by_kind["composio"]["configured"] is True
+    assert by_kind["composio"]["authorization_ready"] is True
+    assert by_kind["mcp"]["bound"] is False
 
 
 def test_disabled_provider_authorization_url_decision_blocks_and_redacts_keys():


### PR DESCRIPTION
## Summary
- Adds backend Composio adapter configuration status for Wiii Connect.
- Reports disabled/missing-key/missing-auth-config/configured states without exposing secrets.
- Wires provider-adapter status to use backend Composio settings.
- Updates Wiii Connect and OpenHuman/Composio audit docs.

## Scope
- New settings: `enable_wiii_connect_composio`, `composio_api_key`, `composio_base_url`, `composio_api_version`, `composio_auth_config_map`.
- New `composio_adapter.py` config parser/capability builder.
- Provider adapter status override support.
- Focused tests for config parsing, redaction, and status override.

## Non-scope
- No Composio API calls.
- No OAuth link generation yet.
- No external provider is enabled in the registry.
- No action execution or token storage.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/api/test_wiii_connect_api.py -q --tb=short` -> 38 passed
- `cd maritime-ai-service; python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py app/core/config/_settings_feature_fields.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/api/test_wiii_connect_api.py alembic/versions/049_create_wiii_connect_storage.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
Provider config can be mistaken for agent readiness or leak keys. This PR only exposes boolean `api_key_present`, provider slug counts, and reason/warning codes. Providers remain disabled and no Composio calls are made.

## Rollback
Revert this PR. Provider adapter status returns to static unbound defaults.

Closes #752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Composio integration support for external provider adapters with backend API configuration
  * Implemented adapter capability status reporting to indicate configuration readiness and potential issues

* **Documentation**
  * Updated architecture design documentation with Composio adapter contract specifications
  * Updated operational readiness audit to document Wiii Connect integration status

* **Chores**
  * Added new Composio feature flag to experimental tier classification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/753?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->