### PR TITLE
Add Wiii Connect execution gateway audit boundary

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -78,6 +78,12 @@ maritime-ai-service/app/engine/wiii_connect/provider_adapters.py
 maritime-ai-service/app/engine/wiii_connect/composio_adapter.py
 ```
 
+The execution gateway preflight and audit boundary lives in:
+
+```text
+maritime-ai-service/app/engine/wiii_connect/execution_gateway.py
+```
+
 The durable storage contract and schema live in:
 
 ```text
@@ -92,6 +98,7 @@ GET  /api/v1/wiii-connect/providers/{slug}/status
 POST /api/v1/wiii-connect/providers/{slug}/sessions
 POST /api/v1/wiii-connect/providers/{slug}/authorization-url
 GET  /api/v1/wiii-connect/providers/{slug}/connections
+POST /api/v1/wiii-connect/providers/{slug}/execution-decision
 GET  /api/v1/wiii-connect/providers/{slug}/callback
 GET  /api/v1/wiii-connect/provider-adapters/status
 GET  /api/v1/wiii-connect/storage/status
@@ -274,6 +281,8 @@ never receives provider tokens or raw payloads.
 `WiiiConnectPersistentStorage`
 
 - writes per-org, per-user connection records to `wiii_connect_connections`;
+- reads the latest sanitized per-org/per-user/provider connection record for
+  execution gateway decisions;
 - appends privacy-safe provider/session/callback/vault/execution events to
   `wiii_connect_audit_ledger`;
 - requires explicit `organization_id` and `user_id` before writing;
@@ -283,6 +292,21 @@ never receives provider tokens or raw payloads.
   blocked instead of allowing un-audited execution.
 - is exposed through controlled status/probe APIs with database probing disabled
   by default, so normal UI renders do not block on storage connectivity.
+
+`WiiiConnectExecutionGatewayDecision`
+
+- is the audited preflight boundary before any provider action can execute;
+- requires the authenticated Wiii org/user connection record from persistent
+  storage, not a frontend-supplied connection claim;
+- checks registry enabled state, `agent_ready`, path allowlist, curated action
+  allowlist, stored scopes, preview evidence, approval-token presence, adapter
+  execution capability, and persistent audit readiness;
+- records only action slug, path, mutation, approval-token presence, preview
+  evidence presence, and sanitized argument key names;
+- never accepts raw provider arguments, raw provider payloads, OAuth tokens,
+  approval token values, Composio API keys, or provider response bodies;
+- currently performs preflight only. It does not call Composio action execution
+  until a curated action catalog and provider execution adapter are enabled.
 
 ## Lifecycle States
 
@@ -337,6 +361,11 @@ The gateway denies by default. Current reason codes:
 - `missing_scope`
 - `missing_preview_evidence`
 - `missing_approval_token`
+- `provider_adapter_mismatch`
+- `provider_adapter_not_bound`
+- `provider_adapter_not_configured`
+- `provider_adapter_cannot_execute`
+- `audit_ledger_not_persistent`
 
 The action is allowed only after all checks pass.
 
@@ -402,6 +431,8 @@ Before real Composio OAuth is enabled:
 - every session/callback/vault/execution decision must produce a privacy-safe
   ledger record shape and be eligible for durable append before provider
   execution is allowed;
+- execution decisions must be requested through the authenticated Wiii backend
+  gateway and must fetch the connection record from Wiii storage by org/user;
 - durable persistence must bind every connection/audit write to a Wiii
   organization and user boundary;
 - frontend may receive connect URLs and state labels, not tokens;
@@ -426,7 +457,10 @@ approval tokens and provider payloads must remain outside chat lifecycle data.
 
 ## Next Slices
 
-1. Add disconnect/delete/reconnect lifecycle controls behind the same policy.
-2. Add browser acceptance for disconnect, gated scope, and denied
-   execute cases.
-3. Enable one low-risk read-only Composio action before any write action.
+1. Add a curated Composio action catalog contract for one low-risk read-only
+   provider action.
+2. Bind Composio adapter `can_execute_actions` only for that curated read-only
+   action and keep writes disabled.
+3. Add disconnect/delete/reconnect lifecycle controls behind the same policy.
+4. Add browser acceptance for connect, denied execute, gated scope, and
+   reconnect cases.

--- a/docs/architecture/wiii-connect/README.md
+++ b/docs/architecture/wiii-connect/README.md
@@ -176,11 +176,12 @@ this repository.
 4. Add tests proving that LMS apply, Pointy, web/weather, document-grounded
    chat, and visual/Code Studio paths bind only the right tools.
 5. Use `ADAPTER_V1_DESIGN.md` as the contract for external providers. Composio
-   remains disabled until registry, vault, OAuth/session callback, scope
-   policy, execution gateway, and audit ledger are implemented against that
-   contract.
+   connection can be enabled only after registry, vault/provider-managed
+   secrets, OAuth/session callback, storage, and audit checks are ready. Agent
+   action execution remains disabled until a curated action catalog and
+   provider execution adapter pass the execution gateway.
 6. Keep the backend `provider_registry.py` as the source of truth for disabled
    external provider catalog entries; frontend catalog state should converge on
    this projection.
