### PR TITLE
refactor(backend): split Wiii Connect provider readiness requirements

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -108,6 +108,10 @@ must keep that provider disabled and non-agent-ready.
 
 - provider slug, kind, auth mode, enabled state;
 - whether it is agent-ready;
+- connection requirements such as Connect Link, provider-managed vault ref, and
+  audit readiness;
+- agent-ready requirements such as scope policy, curated action catalog, and
+  execution gateway;
 - path allowlist;
 - curated action allowlist;
 - provider-specific required fields;
@@ -337,6 +341,8 @@ Before real Composio OAuth is enabled:
   explicit storage probe or backend-controlled storage status, never from
   frontend claims;
 - disabled providers must return a blocked decision with missing requirements;
+- missing connection requirements block OAuth/session start, while missing
+  agent-ready requirements only block tool/action exposure;
 - callback handling must stay blocked until state/code validation, vault storage,
   and provider adapter exchange are ready;
 - callback/webhook handling must bind provider account to Wiii org/user;

--- a/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
+++ b/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
@@ -119,10 +119,33 @@ class WiiiConnectProviderRegistryEntry:
     allowed_paths: tuple[str, ...] = ("external_app_action",)
     action_allowlist: tuple[str, ...] = ()
     requirements: tuple[str, ...] = ()
+    connect_requirements: tuple[str, ...] = ()
+    agent_ready_requirements: tuple[str, ...] = ()
     required_fields: tuple[WiiiConnectRequiredField, ...] = ()
     default_scopes: WiiiConnectScopeGrant = field(default_factory=WiiiConnectScopeGrant)
     source: str = "wiii_connect_registry"
     warnings: tuple[str, ...] = ()
