### PR TITLE
Add Wiii Connect authorization UI

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -104,6 +104,13 @@ inventing a separate external-provider source of truth. Until a provider has
 OAuth, vault, scoped action catalog, gateway, and audit support, the registry
 must keep that provider disabled and non-agent-ready.
 
+The desktop Wiii Connect page now consumes the authenticated backend
+authorization and connection-list endpoints for backend registry providers. It
+opens only backend-issued Connect Links, polls sanitized connection records
+through Wiii, and still keeps provider connection state separate from
+`agent_ready` execution state. The frontend never calls Composio directly and
+never receives provider tokens or raw payloads.
+
 ## Core Entities
 
 `WiiiConnectProviderRegistryEntry`
@@ -419,8 +426,7 @@ approval tokens and provider payloads must remain outside chat lifecycle data.
 
 ## Next Slices
 
-1. Add frontend connection modal that uses Wiii backend routes only.
-2. Add disconnect/delete/reconnect lifecycle controls behind the same policy.
-3. Add browser acceptance for connect, poll, disconnect, gated scope, and denied
+1. Add disconnect/delete/reconnect lifecycle controls behind the same policy.
+2. Add browser acceptance for disconnect, gated scope, and denied
    execute cases.
-4. Enable one low-risk read-only Composio action before any write action.
+3. Enable one low-risk read-only Composio action before any write action.

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -146,7 +146,10 @@ client path that calls Composio only after policy preflight passes, signed
 callback state, and callback reconciliation into durable Wiii connection
 records. It also has an authenticated connection-listing/polling boundary that
 calls Composio `connected_accounts` only through Wiii backend and upserts
-sanitized connection records. It still needs frontend modal UX, disconnect and
-reconnect controls, curated action catalog, execution gateway hardening for
-real provider actions, and end-to-end browser acceptance before Composio actions
-can be enabled for real users.
+sanitized connection records. The desktop Wiii Connect page can now start a
+backend-owned Connect Link, open only backend-issued URLs, refresh/poll
+sanitized provider connection records, and show connection state separately from
+agent-ready execution state. It still needs disconnect and reconnect controls,
+curated action catalog, execution gateway hardening for real provider actions,
+and end-to-end acceptance against real Composio credentials before Composio
+actions can be enabled for real users.

--- a/wiii-desktop/src/__tests__/wiii-connect-page.test.tsx
+++ b/wiii-desktop/src/__tests__/wiii-connect-page.test.tsx
@@ -1,6 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  buildWiiiConnectProviderCallbackUrl,
+  createWiiiConnectProviderAuthorizationUrl,
+  fetchWiiiConnectProviderConnections,
   fetchWiiiConnectProviders,
   startWiiiConnectProviderSession,
 } from "@/api/wiii-connect";
@@ -11,10 +14,20 @@ import { useHostContextStore } from "@/stores/host-context-store";
 import { useUIStore } from "@/stores/ui-store";
 
 vi.mock("@/api/wiii-connect", () => ({
+  buildWiiiConnectProviderCallbackUrl: vi.fn(),
+  createWiiiConnectProviderAuthorizationUrl: vi.fn(),
+  fetchWiiiConnectProviderConnections: vi.fn(),
   fetchWiiiConnectProviders: vi.fn(),
   startWiiiConnectProviderSession: vi.fn(),
 }));
 
+vi.mock("@tauri-apps/plugin-shell", () => ({
+  open: vi.fn().mockRejectedValue(new Error("no tauri runtime")),
+}));
+
+const mockBuildWiiiConnectProviderCallbackUrl = vi.mocked(buildWiiiConnectProviderCallbackUrl);
+const mockCreateWiiiConnectProviderAuthorizationUrl = vi.mocked(createWiiiConnectProviderAuthorizationUrl);
+const mockFetchWiiiConnectProviderConnections = vi.mocked(fetchWiiiConnectProviderConnections);
 const mockFetchWiiiConnectProviders = vi.mocked(fetchWiiiConnectProviders);
 const mockStartWiiiConnectProviderSession = vi.mocked(startWiiiConnectProviderSession);
 
