### PR TITLE
feat(backend): add Wiii Connect Composio connection polling

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -91,6 +91,7 @@ Current session/status API projections:
 GET  /api/v1/wiii-connect/providers/{slug}/status
 POST /api/v1/wiii-connect/providers/{slug}/sessions
 POST /api/v1/wiii-connect/providers/{slug}/authorization-url
+GET  /api/v1/wiii-connect/providers/{slug}/connections
 GET  /api/v1/wiii-connect/providers/{slug}/callback
 GET  /api/v1/wiii-connect/provider-adapters/status
 GET  /api/v1/wiii-connect/storage/status
@@ -229,10 +230,21 @@ must keep that provider disabled and non-agent-ready.
 - issues Composio hosted Connect Link URLs only through the authenticated Wiii
   backend route after registry, adapter, provider-managed vault, and durable
   audit checks pass;
+- lists Composio connected accounts only through an authenticated Wiii backend
+  route filtered by the Wiii external user ID and provider auth config;
 - hashes the Wiii org/user boundary into a stable non-PII Composio user ID;
 - redacts `link_token`, provider account IDs, API keys, auth config IDs, and raw
   provider errors from audit/public metadata;
 - still keeps action execution disabled until gateway/curated-action enablement.
+
+`WiiiConnectComposioConnectionListResult`
+
+- normalizes Composio `connected_accounts` responses into
+  `WiiiConnectConnectionRecordV1`;
+- filters calls by Wiii-owned external user ID and provider `auth_config_id`;
+- returns only connection lifecycle metadata and public vault-reference presence;
+- never returns credential state, provider raw payloads, auth config IDs, API
+  keys, or provider error bodies.
 
 `WiiiConnectAuthorizationUrlRequest`
 
@@ -360,6 +372,9 @@ Before real Composio OAuth is enabled:
 - Wiii backend must create authorization sessions with state and nonce;
 - session start must return a backend decision first, and the frontend must
   never call Composio directly;
+- connection polling must call Wiii backend only; Wiii backend may call
+  Composio `GET /api/v3.1/connected_accounts` with user/auth-config filters and
+  then upsert sanitized records into Wiii storage;
 - authorization URLs must come from a bound provider adapter decision, not from
   raw frontend input or ad hoc session arguments;
 - Wiii must append signed `wiii_state` to the provider callback URL before
@@ -404,10 +419,8 @@ approval tokens and provider payloads must remain outside chat lifecycle data.
 
 ## Next Slices
 
-1. Add callback reconciliation that maps Composio `connected_account_id` to a
-   Wiii connection record without storing provider secrets.
-2. Add frontend connection modal that uses Wiii backend routes only.
-3. Add connection polling/listing equivalent to OpenHuman `list_connections`.
-4. Add browser acceptance for connect, poll, disconnect, gated scope, and denied
+1. Add frontend connection modal that uses Wiii backend routes only.
+2. Add disconnect/delete/reconnect lifecycle controls behind the same policy.
+3. Add browser acceptance for connect, poll, disconnect, gated scope, and denied
    execute cases.
-5. Enable one low-risk read-only Composio action before any write action.
+4. Enable one low-risk read-only Composio action before any write action.

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -144,7 +144,9 @@ callback/vault boundary, durable connection/audit storage, controlled storage
 probe, Composio adapter configuration status, an authenticated Connect Link
 client path that calls Composio only after policy preflight passes, signed
 callback state, and callback reconciliation into durable Wiii connection
