### PR TITLE
feat(backend): add authenticated Composio Connect Link path

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -208,10 +208,17 @@ must keep that provider disabled and non-agent-ready.
 
 `WiiiConnectComposioAdapterConfig`
 
-- reads backend-only Composio settings without exposing `composio_api_key`;
+- reads backend-only Composio settings without exposing `composio_api_key` in
+  public metadata;
 - supports provider-to-`auth_config_id` maps via JSON or comma-separated text;
 - reports disabled, missing API key, missing auth config map, or configured
   status as provider adapter capability metadata;
+- issues Composio hosted Connect Link URLs only through the authenticated Wiii
+  backend route after registry, adapter, provider-managed vault, and durable
+  audit checks pass;
+- hashes the Wiii org/user boundary into a stable non-PII Composio user ID;
+- redacts `link_token`, provider account IDs, API keys, auth config IDs, and raw
+  provider errors from audit/public metadata;
 - still keeps action execution disabled until gateway/curated-action enablement.
 
 `WiiiConnectAuthorizationUrlRequest`
@@ -329,12 +336,17 @@ Before real Composio OAuth is enabled:
 
 - backend settings must explicitly set `enable_wiii_connect_composio`, provide a
   Composio project API key, and map provider slugs to Composio auth config IDs;
+- `POST /api/v1/wiii-connect/providers/{slug}/authorization-url` must require
+  Wiii authentication before any provider call;
+- Wiii must use Composio hosted Connect Link
+  `/api/v3.1/connected_accounts/link` for Composio-managed OAuth instead of the
+  older direct initiate flow;
 - provider connection readiness must stay separate from `agent_ready`; account
   connection can be enabled before any curated action schema is exposed to an
   agent;
 - Wiii backend must create authorization sessions with state and nonce;
-- session start must return a backend decision first, not let the frontend call
-  Composio directly;
+- session start must return a backend decision first, and the frontend must
+  never call Composio directly;
 - authorization URLs must come from a bound provider adapter decision, not from
   raw frontend input or ad hoc session arguments;
 - authorization URL decisions may consume durable audit readiness only from an
@@ -355,7 +367,9 @@ Before real Composio OAuth is enabled:
   organization and user boundary;
 - frontend may receive connect URLs and state labels, not tokens;
 - stale pending/error OAuth rows must be cleaned up or expired safely;
-- provider errors must be sanitized before reaching UI or chat.
+- provider errors must be sanitized before reaching UI or chat;
+- Composio action execution must remain disabled until curated action catalog,
+  scope policy, and execution gateway are implemented.
 
 ## Write And Apply Requirements
 
@@ -373,11 +387,10 @@ approval tokens and provider payloads must remain outside chat lifecycle data.
 
 ## Next Slices
 
-1. Add encrypted vault integration or provider-managed secret reference storage.
-2. Add provider adapter implementation/configuration for one provider broker
-   without enabling broad action execution.
-3. Add frontend connection modal that uses Wiii backend routes only.
-4. Persist provider registry and connection records behind backend-owned storage.
-5. Add browser acceptance for connect, poll, disconnect, gated scope, and denied
+1. Add callback reconciliation that maps Composio `connected_account_id` to a
+   Wiii connection record without storing provider secrets.
+2. Add frontend connection modal that uses Wiii backend routes only.
+3. Add connection polling/listing equivalent to OpenHuman `list_connections`.
+4. Add browser acceptance for connect, poll, disconnect, gated scope, and denied
    execute cases.
-6. Enable one low-risk read-only Composio action before any write action.
+5. Enable one low-risk read-only Composio action before any write action.

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -19,13 +19,20 @@ for the Adapter V1 gateway, vault, scope policy, and audit ledger.
 
 ## Official Composio Runtime Model
 
-Current Composio docs describe a session-based model:
+Current Composio docs describe a session/connected-account model:
 
 - a session is scoped to a user ID, tool access, authentication, and execution
   state;
 - connected accounts are stored under the app's user ID, so executions use the
   right user's account;
 - Connect Links or `session.authorize()` initiate authentication;
+- Composio-managed OAuth should use hosted Connect Link rather than the older
+  `initiate()` path; the REST endpoint is
+  `POST /api/v3.1/connected_accounts/link`;
+- Connect Link requires `auth_config_id` and a stable app user ID, and may take
+  a callback URL;
+- successful Connect Link responses include a hosted `redirect_url`, while Wiii
+  should not expose or store `link_token` in public metadata;
 - connected account responses mask sensitive credential fields by default;
 - sessions can be configured with allowed toolkits, auth configs, connected
   accounts, and optionally a workbench;
