### PR TITLE
feat(backend): reconcile Wiii Connect Composio callbacks

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -61,6 +61,7 @@ The OAuth callback/vault boundary contract lives in:
 
 ```text
 maritime-ai-service/app/engine/wiii_connect/callback_boundary.py
+maritime-ai-service/app/engine/wiii_connect/callback_state.py
 ```
 
 The vault policy and audit ledger contracts live in:
@@ -169,15 +170,27 @@ must keep that provider disabled and non-agent-ready.
 `WiiiConnectCallbackRequest`
 
 - records only callback shape: state/code/error presence and sanitized key names;
+- supports Composio Connect Link callbacks where a provider-managed connected
+  account reference is present instead of a raw OAuth code;
+- requires Wiii-owned signed callback state to be valid before accepting;
 - never returns OAuth code, state value, token, client secret, or raw provider
   payload.
 
 `WiiiConnectCallbackDecision`
 
 - returns `blocked` or `accepted`;
-- blocks disabled providers, provider errors, missing state, missing code, missing
-  vault, or missing provider adapter;
+- blocks disabled providers, provider errors, missing state, invalid state,
+  missing provider connection reference, missing vault, or missing provider
+  adapter;
 - issues a vault reference only after vault and provider adapter are both ready.
+
+`WiiiConnectCallbackStateClaims`
+
+- verifies the Wiii-owned `wiii_state` query value appended to provider callback
+  URLs;
+- binds callbacks back to the Wiii organization/user boundary without exposing
+  the raw state value in audit or public metadata;
+- rejects tampered, expired, wrong-provider, and malformed state values.
 
 `WiiiConnectVaultCapability`
 
@@ -349,14 +362,18 @@ Before real Composio OAuth is enabled:
   never call Composio directly;
 - authorization URLs must come from a bound provider adapter decision, not from
   raw frontend input or ad hoc session arguments;
+- Wiii must append signed `wiii_state` to the provider callback URL before
+  calling Composio, and callbacks must verify that state before any connection
+  upsert;
 - authorization URL decisions may consume durable audit readiness only from an
   explicit storage probe or backend-controlled storage status, never from
   frontend claims;
 - disabled providers must return a blocked decision with missing requirements;
 - missing connection requirements block OAuth/session start, while missing
   agent-ready requirements only block tool/action exposure;
-- callback handling must stay blocked until state/code validation, vault storage,
-  and provider adapter exchange are ready;
+- callback handling must stay blocked until signed state validation,
+  provider-managed connection reference or code presence, vault storage, and
+  provider adapter exchange are ready;
 - callback/webhook handling must bind provider account to Wiii org/user;
 - credential material must be stored in an encrypted vault or provider-managed
   backend secret store;

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -141,8 +141,10 @@ Before Wiii enables Composio:
 
 Wiii now has a V0 snapshot/dashboard, V1 policy contract, provider registry,
 callback/vault boundary, durable connection/audit storage, controlled storage