+
+    def connection_requirements(self) -> tuple[str, ...]:
+        """Return prerequisites that block starting OAuth/Connect Link."""
+
+        if self.connect_requirements:
+            return self.connect_requirements
+        if self.agent_ready_requirements:
+            return ()
+        return self.requirements
+
+    def all_requirements(self) -> tuple[str, ...]:
+        """Return stable public requirements without duplicating entries."""
+
+        result: list[str] = []
+        for requirement in (
+            self.requirements
+            or self.connect_requirements + self.agent_ready_requirements
+        ):
+            if requirement and requirement not in result:
+                result.append(requirement)
+        return tuple(result)
 
     def allows_action(self, action_slug: str) -> bool:
         """Return true when an action is in the curated allowlist.
@@ -160,7 +183,9 @@ class WiiiConnectProviderRegistryEntry:
             "description": self.description,
             "allowed_paths": list(self.allowed_paths),
             "action_count": len(self.action_allowlist),
-            "requirements": list(self.requirements),
+            "requirements": list(self.all_requirements()),
+            "connect_requirements": list(self.connection_requirements()),
+            "agent_ready_requirements": list(self.agent_ready_requirements),
             "required_fields": [
                 field.to_public_metadata() for field in self.required_fields
             ],

--- a/maritime-ai-service/app/engine/wiii_connect/connection_sessions.py
+++ b/maritime-ai-service/app/engine/wiii_connect/connection_sessions.py
@@ -168,7 +168,7 @@ def provider_connection_status_for_entry(
 ) -> WiiiConnectProviderConnectionStatus:
     """Project one registry entry into connection-session readiness metadata."""
 
-    missing_requirements = tuple(entry.requirements)
+    missing_requirements = entry.connection_requirements()
     reason = _session_block_reason(entry, missing_requirements)
     if reason == "authorization_url_issued":
         reason = "provider_adapter_not_bound"
@@ -196,7 +196,7 @@ def begin_connection_session(
 ) -> WiiiConnectSessionStartDecision:
     """Decide whether Wiii may start provider authorization for this request."""
 
-    missing_requirements = tuple(entry.requirements)
+    missing_requirements = entry.connection_requirements()
     reason = _session_block_reason(entry, missing_requirements)
     required_next = missing_requirements
     session_authorization_url = ""

--- a/maritime-ai-service/app/engine/wiii_connect/provider_registry.py
+++ b/maritime-ai-service/app/engine/wiii_connect/provider_registry.py
@@ -19,13 +19,21 @@ from .adapter_v1 import (
 WIII_CONNECT_PROVIDER_REGISTRY_VERSION = "wiii_connect_provider_registry.v1"
 
 
-_DISABLED_COMPOSIO_REQUIREMENTS = (
+_DISABLED_COMPOSIO_CONNECT_REQUIREMENTS = (
     "oauth_or_connect_link",
-    "encrypted_vault_ref",
+    "provider_managed_vault_ref",
+    "audit_ledger",
+)
+
+_DISABLED_COMPOSIO_AGENT_READY_REQUIREMENTS = (
     "scope_policy",
     "curated_action_catalog",
     "execution_gateway",
-    "audit_ledger",
+)
+
+_DISABLED_COMPOSIO_REQUIREMENTS = (
+    _DISABLED_COMPOSIO_CONNECT_REQUIREMENTS
+    + _DISABLED_COMPOSIO_AGENT_READY_REQUIREMENTS
 )
 
 
@@ -38,6 +46,8 @@ _PROVIDER_REGISTRY: tuple[WiiiConnectProviderRegistryEntry, ...] = (
         category="social",
         description="Facebook Pages/content via a brokered OAuth adapter.",
         requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        connect_requirements=_DISABLED_COMPOSIO_CONNECT_REQUIREMENTS,
+        agent_ready_requirements=_DISABLED_COMPOSIO_AGENT_READY_REQUIREMENTS,
         warnings=("adapter_disabled",),
     ),
     WiiiConnectProviderRegistryEntry(
@@ -48,6 +58,8 @@ _PROVIDER_REGISTRY: tuple[WiiiConnectProviderRegistryEntry, ...] = (
         category="productivity",
         description="Gmail read/write actions with explicit scope gates.",
         requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        connect_requirements=_DISABLED_COMPOSIO_CONNECT_REQUIREMENTS,
+        agent_ready_requirements=_DISABLED_COMPOSIO_AGENT_READY_REQUIREMENTS,
         warnings=("adapter_disabled",),
     ),
     WiiiConnectProviderRegistryEntry(
@@ -58,6 +70,8 @@ _PROVIDER_REGISTRY: tuple[WiiiConnectProviderRegistryEntry, ...] = (
         category="productivity",
         description="Calendar lookup and event drafting through Composio.",
         requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        connect_requirements=_DISABLED_COMPOSIO_CONNECT_REQUIREMENTS,
+        agent_ready_requirements=_DISABLED_COMPOSIO_AGENT_READY_REQUIREMENTS,
         warnings=("adapter_disabled",),
     ),
     WiiiConnectProviderRegistryEntry(
@@ -68,6 +82,8 @@ _PROVIDER_REGISTRY: tuple[WiiiConnectProviderRegistryEntry, ...] = (
         category="productivity",
         description="Drive file lookup and source reference workflows.",
         requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        connect_requirements=_DISABLED_COMPOSIO_CONNECT_REQUIREMENTS,
+        agent_ready_requirements=_DISABLED_COMPOSIO_AGENT_READY_REQUIREMENTS,
         warnings=("adapter_disabled",),
     ),
     WiiiConnectProviderRegistryEntry(
@@ -78,6 +94,8 @@ _PROVIDER_REGISTRY: tuple[WiiiConnectProviderRegistryEntry, ...] = (
         category="productivity",
         description="Notion workspace search and page drafting.",
         requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        connect_requirements=_DISABLED_COMPOSIO_CONNECT_REQUIREMENTS,
+        agent_ready_requirements=_DISABLED_COMPOSIO_AGENT_READY_REQUIREMENTS,
         warnings=("adapter_disabled",),
     ),
     WiiiConnectProviderRegistryEntry(
@@ -88,6 +106,8 @@ _PROVIDER_REGISTRY: tuple[WiiiConnectProviderRegistryEntry, ...] = (
         category="chat",
         description="Slack workspace/channel read and message drafting.",
         requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        connect_requirements=_DISABLED_COMPOSIO_CONNECT_REQUIREMENTS,
+        agent_ready_requirements=_DISABLED_COMPOSIO_AGENT_READY_REQUIREMENTS,
         warnings=("adapter_disabled",),
     ),
     WiiiConnectProviderRegistryEntry(
@@ -98,6 +118,8 @@ _PROVIDER_REGISTRY: tuple[WiiiConnectProviderRegistryEntry, ...] = (
         category="platform",
         description="GitHub issue, PR, and repository workflows.",
         requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        connect_requirements=_DISABLED_COMPOSIO_CONNECT_REQUIREMENTS,
+        agent_ready_requirements=_DISABLED_COMPOSIO_AGENT_READY_REQUIREMENTS,
         warnings=("adapter_disabled",),
     ),
     WiiiConnectProviderRegistryEntry(
@@ -108,6 +130,8 @@ _PROVIDER_REGISTRY: tuple[WiiiConnectProviderRegistryEntry, ...] = (
         category="productivity",
         description="Airtable base lookup and record drafting.",
         requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        connect_requirements=_DISABLED_COMPOSIO_CONNECT_REQUIREMENTS,
+        agent_ready_requirements=_DISABLED_COMPOSIO_AGENT_READY_REQUIREMENTS,
         warnings=("adapter_disabled",),
     ),
     WiiiConnectProviderRegistryEntry(
@@ -118,6 +142,8 @@ _PROVIDER_REGISTRY: tuple[WiiiConnectProviderRegistryEntry, ...] = (
         category="productivity",
         description="Asana project/task lookup and task drafting.",
         requirements=_DISABLED_COMPOSIO_REQUIREMENTS,
+        connect_requirements=_DISABLED_COMPOSIO_CONNECT_REQUIREMENTS,
+        agent_ready_requirements=_DISABLED_COMPOSIO_AGENT_READY_REQUIREMENTS,
         warnings=("adapter_disabled",),
     ),
 )

--- a/maritime-ai-service/app/engine/wiii_connect/snapshot.py
+++ b/maritime-ai-service/app/engine/wiii_connect/snapshot.py
@@ -510,7 +510,7 @@ def _external_provider_connections(now: str) -> tuple[WiiiConnectionRecord, ...]
                     "auth_mode": entry.auth_mode,
                     "category": entry.category,
                     "action_count": len(entry.action_allowlist),
-                    "requirement_count": len(entry.requirements),
+                    "requirement_count": len(entry.all_requirements()),
                 },
             )
         )

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -225,7 +225,8 @@ async def test_wiii_connect_provider_status_api_is_fail_closed(app):
     assert payload["provider_slug"] == "facebook"
     assert payload["can_start_authorization"] is False
     assert payload["reason"] == "provider_disabled"
-    assert "execution_gateway" in payload["missing_requirements"]
+    assert "provider_managed_vault_ref" in payload["missing_requirements"]
+    assert "execution_gateway" not in payload["missing_requirements"]
 
 
 @pytest.mark.asyncio

--- a/maritime-ai-service/tests/unit/test_wiii_connect_connection_sessions.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_connection_sessions.py
@@ -14,7 +14,8 @@ def test_disabled_provider_status_is_fail_closed_and_privacy_safe():
     assert metadata["provider_slug"] == "facebook"
     assert metadata["can_start_authorization"] is False
     assert metadata["reason"] == "provider_disabled"
-    assert "encrypted_vault_ref" in metadata["missing_requirements"]
+    assert "provider_managed_vault_ref" in metadata["missing_requirements"]
+    assert "execution_gateway" not in metadata["missing_requirements"]
 
     serialized = json.dumps(metadata, sort_keys=True)
     assert "access_token" not in serialized

--- a/maritime-ai-service/tests/unit/test_wiii_connect_provider_registry.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_provider_registry.py
@@ -18,11 +18,21 @@ def test_provider_registry_exposes_disabled_composio_catalog_without_secrets():
     assert by_slug["gmail"]["agent_ready"] is False
     assert by_slug["github"]["requirements"] == [
         "oauth_or_connect_link",
-        "encrypted_vault_ref",
+        "provider_managed_vault_ref",
+        "audit_ledger",
         "scope_policy",
         "curated_action_catalog",
         "execution_gateway",
+    ]
+    assert by_slug["github"]["connect_requirements"] == [
+        "oauth_or_connect_link",
+        "provider_managed_vault_ref",
         "audit_ledger",
+    ]
+    assert by_slug["github"]["agent_ready_requirements"] == [
+        "scope_policy",
+        "curated_action_catalog",
+        "execution_gateway",
     ]
 
     serialized = json.dumps(metadata, sort_keys=True)


### PR DESCRIPTION
## Summary
- Splits Wiii Connect provider requirements into connection prerequisites and agent/action readiness prerequisites.
- Session/status readiness now blocks on connection requirements only.
- Public registry metadata still exposes aggregate requirements plus explicit connect_requirements and gent_ready_requirements.

Closes #756.

## Scope
- Backend Wiii Connect registry/session contract.
- Snapshot requirement count handling.
- Focused tests and Adapter V1 docs.

## Non-Scope
- No real Composio network calls.
- No provider action execution enablement.
- No frontend UI changes.

## Verification
- python -m pytest tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py -q --tb=short -> 27 passed
- python -m pytest tests/unit/test_feature_tiers.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/api/test_wiii_connect_api.py -q --tb=short -> 43 passed
- python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7 -> passed
- git diff --check -> passed

## Risk
OAuth/connector readiness semantics. Disabled providers remain blocked, and action execution still requires gent_ready plus gateway checks.

## Rollback
Revert this PR to restore the single requirements field behavior.