@@ -134,7 +141,8 @@ Before Wiii enables Composio:
 
 Wiii now has a V0 snapshot/dashboard, V1 policy contract, provider registry,
 callback/vault boundary, durable connection/audit storage, controlled storage
-probe, and Composio adapter configuration status. It still needs real OAuth
-endpoint implementation, vault/provider-managed secret reference integration,
-provider-specific adapter clients, and end-to-end browser acceptance before
-Composio can be enabled for real users.
+probe, Composio adapter configuration status, and an authenticated Connect Link
+client path that calls Composio only after policy preflight passes. It still
+needs callback reconciliation, connection listing/polling, frontend modal UX,
+curated action catalog, execution gateway, and end-to-end browser acceptance
+before Composio actions can be enabled for real users.

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -4,16 +4,24 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.core.security import require_auth
+from app.core.security_models import AuthenticatedUser
 from app.engine.wiii_connect import (
     WiiiConnectAuthorizationUrlRequest,
     WiiiConnectCallbackRequest,
     WiiiConnectSessionStartRequest,
     audit_ledger_status_public_metadata,
+    build_audit_ledger_record,
+    build_composio_adapter_config,
+    build_composio_connect_enabled_entry,
+    build_composio_external_user_id,
+    build_composio_provider_managed_vault_capability,
     build_composio_provider_adapter_capability,
     begin_connection_session,
+    create_composio_connect_link,
     decide_authorization_url,
     default_persistent_storage_status_metadata,
     get_wiii_connect_provider_entry,
@@ -137,6 +145,7 @@ async def start_wiii_connect_provider_session(
 async def create_wiii_connect_provider_authorization_url(
     slug: str,
     body: WiiiConnectStartSessionBody | None = None,
+    current_user: AuthenticatedUser = Depends(require_auth),
 ) -> dict[str, object]:
     """Return the provider adapter decision before exposing a connect URL."""
 
@@ -144,24 +153,70 @@ async def create_wiii_connect_provider_authorization_url(
     if entry is None:
         raise HTTPException(status_code=404, detail="unknown_wiii_connect_provider")
     body = body or WiiiConnectStartSessionBody()
+    composio_config = build_composio_adapter_config()
+    effective_entry = build_composio_connect_enabled_entry(entry, composio_config)
+    redirect_uri = _safe_redirect_uri(body.redirect_uri)
     request = WiiiConnectAuthorizationUrlRequest(
-        provider_slug=entry.slug,
+        provider_slug=effective_entry.slug,
         surface=body.surface,
         requested_scopes=scope_grant_from_mapping(body.requested_scopes),
         state_present=body.state_present,
-        redirect_uri_present=bool(body.redirect_uri),
+        redirect_uri_present=bool(redirect_uri),
         request_metadata_keys=tuple(body.request_metadata.keys()),
     )
     storage = _wiii_connect_storage_status_metadata(
         probe_database=body.probe_database,
     )
-    decision = decide_authorization_url(
-        entry,
+    audit_ledger_metadata = {
+        "persistent": bool(
+            storage.get("persistent") and storage.get("audit_ledger_ready")
+        )
+    }
+    adapter_capability = build_composio_provider_adapter_capability(composio_config)
+    vault_capability = build_composio_provider_managed_vault_capability(
+        composio_config,
+    )
+    preflight = decide_authorization_url(
+        effective_entry,
         request,
-        audit_ledger_metadata={
-            "persistent": bool(
-                storage.get("persistent") and storage.get("audit_ledger_ready")
-            )
+        adapter_capability=adapter_capability,
+        vault_capability=vault_capability,
+        audit_ledger_metadata=audit_ledger_metadata,
+        authorization_url="wiii-connect://preflight",
+    )
+    if not preflight.ready:
+        _append_authorization_audit(
+            preflight,
+            storage,
+            current_user=current_user,
+            metadata={"stage": "preflight"},
+        )
+        return preflight.to_public_metadata()
+
+    link = await create_composio_connect_link(
+        config=composio_config,
+        provider_slug=effective_entry.slug,
+        user_id=build_composio_external_user_id(
+            organization_id=current_user.organization_id,
+            user_id=current_user.user_id,
+        ),
+        callback_url=redirect_uri,
+    )
+    decision = decide_authorization_url(
+        effective_entry,
+        request,
+        adapter_capability=adapter_capability,
+        vault_capability=vault_capability,
+        audit_ledger_metadata=audit_ledger_metadata,
+        authorization_url=link.redirect_url if link.ready else "",
+    )
+    _append_authorization_audit(
+        decision,
+        storage,
+        current_user=current_user,
+        metadata={
+            "stage": "connect_link",
+            "connect_link": link.to_audit_metadata(),
         },
     )
     return decision.to_public_metadata()
@@ -203,3 +258,50 @@ def _wiii_connect_storage_status_metadata(
         .status(probe_database=True)
         .to_public_metadata()
     )
+
+
+def _append_authorization_audit(
+    decision: Any,
+    storage_metadata: dict[str, Any],
+    *,
+    current_user: AuthenticatedUser,
+    metadata: dict[str, Any],
+) -> None:
+    if not bool(storage_metadata.get("persistent") and storage_metadata.get("audit_ledger_ready")):
+        return
+    record = build_audit_ledger_record(
+        event_kind="provider",
+        provider_slug=decision.provider_slug,
+        status=decision.status,
+        reason=decision.reason,
+        surface=decision.audit_event.request.surface if decision.audit_event else "backend",
+        metadata={
+            "request": (
+                decision.audit_event.request.to_audit_metadata()
+                if decision.audit_event
+                else {}
+            ),
+            **metadata,
+        },
+    )
+    get_wiii_connect_persistent_storage().append_audit_record(
+        record,
+        organization_id=_wiii_connect_owner_organization_id(current_user),
+        user_id=current_user.user_id,
+    )
+
+
+def _wiii_connect_owner_organization_id(user: AuthenticatedUser) -> str:
+    if user.organization_id:
+        return user.organization_id
+    return build_composio_external_user_id(
+        organization_id=None,
+        user_id=user.user_id,
+    )
+
+
+def _safe_redirect_uri(value: str | None) -> str:
+    text = str(value or "").strip()
+    if text.startswith(("https://", "http://")):
+        return text
+    return ""

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -32,8 +32,13 @@ from .callback_boundary import (
 from .composio_adapter import (
     WIII_CONNECT_COMPOSIO_ADAPTER_VERSION,
     WiiiConnectComposioAdapterConfig,
+    WiiiConnectComposioConnectLinkResult,
     build_composio_adapter_config,
+    build_composio_connect_enabled_entry,
+    build_composio_external_user_id,
+    build_composio_provider_managed_vault_capability,
     build_composio_provider_adapter_capability,
+    create_composio_connect_link,
     parse_composio_auth_config_map,
 )
 from .connection_sessions import (
@@ -107,6 +112,7 @@ __all__ = [
     "WiiiConnectCallbackDecision",
     "WiiiConnectCallbackRequest",
     "WiiiConnectComposioAdapterConfig",
+    "WiiiConnectComposioConnectLinkResult",
     "WiiiConnectConnectionSessionAuditEvent",
     "WiiiConnectConnectionRecordV1",
     "WiiiConnectExecutionDecision",
@@ -141,6 +147,9 @@ __all__ = [
     "decide_external_execution",
     "decide_authorization_url",
     "decide_vault_secret_write",
+    "build_composio_connect_enabled_entry",
+    "build_composio_external_user_id",
+    "build_composio_provider_managed_vault_capability",
     "default_provider_adapter_capability",
     "default_persistent_storage_status_metadata",
     "default_wiii_connect_vault_capability",
@@ -156,6 +165,7 @@ __all__ = [
     "provider_connection_status",
     "provider_connection_status_for_entry",
     "provider_registry_public_metadata",
+    "create_composio_connect_link",
     "scope_grant_from_mapping",
     "vault_status_public_metadata",
 ]

--- a/maritime-ai-service/app/engine/wiii_connect/composio_adapter.py
+++ b/maritime-ai-service/app/engine/wiii_connect/composio_adapter.py
@@ -1,17 +1,22 @@
-"""Composio adapter configuration status for Wiii Connect.
+"""Composio adapter configuration and Connect Link boundary for Wiii Connect.
 
-This module does not call Composio. It turns backend settings into a
-privacy-safe provider adapter capability so operators can see whether Wiii is
-configured enough to attempt a future Connect Link flow.
+The status helpers expose only privacy-safe readiness metadata. The Connect
+Link client is the only function in this module that may call Composio, and it
+returns only the hosted redirect URL needed by the UI.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from typing import Any, Mapping
 
+import httpx
+
+from .adapter_v1 import WiiiConnectProviderRegistryEntry
 from .provider_adapters import WiiiConnectProviderAdapterCapability
+from .vault import WiiiConnectVaultCapability, default_wiii_connect_vault_capability
 
 
 WIII_CONNECT_COMPOSIO_ADAPTER_VERSION = "wiii_connect_composio_adapter.v1"
@@ -22,6 +27,7 @@ class WiiiConnectComposioAdapterConfig:
     """Sanitized Composio adapter configuration state."""
 
     enabled: bool = False
+    api_key: str = field(default="", repr=False)
     api_key_present: bool = False
     base_url: str = "https://backend.composio.dev"
     api_version: str = "v3.1"
@@ -30,6 +36,12 @@ class WiiiConnectComposioAdapterConfig:
     @property
     def auth_config_count(self) -> int:
         return len(self.auth_config_by_provider or {})
+
+    def auth_config_id_for_provider(self, provider_slug: str) -> str:
+        return (self.auth_config_by_provider or {}).get(
+            _normalize_provider_slug(provider_slug),
+            "",
+        )
 
     def to_public_metadata(self) -> dict[str, Any]:
         return {
@@ -40,6 +52,26 @@ class WiiiConnectComposioAdapterConfig:
             "api_version": self.api_version,
             "auth_config_count": self.auth_config_count,
             "provider_slugs": sorted((self.auth_config_by_provider or {}).keys()),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectComposioConnectLinkResult:
+    """Sanitized result of a Composio Connect Link creation attempt."""
+
+    ready: bool = False
+    redirect_url: str = ""
+    expires_at: str = ""
+    connected_account_ref_present: bool = False
+    reason: str = "not_requested"
+
+    def to_audit_metadata(self) -> dict[str, Any]:
+        return {
+            "ready": self.ready,
+            "redirect_url_present": bool(self.redirect_url),
+            "expires_at_present": bool(self.expires_at),
+            "connected_account_ref_present": self.connected_account_ref_present,
+            "reason": _safe_connect_link_reason(self.reason),
         }
 
 
@@ -89,9 +121,11 @@ def build_composio_adapter_config(
     auth_config_map = parse_composio_auth_config_map(
         getattr(settings_obj, "composio_auth_config_map", ""),
     )
+    api_key = str(getattr(settings_obj, "composio_api_key", "") or "").strip()
     return WiiiConnectComposioAdapterConfig(
         enabled=bool(getattr(settings_obj, "enable_wiii_connect_composio", False)),
-        api_key_present=bool(str(getattr(settings_obj, "composio_api_key", "") or "").strip()),
+        api_key=api_key,
+        api_key_present=bool(api_key),
         base_url=str(
             getattr(settings_obj, "composio_base_url", "https://backend.composio.dev")
             or "https://backend.composio.dev"
@@ -159,6 +193,148 @@ def build_composio_provider_adapter_capability(
     )
 
 
+def build_composio_provider_managed_vault_capability(
+    config: WiiiConnectComposioAdapterConfig | None = None,
+    *,
+    settings_obj: Any | None = None,
+) -> WiiiConnectVaultCapability:
+    """Return the vault policy for Composio-managed credentials."""
+
+    resolved = config or build_composio_adapter_config(settings_obj)
+    capability = build_composio_provider_adapter_capability(resolved)
+    if not capability.authorization_ready:
+        return default_wiii_connect_vault_capability()
+    return WiiiConnectVaultCapability(
+        enabled=True,
+        backend="provider_managed",
+        accepts_secret_material=True,
+        provider_managed=True,
+        key_namespace="composio",
+        reason="ready",
+        warnings=("secrets_remain_provider_managed",),
+    )
+
+
+def build_composio_connect_enabled_entry(
+    entry: WiiiConnectProviderRegistryEntry,
+    config: WiiiConnectComposioAdapterConfig | None = None,
+    *,
+    settings_obj: Any | None = None,
+) -> WiiiConnectProviderRegistryEntry:
+    """Enable only the connect phase when Composio is configured for a slug."""
+
+    if entry.provider_kind != "composio":
+        return entry
+    resolved = config or build_composio_adapter_config(settings_obj)
+    capability = build_composio_provider_adapter_capability(resolved)
+    if (
+        not capability.authorization_ready
+        or not resolved.auth_config_id_for_provider(entry.slug)
+    ):
+        return entry
+
+    warnings = tuple(
+        warning for warning in entry.warnings if warning != "adapter_disabled"
+    )
+    warnings = _append_unique(
+        warnings,
+        "agent_actions_disabled_until_gateway_ready",
+    )
+    return replace(
+        entry,
+        enabled=True,
+        agent_ready=False,
+        requirements=entry.agent_ready_requirements,
+        connect_requirements=(),
+        warnings=warnings,
+    )
+
+
+def build_composio_external_user_id(
+    *,
+    organization_id: str | None,
+    user_id: str,
+) -> str:
+    """Create a stable non-PII Composio user id for Wiii identities."""
+
+    owner = f"{organization_id or 'personal'}:{user_id}".encode("utf-8")
+    digest = hashlib.sha256(owner).hexdigest()[:32]
+    return f"wiii_{digest}"
+
+
+async def create_composio_connect_link(
+    *,
+    config: WiiiConnectComposioAdapterConfig,
+    provider_slug: str,
+    user_id: str,
+    callback_url: str,
+    http_client: httpx.AsyncClient | None = None,
+) -> WiiiConnectComposioConnectLinkResult:
+    """Create a Composio hosted auth link without leaking provider payloads."""
+
+    auth_config_id = config.auth_config_id_for_provider(provider_slug)
+    if not config.enabled or not config.api_key_present or not auth_config_id:
+        return WiiiConnectComposioConnectLinkResult(
+            reason="provider_adapter_not_configured",
+        )
+    if not user_id or not callback_url:
+        return WiiiConnectComposioConnectLinkResult(
+            reason="missing_user_or_callback",
+        )
+
+    payload = {
+        "auth_config_id": auth_config_id,
+        "user_id": user_id,
+        "callback_url": callback_url,
+    }
+    url = (
+        f"{config.base_url.rstrip('/')}/api/"
+        f"{config.api_version.strip('/')}/connected_accounts/link"
+    )
+    client_created = http_client is None
+    client = http_client or httpx.AsyncClient(timeout=20)
+    try:
+        response = await client.post(
+            url,
+            json=payload,
+            headers={"x-api-key": config.api_key},
+        )
+    except httpx.HTTPError:
+        return WiiiConnectComposioConnectLinkResult(
+            reason="provider_transport_error",
+        )
+    finally:
+        if client_created:
+            await client.aclose()
+
+    if response.status_code < 200 or response.status_code >= 300:
+        return WiiiConnectComposioConnectLinkResult(
+            reason="provider_response_rejected",
+        )
+
+    try:
+        data = response.json()
+    except ValueError:
+        return WiiiConnectComposioConnectLinkResult(
+            reason="provider_response_invalid",
+        )
+
+    redirect_url = str(data.get("redirect_url") or data.get("redirectUrl") or "").strip()
+    if not redirect_url:
+        return WiiiConnectComposioConnectLinkResult(
+            reason="provider_response_missing_redirect",
+        )
+    return WiiiConnectComposioConnectLinkResult(
+        ready=True,
+        redirect_url=redirect_url,
+        expires_at=str(data.get("expires_at") or data.get("expiresAt") or "").strip(),
+        connected_account_ref_present=bool(
+            data.get("connected_account_id") or data.get("connectedAccountId")
+        ),
+        reason="ready",
+    )
+
+
 def _normalize_mapping(value: Mapping[Any, Any]) -> dict[str, str]:
     result: dict[str, str] = {}
     for raw_provider, raw_auth_config in value.items():
@@ -173,10 +349,36 @@ def _normalize_provider_slug(value: Any) -> str:
     return str(value or "").strip().lower().replace("-", "_")
 
 
+def _append_unique(values: tuple[str, ...], value: str) -> tuple[str, ...]:
+    if value in values:
+        return values
+    return values + (value,)
+
+
+def _safe_connect_link_reason(value: str) -> str:
+    allowed = {
+        "ready",
+        "not_requested",
+        "provider_adapter_not_configured",
+        "missing_user_or_callback",
+        "provider_transport_error",
+        "provider_response_rejected",
+        "provider_response_invalid",
+        "provider_response_missing_redirect",
+    }
+    reason = str(value or "").strip()
+    return reason if reason in allowed else "provider_response_unavailable"
+
+
 __all__ = [
     "WIII_CONNECT_COMPOSIO_ADAPTER_VERSION",
     "WiiiConnectComposioAdapterConfig",
+    "WiiiConnectComposioConnectLinkResult",
     "build_composio_adapter_config",
+    "build_composio_connect_enabled_entry",
+    "build_composio_external_user_id",
+    "build_composio_provider_managed_vault_capability",
     "build_composio_provider_adapter_capability",
+    "create_composio_connect_link",
     "parse_composio_auth_config_map",
 ]

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -7,12 +7,27 @@ import pytest
 from fastapi import FastAPI
 
 from app.api.v1.wiii_connect import router as wiii_connect_router
+from app.core.security import require_auth
+from app.core.security_models import AuthenticatedUser
 
 
 @pytest.fixture
 def app():
     app = FastAPI()
     app.include_router(wiii_connect_router)
+    return app
+
+
+@pytest.fixture
+def authenticated_app():
+    app = FastAPI()
+    app.include_router(wiii_connect_router)
+    app.dependency_overrides[require_auth] = lambda: AuthenticatedUser(
+        user_id="user_1",
+        auth_method="test",
+        role="admin",
+        organization_id="org_1",
+    )
     return app
 
 
@@ -111,7 +126,7 @@ async def test_wiii_connect_storage_status_api_does_not_probe_by_default(
 
 @pytest.mark.asyncio
 async def test_wiii_connect_storage_probe_is_explicit_and_privacy_safe(
-    app,
+    authenticated_app,
     monkeypatch,
 ):
     from app.api.v1 import wiii_connect as wiii_connect_api
@@ -121,6 +136,7 @@ async def test_wiii_connect_storage_probe_is_explicit_and_privacy_safe(
 
     class FakeStorage:
         calls = 0
+        audit_appends = 0
 
         def status(self, *, probe_database: bool = True):
             self.calls += 1
@@ -133,6 +149,12 @@ async def test_wiii_connect_storage_probe_is_explicit_and_privacy_safe(
                 reason="ready",
             )
 
+        def append_audit_record(self, record, *, organization_id: str, user_id: str):
+            self.audit_appends += 1
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            return True
+
     fake_storage = FakeStorage()
     monkeypatch.setattr(
         wiii_connect_api,
@@ -141,7 +163,7 @@ async def test_wiii_connect_storage_probe_is_explicit_and_privacy_safe(
     )
 
     async with httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=app),
+        transport=httpx.ASGITransport(app=authenticated_app),
         base_url="http://test",
     ) as client:
         storage_response = await client.get(
@@ -166,6 +188,7 @@ async def test_wiii_connect_storage_probe_is_explicit_and_privacy_safe(
     assert audit_response.status_code == 200
     assert authorization_response.status_code == 200
     assert fake_storage.calls == 3
+    assert fake_storage.audit_appends == 1
 
     storage_payload = storage_response.json()
     audit_payload = audit_response.json()
@@ -290,6 +313,26 @@ async def test_wiii_connect_authorization_url_api_blocks_without_leaking_secrets
                 "surface": "desktop",
                 "redirect_uri": "https://wiii.example.test/callback",
                 "state_present": True,
+            },
+        )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_authorization_url_api_blocks_without_leaking_secrets_when_authenticated(
+    authenticated_app,
+):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=authenticated_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/wiii-connect/providers/facebook/authorization-url",
+            json={
+                "surface": "desktop",
+                "redirect_uri": "https://wiii.example.test/callback",
+                "state_present": True,
                 "requested_scopes": {"read": True},
                 "request_metadata": {
                     "access_token": "secret-value",
@@ -314,9 +357,204 @@ async def test_wiii_connect_authorization_url_api_blocks_without_leaking_secrets
 
 
 @pytest.mark.asyncio
+async def test_wiii_connect_authorization_url_api_issues_sanitized_composio_link(
+    authenticated_app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+        WiiiConnectComposioConnectLinkResult,
+    )
+    from app.engine.wiii_connect.persistent_storage import (
+        WiiiConnectPersistentStorageStatus,
+    )
+
+    class FakeStorage:
+        audit_appends = 0
+
+        def status(self, *, probe_database: bool = True):
+            return WiiiConnectPersistentStorageStatus(
+                enabled=True,
+                persistent=True,
+                connection_table_ready=True,
+                audit_ledger_ready=True,
+                reason="ready",
+            )
+
+        def append_audit_record(self, record, *, organization_id: str, user_id: str):
+            self.audit_appends += 1
+            metadata = record.to_public_metadata()["metadata"]
+            serialized = json.dumps(metadata, sort_keys=True)
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert metadata["connect_link"]["ready"] is True
+            assert "link_token" not in serialized
+            assert "ca_secret" not in serialized
+            return True
+
+    fake_storage = FakeStorage()
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "build_composio_adapter_config",
+        lambda: WiiiConnectComposioAdapterConfig(
+            enabled=True,
+            api_key="secret-api-key",
+            api_key_present=True,
+            auth_config_by_provider={"facebook": "authcfg_fb"},
+        ),
+    )
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        lambda: fake_storage,
+    )
+
+    async def fake_connect_link(**kwargs):
+        assert kwargs["provider_slug"] == "facebook"
+        assert kwargs["callback_url"] == "https://wiii.example.test/callback"
+        assert kwargs["user_id"].startswith("wiii_")
+        return WiiiConnectComposioConnectLinkResult(
+            ready=True,
+            redirect_url="https://composio.example.test/connect/session",
+            connected_account_ref_present=True,
+            reason="ready",
+        )
+
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "create_composio_connect_link",
+        fake_connect_link,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=authenticated_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/wiii-connect/providers/facebook/authorization-url",
+            json={
+                "surface": "desktop",
+                "redirect_uri": "https://wiii.example.test/callback",
+                "state_present": True,
+                "probe_database": True,
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    serialized = json.dumps(payload, sort_keys=True)
+    assert payload["status"] == "ready"
+    assert payload["reason"] == "authorization_url_issued"
+    assert payload["authorization_url"] == "https://composio.example.test/connect/session"
+    assert payload["adapter"]["can_execute_actions"] is False
+    assert fake_storage.audit_appends == 1
+    assert "secret-api-key" not in serialized
+    assert "authcfg_fb" not in serialized
+    assert "link_token" not in serialized
+    assert "ca_secret" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_authorization_url_api_sanitizes_composio_failure(
+    authenticated_app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+        WiiiConnectComposioConnectLinkResult,
+    )
+    from app.engine.wiii_connect.persistent_storage import (
+        WiiiConnectPersistentStorageStatus,
+    )
+
+    class FakeStorage:
+        def status(self, *, probe_database: bool = True):
+            return WiiiConnectPersistentStorageStatus(
+                enabled=True,
+                persistent=True,
+                connection_table_ready=True,
+                audit_ledger_ready=True,
+                reason="ready",
+            )
+
+        def append_audit_record(self, record, *, organization_id: str, user_id: str):
+            serialized = json.dumps(record.to_public_metadata(), sort_keys=True)
+            assert "provider raw error with secret-api-key" not in serialized
+            return True
+
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "build_composio_adapter_config",
+        lambda: WiiiConnectComposioAdapterConfig(
+            enabled=True,
+            api_key="secret-api-key",
+            api_key_present=True,
+            auth_config_by_provider={"facebook": "authcfg_fb"},
+        ),
+    )
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        lambda: FakeStorage(),
+    )
+
+    async def fake_connect_link(**kwargs):
+        return WiiiConnectComposioConnectLinkResult(
+            ready=False,
+            reason="provider raw error with secret-api-key",
+        )
+
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "create_composio_connect_link",
+        fake_connect_link,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=authenticated_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/wiii-connect/providers/facebook/authorization-url",
+            json={
+                "surface": "desktop",
+                "redirect_uri": "https://wiii.example.test/callback",
+                "state_present": True,
+                "probe_database": True,
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    serialized = json.dumps(payload, sort_keys=True)
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "authorization_url_missing"
+    assert payload["authorization_url"] == ""
+    assert "secret-api-key" not in serialized
+    assert "provider raw error" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_wiii_connect_authorization_url_api_404_for_unknown_provider(app):
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/wiii-connect/providers/not-real/authorization-url",
+        )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_authorization_url_api_404_for_unknown_provider_when_authenticated(
+    authenticated_app,
+):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=authenticated_app),
         base_url="http://test",
     ) as client:
         response = await client.post(

--- a/maritime-ai-service/tests/unit/test_wiii_connect_provider_adapters.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_provider_adapters.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
+import httpx
+import pytest
+
 
 def test_default_provider_adapter_status_is_unbound_and_secret_free():
     from app.engine.wiii_connect.provider_adapters import (
@@ -98,6 +101,113 @@ def test_composio_adapter_config_parses_without_exposing_secret_values():
     assert metadata["config"]["auth_config_count"] == 1
     assert metadata["config"]["provider_slugs"] == ["facebook"]
     assert "secret-value" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_composio_connect_link_client_uses_v31_and_redacts_payload():
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+        create_composio_connect_link,
+    )
+
+    captured = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["api_key"] = request.headers.get("x-api-key")
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            201,
+            json={
+                "link_token": "secret-link-token",
+                "redirect_url": "https://composio.example.test/connect/session",
+                "expires_at": "2026-05-28T00:00:00Z",
+                "connected_account_id": "ca_secret",
+            },
+        )
+
+    config = WiiiConnectComposioAdapterConfig(
+        enabled=True,
+        api_key="secret-api-key",
+        api_key_present=True,
+        base_url="https://backend.composio.dev",
+        api_version="v3.1",
+        auth_config_by_provider={"facebook": "authcfg_fb"},
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await create_composio_connect_link(
+            config=config,
+            provider_slug="facebook",
+            user_id="wiii_user_hash",
+            callback_url="https://wiii.example.test/callback",
+            http_client=client,
+        )
+
+    metadata = result.to_audit_metadata()
+    serialized = json.dumps(
+        {"metadata": metadata, "public_config": config.to_public_metadata()},
+        sort_keys=True,
+    )
+
+    assert captured["url"] == (
+        "https://backend.composio.dev/api/v3.1/connected_accounts/link"
+    )
+    assert captured["api_key"] == "secret-api-key"
+    assert captured["body"] == {
+        "auth_config_id": "authcfg_fb",
+        "user_id": "wiii_user_hash",
+        "callback_url": "https://wiii.example.test/callback",
+    }
+    assert result.ready is True
+    assert result.redirect_url == "https://composio.example.test/connect/session"
+    assert metadata["redirect_url_present"] is True
+    assert metadata["connected_account_ref_present"] is True
+    assert "secret-api-key" not in serialized
+    assert "secret-link-token" not in serialized
+    assert "ca_secret" not in serialized
+    assert "authcfg_fb" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_composio_connect_link_client_sanitizes_provider_errors():
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+        create_composio_connect_link,
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            401,
+            json={
+                "error": {
+                    "message": "Invalid API key secret-api-key",
+                    "access_token": "secret-token",
+                }
+            },
+        )
+
+    config = WiiiConnectComposioAdapterConfig(
+        enabled=True,
+        api_key="secret-api-key",
+        api_key_present=True,
+        auth_config_by_provider={"facebook": "authcfg_fb"},
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await create_composio_connect_link(
+            config=config,
+            provider_slug="facebook",
+            user_id="wiii_user_hash",
+            callback_url="https://wiii.example.test/callback",
+            http_client=client,
+        )
+
+    serialized = json.dumps(result.to_audit_metadata(), sort_keys=True)
+
+    assert result.ready is False
+    assert result.redirect_url == ""
+    assert result.reason == "provider_response_rejected"
+    assert "secret-api-key" not in serialized
+    assert "secret-token" not in serialized
 
 
 def test_provider_adapter_status_accepts_backend_capability_override():


### PR DESCRIPTION
Closes #758

## Summary
- Adds a backend-only Composio Connect Link client for POST /api/v3.1/connected_accounts/link.
- Requires Wiii auth before /wiii-connect/providers/{slug}/authorization-url can call a provider.
- Runs registry, adapter, provider-managed vault, and durable audit preflight before issuing a connect URL.
- Returns only sanitized authorization metadata and redirect URL; no API key, auth config ID, link token, connected-account ID, or raw provider error is exposed.
- Updates Wiii Connect/OpenHuman audit docs to record the adopted Connect Link pattern.

## Scope
- Backend Wiii Connect authorization URL path.
- Composio adapter config/client helpers.
- Focused unit coverage for auth, success, provider failure, redaction, and API version/path.

## Non-Scope
- No Composio action execution.
- No callback reconciliation or connection polling yet.
- No frontend connection modal in this slice.
- No real Composio secret or environment config added.

## Verification
- cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py -q --tb=short -> 23 passed.
- cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/api/test_wiii_connect_api.py -q --tb=short -> 44 passed.
- cd maritime-ai-service; python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7 -> passed.
- git diff --check -> passed.

## Risk
OAuth/provider routing is high-risk. This keeps provider calls behind Wiii auth and durable audit preflight, does not store provider tokens, and leaves action execution disabled until curated catalog/scope/gateway work lands.

## Rollback
Revert this PR. Existing status/catalog endpoints remain read-only; no migration or secret/config change is introduced.