@@ -22,6 +35,12 @@ describe("WiiiConnectPage", () => {
   beforeEach(() => {
     mockFetchWiiiConnectProviders.mockReset();
     mockFetchWiiiConnectProviders.mockRejectedValue(new Error("offline"));
+    mockBuildWiiiConnectProviderCallbackUrl.mockReset();
+    mockBuildWiiiConnectProviderCallbackUrl.mockReturnValue("http://localhost:8080/api/v1/wiii-connect/providers/facebook/callback");
+    mockCreateWiiiConnectProviderAuthorizationUrl.mockReset();
+    mockCreateWiiiConnectProviderAuthorizationUrl.mockRejectedValue(new Error("offline"));
+    mockFetchWiiiConnectProviderConnections.mockReset();
+    mockFetchWiiiConnectProviderConnections.mockRejectedValue(new Error("offline"));
     mockStartWiiiConnectProviderSession.mockReset();
     mockStartWiiiConnectProviderSession.mockRejectedValue(new Error("offline"));
     useHostContextStore.getState().clear();
@@ -149,7 +168,7 @@ describe("WiiiConnectPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Composio/i }));
     expect(screen.getByRole("button", { name: /Facebook/i })).toBeTruthy();
-    expect(screen.getAllByText("Chưa bật").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Chưa nối").length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole("button", { name: /Facebook/i }));
     expect(screen.getByText("Token vault")).toBeTruthy();
@@ -246,7 +265,7 @@ describe("WiiiConnectPage", () => {
     expect(await screen.findByText("Registry backend")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: /Composio/i }));
     fireEvent.click(screen.getByRole("button", { name: /Facebook/i }));
-    fireEvent.click(screen.getByRole("button", { name: "Kiểm tra khả năng kết nối" }));
+    fireEvent.click(screen.getByRole("button", { name: "Kiểm tra policy" }));
 
     expect(mockStartWiiiConnectProviderSession).toHaveBeenCalledWith("facebook", {
       surface: "desktop",
@@ -262,5 +281,111 @@ describe("WiiiConnectPage", () => {
     expect(screen.getByText("Không phát hành")).toBeTruthy();
     expect(screen.queryByText("access_token")).toBeNull();
     expect(screen.queryByText("secret-value")).toBeNull();
+  });
+
+  it("starts backend-owned authorization and renders sanitized provider connections", async () => {
+    mockFetchWiiiConnectProviders.mockResolvedValue({
+      version: "wiii_connect_provider_registry.v1",
+      adapter_version: "wiii_connect_adapter.v1",
+      providers: [
+        {
+          slug: "facebook",
+          label: "Facebook",
+          provider_kind: "composio",
+          auth_mode: "oauth2",
+          enabled: true,
+          agent_ready: false,
+          category: "social",
+          description: "Facebook provider from backend registry.",
+          requirements: ["curated_action_catalog"],
+          connect_requirements: ["provider_managed_vault_ref", "durable_audit_ledger"],
+          agent_ready_requirements: ["execution_gateway"],
+          action_count: 0,
+        },
+      ],
+    });
+    mockCreateWiiiConnectProviderAuthorizationUrl.mockResolvedValue({
+      version: "wiii_connect_provider_adapter.v1",
+      status: "ready",
+      reason: "authorization_url_issued",
+      provider_slug: "facebook",
+      label: "Facebook",
+      provider_kind: "composio",
+      auth_mode: "oauth2",
+      authorization_url: "https://composio.example/connect/safe",
+      adapter: {
+        version: "wiii_connect_provider_adapter.v1",
+        provider_kind: "composio",
+        adapter_name: "composio",
+        bound: true,
+        configured: true,
+        can_create_authorization_url: true,
+        can_exchange_callback: true,
+        can_execute_actions: false,
+        authorization_ready: true,
+        reason: "configured",
+        warnings: [],
+      },
+      required_next: [],
+      audit_event: null,
+    });
+    mockFetchWiiiConnectProviderConnections.mockResolvedValue({
+      version: "wiii_connect_connection_list.v1",
+      status: "ready",
+      reason: "listed",
+      provider_slug: "facebook",
+      provider_kind: "composio",
+      connection_count: 1,
+      connections: [
+        {
+          version: "wiii_connect_adapter.v1",
+          connection_id: "conn_public_1",
+          provider_slug: "facebook",
+          state: "connected",
+          active: true,
+          scopes: { read: true, write: false },
+          vault_ref_present: true,
+          account_label: "Wiii Facebook Page",
+          external_account_ref: "fb_page_public",
+          last_checked_at: "2026-05-28T00:00:00Z",
+          reason: "provider_listed",
+          warnings: [],
+        },
+      ],
+      provider: { status: "ready" },
+      storage: { persistent: true },
+    });
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(<WiiiConnectPage />);
+
+    expect(await screen.findByText("Registry backend")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Composio/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Facebook/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Kết nối qua Wiii" }));
+
+    expect(await screen.findByText("Connect Link backend")).toBeTruthy();
+    expect(mockCreateWiiiConnectProviderAuthorizationUrl).toHaveBeenCalledWith("facebook", {
+      surface: "desktop",
+      redirect_uri: "http://localhost:8080/api/v1/wiii-connect/providers/facebook/callback",
+      probe_database: true,
+      requested_scopes: { read: true },
+      request_metadata: {
+        source: "wiii_connect_page",
+        provider: "composio",
+      },
+    });
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://composio.example/connect/safe",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(await screen.findByText("Connection thật")).toBeTruthy();
+    expect(screen.getAllByText("Wiii Facebook Page").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Đã kết nối").length).toBeGreaterThan(0);
+    expect(screen.queryByText("access_token")).toBeNull();
+    expect(screen.queryByText("secret-value")).toBeNull();
+
+    openSpy.mockRestore();
   });
 });

--- a/wiii-desktop/src/api/types.ts
+++ b/wiii-desktop/src/api/types.ts
@@ -465,6 +465,8 @@ export interface WiiiConnectProviderRegistryEntry {
   allowed_paths?: string[];
   action_count?: number;
   requirements?: string[];
+  connect_requirements?: string[];
+  agent_ready_requirements?: string[];
   required_fields?: Array<Record<string, unknown>>;
   default_scopes?: Record<string, boolean>;
   source?: string;
@@ -494,6 +496,7 @@ export interface WiiiConnectProviderConnectionStatus {
 export interface WiiiConnectSessionStartBody {
   surface?: string;
   redirect_uri?: string | null;
+  probe_database?: boolean;
   requested_scopes?: Record<string, boolean>;
   request_metadata?: Record<string, unknown>;
 }
@@ -523,6 +526,61 @@ export interface WiiiConnectSessionStartDecision {
   authorization_url?: string;
   required_next?: string[];
   audit_event?: WiiiConnectSessionAuditEvent | null;
+}
+
+export interface WiiiConnectProviderAdapterCapability {
+  version: string;
+  provider_kind: string;
+  adapter_name: string;
+  bound: boolean;
+  configured: boolean;
+  can_create_authorization_url: boolean;
+  can_exchange_callback: boolean;
+  can_execute_actions: boolean;
+  authorization_ready: boolean;
+  reason: string;
+  warnings?: string[];
+}
+
+export interface WiiiConnectAuthorizationUrlDecision {
+  version: string;
+  status: "blocked" | "ready" | string;
+  reason: string;
+  provider_slug: string;
+  label: string;
+  provider_kind: string;
+  auth_mode: string;
+  authorization_url?: string;
+  adapter?: WiiiConnectProviderAdapterCapability | null;
+  required_next?: string[];
+  audit_event?: WiiiConnectSessionAuditEvent | null;
+}
+
+export interface WiiiConnectProviderConnectionRecord {
+  version: string;
+  connection_id: string;
+  provider_slug: string;
+  state: string;
+  active?: boolean;
+  scopes?: Record<string, boolean>;
+  vault_ref_present?: boolean;
+  account_label?: string;
+  external_account_ref?: string;
+  last_checked_at?: string | null;
+  reason?: string;
+  warnings?: string[];
+}
+
+export interface WiiiConnectProviderConnectionListResponse {
+  version: string;
+  status: "blocked" | "ready" | string;
+  reason: string;
+  provider_slug: string;
+  provider_kind: string;
+  connection_count: number;
+  connections: WiiiConnectProviderConnectionRecord[];
+  provider?: Record<string, unknown> | null;
+  storage?: Record<string, unknown> | null;
 }
 
 export interface SSEChatLifecycleEvent {

--- a/wiii-desktop/src/api/wiii-connect.ts
+++ b/wiii-desktop/src/api/wiii-connect.ts
@@ -1,5 +1,7 @@
 import { getClient } from "./client";
 import type {
+  WiiiConnectAuthorizationUrlDecision,
+  WiiiConnectProviderConnectionListResponse,
   WiiiConnectProviderConnectionStatus,
   WiiiConnectProviderRegistryResponse,
   WiiiConnectSessionStartBody,
@@ -25,5 +27,33 @@ export async function startWiiiConnectProviderSession(
   return getClient().post<WiiiConnectSessionStartDecision>(
     `/api/v1/wiii-connect/providers/${encodeURIComponent(slug)}/sessions`,
     body,
+  );
+}
+
+export async function createWiiiConnectProviderAuthorizationUrl(
+  slug: string,
+  body: WiiiConnectSessionStartBody = {},
+): Promise<WiiiConnectAuthorizationUrlDecision> {
+  return getClient().post<WiiiConnectAuthorizationUrlDecision>(
+    `/api/v1/wiii-connect/providers/${encodeURIComponent(slug)}/authorization-url`,
+    body,
+  );
+}
+
+export async function fetchWiiiConnectProviderConnections(
+  slug: string,
+  options: { probeDatabase?: boolean } = {},
+): Promise<WiiiConnectProviderConnectionListResponse> {
+  return getClient().get<WiiiConnectProviderConnectionListResponse>(
+    `/api/v1/wiii-connect/providers/${encodeURIComponent(slug)}/connections`,
+    {
+      probe_database: options.probeDatabase === false ? "false" : "true",
+    },
+  );
+}
+
+export function buildWiiiConnectProviderCallbackUrl(slug: string): string {
+  return getClient().getUrl(
+    `/api/v1/wiii-connect/providers/${encodeURIComponent(slug)}/callback`,
   );
 }

--- a/wiii-desktop/src/components/connect/WiiiConnectPage.tsx
+++ b/wiii-desktop/src/components/connect/WiiiConnectPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import {
   Activity,
@@ -8,14 +8,17 @@ import {
   CloudSun,
   Code2,
   Database,
+  ExternalLink,
   FileText,
   Globe2,
   GraduationCap,
   Info,
+  Loader2,
   Lock,
   MousePointer2,
   Network,
   PlugZap,
+  RefreshCw,
   Route,
   Search,
   Server,
@@ -24,6 +27,9 @@ import {
   XCircle,
 } from "lucide-react";
 import type {
+  WiiiConnectAuthorizationUrlDecision,
+  WiiiConnectProviderConnectionListResponse,
+  WiiiConnectProviderConnectionRecord,
   WiiiConnectProviderRegistryEntry,
   WiiiConnectSessionStartDecision,
   WiiiConnectRuntimeConnection,
@@ -31,6 +37,9 @@ import type {
   WiiiConnectRuntimeSnapshot,
 } from "@/api/types";
 import {
+  buildWiiiConnectProviderCallbackUrl,
+  createWiiiConnectProviderAuthorizationUrl,
+  fetchWiiiConnectProviderConnections,
   fetchWiiiConnectProviders,
   startWiiiConnectProviderSession,
 } from "@/api/wiii-connect";
@@ -103,6 +112,13 @@ interface CatalogCard {
   detailRows: Array<[string, string]>;
   requirements?: string[];
   disabledReason?: string;
+}
+
+interface ProviderConnectionListState {
+  response?: WiiiConnectProviderConnectionListResponse;
+  loading: boolean;
+  error?: string;
+  lastFetchedAt?: string;
 }
 
 const tabs: FullPageTab[] = [
@@ -499,6 +515,20 @@ function isEmbeddedWindow(): boolean {
   return window.parent !== window;
 }
 
+async function openExternalUrl(url: string): Promise<void> {
+  const parsed = new URL(url);
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("unsupported_authorization_url");
+  }
+  try {
+    const { open } = await import("@tauri-apps/plugin-shell");
+    await open(parsed.toString());
+    return;
+  } catch {
+    window.open(parsed.toString(), "_blank", "noopener,noreferrer");
+  }
+}
+
 function connectionTone(connection: WiiiConnectRuntimeConnection): CapabilityStatusTone {
   if (connection.status === "error" || connection.status === "expired") return "warn";
   if (connection.status === "pending" || connection.status === "preview") return "pending";
@@ -510,6 +540,9 @@ function connectionTone(connection: WiiiConnectRuntimeConnection): CapabilitySta
 
 function statusLabel(status: string | undefined): string {
   if (status === "connected") return "Đã kết nối";
+  if (status === "authorizing") return "Đang xác thực";
+  if (status === "waiting") return "Đang chờ";
+  if (status === "disconnected") return "Chưa nối";
   if (status === "preview") return "Preview";
   if (status === "pending") return "Đang chờ";
   if (status === "expired") return "Hết hạn";
@@ -517,6 +550,37 @@ function statusLabel(status: string | undefined): string {
   if (status === "disabled") return "Tắt";
   if (status === "not_connected") return "Chưa nối";
   return compactText(status, "Không rõ");
+}
+
+function providerConnectionTone(
+  connection: WiiiConnectProviderConnectionRecord | undefined,
+  response?: WiiiConnectProviderConnectionListResponse,
+): CapabilityStatusTone {
+  if (connection) {
+    if (connection.state === "connected" || connection.active) return "ok";
+    if (connection.state === "authorizing" || connection.state === "waiting") return "pending";
+    if (connection.state === "expired" || connection.state === "error") return "warn";
+    return "off";
+  }
+  if (response?.status === "blocked") return response.reason === "provider_disabled" ? "off" : "warn";
+  if (response?.status === "ready") return "off";
+  return "off";
+}
+
+function primaryProviderConnection(
+  response: WiiiConnectProviderConnectionListResponse | undefined,
+): WiiiConnectProviderConnectionRecord | undefined {
+  return response?.connections?.[0];
+}
+
+function providerConnectionSummary(
+  connection: WiiiConnectProviderConnectionRecord | undefined,
+): string {
+  if (!connection) return "Chưa có account";
+  return compactText(
+    connection.account_label || connection.external_account_ref || connection.reason,
+    "Đã có connection",
+  );
 }
 
 function compactText(value: unknown, fallback = "Chưa có"): string {
@@ -782,12 +846,22 @@ function buildNativeCatalogCards(
 
 function buildExternalCatalogCards(
   providerRegistry: WiiiConnectProviderRegistryEntry[] | null,
+  providerConnectionLists: Record<string, ProviderConnectionListState> = {},
 ): CatalogCard[] {
   const definitions =
     registryEntriesToExternalDefinitions(providerRegistry) ?? externalCatalogDefinitions;
 
   return definitions.map((definition) => {
     const fromBackend = definition.source === "backend";
+    const connectionResponse = providerConnectionLists[definition.id]?.response;
+    const providerConnection = primaryProviderConnection(connectionResponse);
+    const tone = providerConnectionTone(providerConnection, connectionResponse);
+    const connectionStatus = providerConnection
+      ? statusLabel(providerConnection.state)
+      : connectionResponse?.status === "blocked"
+        ? "Bị chặn"
+        : "Chưa nối";
+    const reason = connectionResponse?.reason;
     return {
       id: `${definition.provider}-${definition.id}`,
       providerSlug: definition.id,
@@ -798,26 +872,30 @@ function buildExternalCatalogCards(
       category: definition.category,
       categoryLabel: categoryLabel(definition.category),
       icon: definition.icon,
-      tone: "off" as CapabilityStatusTone,
-      status: "Chưa bật",
+      tone,
+      status: connectionStatus,
       statusDetail: fromBackend
-        ? "Backend registry đã khai báo provider này; adapter vẫn bị khóa cho đến khi có vault, policy và audit."
+        ? "Backend registry đã khai báo provider này; agent action vẫn bị khóa cho đến khi có scope, policy và audit."
         : "Wiii chưa có adapter, vault và permission gate cho kết nối này.",
       agentReady: false,
-      connected: false,
+      connected: tone === "ok",
       registrySource: definition.source ?? "local",
       detailRows: [
         ["Provider", providerKindLabels[definition.provider] ?? definition.provider],
         ["Nguồn", fromBackend ? "Backend registry" : "Local fallback"],
         ["Auth", compactText(definition.authMode, "Chưa khai báo")],
         ["Action", definition.actionCount != null ? `${definition.actionCount}` : "Chưa khai báo"],
-        ["Trạng thái", "Chưa có kết nối thật trong Wiii"],
+        ["Trạng thái", connectionStatus],
+        ["Account", providerConnectionSummary(providerConnection)],
+        ["Vault ref", providerConnection?.vault_ref_present ? "Có" : "Chưa"],
+        ["Scope", providerConnection ? scopeSummary(providerConnection.scopes) : "Chưa"],
         ["Agent-ready", "Chưa"],
-        ["Mutation", "Bị chặn cho đến khi có adapter và audit"],
+        ["Mutation", "Bị chặn cho đến khi có curated action và execution gateway"],
+        ...(reason ? ([["Lý do", compactText(reason)]] as Array<[string, string]>) : []),
       ],
       requirements: definition.requirements,
       disabledReason: fromBackend
-        ? "Provider có trong registry backend nhưng execution gateway chưa cho phép connect/call thật."
+        ? "Provider có trong registry backend. Kết nối account được phép khi backend cấp URL; action vẫn fail-closed."
         : "Cần thiết kế adapter/vault/policy trước khi bật Connect.",
     };
   });
@@ -827,10 +905,11 @@ function buildConnectionCatalogCards(
   snapshot: WiiiConnectRuntimeSnapshot | null,
   fallbackModel: CapabilityStatusViewModel,
   providerRegistry: WiiiConnectProviderRegistryEntry[] | null,
+  providerConnectionLists: Record<string, ProviderConnectionListState> = {},
 ): CatalogCard[] {
   return [
     ...buildNativeCatalogCards(snapshot, fallbackModel),
-    ...buildExternalCatalogCards(providerRegistry),
+    ...buildExternalCatalogCards(providerRegistry, providerConnectionLists),
   ];
 }
 
@@ -879,15 +958,27 @@ function sessionDecisionTone(
 function ConnectionDetailPanel({
   card,
   sessionDecision,
+  authorizationDecision,
   sessionLoading,
+  authorizationLoading,
   sessionError,
+  authorizationError,
+  connectionList,
   onRequestSession,
+  onRequestAuthorization,
+  onRefreshConnections,
 }: {
   card: CatalogCard | null;
   sessionDecision?: WiiiConnectSessionStartDecision;
+  authorizationDecision?: WiiiConnectAuthorizationUrlDecision;
   sessionLoading?: boolean;
+  authorizationLoading?: boolean;
   sessionError?: string;
+  authorizationError?: string;
+  connectionList?: ProviderConnectionListState;
   onRequestSession?: (card: CatalogCard) => Promise<void>;
+  onRequestAuthorization?: (card: CatalogCard) => Promise<void>;
+  onRefreshConnections?: (card: CatalogCard) => Promise<unknown>;
 }) {
   if (!card) {
     return (
@@ -902,6 +993,15 @@ function ConnectionDetailPanel({
     card.provider !== "wiii_native" &&
     card.registrySource === "backend" &&
     Boolean(onRequestSession);
+  const canRequestAuthorization =
+    card.provider !== "wiii_native" &&
+    card.registrySource === "backend" &&
+    Boolean(onRequestAuthorization);
+  const canRefreshConnections =
+    card.provider !== "wiii_native" &&
+    card.registrySource === "backend" &&
+    Boolean(onRefreshConnections);
+  const providerConnection = primaryProviderConnection(connectionList?.response);
 
   return (
     <aside className="rounded-lg border border-[var(--border)] bg-surface p-4">
@@ -981,32 +1081,163 @@ function ConnectionDetailPanel({
         </div>
       )}
 
+      {authorizationDecision && (
+        <div className="mt-4 rounded-md border border-[var(--border)] bg-surface-secondary px-3 py-3">
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <div className="text-xs font-semibold uppercase text-text-tertiary">
+              Connect Link backend
+            </div>
+            <StatusPill tone={sessionDecisionTone(authorizationDecision)}>
+              {authorizationDecision.status}
+            </StatusPill>
+          </div>
+          <dl className="grid gap-2 text-xs">
+            <div>
+              <dt className="text-text-tertiary">Lý do</dt>
+              <dd className="mt-0.5 font-medium text-text">{authorizationDecision.reason}</dd>
+            </div>
+            <div>
+              <dt className="text-text-tertiary">URL</dt>
+              <dd className="mt-0.5 font-medium text-text">
+                {authorizationDecision.authorization_url ? "Backend đã cấp URL" : "Không phát hành"}
+              </dd>
+            </div>
+          </dl>
+          {authorizationDecision.required_next && authorizationDecision.required_next.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {authorizationDecision.required_next.map((requirement) => (
+                <span
+                  key={`${card.id}-auth-${requirement}`}
+                  className="rounded-md border border-[var(--border)] bg-surface px-2 py-1 text-xs text-text-secondary"
+                >
+                  {requirement}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {connectionList && (
+        <div className="mt-4 rounded-md border border-[var(--border)] bg-surface-secondary px-3 py-3">
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <div className="text-xs font-semibold uppercase text-text-tertiary">
+              Connection thật
+            </div>
+            <StatusPill tone={providerConnectionTone(providerConnection, connectionList.response)}>
+              {providerConnection ? statusLabel(providerConnection.state) : connectionList.response?.status ?? "chưa đọc"}
+            </StatusPill>
+          </div>
+          <dl className="grid gap-2 text-xs">
+            <div>
+              <dt className="text-text-tertiary">Account</dt>
+              <dd className="mt-0.5 font-medium text-text">
+                {providerConnectionSummary(providerConnection)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-text-tertiary">Lý do</dt>
+              <dd className="mt-0.5 font-medium text-text">
+                {connectionList.response?.reason ?? connectionList.error ?? "Chưa có"}
+              </dd>
+            </div>
+            {connectionList.lastFetchedAt && (
+              <div>
+                <dt className="text-text-tertiary">Làm mới</dt>
+                <dd className="mt-0.5 font-medium text-text">
+                  {formatDateTime(connectionList.lastFetchedAt)}
+                </dd>
+              </div>
+            )}
+          </dl>
+          {providerConnection?.warnings && providerConnection.warnings.length > 0 && (
+            <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-2 py-2 text-xs text-amber-800">
+              {providerConnection.warnings.length} cảnh báo trong connection này.
+            </div>
+          )}
+        </div>
+      )}
+
       {sessionError && (
         <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
           {sessionError}
         </div>
       )}
 
-      <button
-        type="button"
-        disabled={!canRequestSession || sessionLoading}
-        onClick={() => {
-          if (canRequestSession) void onRequestSession?.(card);
-        }}
-        className={`mt-4 inline-flex h-9 items-center justify-center rounded-md border px-3 text-sm font-medium ${
-          canRequestSession
-            ? "border-primary/30 bg-primary/10 text-primary hover:bg-primary/15"
-            : "border-[var(--border)] bg-surface-secondary text-text-tertiary"
-        }`}
-      >
-        {card.provider === "wiii_native"
-          ? "Quan sát từ runtime"
-          : canRequestSession
-            ? sessionLoading
-              ? "Đang kiểm tra..."
-              : "Kiểm tra khả năng kết nối"
-            : "Chưa thể kết nối"}
-      </button>
+      {authorizationError && (
+        <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          {authorizationError}
+        </div>
+      )}
+
+      {connectionList?.error && (
+        <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          {connectionList.error}
+        </div>
+      )}
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <button
+          type="button"
+          disabled={!canRequestAuthorization || authorizationLoading}
+          onClick={() => {
+            if (canRequestAuthorization) void onRequestAuthorization?.(card);
+          }}
+          className={`inline-flex h-9 items-center justify-center gap-2 rounded-md border px-3 text-sm font-medium ${
+            canRequestAuthorization
+              ? "border-primary/30 bg-primary/10 text-primary hover:bg-primary/15"
+              : "border-[var(--border)] bg-surface-secondary text-text-tertiary"
+          }`}
+        >
+          {authorizationLoading ? (
+            <Loader2 size={14} className="animate-spin" aria-hidden="true" />
+          ) : (
+            <ExternalLink size={14} aria-hidden="true" />
+          )}
+          {card.provider === "wiii_native"
+            ? "Quan sát từ runtime"
+            : canRequestAuthorization
+              ? authorizationLoading
+                ? "Đang mở..."
+                : "Kết nối qua Wiii"
+              : "Chưa thể kết nối"}
+        </button>
+
+        <button
+          type="button"
+          disabled={!canRefreshConnections || connectionList?.loading}
+          onClick={() => {
+            if (canRefreshConnections) void onRefreshConnections?.(card);
+          }}
+          className={`inline-flex h-9 items-center justify-center gap-2 rounded-md border px-3 text-sm font-medium ${
+            canRefreshConnections
+              ? "border-[var(--border)] bg-surface-secondary text-text-secondary hover:text-text"
+              : "border-[var(--border)] bg-surface-secondary text-text-tertiary"
+          }`}
+        >
+          <RefreshCw
+            size={14}
+            className={connectionList?.loading ? "animate-spin" : ""}
+            aria-hidden="true"
+          />
+          Làm mới trạng thái
+        </button>
+
+        <button
+          type="button"
+          disabled={!canRequestSession || sessionLoading}
+          onClick={() => {
+            if (canRequestSession) void onRequestSession?.(card);
+          }}
+          className={`inline-flex h-9 items-center justify-center rounded-md border px-3 text-sm font-medium ${
+            canRequestSession
+              ? "border-[var(--border)] bg-surface-secondary text-text-secondary hover:text-text"
+              : "border-[var(--border)] bg-surface-secondary text-text-tertiary"
+          }`}
+        >
+          {sessionLoading ? "Đang kiểm tra..." : "Kiểm tra policy"}
+        </button>
+      </div>
       <p className="mt-2 text-xs text-text-tertiary">
         {card.disabledReason ?? card.statusDetail}
       </p>
@@ -1032,12 +1263,27 @@ function ConnectionCatalog({
   const [sessionDecisions, setSessionDecisions] = useState<
     Record<string, WiiiConnectSessionStartDecision>
   >({});
+  const [authorizationDecisions, setAuthorizationDecisions] = useState<
+    Record<string, WiiiConnectAuthorizationUrlDecision>
+  >({});
   const [sessionErrors, setSessionErrors] = useState<Record<string, string>>({});
+  const [authorizationErrors, setAuthorizationErrors] = useState<Record<string, string>>({});
   const [sessionLoadingSlug, setSessionLoadingSlug] = useState<string | null>(null);
+  const [authorizationLoadingSlug, setAuthorizationLoadingSlug] = useState<string | null>(null);
+  const [providerConnectionLists, setProviderConnectionLists] = useState<
+    Record<string, ProviderConnectionListState>
+  >({});
+  const connectionPollTokenRef = useRef(0);
+
+  useEffect(() => {
+    return () => {
+      connectionPollTokenRef.current += 1;
+    };
+  }, []);
 
   const cards = useMemo(
-    () => buildConnectionCatalogCards(snapshot, fallbackModel, providerRegistry),
-    [snapshot, fallbackModel, providerRegistry],
+    () => buildConnectionCatalogCards(snapshot, fallbackModel, providerRegistry, providerConnectionLists),
+    [snapshot, fallbackModel, providerRegistry, providerConnectionLists],
   );
 
   const normalizedQuery = query.trim().toLowerCase();
@@ -1080,6 +1326,97 @@ function ConnectionCatalog({
       }));
     } finally {
       setSessionLoadingSlug((current) => (current === slug ? null : current));
+    }
+  };
+
+  const refreshProviderConnections = async (
+    card: CatalogCard,
+  ): Promise<WiiiConnectProviderConnectionListResponse | null> => {
+    if (card.provider === "wiii_native" || card.registrySource !== "backend") return null;
+    const slug = card.providerSlug;
+    setProviderConnectionLists((current) => ({
+      ...current,
+      [slug]: {
+        ...current[slug],
+        loading: true,
+        error: undefined,
+      },
+    }));
+    try {
+      const response = await fetchWiiiConnectProviderConnections(slug, {
+        probeDatabase: true,
+      });
+      setProviderConnectionLists((current) => ({
+        ...current,
+        [slug]: {
+          response,
+          loading: false,
+          lastFetchedAt: new Date().toISOString(),
+        },
+      }));
+      return response;
+    } catch {
+      setProviderConnectionLists((current) => ({
+        ...current,
+        [slug]: {
+          ...current[slug],
+          loading: false,
+          error: "Không thể đọc trạng thái connection từ backend.",
+          lastFetchedAt: new Date().toISOString(),
+        },
+      }));
+      return null;
+    }
+  };
+
+  const pollProviderConnectionsAfterAuthorization = async (card: CatalogCard) => {
+    const pollToken = connectionPollTokenRef.current + 1;
+    connectionPollTokenRef.current = pollToken;
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      if (attempt > 0) {
+        await new Promise((resolve) => window.setTimeout(resolve, 3000));
+      }
+      if (connectionPollTokenRef.current !== pollToken) return;
+      const response = await refreshProviderConnections(card);
+      if (connectionPollTokenRef.current !== pollToken) return;
+      if (response?.connections.some((connection) => connection.state === "connected" || connection.active)) {
+        return;
+      }
+    }
+  };
+
+  const requestAuthorizationUrl = async (card: CatalogCard) => {
+    if (card.provider === "wiii_native" || card.registrySource !== "backend") return;
+    const slug = card.providerSlug;
+    setAuthorizationLoadingSlug(slug);
+    setAuthorizationErrors((current) => {
+      const next = { ...current };
+      delete next[slug];
+      return next;
+    });
+    try {
+      const decision = await createWiiiConnectProviderAuthorizationUrl(slug, {
+        surface: "desktop",
+        redirect_uri: buildWiiiConnectProviderCallbackUrl(slug),
+        probe_database: true,
+        requested_scopes: { read: true },
+        request_metadata: {
+          source: "wiii_connect_page",
+          provider: card.provider,
+        },
+      });
+      setAuthorizationDecisions((current) => ({ ...current, [slug]: decision }));
+      if (decision.status === "ready" && decision.authorization_url) {
+        await openExternalUrl(decision.authorization_url);
+        void pollProviderConnectionsAfterAuthorization(card);
+      }
+    } catch {
+      setAuthorizationErrors((current) => ({
+        ...current,
+        [slug]: "Không thể bắt đầu Connect Link từ backend.",
+      }));
+    } finally {
+      setAuthorizationLoadingSlug((current) => (current === slug ? null : current));
     }
   };
 
@@ -1231,9 +1568,15 @@ function ConnectionCatalog({
         <ConnectionDetailPanel
           card={selectedCard}
           sessionDecision={selectedCard ? sessionDecisions[selectedCard.providerSlug] : undefined}
+          authorizationDecision={selectedCard ? authorizationDecisions[selectedCard.providerSlug] : undefined}
           sessionLoading={selectedCard ? sessionLoadingSlug === selectedCard.providerSlug : false}
+          authorizationLoading={selectedCard ? authorizationLoadingSlug === selectedCard.providerSlug : false}
           sessionError={selectedCard ? sessionErrors[selectedCard.providerSlug] : undefined}
+          authorizationError={selectedCard ? authorizationErrors[selectedCard.providerSlug] : undefined}
+          connectionList={selectedCard ? providerConnectionLists[selectedCard.providerSlug] : undefined}
           onRequestSession={requestSessionDecision}
+          onRequestAuthorization={requestAuthorizationUrl}
+          onRefreshConnections={refreshProviderConnections}
         />
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Extends the desktop Wiii Connect API/types for backend-owned `authorization-url` and provider `connections` endpoints.
- Updates Wiii Connect catalog detail so backend registry providers can open only backend-issued Connect Links, refresh/poll sanitized connection state, and keep connection status separate from agent-ready execution.
- Updates OpenHuman/Composio docs to reflect the new frontend control-plane state.

## Scope
- `wiii-desktop/src/api/wiii-connect.ts`
- `wiii-desktop/src/api/types.ts`
- `wiii-desktop/src/components/connect/WiiiConnectPage.tsx`
- focused Wiii Connect page tests
- Wiii Connect architecture/source-audit docs

## Non-scope
- No Composio secrets/config changes.
- No direct frontend calls to Composio.
- No action execution, write/apply behavior, disconnect, or reconnect lifecycle.
- No LMS mutation behavior changes.

## Verification
- `cd wiii-desktop; npx vitest run src/__tests__/wiii-connect-page.test.tsx` -> passed, 5 tests.
- `cd wiii-desktop; npx tsc --noEmit` -> passed.
- `cd wiii-desktop; npm run build:embed` -> passed; Vite emitted existing bundle-size/dynamic-import warnings.
- Browser smoke on `http://127.0.0.1:1420` with mocked backend registry -> passed (`browser_smoke_ok`).
- `git diff --check` -> passed.

## Risk
- Medium frontend/control-plane risk: users can now trigger backend authorization URL creation from the Wiii Connect page, but only via Wiii backend auth/policy and only with backend-issued URLs.
- External action execution remains fail-closed; connected account state does not grant agent-ready status.
- Polling is scoped to the selected provider after a user-triggered authorization/refresh, not global background polling.

## Rollback
- Revert this PR to restore the registry/session-decision-only Wiii Connect page.
- Backend Connect Link/callback/polling contracts from earlier PRs remain untouched.

Closes #764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backend-owned provider authorization flow with backend-issued Connect Links
  * Provider connection status tracking and real-time display
  * Connection status refresh capability with automatic polling and retry logic

* **Documentation**
  * Updated architecture guidelines for backend-owned Composio integration approach
  * Revised operational audit documentation to reflect new integration posture

* **Tests**
  * Expanded test coverage for provider authorization flow and connection management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->