-records. It still needs connection listing/polling, frontend modal UX, curated
-action catalog, execution gateway hardening for real provider actions, and
-end-to-end browser acceptance before Composio actions can be enabled for real
-users.
+records. It also has an authenticated connection-listing/polling boundary that
+calls Composio `connected_accounts` only through Wiii backend and upserts
+sanitized connection records. It still needs frontend modal UX, disconnect and
+reconnect controls, curated action catalog, execution gateway hardening for
+real provider actions, and end-to-end browser acceptance before Composio actions
+can be enabled for real users.

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -31,6 +31,7 @@ from app.engine.wiii_connect import (
     default_persistent_storage_status_metadata,
     get_wiii_connect_provider_entry,
     get_wiii_connect_persistent_storage,
+    list_composio_connected_accounts,
     normalize_connection_state,
     provider_adapter_status_public_metadata,
     provider_callback_decision,
@@ -246,6 +247,71 @@ async def create_wiii_connect_provider_authorization_url(
             storage_metadata=storage,
         )
     return decision.to_public_metadata()
+
+
+@router.get("/providers/{slug}/connections")
+async def list_wiii_connect_provider_connections(
+    slug: str,
+    probe_database: bool = True,
+    current_user: AuthenticatedUser = Depends(require_auth),
+) -> dict[str, object]:
+    """List sanitized connected accounts for the authenticated Wiii user."""
+
+    entry = get_wiii_connect_provider_entry(slug)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="unknown_wiii_connect_provider")
+    composio_config = build_composio_adapter_config()
+    effective_entry = build_composio_connect_enabled_entry(entry, composio_config)
+    adapter_capability = build_composio_provider_adapter_capability(composio_config)
+    if not effective_entry.enabled or not adapter_capability.authorization_ready:
+        return {
+            "version": "wiii_connect_connection_list.v1",
+            "status": "blocked",
+            "reason": (
+                "provider_disabled"
+                if not effective_entry.enabled
+                else adapter_capability.reason
+            ),
+            "provider_slug": effective_entry.slug,
+            "provider_kind": effective_entry.provider_kind,
+            "connection_count": 0,
+            "connections": [],
+            "provider": None,
+            "storage": default_persistent_storage_status_metadata(),
+        }
+
+    provider_result = await list_composio_connected_accounts(
+        config=composio_config,
+        provider_slug=effective_entry.slug,
+        user_id=build_composio_external_user_id(
+            organization_id=current_user.organization_id,
+            user_id=current_user.user_id,
+        ),
+    )
+    storage = _wiii_connect_storage_status_metadata(
+        probe_database=probe_database,
+    )
+    if provider_result.ready:
+        _upsert_listed_connections(
+            provider_result.connections,
+            effective_entry,
+            current_user=current_user,
+            storage_metadata=storage,
+        )
+    return {
+        "version": "wiii_connect_connection_list.v1",
+        "status": "ready" if provider_result.ready else "blocked",
+        "reason": provider_result.reason,
+        "provider_slug": effective_entry.slug,
+        "provider_kind": effective_entry.provider_kind,
+        "connection_count": len(provider_result.connections),
+        "connections": [
+            connection.to_public_metadata()
+            for connection in provider_result.connections
+        ],
+        "provider": provider_result.to_public_metadata(),
+        "storage": storage,
+    }
 
 
 @router.get("/providers/{slug}/callback")
@@ -471,6 +537,25 @@ def _upsert_callback_connection(
         user_id=state_claims.user_id,
         provider_kind=entry.provider_kind,
     )
