### PR TITLE
fix(backend): split Wiii Connect connect readiness from agent readiness

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -220,9 +220,11 @@ must keep that provider disabled and non-agent-ready.
 `WiiiConnectAuthorizationUrlDecision`
 
 - returns `blocked` or `ready`;
-- requires enabled provider, agent-ready registry entry, backend-created state,
-  backend-bound redirect URI, bound/configured adapter, vault capability,
-  persistent audit ledger, and an adapter-supplied authorization URL;
+- requires enabled provider, backend-created state, backend-bound redirect URI,
+  bound/configured adapter, vault capability, persistent audit ledger, and an
+  adapter-supplied authorization URL;
+- does not require `agent_ready`; users may connect accounts before Wiii exposes
+  curated actions to agents;
 - rejects adapter/provider-kind mismatch before any OAuth handoff;
 - direct session callers may not bypass adapter policy by passing a URL.
 
@@ -265,7 +267,9 @@ Composio-like statuses map as follows:
 
 ## Agent-Ready Gate
 
-`connected` is only transport/auth state. `agent_ready` requires all of:
+`connected` is only transport/auth state. A provider may be enabled for
+connection without being `agent_ready`. `agent_ready` is required for execution
+and requires all of:
 
 1. provider registry entry is enabled;
 2. provider registry entry is marked agent-ready;
@@ -321,6 +325,9 @@ Before real Composio OAuth is enabled:
 
 - backend settings must explicitly set `enable_wiii_connect_composio`, provide a
   Composio project API key, and map provider slugs to Composio auth config IDs;
+- provider connection readiness must stay separate from `agent_ready`; account
+  connection can be enabled before any curated action schema is exposed to an
+  agent;
 - Wiii backend must create authorization sessions with state and nonce;
 - session start must return a backend decision first, not let the frontend call
   Composio directly;