-probe, Composio adapter configuration status, and an authenticated Connect Link
-client path that calls Composio only after policy preflight passes. It still
-needs callback reconciliation, connection listing/polling, frontend modal UX,
-curated action catalog, execution gateway, and end-to-end browser acceptance
-before Composio actions can be enabled for real users.
+probe, Composio adapter configuration status, an authenticated Connect Link
+client path that calls Composio only after policy preflight passes, signed
+callback state, and callback reconciliation into durable Wiii connection
+records. It still needs connection listing/polling, frontend modal UX, curated
+action catalog, execution gateway hardening for real provider actions, and
+end-to-end browser acceptance before Composio actions can be enabled for real
+users.

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -7,12 +7,16 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.core.config import settings
 from app.core.security import require_auth
 from app.core.security_models import AuthenticatedUser
 from app.engine.wiii_connect import (
     WiiiConnectAuthorizationUrlRequest,
     WiiiConnectCallbackRequest,
+    WiiiConnectConnectionRecordV1,
     WiiiConnectSessionStartRequest,
+    WiiiConnectVaultSecretRef,
+    append_wiii_connect_callback_state,
     audit_ledger_status_public_metadata,
     build_audit_ledger_record,
     build_composio_adapter_config,
@@ -20,17 +24,21 @@ from app.engine.wiii_connect import (
     build_composio_external_user_id,
     build_composio_provider_managed_vault_capability,
     build_composio_provider_adapter_capability,
+    build_wiii_connect_callback_state,
     begin_connection_session,
     create_composio_connect_link,
     decide_authorization_url,
     default_persistent_storage_status_metadata,
     get_wiii_connect_provider_entry,
     get_wiii_connect_persistent_storage,
+    normalize_connection_state,
     provider_adapter_status_public_metadata,
     provider_callback_decision,
+    provider_callback_decision_for_entry,
     provider_connection_status,
     provider_registry_public_metadata,
     scope_grant_from_mapping,
+    verify_wiii_connect_callback_state,
     vault_status_public_metadata,
 )
 
@@ -156,12 +164,22 @@ async def create_wiii_connect_provider_authorization_url(
     composio_config = build_composio_adapter_config()
     effective_entry = build_composio_connect_enabled_entry(entry, composio_config)
     redirect_uri = _safe_redirect_uri(body.redirect_uri)
+    callback_state = build_wiii_connect_callback_state(
+        provider_slug=effective_entry.slug,
+        organization_id=_wiii_connect_owner_organization_id(current_user),
+        user_id=current_user.user_id,
+        secret_key=settings.session_secret_key,
+    )
+    callback_url = append_wiii_connect_callback_state(
+        redirect_uri,
+        callback_state,
+    )
     request = WiiiConnectAuthorizationUrlRequest(
         provider_slug=effective_entry.slug,
         surface=body.surface,
         requested_scopes=scope_grant_from_mapping(body.requested_scopes),
-        state_present=body.state_present,
-        redirect_uri_present=bool(redirect_uri),
+        state_present=bool(callback_state),
+        redirect_uri_present=bool(callback_url),
         request_metadata_keys=tuple(body.request_metadata.keys()),
     )
     storage = _wiii_connect_storage_status_metadata(
@@ -200,7 +218,7 @@ async def create_wiii_connect_provider_authorization_url(
             organization_id=current_user.organization_id,
             user_id=current_user.user_id,
         ),
-        callback_url=redirect_uri,
+        callback_url=callback_url,
     )
     decision = decide_authorization_url(
         effective_entry,
@@ -219,6 +237,14 @@ async def create_wiii_connect_provider_authorization_url(
             "connect_link": link.to_audit_metadata(),
         },
     )
+    if decision.ready:
+        _upsert_authorizing_connection(
+            link,
+            effective_entry,
+            request,
+            current_user=current_user,
+            storage_metadata=storage,
+        )
     return decision.to_public_metadata()
 
 
@@ -229,21 +255,69 @@ async def receive_wiii_connect_provider_callback(
     state: str | None = None,
     code: str | None = None,
     error: str | None = None,
+    connected_account_id: str | None = None,
+    status: str | None = None,
     surface: str = "desktop",
 ) -> dict[str, object]:
     """Return a fail-closed callback decision without exchanging credentials."""
 
+    entry = get_wiii_connect_provider_entry(slug)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="unknown_wiii_connect_provider")
+    composio_config = build_composio_adapter_config()
+    effective_entry = build_composio_connect_enabled_entry(entry, composio_config)
+    callback_state = state or request.query_params.get("wiii_state")
+    state_claims = verify_wiii_connect_callback_state(
+        callback_state,
+        provider_slug=effective_entry.slug,
+        secret_key=settings.session_secret_key,
+    )
+    provider_connection_id = _safe_provider_connection_id(
+        connected_account_id
+        or request.query_params.get("connection_id")
+        or request.query_params.get("connectedAccountId")
+        or request.query_params.get("id")
+    )
     callback_request = WiiiConnectCallbackRequest(
-        provider_slug=slug.strip().lower().replace("-", "_"),
+        provider_slug=effective_entry.slug,
         surface=surface,
-        state_present=bool(state),
+        state_present=bool(callback_state),
         code_present=bool(code),
+        connection_ref_present=bool(provider_connection_id),
         error_present=bool(error),
+        state_valid=state_claims.valid,
         request_metadata_keys=tuple(request.query_params.keys()),
     )
-    decision = provider_callback_decision(slug, callback_request)
-    if decision is None:
-        raise HTTPException(status_code=404, detail="unknown_wiii_connect_provider")
+    adapter_capability = build_composio_provider_adapter_capability(composio_config)
+    vault_capability = build_composio_provider_managed_vault_capability(
+        composio_config,
+    )
+    decision = provider_callback_decision_for_entry(
+        effective_entry,
+        callback_request,
+        vault_capability=vault_capability,
+        provider_adapter_bound=adapter_capability.bound,
+    )
+    storage = _wiii_connect_storage_status_metadata(probe_database=True)
+    _append_callback_audit(
+        decision,
+        storage,
+        state_claims=state_claims,
+        metadata={
+            "state": state_claims.to_audit_metadata(),
+            "provider_status_present": bool(status),
+            "provider_connection_ref_present": bool(provider_connection_id),
+        },
+    )
+    if decision.accepted:
+        _upsert_callback_connection(
+            provider_connection_id=provider_connection_id,
+            provider_status=status,
+            entry=effective_entry,
+            request=callback_request,
+            state_claims=state_claims,
+            storage_metadata=storage,
+        )
     return decision.to_public_metadata()
 
 
@@ -291,6 +365,122 @@ def _append_authorization_audit(
     )
 
 
+def _append_callback_audit(
+    decision: Any,
+    storage_metadata: dict[str, Any],
+    *,
+    state_claims: Any,
+    metadata: dict[str, Any],
+) -> None:
+    if (
+        not state_claims.valid
+        or not bool(
+            storage_metadata.get("persistent")
+            and storage_metadata.get("audit_ledger_ready")
+        )
+    ):
+        return
+    record = build_audit_ledger_record(
+        event_kind="callback",
+        provider_slug=decision.provider_slug,
+        status=decision.status,
+        reason=decision.reason,
+        surface=decision.audit_event.request.surface if decision.audit_event else "backend",
+        metadata={
+            "request": (
+                decision.audit_event.request.to_audit_metadata()
+                if decision.audit_event
+                else {}
+            ),
+            **metadata,
+        },
+    )
+    get_wiii_connect_persistent_storage().append_audit_record(
+        record,
+        organization_id=state_claims.organization_id,
+        user_id=state_claims.user_id,
+    )
+
+
+def _upsert_authorizing_connection(
+    link: Any,
+    entry: Any,
+    request: WiiiConnectAuthorizationUrlRequest,
+    *,
+    current_user: AuthenticatedUser,
+    storage_metadata: dict[str, Any],
+) -> None:
+    connection_id = _safe_provider_connection_id(
+        getattr(link, "connected_account_id", ""),
+    )
+    if not connection_id or not _connection_storage_ready(storage_metadata):
+        return
+    connection = WiiiConnectConnectionRecordV1(
+        connection_id=connection_id,
+        provider_slug=entry.slug,
+        state="authorizing",
+        scopes=request.requested_scopes,
+        vault_ref=WiiiConnectVaultSecretRef(
+            provider_slug=entry.slug,
+            connection_id=connection_id,
+            vault_key_id=f"provider-managed://composio/{connection_id}",
+            secret_version="provider_managed",
+        ),
+        reason="connect_link_issued",
+        warnings=("awaiting_provider_callback_or_poll",),
+    )
+    get_wiii_connect_persistent_storage().upsert_connection_record(
+        connection,
+        organization_id=_wiii_connect_owner_organization_id(current_user),
+        user_id=current_user.user_id,
+        provider_kind=entry.provider_kind,
+    )
+
+
+def _upsert_callback_connection(
+    *,
+    provider_connection_id: str,
+    provider_status: str | None,
+    entry: Any,
+    request: WiiiConnectCallbackRequest,
+    state_claims: Any,
+    storage_metadata: dict[str, Any],
+) -> None:
+    if not provider_connection_id or not _connection_storage_ready(storage_metadata):
+        return
+    provider_state = provider_status or "PENDING"
+    connection = WiiiConnectConnectionRecordV1(
+        connection_id=provider_connection_id,
+        provider_slug=entry.slug,
+        state=normalize_connection_state(provider_state),
+        scopes=scope_grant_from_mapping({"read": True}),
+        vault_ref=WiiiConnectVaultSecretRef(
+            provider_slug=entry.slug,
+            connection_id=provider_connection_id,
+            vault_key_id=f"provider-managed://composio/{provider_connection_id}",
+            secret_version="provider_managed",
+        ),
+        reason=f"callback_{request.surface}",
+        warnings=()
+        if normalize_connection_state(provider_state) == "connected"
+        else ("awaiting_connection_poll",),
+    )
+    get_wiii_connect_persistent_storage().upsert_connection_record(
+        connection,
+        organization_id=state_claims.organization_id,
+        user_id=state_claims.user_id,
+        provider_kind=entry.provider_kind,
+    )
+
+
+def _connection_storage_ready(storage_metadata: dict[str, Any]) -> bool:
+    return bool(
+        storage_metadata.get("persistent")
+        and storage_metadata.get("connection_table_ready")
+        and storage_metadata.get("audit_ledger_ready")
+    )
+
+
 def _wiii_connect_owner_organization_id(user: AuthenticatedUser) -> str:
     if user.organization_id:
         return user.organization_id
@@ -305,3 +495,12 @@ def _safe_redirect_uri(value: str | None) -> str:
     if text.startswith(("https://", "http://")):
         return text
     return ""
+
+
+def _safe_provider_connection_id(value: str | None) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if any(marker in text.lower() for marker in ("token", "secret", "password")):
+        return ""
+    return text[:160]

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -29,6 +29,14 @@ from .callback_boundary import (
     provider_callback_decision,
     provider_callback_decision_for_entry,
 )
+from .callback_state import (
+    WIII_CONNECT_CALLBACK_STATE_PARAM,
+    WIII_CONNECT_CALLBACK_STATE_VERSION,
+    WiiiConnectCallbackStateClaims,
+    append_wiii_connect_callback_state,
+    build_wiii_connect_callback_state,
+    verify_wiii_connect_callback_state,
+)
 from .composio_adapter import (
     WIII_CONNECT_COMPOSIO_ADAPTER_VERSION,
     WiiiConnectComposioAdapterConfig,
@@ -98,6 +106,8 @@ __all__ = [
     "WIII_CONNECT_ADAPTER_VERSION",
     "WIII_CONNECT_AUDIT_LEDGER_VERSION",
     "WIII_CONNECT_CALLBACK_CONTRACT_VERSION",
+    "WIII_CONNECT_CALLBACK_STATE_PARAM",
+    "WIII_CONNECT_CALLBACK_STATE_VERSION",
     "WIII_CONNECT_COMPOSIO_ADAPTER_VERSION",
     "WIII_CONNECT_PROVIDER_ADAPTER_VERSION",
     "WIII_CONNECT_PERSISTENT_STORAGE_VERSION",
@@ -111,6 +121,7 @@ __all__ = [
     "WiiiConnectCallbackAuditEvent",
     "WiiiConnectCallbackDecision",
     "WiiiConnectCallbackRequest",
+    "WiiiConnectCallbackStateClaims",
     "WiiiConnectComposioAdapterConfig",
     "WiiiConnectComposioConnectLinkResult",
     "WiiiConnectConnectionSessionAuditEvent",
@@ -139,6 +150,7 @@ __all__ = [
     "WiiiConnectionSnapshot",
     "WiiiPathCapabilityRecord",
     "audit_ledger_status_public_metadata",
+    "append_wiii_connect_callback_state",
     "begin_connection_session",
     "build_composio_adapter_config",
     "build_composio_provider_adapter_capability",
@@ -150,6 +162,7 @@ __all__ = [
     "build_composio_connect_enabled_entry",
     "build_composio_external_user_id",
     "build_composio_provider_managed_vault_capability",
+    "build_wiii_connect_callback_state",
     "default_provider_adapter_capability",
     "default_persistent_storage_status_metadata",
     "default_wiii_connect_vault_capability",
@@ -167,5 +180,6 @@ __all__ = [
     "provider_registry_public_metadata",
     "create_composio_connect_link",
     "scope_grant_from_mapping",
+    "verify_wiii_connect_callback_state",
     "vault_status_public_metadata",
 ]

--- a/maritime-ai-service/app/engine/wiii_connect/callback_boundary.py
+++ b/maritime-ai-service/app/engine/wiii_connect/callback_boundary.py
@@ -23,7 +23,9 @@ CallbackDecisionReason = Literal[
     "provider_disabled",
     "provider_error",
     "missing_state",
+    "invalid_state",
     "missing_code",
+    "missing_connection_ref",
     "vault_not_configured",
     "provider_adapter_not_bound",
     "accepted",
@@ -40,7 +42,9 @@ class WiiiConnectCallbackRequest:
     surface: str = "desktop"
     state_present: bool = False
     code_present: bool = False
+    connection_ref_present: bool = False
     error_present: bool = False
+    state_valid: bool = False
     request_metadata_keys: tuple[str, ...] = ()
 
     def to_audit_metadata(self) -> dict[str, Any]:
@@ -49,7 +53,9 @@ class WiiiConnectCallbackRequest:
             "surface": self.surface,
             "state_present": self.state_present,
             "code_present": self.code_present,
+            "connection_ref_present": self.connection_ref_present,
             "error_present": self.error_present,
+            "state_valid": self.state_valid,
             "request_metadata_keys": [
                 _safe_metadata_key(key) for key in self.request_metadata_keys
             ],
@@ -175,8 +181,12 @@ def _callback_reason(
         return "provider_error"
     if not request.state_present:
         return "missing_state"
-    if not request.code_present:
+    if not request.state_valid:
+        return "invalid_state"
+    if not request.code_present and not request.connection_ref_present:
         return "missing_code"
+    if not request.connection_ref_present:
+        return "missing_connection_ref"
     if not vault_ready:
         return "vault_not_configured"
     if not provider_adapter_bound:

--- a/maritime-ai-service/app/engine/wiii_connect/callback_state.py
+++ b/maritime-ai-service/app/engine/wiii_connect/callback_state.py
@@ -1,0 +1,186 @@
+"""Signed callback state for Wiii Connect provider handoffs."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+
+WIII_CONNECT_CALLBACK_STATE_VERSION = "wiii_connect_callback_state.v1"
+WIII_CONNECT_CALLBACK_STATE_PARAM = "wiii_state"
+_MAX_STATE_AGE_SECONDS = 30 * 60
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectCallbackStateClaims:
+    """Verified Wiii-owned callback state claims."""
+
+    valid: bool = False
+    reason: str = "missing_state"
+    provider_slug: str = ""
+    organization_id: str = ""
+    user_id: str = ""
+    issued_at: int = 0
+
+    def to_audit_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_CALLBACK_STATE_VERSION,
+            "valid": self.valid,
+            "reason": self.reason,
+            "provider_slug": self.provider_slug,
+            "organization_id_present": bool(self.organization_id),
+            "user_id_present": bool(self.user_id),
+            "issued_at_present": bool(self.issued_at),
+        }
+
+
+def build_wiii_connect_callback_state(
+    *,
+    provider_slug: str,
+    organization_id: str,
+    user_id: str,
+    secret_key: str,
+    issued_at: int | None = None,
+    nonce: str | None = None,
+) -> str:
+    """Build a signed, URL-safe state value for provider callbacks."""
+
+    secret = str(secret_key or "").encode("utf-8")
+    if not secret:
+        return ""
+    payload = {
+        "v": 1,
+        "p": _normalize_slug(provider_slug),
+        "o": str(organization_id or "").strip(),
+        "u": str(user_id or "").strip(),
+        "iat": int(issued_at if issued_at is not None else time.time()),
+        "n": nonce or secrets.token_urlsafe(16),
+    }
+    if not payload["p"] or not payload["u"]:
+        return ""
+    payload_b64 = _b64encode(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    signature = _sign(payload_b64, secret)
+    return f"{payload_b64}.{signature}"
+
+
+def verify_wiii_connect_callback_state(
+    state: str | None,
+    *,
+    provider_slug: str,
+    secret_key: str,
+    now: int | None = None,
+    max_age_seconds: int = _MAX_STATE_AGE_SECONDS,
+) -> WiiiConnectCallbackStateClaims:
+    """Verify callback state without exposing the raw state value."""
+
+    text = str(state or "").strip()
+    if not text:
+        return WiiiConnectCallbackStateClaims(reason="missing_state")
+    secret = str(secret_key or "").encode("utf-8")
+    if not secret:
+        return WiiiConnectCallbackStateClaims(reason="state_secret_missing")
+    try:
+        payload_b64, signature = text.split(".", 1)
+    except ValueError:
+        return WiiiConnectCallbackStateClaims(reason="invalid_state_format")
+    expected = _sign(payload_b64, secret)
+    if not hmac.compare_digest(signature, expected):
+        return WiiiConnectCallbackStateClaims(reason="invalid_state_signature")
+    try:
+        payload = json.loads(_b64decode(payload_b64).decode("utf-8"))
+    except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
+        return WiiiConnectCallbackStateClaims(reason="invalid_state_payload")
+
+    callback_provider = _normalize_slug(payload.get("p"))
+    expected_provider = _normalize_slug(provider_slug)
+    if callback_provider != expected_provider:
+        return WiiiConnectCallbackStateClaims(
+            reason="state_provider_mismatch",
+            provider_slug=callback_provider,
+        )
+    issued_at = _safe_int(payload.get("iat"))
+    current_time = int(now if now is not None else time.time())
+    if not issued_at or issued_at > current_time + 60:
+        return WiiiConnectCallbackStateClaims(
+            reason="invalid_state_time",
+            provider_slug=callback_provider,
+        )
+    if current_time - issued_at > max_age_seconds:
+        return WiiiConnectCallbackStateClaims(
+            reason="state_expired",
+            provider_slug=callback_provider,
+            issued_at=issued_at,
+        )
+    user_id = str(payload.get("u") or "").strip()
+    if not user_id:
+        return WiiiConnectCallbackStateClaims(
+            reason="state_user_missing",
+            provider_slug=callback_provider,
+            issued_at=issued_at,
+        )
+    return WiiiConnectCallbackStateClaims(
+        valid=True,
+        reason="valid",
+        provider_slug=callback_provider,
+        organization_id=str(payload.get("o") or "").strip(),
+        user_id=user_id,
+        issued_at=issued_at,
+    )
+
+
+def append_wiii_connect_callback_state(
+    callback_url: str,
+    state: str,
+) -> str:
+    """Attach Wiii state to a callback URL without dropping existing params."""
+
+    text = str(callback_url or "").strip()
+    state_text = str(state or "").strip()
+    if not text or not state_text:
+        return text
+    parts = urlsplit(text)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query[WIII_CONNECT_CALLBACK_STATE_PARAM] = state_text
+    return urlunsplit(
+        (
+            parts.scheme,
+            parts.netloc,
+            parts.path,
+            urlencode(query),
+            parts.fragment,
+        )
+    )
+
+
+def _sign(payload_b64: str, secret: bytes) -> str:
+    digest = hmac.new(secret, payload_b64.encode("ascii"), hashlib.sha256).digest()
+    return _b64encode(digest)
+
+
+def _b64encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode((value + padding).encode("ascii"))
+
+
+def _normalize_slug(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_")
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0

--- a/maritime-ai-service/app/engine/wiii_connect/composio_adapter.py
+++ b/maritime-ai-service/app/engine/wiii_connect/composio_adapter.py
@@ -61,6 +61,7 @@ class WiiiConnectComposioConnectLinkResult:
 
     ready: bool = False
     redirect_url: str = ""
+    connected_account_id: str = field(default="", repr=False)
     expires_at: str = ""
     connected_account_ref_present: bool = False
     reason: str = "not_requested"
@@ -324,13 +325,15 @@ async def create_composio_connect_link(
         return WiiiConnectComposioConnectLinkResult(
             reason="provider_response_missing_redirect",
         )
+    connected_account_id = str(
+        data.get("connected_account_id") or data.get("connectedAccountId") or ""
+    ).strip()
     return WiiiConnectComposioConnectLinkResult(
         ready=True,
         redirect_url=redirect_url,
+        connected_account_id=connected_account_id,
         expires_at=str(data.get("expires_at") or data.get("expiresAt") or "").strip(),
-        connected_account_ref_present=bool(
-            data.get("connected_account_id") or data.get("connectedAccountId")
-        ),
+        connected_account_ref_present=bool(connected_account_id),
         reason="ready",
     )
 

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from urllib.parse import parse_qs, urlsplit
 
 import httpx
 import pytest
@@ -372,6 +373,7 @@ async def test_wiii_connect_authorization_url_api_issues_sanitized_composio_link
 
     class FakeStorage:
         audit_appends = 0
+        connection_upserts = 0
 
         def status(self, *, probe_database: bool = True):
             return WiiiConnectPersistentStorageStatus(
@@ -393,6 +395,22 @@ async def test_wiii_connect_authorization_url_api_issues_sanitized_composio_link
             assert "ca_secret" not in serialized
             return True
 
+        def upsert_connection_record(
+            self,
+            connection,
+            *,
+            organization_id: str,
+            user_id: str,
+            provider_kind: str,
+        ):
+            self.connection_upserts += 1
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert provider_kind == "composio"
+            assert connection.connection_id == "ca_123"
+            assert connection.state == "authorizing"
+            return True
+
     fake_storage = FakeStorage()
     monkeypatch.setattr(
         wiii_connect_api,
@@ -412,11 +430,16 @@ async def test_wiii_connect_authorization_url_api_issues_sanitized_composio_link
 
     async def fake_connect_link(**kwargs):
         assert kwargs["provider_slug"] == "facebook"
-        assert kwargs["callback_url"] == "https://wiii.example.test/callback"
+        callback = urlsplit(kwargs["callback_url"])
+        assert callback.scheme == "https"
+        assert callback.netloc == "wiii.example.test"
+        assert callback.path == "/callback"
+        assert "wiii_state" in parse_qs(callback.query)
         assert kwargs["user_id"].startswith("wiii_")
         return WiiiConnectComposioConnectLinkResult(
             ready=True,
             redirect_url="https://composio.example.test/connect/session",
+            connected_account_id="ca_123",
             connected_account_ref_present=True,
             reason="ready",
         )
@@ -449,6 +472,7 @@ async def test_wiii_connect_authorization_url_api_issues_sanitized_composio_link
     assert payload["authorization_url"] == "https://composio.example.test/connect/session"
     assert payload["adapter"]["can_execute_actions"] is False
     assert fake_storage.audit_appends == 1
+    assert fake_storage.connection_upserts == 1
     assert "secret-api-key" not in serialized
     assert "authcfg_fb" not in serialized
     assert "link_token" not in serialized
@@ -594,6 +618,113 @@ async def test_wiii_connect_callback_api_blocks_and_redacts_oauth_values(app):
     assert "oauth-code-value" not in serialized
     assert "client_secret" not in serialized
     assert "secret-value" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_callback_api_reconciles_signed_composio_connection(
+    app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+    from app.core.config import settings
+    from app.engine.wiii_connect.callback_state import (
+        build_wiii_connect_callback_state,
+    )
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+    )
+    from app.engine.wiii_connect.persistent_storage import (
+        WiiiConnectPersistentStorageStatus,
+    )
+
+    class FakeStorage:
+        audit_appends = 0
+        connection_upserts = 0
+
+        def status(self, *, probe_database: bool = True):
+            return WiiiConnectPersistentStorageStatus(
+                enabled=True,
+                persistent=True,
+                connection_table_ready=True,
+                audit_ledger_ready=True,
+                reason="ready",
+            )
+
+        def append_audit_record(self, record, *, organization_id: str, user_id: str):
+            self.audit_appends += 1
+            metadata = record.to_public_metadata()["metadata"]
+            serialized = json.dumps(metadata, sort_keys=True)
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert metadata["state"]["valid"] is True
+            assert "secret-state-value" not in serialized
+            return True
+
+        def upsert_connection_record(
+            self,
+            connection,
+            *,
+            organization_id: str,
+            user_id: str,
+            provider_kind: str,
+        ):
+            self.connection_upserts += 1
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert provider_kind == "composio"
+            assert connection.connection_id == "ca_123"
+            assert connection.state == "connected"
+            return True
+
+    state = build_wiii_connect_callback_state(
+        provider_slug="facebook",
+        organization_id="org_1",
+        user_id="user_1",
+        secret_key=settings.session_secret_key,
+    )
+    fake_storage = FakeStorage()
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "build_composio_adapter_config",
+        lambda: WiiiConnectComposioAdapterConfig(
+            enabled=True,
+            api_key="secret-api-key",
+            api_key_present=True,
+            auth_config_by_provider={"facebook": "authcfg_fb"},
+        ),
+    )
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        lambda: fake_storage,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/wiii-connect/providers/facebook/callback",
+            params={
+                "wiii_state": state,
+                "connected_account_id": "ca_123",
+                "status": "ACTIVE",
+                "client_secret": "secret-value",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    serialized = json.dumps(payload, sort_keys=True)
+    assert payload["status"] == "accepted"
+    assert payload["reason"] == "accepted"
+    assert payload["vault_ref_issued"] is True
+    assert fake_storage.audit_appends == 1
+    assert fake_storage.connection_upserts == 1
+    assert "secret-api-key" not in serialized
+    assert "authcfg_fb" not in serialized
+    assert "secret-value" not in serialized
+    assert state not in serialized
 
 
 @pytest.mark.asyncio

--- a/maritime-ai-service/tests/unit/test_wiii_connect_callback_boundary.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_callback_boundary.py
@@ -56,14 +56,20 @@ def test_callback_requires_state_code_vault_and_adapter_before_accepting():
     )
     missing_code = provider_callback_decision_for_entry(
         entry,
-        WiiiConnectCallbackRequest(provider_slug="internal_test", state_present=True),
+        WiiiConnectCallbackRequest(
+            provider_slug="internal_test",
+            state_present=True,
+            state_valid=True,
+        ),
     )
     missing_vault = provider_callback_decision_for_entry(
         entry,
         WiiiConnectCallbackRequest(
             provider_slug="internal_test",
             state_present=True,
+            state_valid=True,
             code_present=True,
+            connection_ref_present=True,
         ),
     )
     missing_adapter = provider_callback_decision_for_entry(
@@ -71,7 +77,9 @@ def test_callback_requires_state_code_vault_and_adapter_before_accepting():
         WiiiConnectCallbackRequest(
             provider_slug="internal_test",
             state_present=True,
+            state_valid=True,
             code_present=True,
+            connection_ref_present=True,
         ),
         vault_ready=True,
     )
@@ -80,7 +88,9 @@ def test_callback_requires_state_code_vault_and_adapter_before_accepting():
         WiiiConnectCallbackRequest(
             provider_slug="internal_test",
             state_present=True,
+            state_valid=True,
             code_present=True,
+            connection_ref_present=True,
         ),
         vault_ready=True,
         provider_adapter_bound=True,
@@ -117,7 +127,9 @@ def test_callback_accepts_vault_capability_without_boolean_override():
         WiiiConnectCallbackRequest(
             provider_slug="internal_test",
             state_present=True,
+            state_valid=True,
             code_present=True,
+            connection_ref_present=True,
         ),
         vault_capability=WiiiConnectVaultCapability(
             enabled=True,

--- a/maritime-ai-service/tests/unit/test_wiii_connect_callback_state.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_callback_state.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlsplit
+
+
+def test_callback_state_round_trip_is_signed_and_privacy_safe():
+    from app.engine.wiii_connect.callback_state import (
+        WIII_CONNECT_CALLBACK_STATE_PARAM,
+        append_wiii_connect_callback_state,
+        build_wiii_connect_callback_state,
+        verify_wiii_connect_callback_state,
+    )
+
+    state = build_wiii_connect_callback_state(
+        provider_slug="facebook",
+        organization_id="org_1",
+        user_id="user_1",
+        secret_key="test-secret-key",
+        issued_at=1_000,
+        nonce="nonce_1",
+    )
+    callback_url = append_wiii_connect_callback_state(
+        "https://wiii.example.test/callback?existing=1",
+        state,
+    )
+    params = parse_qs(urlsplit(callback_url).query)
+    claims = verify_wiii_connect_callback_state(
+        params[WIII_CONNECT_CALLBACK_STATE_PARAM][0],
+        provider_slug="facebook",
+        secret_key="test-secret-key",
+        now=1_100,
+    )
+    metadata = claims.to_audit_metadata()
+
+    assert claims.valid is True
+    assert claims.provider_slug == "facebook"
+    assert claims.organization_id == "org_1"
+    assert claims.user_id == "user_1"
+    assert params["existing"] == ["1"]
+    assert metadata["organization_id_present"] is True
+    assert metadata["user_id_present"] is True
+
+
+def test_callback_state_rejects_tamper_provider_and_expiry():
+    from app.engine.wiii_connect.callback_state import (
+        build_wiii_connect_callback_state,
+        verify_wiii_connect_callback_state,
+    )
+
+    state = build_wiii_connect_callback_state(
+        provider_slug="facebook",
+        organization_id="org_1",
+        user_id="user_1",
+        secret_key="test-secret-key",
+        issued_at=1_000,
+        nonce="nonce_1",
+    )
+    tampered = f"{state}x"
+    tampered_claims = verify_wiii_connect_callback_state(
+        tampered,
+        provider_slug="facebook",
+        secret_key="test-secret-key",
+        now=1_100,
+    )
+    mismatch = verify_wiii_connect_callback_state(
+        state,
+        provider_slug="gmail",
+        secret_key="test-secret-key",
+        now=1_100,
+    )
+    expired = verify_wiii_connect_callback_state(
+        state,
+        provider_slug="facebook",
+        secret_key="test-secret-key",
+        now=3_000,
+    )
+
+    assert tampered_claims.valid is False
+    assert tampered_claims.reason == "invalid_state_signature"
+    assert mismatch.valid is False
+    assert mismatch.reason == "state_provider_mismatch"
+    assert expired.valid is False
+    assert expired.reason == "state_expired"


### PR DESCRIPTION
Closes #760

## Summary
- Adds Wiii-owned signed callback state for Composio Connect Link handoffs.
- Appends wiii_state to callback URLs before calling Composio and verifies it on callback.
- Persists an uthorizing connection record when Composio returns a connected-account reference during link creation.
- Reconciles signed callbacks into durable Wiii connection records when provider status and storage policy pass.
- Extends callback policy to distinguish missing/invalid state and provider-managed connection refs without exposing token/raw provider payloads.

## Scope
- Backend Wiii Connect callback state and callback reconciliation.
- Durable connection/audit writes for provider-managed Composio account refs.
- Focused unit/API tests and Wiii Connect architecture docs.

## Non-Scope
- No Composio action execution.
- No frontend modal yet.
- No connection listing/polling yet.
- No provider token storage in Wiii.

## Verification
- cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_callback_state.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py -q --tb=short -> 29 passed.
- cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_callback_state.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/api/test_wiii_connect_api.py -q --tb=short -> 47 passed.
- cd maritime-ai-service; python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py tests/unit/test_wiii_connect_callback_state.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7 -> passed.
- git diff --check -> passed.

## Risk
OAuth callback reconciliation is high-risk. This PR verifies Wiii-owned signed state before binding provider callbacks to org/user, stores only provider-managed references and public vault metadata, and keeps action execution disabled.

## Rollback
Revert this PR. The prior authenticated Connect Link path remains available but callback/connection reconciliation returns to fail-closed metadata only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Adapter V1 design documentation to clarify OAuth callback validation requirements and security boundaries.
  * Enhanced audit documentation with details on signed callback state handling and connection reconciliation.

* **New Features**
  * Implemented signed callback state validation to enhance OAuth security during provider authentication flows.

* **Bug Fixes**
  * Improved callback endpoint robustness with fail-closed validation of incoming provider connections.
  * Enhanced callback request validation to properly handle both authorization codes and provider-managed connection references.

* **Tests**
  * Added comprehensive test coverage for callback state validation and signature verification.
  * Expanded callback API tests to validate connection reconciliation workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->