+
+
+def _upsert_listed_connections(
+    connections: tuple[WiiiConnectConnectionRecordV1, ...],
+    entry: Any,
+    *,
+    current_user: AuthenticatedUser,
+    storage_metadata: dict[str, Any],
+) -> None:
+    if not _connection_storage_ready(storage_metadata):
+        return
+    storage = get_wiii_connect_persistent_storage()
+    for connection in connections:
+        storage.upsert_connection_record(
+            connection,
+            organization_id=_wiii_connect_owner_organization_id(current_user),
+            user_id=current_user.user_id,
+            provider_kind=entry.provider_kind,
+        )
 
 
 def _connection_storage_ready(storage_metadata: dict[str, Any]) -> bool:

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -39,7 +39,9 @@ from .callback_state import (
 )
 from .composio_adapter import (
     WIII_CONNECT_COMPOSIO_ADAPTER_VERSION,
+    WIII_CONNECT_COMPOSIO_CONNECTION_LIST_VERSION,
     WiiiConnectComposioAdapterConfig,
+    WiiiConnectComposioConnectionListResult,
     WiiiConnectComposioConnectLinkResult,
     build_composio_adapter_config,
     build_composio_connect_enabled_entry,
@@ -47,6 +49,7 @@ from .composio_adapter import (
     build_composio_provider_managed_vault_capability,
     build_composio_provider_adapter_capability,
     create_composio_connect_link,
+    list_composio_connected_accounts,
     parse_composio_auth_config_map,
 )
 from .connection_sessions import (
@@ -109,6 +112,7 @@ __all__ = [
     "WIII_CONNECT_CALLBACK_STATE_PARAM",
     "WIII_CONNECT_CALLBACK_STATE_VERSION",
     "WIII_CONNECT_COMPOSIO_ADAPTER_VERSION",
+    "WIII_CONNECT_COMPOSIO_CONNECTION_LIST_VERSION",
     "WIII_CONNECT_PROVIDER_ADAPTER_VERSION",
     "WIII_CONNECT_PERSISTENT_STORAGE_VERSION",
     "WIII_CONNECT_SESSION_CONTRACT_VERSION",
@@ -123,6 +127,7 @@ __all__ = [
     "WiiiConnectCallbackRequest",
     "WiiiConnectCallbackStateClaims",
     "WiiiConnectComposioAdapterConfig",
+    "WiiiConnectComposioConnectionListResult",
     "WiiiConnectComposioConnectLinkResult",
     "WiiiConnectConnectionSessionAuditEvent",
     "WiiiConnectConnectionRecordV1",
@@ -170,6 +175,7 @@ __all__ = [
     "get_wiii_connect_persistent_storage",
     "is_connection_baseline_ready",
     "list_wiii_connect_provider_registry",
+    "list_composio_connected_accounts",
     "normalize_connection_state",
     "parse_composio_auth_config_map",
     "provider_adapter_status_public_metadata",

--- a/maritime-ai-service/app/engine/wiii_connect/composio_adapter.py
+++ b/maritime-ai-service/app/engine/wiii_connect/composio_adapter.py
@@ -14,12 +14,18 @@ from typing import Any, Mapping
 
 import httpx
 
-from .adapter_v1 import WiiiConnectProviderRegistryEntry
+from .adapter_v1 import (
+    WiiiConnectConnectionRecordV1,
+    WiiiConnectProviderRegistryEntry,
+    WiiiConnectVaultSecretRef,
+    normalize_connection_state,
+)
 from .provider_adapters import WiiiConnectProviderAdapterCapability
 from .vault import WiiiConnectVaultCapability, default_wiii_connect_vault_capability
 
 
 WIII_CONNECT_COMPOSIO_ADAPTER_VERSION = "wiii_connect_composio_adapter.v1"
+WIII_CONNECT_COMPOSIO_CONNECTION_LIST_VERSION = "wiii_connect_composio_connections.v1"
 
 
 @dataclass(frozen=True, slots=True)
@@ -73,6 +79,28 @@ class WiiiConnectComposioConnectLinkResult:
             "expires_at_present": bool(self.expires_at),
             "connected_account_ref_present": self.connected_account_ref_present,
             "reason": _safe_connect_link_reason(self.reason),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectComposioConnectionListResult:
+    """Sanitized Composio connected-account list result."""
+
+    ready: bool = False
+    reason: str = "not_requested"
+    connections: tuple[WiiiConnectConnectionRecordV1, ...] = ()
+    cursor: str = ""
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_COMPOSIO_CONNECTION_LIST_VERSION,
+            "status": "ready" if self.ready else "blocked",
+            "reason": _safe_connection_list_reason(self.reason),
+            "connection_count": len(self.connections),
+            "cursor_present": bool(self.cursor),
+            "connections": [
+                connection.to_public_metadata() for connection in self.connections
+            ],
         }
 
 
@@ -338,6 +366,78 @@ async def create_composio_connect_link(
     )
 
 
+async def list_composio_connected_accounts(
+    *,
+    config: WiiiConnectComposioAdapterConfig,
+    provider_slug: str,
+    user_id: str,
+    limit: int = 50,
+    http_client: httpx.AsyncClient | None = None,
+) -> WiiiConnectComposioConnectionListResult:
+    """List Composio connected accounts for one Wiii external user id."""
+
+    auth_config_id = config.auth_config_id_for_provider(provider_slug)
+    if not config.enabled or not config.api_key_present or not auth_config_id:
+        return WiiiConnectComposioConnectionListResult(
+            reason="provider_adapter_not_configured",
+        )
+    if not user_id:
+        return WiiiConnectComposioConnectionListResult(reason="missing_user")
+
+    url = (
+        f"{config.base_url.rstrip('/')}/api/"
+        f"{config.api_version.strip('/')}/connected_accounts"
+    )
+    params: list[tuple[str, str | int]] = [
+        ("user_ids", user_id),
+        ("auth_config_ids", auth_config_id),
+        ("limit", max(1, min(int(limit or 50), 100))),
+    ]
+    client_created = http_client is None
+    client = http_client or httpx.AsyncClient(timeout=20)
+    try:
+        response = await client.get(
+            url,
+            params=params,
+            headers={"x-api-key": config.api_key},
+        )
+    except httpx.HTTPError:
+        return WiiiConnectComposioConnectionListResult(
+            reason="provider_transport_error",
+        )
+    finally:
+        if client_created:
+            await client.aclose()
+
+    if response.status_code < 200 or response.status_code >= 300:
+        return WiiiConnectComposioConnectionListResult(
+            reason="provider_response_rejected",
+        )
+    try:
+        data = response.json()
+    except ValueError:
+        return WiiiConnectComposioConnectionListResult(
+            reason="provider_response_invalid",
+        )
+
+    connections = tuple(
+        connection
+        for connection in (
+            _connection_record_from_composio_account(provider_slug, account)
+            for account in _extract_connection_items(data)
+        )
+        if connection is not None
+    )
+    return WiiiConnectComposioConnectionListResult(
+        ready=True,
+        reason="ready",
+        connections=connections,
+        cursor=str(data.get("cursor") or data.get("next_cursor") or "").strip()
+        if isinstance(data, dict)
+        else "",
+    )
+
+
 def _normalize_mapping(value: Mapping[Any, Any]) -> dict[str, str]:
     result: dict[str, str] = {}
     for raw_provider, raw_auth_config in value.items():
@@ -358,6 +458,52 @@ def _append_unique(values: tuple[str, ...], value: str) -> tuple[str, ...]:
     return values + (value,)
 
 
+def _connection_record_from_composio_account(
+    provider_slug: str,
+    account: Any,
+) -> WiiiConnectConnectionRecordV1 | None:
+    if not isinstance(account, Mapping):
+        return None
+    connection_id = str(
+        account.get("id")
+        or account.get("nanoid")
+        or account.get("nanoId")
+        or account.get("connected_account_id")
+        or account.get("connectedAccountId")
+        or ""
+    ).strip()
+    if not connection_id:
+        return None
+    status = str(account.get("status") or "").strip()
+    return WiiiConnectConnectionRecordV1(
+        connection_id=connection_id,
+        provider_slug=_normalize_provider_slug(provider_slug),
+        state=normalize_connection_state(status),
+        vault_ref=WiiiConnectVaultSecretRef(
+            provider_slug=_normalize_provider_slug(provider_slug),
+            connection_id=connection_id,
+            vault_key_id=f"provider-managed://composio/{connection_id}",
+            secret_version="provider_managed",
+        ),
+        reason="provider_connection_list",
+        warnings=()
+        if normalize_connection_state(status) == "connected"
+        else ("provider_status_not_active",),
+    )
+
+
+def _extract_connection_items(data: Any) -> list[Any]:
+    if isinstance(data, list):
+        return data
+    if not isinstance(data, Mapping):
+        return []
+    for key in ("items", "data", "connected_accounts", "connectedAccounts", "connections"):
+        value = data.get(key)
+        if isinstance(value, list):
+            return value
+    return []
+
+
 def _safe_connect_link_reason(value: str) -> str:
     allowed = {
         "ready",
@@ -373,9 +519,25 @@ def _safe_connect_link_reason(value: str) -> str:
     return reason if reason in allowed else "provider_response_unavailable"
 
 
+def _safe_connection_list_reason(value: str) -> str:
+    allowed = {
+        "ready",
+        "not_requested",
+        "provider_adapter_not_configured",
+        "missing_user",
+        "provider_transport_error",
+        "provider_response_rejected",
+        "provider_response_invalid",
+    }
+    reason = str(value or "").strip()
+    return reason if reason in allowed else "provider_response_unavailable"
+
+
 __all__ = [
     "WIII_CONNECT_COMPOSIO_ADAPTER_VERSION",
+    "WIII_CONNECT_COMPOSIO_CONNECTION_LIST_VERSION",
     "WiiiConnectComposioAdapterConfig",
+    "WiiiConnectComposioConnectionListResult",
     "WiiiConnectComposioConnectLinkResult",
     "build_composio_adapter_config",
     "build_composio_connect_enabled_entry",
@@ -383,5 +545,6 @@ __all__ = [
     "build_composio_provider_managed_vault_capability",
     "build_composio_provider_adapter_capability",
     "create_composio_connect_link",
+    "list_composio_connected_accounts",
     "parse_composio_auth_config_map",
 ]

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -561,6 +561,121 @@ async def test_wiii_connect_authorization_url_api_sanitizes_composio_failure(
 
 
 @pytest.mark.asyncio
+async def test_wiii_connect_connections_api_requires_auth(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/wiii-connect/providers/facebook/connections")
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_connections_api_lists_and_persists_safely(
+    authenticated_app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+    from app.engine.wiii_connect.adapter_v1 import WiiiConnectConnectionRecordV1
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+        WiiiConnectComposioConnectionListResult,
+    )
+    from app.engine.wiii_connect.persistent_storage import (
+        WiiiConnectPersistentStorageStatus,
+    )
+
+    class FakeStorage:
+        upserts = 0
+
+        def status(self, *, probe_database: bool = True):
+            return WiiiConnectPersistentStorageStatus(
+                enabled=True,
+                persistent=True,
+                connection_table_ready=True,
+                audit_ledger_ready=True,
+                reason="ready",
+            )
+
+        def upsert_connection_record(
+            self,
+            connection,
+            *,
+            organization_id: str,
+            user_id: str,
+            provider_kind: str,
+        ):
+            self.upserts += 1
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert provider_kind == "composio"
+            assert connection.connection_id == "ca_active"
+            return True
+
+    fake_storage = FakeStorage()
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "build_composio_adapter_config",
+        lambda: WiiiConnectComposioAdapterConfig(
+            enabled=True,
+            api_key="secret-api-key",
+            api_key_present=True,
+            auth_config_by_provider={"facebook": "authcfg_fb"},
+        ),
+    )
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        lambda: fake_storage,
+    )
+
+    async def fake_list_connections(**kwargs):
+        assert kwargs["provider_slug"] == "facebook"
+        assert kwargs["user_id"].startswith("wiii_")
+        return WiiiConnectComposioConnectionListResult(
+            ready=True,
+            reason="ready",
+            connections=(
+                WiiiConnectConnectionRecordV1(
+                    connection_id="ca_active",
+                    provider_slug="facebook",
+                    state="connected",
+                    reason="provider_connection_list",
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "list_composio_connected_accounts",
+        fake_list_connections,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=authenticated_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/wiii-connect/providers/facebook/connections",
+            params={"probe_database": "true"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    serialized = json.dumps(payload, sort_keys=True)
+    assert payload["status"] == "ready"
+    assert payload["reason"] == "ready"
+    assert payload["connection_count"] == 1
+    assert payload["connections"][0]["connection_id"] == "ca_active"
+    assert payload["connections"][0]["state"] == "connected"
+    assert fake_storage.upserts == 1
+    assert "secret-api-key" not in serialized
+    assert "authcfg_fb" not in serialized
+    assert "access_token" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_wiii_connect_authorization_url_api_404_for_unknown_provider(app):
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app),

--- a/maritime-ai-service/tests/unit/test_wiii_connect_provider_adapters.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_provider_adapters.py
@@ -210,6 +210,104 @@ async def test_composio_connect_link_client_sanitizes_provider_errors():
     assert "secret-token" not in serialized
 
 
+@pytest.mark.asyncio
+async def test_composio_connection_list_client_filters_and_sanitizes_accounts():
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+        list_composio_connected_accounts,
+    )
+
+    captured = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["api_key"] = request.headers.get("x-api-key")
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "id": "ca_active",
+                        "status": "ACTIVE",
+                        "state": {"val": {"access_token": "secret-token"}},
+                    },
+                    {
+                        "id": "ca_pending",
+                        "status": "INITIATED",
+                        "state": {"val": {"refresh_token": "secret-token"}},
+                    },
+                ],
+                "cursor": "secret-cursor-value",
+            },
+        )
+
+    config = WiiiConnectComposioAdapterConfig(
+        enabled=True,
+        api_key="secret-api-key",
+        api_key_present=True,
+        auth_config_by_provider={"facebook": "authcfg_fb"},
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await list_composio_connected_accounts(
+            config=config,
+            provider_slug="facebook",
+            user_id="wiii_user_hash",
+            http_client=client,
+        )
+
+    public = result.to_public_metadata()
+    serialized = json.dumps(public, sort_keys=True)
+
+    assert captured["url"].startswith(
+        "https://backend.composio.dev/api/v3.1/connected_accounts?"
+    )
+    assert "user_ids=wiii_user_hash" in captured["url"]
+    assert "auth_config_ids=authcfg_fb" in captured["url"]
+    assert captured["api_key"] == "secret-api-key"
+    assert result.ready is True
+    assert public["connection_count"] == 2
+    assert public["connections"][0]["connection_id"] == "ca_active"
+    assert public["connections"][0]["state"] == "connected"
+    assert public["connections"][1]["state"] == "waiting"
+    assert "secret-api-key" not in serialized
+    assert "secret-token" not in serialized
+    assert "secret-cursor-value" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_composio_connection_list_client_sanitizes_provider_errors():
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+        list_composio_connected_accounts,
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            401,
+            json={"error": {"message": "Invalid key secret-api-key"}},
+        )
+
+    config = WiiiConnectComposioAdapterConfig(
+        enabled=True,
+        api_key="secret-api-key",
+        api_key_present=True,
+        auth_config_by_provider={"facebook": "authcfg_fb"},
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await list_composio_connected_accounts(
+            config=config,
+            provider_slug="facebook",
+            user_id="wiii_user_hash",
+            http_client=client,
+        )
+
+    serialized = json.dumps(result.to_public_metadata(), sort_keys=True)
+
+    assert result.ready is False
+    assert result.reason == "provider_response_rejected"
+    assert "secret-api-key" not in serialized
+
+
 def test_provider_adapter_status_accepts_backend_capability_override():
     from app.engine.wiii_connect.provider_adapters import (
         WiiiConnectProviderAdapterCapability,


### PR DESCRIPTION
Closes #762

## Summary
- Adds a backend-only Composio connected_accounts listing client filtered by Wiii external user ID and provider auth config.
- Adds authenticated GET /wiii-connect/providers/{slug}/connections for OpenHuman-style connection polling.
- Normalizes Composio statuses into Wiii connection lifecycle states and upserts sanitized records into durable storage when available.
- Returns only privacy-safe connection metadata; no API key, auth config ID, credential state, cursor value, token, or raw provider error body.
- Keeps action execution disabled.

## Scope
- Backend Wiii Connect connection listing/polling.
- Composio adapter list client and API projection.
- Focused unit/API tests and architecture/audit docs.

## Non-Scope
- No frontend modal yet.
- No disconnect/delete/reconnect controls yet.
- No Composio action execution.

## Verification
- cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py -q --tb=short -> 28 passed.
- cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_callback_state.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/api/test_wiii_connect_api.py -q --tb=short -> 51 passed.
- cd maritime-ai-service; python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py tests/unit/test_wiii_connect_callback_state.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7 -> passed.
- git diff --check -> passed.

## Risk
Connection polling touches provider account metadata and tenant boundaries. The endpoint requires Wiii auth, filters provider calls by Wiii-owned external user ID and auth config, persists only sanitized connection metadata, and does not expose action schemas or execute provider actions.

## Rollback
Revert this PR. Connect Link and callback reconciliation remain, but live connection polling returns to unavailable until this route is reintroduced.