--- a/maritime-ai-service/app/engine/wiii_connect/connection_sessions.py
+++ b/maritime-ai-service/app/engine/wiii_connect/connection_sessions.py
@@ -24,7 +24,6 @@ WIII_CONNECT_SESSION_CONTRACT_VERSION = "wiii_connect_session.v1"
 SessionDecisionStatus = Literal["blocked", "ready"]
 SessionDecisionReason = Literal[
     "provider_disabled",
-    "provider_not_agent_ready",
     "missing_connect_prerequisites",
     "provider_adapter_not_bound",
     "provider_adapter_mismatch",
@@ -259,8 +258,6 @@ def _session_block_reason(
 ) -> SessionDecisionReason:
     if not entry.enabled:
         return "provider_disabled"
-    if not entry.agent_ready:
-        return "provider_not_agent_ready"
     if missing_requirements:
         return "missing_connect_prerequisites"
     return "authorization_url_issued"
@@ -271,7 +268,6 @@ def _session_reason_from_authorization_decision(
 ) -> SessionDecisionReason:
     if decision.reason in {
         "provider_disabled",
-        "provider_not_agent_ready",
         "provider_adapter_mismatch",
         "provider_adapter_not_bound",
         "provider_adapter_not_configured",

--- a/maritime-ai-service/app/engine/wiii_connect/provider_adapters.py
+++ b/maritime-ai-service/app/engine/wiii_connect/provider_adapters.py
@@ -29,7 +29,6 @@ WIII_CONNECT_PROVIDER_ADAPTER_VERSION = "wiii_connect_provider_adapter.v1"
 AdapterDecisionStatus = Literal["blocked", "ready"]
 AdapterDecisionReason = Literal[
     "provider_disabled",
-    "provider_not_agent_ready",
     "missing_state",
     "missing_redirect_uri",
     "provider_adapter_mismatch",
@@ -264,8 +263,6 @@ def _authorization_reason(
 ) -> AdapterDecisionReason:
     if not entry.enabled:
         return "provider_disabled"
-    if not entry.agent_ready:
-        return "provider_not_agent_ready"
     if not request.state_present:
         return "missing_state"
     if not request.redirect_uri_present:
@@ -290,8 +287,6 @@ def _authorization_reason(
 def _required_next_for_reason(reason: AdapterDecisionReason) -> tuple[str, ...]:
     if reason == "provider_disabled":
         return ("enable_provider_registry_entry",)
-    if reason == "provider_not_agent_ready":
-        return ("mark_provider_agent_ready",)
     if reason == "missing_state":
         return ("create_backend_state_nonce",)
     if reason == "missing_redirect_uri":

--- a/maritime-ai-service/tests/unit/test_wiii_connect_adapter_v1.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_adapter_v1.py
@@ -58,6 +58,29 @@ def test_external_execute_requires_connection_action_path_scope_and_approval():
         state="connected",
         scopes=WiiiConnectScopeGrant(read=True, write=True, apply=True),
     )
+    connect_only_entry = WiiiConnectProviderRegistryEntry(
+        slug="facebook",
+        label="Facebook",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        enabled=True,
+        agent_ready=False,
+        allowed_paths=("external_app_action",),
+        action_allowlist=("FACEBOOK_CREATE_POST",),
+    )
+
+    not_agent_ready = decide_external_execution(
+        connect_only_entry,
+        connection,
+        WiiiConnectExecutionRequest(
+            provider_slug="facebook",
+            action_slug="FACEBOOK_CREATE_POST",
+            path="external_app_action",
+            mutation="write",
+        ),
+    )
+    assert not_agent_ready.allowed is False
+    assert not_agent_ready.reason == "provider_not_agent_ready"
 
     uncurated = decide_external_execution(
         entry,

--- a/maritime-ai-service/tests/unit/test_wiii_connect_connection_sessions.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_connection_sessions.py
@@ -56,7 +56,7 @@ def test_session_start_redacts_sensitive_request_metadata_keys():
     assert "secret-value" not in serialized
 
 
-def test_ready_session_requires_adapter_authorization_url_even_when_entry_enabled():
+def test_ready_session_requires_adapter_authorization_url_not_agent_ready():
     from app.engine.wiii_connect.adapter_v1 import WiiiConnectProviderRegistryEntry
     from app.engine.wiii_connect.connection_sessions import (
         WiiiConnectSessionStartRequest,
@@ -74,7 +74,7 @@ def test_ready_session_requires_adapter_authorization_url_even_when_entry_enable
         provider_kind="composio",
         auth_mode="oauth2",
         enabled=True,
-        agent_ready=True,
+        agent_ready=False,
         requirements=(),
     )
 

--- a/maritime-ai-service/tests/unit/test_wiii_connect_provider_adapters.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_provider_adapters.py
@@ -175,7 +175,7 @@ def test_authorization_url_requires_shape_adapter_vault_audit_and_url():
         provider_kind="composio",
         auth_mode="oauth2",
         enabled=True,
-        agent_ready=True,
+        agent_ready=False,
         requirements=(),
     )
     valid_request = WiiiConnectAuthorizationUrlRequest(


### PR DESCRIPTION
## Summary
- Separates Wiii Connect OAuth/connect-link authorization readiness from agent execution readiness.
- Keeps external provider action execution fail-closed behind gent_ready, path/action/scope/approval gates.
- Updates Adapter V1 docs to match the OpenHuman/Composio pattern: connected is not agent-ready.

Closes #754.

## Scope
- Backend Wiii Connect session/authorization policy.
- Focused Wiii Connect tests and docs.

## Non-Scope
- No real Composio network calls.
- No Composio action execution.
- No frontend connection modal changes.

## Verification
- python -m pytest tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py -q --tb=short -> 24 passed
- python -m pytest tests/unit/test_feature_tiers.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/api/test_wiii_connect_api.py -q --tb=short -> 43 passed
- python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7 -> passed
- git diff --check -> passed

## Risk
OAuth/connector control-plane behavior. Risk is bounded by keeping disabled providers blocked and keeping actual external execution unchanged/fail-closed.

## Rollback
Revert this PR to restore the previous stricter behavior where authorization also required gent_ready.