-7. Add a Composio adapter only after the native Wiii snapshot and Adapter V1
-   gateway are stable.
+7. Add one low-risk read-only Composio action through the gateway before any
+   write/apply action.

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -149,7 +149,11 @@ calls Composio `connected_accounts` only through Wiii backend and upserts
 sanitized connection records. The desktop Wiii Connect page can now start a
 backend-owned Connect Link, open only backend-issued URLs, refresh/poll
 sanitized provider connection records, and show connection state separately from
-agent-ready execution state. It still needs disconnect and reconnect controls,
-curated action catalog, execution gateway hardening for real provider actions,
-and end-to-end acceptance against real Composio credentials before Composio
-actions can be enabled for real users.
+agent-ready execution state. Wiii now also has an authenticated execution
+gateway preflight endpoint that fetches the stored org/user connection record,
+checks path/action/scope/evidence/adapter/audit policy, and appends a
+privacy-safe execution ledger record without calling Composio action execution.
+It still needs a curated action catalog, provider execution adapter enablement
+for one low-risk read-only action, disconnect/reconnect controls, and
+end-to-end acceptance against real Composio credentials before Composio actions
+can be enabled for real users.

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -14,6 +14,7 @@ from app.engine.wiii_connect import (
     WiiiConnectAuthorizationUrlRequest,
     WiiiConnectCallbackRequest,
     WiiiConnectConnectionRecordV1,
+    WiiiConnectExecutionRequest,
     WiiiConnectSessionStartRequest,
     WiiiConnectVaultSecretRef,
     append_wiii_connect_callback_state,
@@ -28,6 +29,7 @@ from app.engine.wiii_connect import (
     begin_connection_session,
     create_composio_connect_link,
     decide_authorization_url,
+    decide_execution_gateway,
     default_persistent_storage_status_metadata,
     get_wiii_connect_provider_entry,
     get_wiii_connect_persistent_storage,
@@ -42,6 +44,7 @@ from app.engine.wiii_connect import (
     verify_wiii_connect_callback_state,
     vault_status_public_metadata,
 )
+from app.engine.wiii_connect.adapter_v1 import ActionMutation
 
 
 router = APIRouter(prefix="/wiii-connect", tags=["wiii-connect"])
@@ -58,6 +61,22 @@ class WiiiConnectStartSessionBody(BaseModel):
     probe_database: bool = False
     requested_scopes: dict[str, bool] = Field(default_factory=dict)
     request_metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class WiiiConnectExecutionDecisionBody(BaseModel):
+    """Safe request body for an external provider action preflight."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    surface: str = "desktop"
+    connection_id: str | None = None
+    action_slug: str
+    path: str = "external_app_action"
+    mutation: str = "read"
+    preview_evidence_required: bool = False
+    preview_evidence_id: str | None = None
+    approval_token_present: bool = False
+    argument_keys: list[str] = Field(default_factory=list)
 
 
 @router.get("/providers")
@@ -314,6 +333,75 @@ async def list_wiii_connect_provider_connections(
     }
 
 
+@router.post("/providers/{slug}/execution-decision")
+async def decide_wiii_connect_provider_execution(
+    slug: str,
+    body: WiiiConnectExecutionDecisionBody,
+    current_user: AuthenticatedUser = Depends(require_auth),
+) -> dict[str, object]:
+    """Return the audited fail-closed decision for one provider action.
+
+    This endpoint is a gateway preflight only. It does not execute provider
+    actions and it never accepts raw provider arguments, provider payloads, or
+    approval token values.
+    """
+
+    entry = get_wiii_connect_provider_entry(slug)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="unknown_wiii_connect_provider")
+    composio_config = build_composio_adapter_config()
+    effective_entry = build_composio_connect_enabled_entry(entry, composio_config)
+    storage = _wiii_connect_storage_status_metadata(probe_database=True)
+    storage_ready = _connection_storage_ready(storage)
+    connection = (
+        get_wiii_connect_persistent_storage().get_connection_record(
+            organization_id=_wiii_connect_owner_organization_id(current_user),
+            user_id=current_user.user_id,
+            provider_slug=effective_entry.slug,
+            connection_id=body.connection_id,
+        )
+        if storage_ready
+        else None
+    )
+    request = WiiiConnectExecutionRequest(
+        provider_slug=effective_entry.slug,
+        action_slug=_safe_action_slug(body.action_slug),
+        path=_safe_path(body.path),
+        mutation=_safe_mutation(body.mutation),
+        approval_token_present=bool(body.approval_token_present),
+        preview_evidence_id=_safe_public_id(body.preview_evidence_id),
+        preview_evidence_required=bool(body.preview_evidence_required),
+        argument_keys=tuple(_safe_argument_keys(body.argument_keys)),
+    )
+    gateway = decide_execution_gateway(
+        effective_entry,
+        connection,
+        request,
+        adapter_capability=build_composio_provider_adapter_capability(
+            composio_config,
+        ),
+        audit_ledger_metadata={
+            "persistent": bool(storage.get("persistent") and storage.get("audit_ledger_ready")),
+        },
+    )
+    _append_execution_audit(
+        gateway,
+        request,
+        storage,
+        current_user=current_user,
+        metadata={
+            "surface": body.surface,
+            "connection_id_present": bool(body.connection_id),
+            "connection_found": connection is not None,
+            "storage": storage,
+        },
+    )
+    payload = gateway.to_public_metadata()
+    payload["provider_slug"] = effective_entry.slug
+    payload["storage"] = storage
+    return payload
+
+
 @router.get("/providers/{slug}/callback")
 async def receive_wiii_connect_provider_callback(
     slug: str,
@@ -468,6 +556,35 @@ def _append_callback_audit(
     )
 
 
+def _append_execution_audit(
+    gateway: Any,
+    request: WiiiConnectExecutionRequest,
+    storage_metadata: dict[str, Any],
+    *,
+    current_user: AuthenticatedUser,
+    metadata: dict[str, Any],
+) -> None:
+    if not bool(storage_metadata.get("persistent") and storage_metadata.get("audit_ledger_ready")):
+        return
+    record = build_audit_ledger_record(
+        event_kind="execution",
+        provider_slug=gateway.decision.provider_slug,
+        status=gateway.status,
+        reason=gateway.reason,
+        surface=_safe_surface(metadata.get("surface") or "backend"),
+        metadata={
+            "request": request.to_audit_metadata(),
+            "decision": gateway.decision.to_metadata(),
+            **metadata,
+        },
+    )
+    get_wiii_connect_persistent_storage().append_audit_record(
+        record,
+        organization_id=_wiii_connect_owner_organization_id(current_user),
+        user_id=current_user.user_id,
+    )
+
+
 def _upsert_authorizing_connection(
     link: Any,
     entry: Any,
@@ -589,3 +706,41 @@ def _safe_provider_connection_id(value: str | None) -> str:
     if any(marker in text.lower() for marker in ("token", "secret", "password")):
         return ""
     return text[:160]
+
+
+def _safe_action_slug(value: str) -> str:
+    return str(value or "").strip().upper().replace("-", "_")[:120]
+
+
+def _safe_path(value: str) -> str:
+    return str(value or "").strip().lower().replace("-", "_")[:120]
+
+
+def _safe_mutation(value: str) -> ActionMutation:
+    normalized = str(value or "").strip().lower()
+    if normalized in {"read", "preview", "write", "apply", "admin"}:
+        return normalized  # type: ignore[return-value]
+    return "read"
+
+
+def _safe_argument_keys(values: list[str]) -> list[str]:
+    result: list[str] = []
+    for value in values[:50]:
+        key = str(value or "").strip()
+        if key:
+            result.append(key[:120])
+    return result
+
+
+def _safe_public_id(value: str | None) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if any(marker in text.lower() for marker in ("token", "secret", "password")):
+        return None
+    return text[:160]
+
+
+def _safe_surface(value: Any) -> str:
+    text = str(value or "").strip().lower().replace("-", "_")
+    return text[:80] or "backend"

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -63,6 +63,11 @@ from .connection_sessions import (
     provider_connection_status_for_entry,
     scope_grant_from_mapping,
 )
+from .execution_gateway import (
+    WIII_CONNECT_EXECUTION_GATEWAY_VERSION,
+    WiiiConnectExecutionGatewayDecision,
+    decide_execution_gateway,
+)
 from .provider_adapters import (
     WIII_CONNECT_PROVIDER_ADAPTER_VERSION,
     WiiiConnectAuthorizationUrlAuditEvent,
@@ -113,6 +118,7 @@ __all__ = [
     "WIII_CONNECT_CALLBACK_STATE_VERSION",
     "WIII_CONNECT_COMPOSIO_ADAPTER_VERSION",
     "WIII_CONNECT_COMPOSIO_CONNECTION_LIST_VERSION",
+    "WIII_CONNECT_EXECUTION_GATEWAY_VERSION",
     "WIII_CONNECT_PROVIDER_ADAPTER_VERSION",
     "WIII_CONNECT_PERSISTENT_STORAGE_VERSION",
     "WIII_CONNECT_SESSION_CONTRACT_VERSION",
@@ -132,6 +138,7 @@ __all__ = [
     "WiiiConnectConnectionSessionAuditEvent",
     "WiiiConnectConnectionRecordV1",
     "WiiiConnectExecutionDecision",
+    "WiiiConnectExecutionGatewayDecision",
     "WiiiConnectExecutionRequest",
     "WiiiConnectInMemoryAuditLedger",
     "WiiiConnectProviderAdapterCapability",
@@ -162,6 +169,7 @@ __all__ = [
     "build_wiii_connect_snapshot",
     "build_audit_ledger_record",
     "decide_external_execution",
+    "decide_execution_gateway",
     "decide_authorization_url",
     "decide_vault_secret_write",
     "build_composio_connect_enabled_entry",

--- a/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
+++ b/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
@@ -42,6 +42,11 @@ ExecutionDenyReason = Literal[
     "allowed",
     "provider_disabled",
     "provider_not_agent_ready",
+    "provider_adapter_mismatch",
+    "provider_adapter_not_bound",
+    "provider_adapter_not_configured",
+    "provider_adapter_cannot_execute",
+    "audit_ledger_not_persistent",
     "connection_missing",
     "connection_provider_mismatch",
     "connection_not_connected",
@@ -270,7 +275,7 @@ class WiiiConnectExecutionRequest:
             "mutation": self.mutation,
             "approval_token_present": self.approval_token_present,
             "preview_evidence_present": bool(self.preview_evidence_id),
-            "argument_keys": list(self.argument_keys),
+            "argument_keys": [_safe_audit_key(key) for key in self.argument_keys],
         }
 
 
@@ -450,3 +455,15 @@ def _deny(
             f"deny:{reason}",
         ),
     )
+
+
+_SENSITIVE_KEY_MARKERS = ("token", "secret", "password", "credential", "key", "code")
+
+
+def _safe_audit_key(key: str) -> str:
+    normalized = str(key or "").strip().lower()
+    if not normalized:
+        return "empty"
+    if any(marker in normalized for marker in _SENSITIVE_KEY_MARKERS):
+        return "redacted_sensitive_field"
+    return normalized[:80]

--- a/maritime-ai-service/app/engine/wiii_connect/execution_gateway.py
+++ b/maritime-ai-service/app/engine/wiii_connect/execution_gateway.py
@@ -1,0 +1,190 @@
+"""Audited Wiii Connect execution gateway boundary.
+
+This module is the provider-neutral policy step immediately before any
+third-party action could run. It performs no provider network calls; adapter
+implementations remain responsible for execution after this gateway allows a
+request.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .adapter_v1 import (
+    WIII_CONNECT_ADAPTER_VERSION,
+    WiiiConnectConnectionRecordV1,
+    WiiiConnectExecutionDecision,
+    WiiiConnectExecutionRequest,
+    WiiiConnectProviderRegistryEntry,
+    decide_external_execution,
+)
+from .provider_adapters import (
+    WIII_CONNECT_PROVIDER_ADAPTER_VERSION,
+    WiiiConnectProviderAdapterCapability,
+    default_provider_adapter_capability,
+)
+
+
+WIII_CONNECT_EXECUTION_GATEWAY_VERSION = "wiii_connect_execution_gateway.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectExecutionGatewayDecision:
+    """Gateway preflight result before provider action execution."""
+
+    decision: WiiiConnectExecutionDecision
+    adapter: WiiiConnectProviderAdapterCapability
+    connection_present: bool = False
+    audit_persistent: bool = False
+    required_next: tuple[str, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def allowed(self) -> bool:
+        return self.decision.allowed
+
+    @property
+    def status(self) -> str:
+        return "allowed" if self.allowed else "blocked"
+
+    @property
+    def reason(self) -> str:
+        return self.decision.reason
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_EXECUTION_GATEWAY_VERSION,
+            "adapter_version": WIII_CONNECT_PROVIDER_ADAPTER_VERSION,
+            "policy_version": WIII_CONNECT_ADAPTER_VERSION,
+            "status": self.status,
+            "reason": self.reason,
+            "connection_present": self.connection_present,
+            "audit_persistent": self.audit_persistent,
+            "decision": self.decision.to_metadata(),
+            "adapter": self.adapter.to_public_metadata(),
+            "required_next": list(self.required_next),
+            "metadata": _safe_metadata(self.metadata),
+        }
+
+
+def decide_execution_gateway(
+    entry: WiiiConnectProviderRegistryEntry,
+    connection: WiiiConnectConnectionRecordV1 | None,
+    request: WiiiConnectExecutionRequest,
+    *,
+    adapter_capability: WiiiConnectProviderAdapterCapability | None = None,
+    audit_ledger_metadata: dict[str, Any] | None = None,
+    require_persistent_audit: bool = True,
+) -> WiiiConnectExecutionGatewayDecision:
+    """Return the fail-closed decision before a provider action may run."""
+
+    adapter = adapter_capability or default_provider_adapter_capability(
+        entry.provider_kind,
+    )
+    audit_persistent = bool((audit_ledger_metadata or {}).get("persistent"))
+
+    base = decide_external_execution(entry, connection, request)
+    if not base.allowed:
+        return WiiiConnectExecutionGatewayDecision(
+            decision=base,
+            adapter=adapter,
+            connection_present=connection is not None,
+            audit_persistent=audit_persistent,
+            required_next=_required_next_for_reason(base.reason),
+            metadata={"request": request.to_audit_metadata()},
+        )
+
+    if adapter.provider_kind != entry.provider_kind:
+        decision = _gateway_deny(entry, request, "provider_adapter_mismatch")
+    elif not adapter.bound:
+        decision = _gateway_deny(entry, request, "provider_adapter_not_bound")
+    elif not adapter.configured:
+        decision = _gateway_deny(entry, request, "provider_adapter_not_configured")
+    elif not adapter.can_execute_actions:
+        decision = _gateway_deny(entry, request, "provider_adapter_cannot_execute")
+    elif require_persistent_audit and not audit_persistent:
+        decision = _gateway_deny(entry, request, "audit_ledger_not_persistent")
+    else:
+        decision = base
+
+    return WiiiConnectExecutionGatewayDecision(
+        decision=decision,
+        adapter=adapter,
+        connection_present=connection is not None,
+        audit_persistent=audit_persistent,
+        required_next=_required_next_for_reason(decision.reason),
+        metadata={"request": request.to_audit_metadata()},
+    )
+
+
+def _gateway_deny(
+    entry: WiiiConnectProviderRegistryEntry,
+    request: WiiiConnectExecutionRequest,
+    reason: str,
+) -> WiiiConnectExecutionDecision:
+    return WiiiConnectExecutionDecision(
+        outcome="denied",
+        reason=reason,  # type: ignore[arg-type]
+        provider_slug=entry.slug,
+        action_slug=request.action_slug,
+        path=request.path,
+        audit_tags=(
+            f"provider:{entry.provider_kind}",
+            f"auth:{entry.auth_mode}",
+            f"deny:{reason}",
+        ),
+    )
+
+
+def _required_next_for_reason(reason: str) -> tuple[str, ...]:
+    if reason == "allowed":
+        return ()
+    mapping: dict[str, tuple[str, ...]] = {
+        "provider_disabled": ("enable_provider_registry_entry",),
+        "provider_not_agent_ready": (
+            "enable_curated_action_catalog",
+            "enable_provider_agent_policy",
+        ),
+        "provider_adapter_mismatch": ("bind_matching_provider_adapter",),
+        "provider_adapter_not_bound": ("bind_provider_adapter",),
+        "provider_adapter_not_configured": ("configure_provider_adapter",),
+        "provider_adapter_cannot_execute": ("implement_provider_action_adapter",),
+        "audit_ledger_not_persistent": ("configure_persistent_audit_ledger",),
+        "connection_missing": ("connect_provider_account",),
+        "connection_provider_mismatch": ("select_matching_connection",),
+        "connection_not_connected": ("refresh_or_reconnect_provider_account",),
+        "path_not_allowed": ("select_allowed_product_path",),
+        "action_not_allowed": ("curate_action_for_provider",),
+        "missing_scope": ("grant_required_scope",),
+        "missing_preview_evidence": ("create_preview_evidence",),
+        "missing_approval_token": ("collect_approval_token",),
+    }
+    return mapping.get(reason, ("inspect_execution_policy",))
+
+
+_SENSITIVE_KEY_MARKERS = ("token", "secret", "password", "credential", "key", "code")
+
+
+def _safe_metadata(value: Any) -> Any:
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for raw_key, raw_value in value.items():
+            key = str(raw_key)
+            if any(marker in key.lower() for marker in _SENSITIVE_KEY_MARKERS):
+                result["redacted_sensitive_field"] = "[redacted]"
+                continue
+            result[key] = _safe_metadata(raw_value)
+        return result
+    if isinstance(value, list):
+        return [_safe_metadata(item) for item in value]
+    if isinstance(value, tuple):
+        return [_safe_metadata(item) for item in value]
+    return value
+
+
+__all__ = [
+    "WIII_CONNECT_EXECUTION_GATEWAY_VERSION",
+    "WiiiConnectExecutionGatewayDecision",
+    "decide_execution_gateway",
+]

--- a/maritime-ai-service/app/engine/wiii_connect/persistent_storage.py
+++ b/maritime-ai-service/app/engine/wiii_connect/persistent_storage.py
@@ -15,7 +15,12 @@ from typing import Any, Callable
 
 from sqlalchemy import text
 
-from .adapter_v1 import WiiiConnectConnectionRecordV1
+from .adapter_v1 import (
+    WiiiConnectConnectionRecordV1,
+    WiiiConnectScopeGrant,
+    WiiiConnectVaultSecretRef,
+    normalize_connection_state,
+)
 from .audit_ledger import WiiiConnectAuditLedgerRecord
 
 
@@ -248,6 +253,90 @@ class WiiiConnectPersistentStorage:
             logger.warning("Wiii Connect connection upsert failed: %s", exc)
             return False
 
+    def get_connection_record(
+        self,
+        *,
+        organization_id: str,
+        user_id: str,
+        provider_slug: str,
+        connection_id: str | None = None,
+    ) -> WiiiConnectConnectionRecordV1 | None:
+        """Fetch the latest sanitized connection row for an org/user/provider."""
+
+        owner = _normalize_owner(organization_id=organization_id, user_id=user_id)
+        slug = str(provider_slug or "").strip().lower().replace("-", "_")
+        safe_connection_id = str(connection_id or "").strip()
+        if owner is None or not slug:
+            return None
+        self._ensure_initialized()
+        if self._session_factory is None:
+            return None
+
+        try:
+            with self._session_factory() as session:
+                result = session.execute(
+                    text(
+                        f"SELECT id, provider_slug, state, scopes, vault_ref, "
+                        f"account_label, external_account_ref, reason, warnings, "
+                        f"last_checked_at "
+                        f"FROM {self.CONNECTIONS_TABLE} "
+                        f"WHERE organization_id = :organization_id "
+                        f"AND user_id = :user_id "
+                        f"AND provider_slug = :provider_slug "
+                        f"AND (:connection_id = '' OR id = :connection_id) "
+                        f"ORDER BY updated_at DESC "
+                        f"LIMIT 1"
+                    ),
+                    {
+                        "organization_id": owner["organization_id"],
+                        "user_id": owner["user_id"],
+                        "provider_slug": slug,
+                        "connection_id": safe_connection_id,
+                    },
+                )
+                row = _fetch_mapping_row(result)
+        except Exception as exc:
+            if _is_missing_storage_table_error(exc):
+                logger.info("Wiii Connect connection storage unavailable; skipping fetch.")
+                return None
+            logger.warning("Wiii Connect connection fetch failed: %s", exc)
+            return None
+
+        if row is None:
+            return None
+        scopes = _decode_json_object(_row_value(row, "scopes"), default={})
+        vault_ref = _decode_json_object(_row_value(row, "vault_ref"), default={})
+        warnings = _decode_json_list(_row_value(row, "warnings"))
+        connection_id_value = str(_row_value(row, "id") or "").strip()
+        has_vault_ref = bool(vault_ref.get("vault_ref_present"))
+        return WiiiConnectConnectionRecordV1(
+            connection_id=connection_id_value,
+            provider_slug=str(_row_value(row, "provider_slug") or slug).strip(),
+            state=normalize_connection_state(str(_row_value(row, "state") or "")),
+            scopes=WiiiConnectScopeGrant(
+                read=bool(scopes.get("read")),
+                preview=bool(scopes.get("preview")),
+                write=bool(scopes.get("write")),
+                apply=bool(scopes.get("apply")),
+                admin=bool(scopes.get("admin")),
+            ),
+            vault_ref=(
+                WiiiConnectVaultSecretRef(
+                    provider_slug=slug,
+                    connection_id=connection_id_value,
+                    vault_key_id="stored_opaque_ref",
+                    secret_version=str(vault_ref.get("secret_version") or ""),
+                )
+                if has_vault_ref
+                else None
+            ),
+            account_label=str(_row_value(row, "account_label") or ""),
+            external_account_ref=str(_row_value(row, "external_account_ref") or ""),
+            last_checked_at=_datetime_to_iso(_row_value(row, "last_checked_at")),
+            reason=str(_row_value(row, "reason") or ""),
+            warnings=tuple(warnings),
+        )
+
 
 def default_persistent_storage_status_metadata() -> dict[str, Any]:
     """Return default non-probed persistent storage status metadata."""
@@ -278,6 +367,61 @@ def _parse_datetime(value: Any) -> datetime | None:
     except ValueError:
         return None
     return parsed.astimezone(UTC) if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _datetime_to_iso(value: Any) -> str | None:
+    parsed = _parse_datetime(value)
+    return parsed.isoformat() if parsed is not None else None
+
+
+def _fetch_mapping_row(result: Any) -> Any | None:
+    mappings = getattr(result, "mappings", None)
+    if callable(mappings):
+        try:
+            return mappings().fetchone()
+        except Exception:
+            return None
+    fetchone = getattr(result, "fetchone", None)
+    if callable(fetchone):
+        return fetchone()
+    return None
+
+
+def _row_value(row: Any, key: str) -> Any:
+    if isinstance(row, dict):
+        return row.get(key)
+    mapping = getattr(row, "_mapping", None)
+    if mapping is not None:
+        return mapping.get(key)
+    try:
+        return row[key]
+    except Exception:
+        return None
+
+
+def _decode_json_object(value: Any, *, default: dict[str, Any]) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return dict(default)
+        return parsed if isinstance(parsed, dict) else dict(default)
+    return dict(default)
+
+
+def _decode_json_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(parsed, list):
+            return [str(item) for item in parsed if str(item).strip()]
+    return []
 
 
 def _is_missing_storage_table_error(exc: Exception) -> bool:

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -676,6 +676,134 @@ async def test_wiii_connect_connections_api_lists_and_persists_safely(
 
 
 @pytest.mark.asyncio
+async def test_wiii_connect_execution_decision_api_requires_auth(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/wiii-connect/providers/facebook/execution-decision",
+            json={"action_slug": "FACEBOOK_GET_PAGE"},
+        )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_execution_decision_api_audits_fail_closed(
+    authenticated_app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+    from app.engine.wiii_connect.adapter_v1 import (
+        WiiiConnectConnectionRecordV1,
+        WiiiConnectScopeGrant,
+    )
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+    )
+    from app.engine.wiii_connect.persistent_storage import (
+        WiiiConnectPersistentStorageStatus,
+    )
+
+    class FakeStorage:
+        audit_appends = 0
+        fetches = 0
+
+        def status(self, *, probe_database: bool = True):
+            return WiiiConnectPersistentStorageStatus(
+                enabled=True,
+                persistent=True,
+                connection_table_ready=True,
+                audit_ledger_ready=True,
+                reason="ready",
+            )
+
+        def get_connection_record(
+            self,
+            *,
+            organization_id: str,
+            user_id: str,
+            provider_slug: str,
+            connection_id: str | None = None,
+        ):
+            self.fetches += 1
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert provider_slug == "facebook"
+            assert connection_id == "ca_active"
+            return WiiiConnectConnectionRecordV1(
+                connection_id="ca_active",
+                provider_slug="facebook",
+                state="connected",
+                scopes=WiiiConnectScopeGrant(read=True, write=True),
+                reason="provider_connection_list",
+            )
+
+        def append_audit_record(self, record, *, organization_id: str, user_id: str):
+            self.audit_appends += 1
+            metadata = record.to_public_metadata()["metadata"]
+            serialized = json.dumps(record.to_public_metadata(), sort_keys=True)
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert metadata["request"]["action_slug"] == "FACEBOOK_GET_PAGE"
+            assert metadata["connection_found"] is True
+            assert "approval_token" not in serialized
+            assert "secret-value" not in serialized
+            assert "access_token" not in serialized
+            return True
+
+    fake_storage = FakeStorage()
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "build_composio_adapter_config",
+        lambda: WiiiConnectComposioAdapterConfig(
+            enabled=True,
+            api_key="secret-api-key",
+            api_key_present=True,
+            auth_config_by_provider={"facebook": "authcfg_fb"},
+        ),
+    )
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        lambda: fake_storage,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=authenticated_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/wiii-connect/providers/facebook/execution-decision",
+            json={
+                "surface": "desktop",
+                "connection_id": "ca_active",
+                "action_slug": "FACEBOOK_GET_PAGE",
+                "path": "external_app_action",
+                "mutation": "read",
+                "argument_keys": ["page_id", "access_token"],
+                "approval_token": "secret-value",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    serialized = json.dumps(payload, sort_keys=True)
+    assert payload["version"] == "wiii_connect_execution_gateway.v1"
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "provider_not_agent_ready"
+    assert payload["connection_present"] is True
+    assert payload["adapter"]["can_execute_actions"] is False
+    assert fake_storage.fetches == 1
+    assert fake_storage.audit_appends == 1
+    assert "secret-api-key" not in serialized
+    assert "authcfg_fb" not in serialized
+    assert "secret-value" not in serialized
+    assert "access_token" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_wiii_connect_authorization_url_api_404_for_unknown_provider(app):
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app),

--- a/maritime-ai-service/tests/unit/test_wiii_connect_adapter_v1.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_adapter_v1.py
@@ -177,6 +177,95 @@ def test_wildcard_only_action_allowlist_stays_fail_closed():
     assert entry.allows_action("SLACK_SEND_MESSAGE") is False
 
 
+def test_execution_gateway_requires_adapter_execution_and_persistent_audit():
+    from app.engine.wiii_connect.adapter_v1 import (
+        WiiiConnectConnectionRecordV1,
+        WiiiConnectExecutionRequest,
+        WiiiConnectProviderRegistryEntry,
+        WiiiConnectScopeGrant,
+    )
+    from app.engine.wiii_connect.execution_gateway import decide_execution_gateway
+    from app.engine.wiii_connect.provider_adapters import (
+        WiiiConnectProviderAdapterCapability,
+    )
+
+    entry = WiiiConnectProviderRegistryEntry(
+        slug="facebook",
+        label="Facebook",
+        provider_kind="composio",
+        auth_mode="oauth2",
+        enabled=True,
+        agent_ready=True,
+        allowed_paths=("external_app_action",),
+        action_allowlist=("FACEBOOK_GET_PAGE",),
+    )
+    connection = WiiiConnectConnectionRecordV1(
+        connection_id="conn_1",
+        provider_slug="facebook",
+        state="connected",
+        scopes=WiiiConnectScopeGrant(read=True),
+    )
+    request = WiiiConnectExecutionRequest(
+        provider_slug="facebook",
+        action_slug="FACEBOOK_GET_PAGE",
+        path="external_app_action",
+        mutation="read",
+        argument_keys=("page_id", "access_token"),
+    )
+    adapter_without_execute = WiiiConnectProviderAdapterCapability(
+        provider_kind="composio",
+        adapter_name="composio_adapter",
+        bound=True,
+        configured=True,
+        can_create_authorization_url=True,
+        can_exchange_callback=True,
+        can_execute_actions=False,
+        reason="ready",
+    )
+    adapter_with_execute = WiiiConnectProviderAdapterCapability(
+        provider_kind="composio",
+        adapter_name="composio_adapter",
+        bound=True,
+        configured=True,
+        can_create_authorization_url=True,
+        can_exchange_callback=True,
+        can_execute_actions=True,
+        reason="ready",
+    )
+
+    blocked_adapter = decide_execution_gateway(
+        entry,
+        connection,
+        request,
+        adapter_capability=adapter_without_execute,
+        audit_ledger_metadata={"persistent": True},
+    )
+    blocked_audit = decide_execution_gateway(
+        entry,
+        connection,
+        request,
+        adapter_capability=adapter_with_execute,
+        audit_ledger_metadata={"persistent": False},
+    )
+    allowed = decide_execution_gateway(
+        entry,
+        connection,
+        request,
+        adapter_capability=adapter_with_execute,
+        audit_ledger_metadata={"persistent": True},
+    )
+    serialized = json.dumps(allowed.to_public_metadata(), sort_keys=True)
+
+    assert blocked_adapter.allowed is False
+    assert blocked_adapter.reason == "provider_adapter_cannot_execute"
+    assert blocked_audit.allowed is False
+    assert blocked_audit.reason == "audit_ledger_not_persistent"
+    assert allowed.allowed is True
+    assert allowed.reason == "allowed"
+    assert "redacted_sensitive_field" in serialized
+    assert "access_token" not in serialized
+
+
 def test_public_metadata_does_not_expose_vault_key_or_raw_secret_values():
     from app.engine.wiii_connect.adapter_v1 import (
         WiiiConnectConnectionRecordV1,

--- a/maritime-ai-service/tests/unit/test_wiii_connect_persistent_storage.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_persistent_storage.py
@@ -7,6 +7,9 @@ class _FakeResult:
     def __init__(self, row=None):
         self._row = row
 
+    def mappings(self):
+        return self
+
     def fetchone(self):
         return self._row
 
@@ -141,6 +144,46 @@ def test_connection_upsert_stores_only_public_vault_ref_metadata():
     assert "oauth-token-secret" not in serialized
     assert "vault://tenant/private" not in serialized
     assert session.commits == 1
+
+
+def test_connection_fetch_rehydrates_sanitized_policy_record():
+    from app.engine.wiii_connect.persistent_storage import WiiiConnectPersistentStorage
+
+    session = _FakeSession(
+        row={
+            "id": "conn_1",
+            "provider_slug": "facebook",
+            "state": "ACTIVE",
+            "scopes": json.dumps({"read": True, "write": True, "apply": False}),
+            "vault_ref": json.dumps(
+                {"vault_ref_present": True, "secret_version": "provider_managed"}
+            ),
+            "account_label": "Wiii Page",
+            "external_account_ref": "page_1",
+            "reason": "provider_connection_list",
+            "warnings": json.dumps(["safe_warning"]),
+            "last_checked_at": "2026-05-28T00:00:00+00:00",
+        },
+    )
+    storage = WiiiConnectPersistentStorage(session_factory=lambda: session)
+
+    record = storage.get_connection_record(
+        organization_id="org_1",
+        user_id="user_1",
+        provider_slug="facebook",
+        connection_id="conn_1",
+    )
+    assert record is not None
+    serialized = json.dumps(record.to_public_metadata(), sort_keys=True)
+
+    assert record.connection_id == "conn_1"
+    assert record.state == "connected"
+    assert record.scopes.read is True
+    assert record.scopes.write is True
+    assert record.vault_ref is not None
+    assert record.to_public_metadata()["vault_ref_present"] is True
+    assert "provider-managed://" not in serialized
+    assert "oauth-token" not in serialized
 
 
 def test_persistent_storage_rejects_missing_owner_boundary():


### PR DESCRIPTION
## Summary
- Add an authenticated Wiii Connect execution-decision gateway endpoint before any external provider action can run.
- Add durable storage lookup for sanitized org/user/provider connection records used by gateway policy.
- Add a provider-neutral execution gateway contract that checks connection, path, curated action, scope, preview/approval evidence, adapter execution capability, and persistent audit readiness.
- Update OpenHuman/Composio and Adapter V1 docs to reflect current Wiii state.

## Scope
- Backend Wiii Connect policy/API/storage/tests/docs only.
- No real Composio action execution is enabled.
- No provider credentials, OAuth tokens, approval token values, or provider payloads are stored or exposed.

## Non-Scope
- Disconnect/reconnect controls.
- Curated Composio action catalog.
- Real Composio action execution adapter.
- Browser UI changes.

## Verification
- cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py -q --tb=short -> 43 passed.
- cd maritime-ai-service; python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7 -> passed.
- git diff --check -> passed.

## Risk
- High-risk surface: external provider action execution policy. This PR keeps provider execution disabled and only adds a preflight/audit boundary.
- If persistent storage is not ready, gateway decisions fail closed rather than allowing unaudited execution.

## Rollback
- Revert this PR. Existing provider catalog, Connect Link, callback, and connection-listing paths remain independent.

Closes #766