### PR TITLE
Add Wiii Connect curated action catalog

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -39,6 +39,12 @@ The implemented backend contract lives in:
 maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
 ```
 
+The curated action catalog contract lives in:
+
+```text
+maritime-ai-service/app/engine/wiii_connect/action_catalog.py
+```
+
 The backend-owned provider catalog lives in:
 
 ```text
@@ -98,6 +104,7 @@ GET  /api/v1/wiii-connect/providers/{slug}/status
 POST /api/v1/wiii-connect/providers/{slug}/sessions
 POST /api/v1/wiii-connect/providers/{slug}/authorization-url
 GET  /api/v1/wiii-connect/providers/{slug}/connections
+GET  /api/v1/wiii-connect/providers/{slug}/actions
 POST /api/v1/wiii-connect/providers/{slug}/execution-decision
 GET  /api/v1/wiii-connect/providers/{slug}/callback
 GET  /api/v1/wiii-connect/provider-adapters/status
@@ -132,6 +139,18 @@ never receives provider tokens or raw payloads.
 - curated action allowlist;
 - provider-specific required fields;
 - default scopes and safe public metadata.
+
+`WiiiConnectCuratedAction`
+
+- reviewed action candidate for one provider;
+- records action slug, mutation class, product path, required scopes,
+  preview/approval requirements, and sanitized argument key names;
+- starts disabled until the live provider schema is verified and adapter
+  execution is implemented;
+- never stores raw Composio schemas, provider payloads, provider responses, or
+  secrets;
+- exposes public catalog summary through both provider registry metadata and
+  `GET /api/v1/wiii-connect/providers/{slug}/actions`.
 
 `WiiiConnectVaultSecretRef`
 
@@ -308,6 +327,11 @@ never receives provider tokens or raw payloads.
 - currently performs preflight only. It does not call Composio action execution
   until a curated action catalog and provider execution adapter are enabled.
 
+The first catalog candidate is `FACEBOOK_GET_PAGE_PROFILE`, a disabled
+read-only Facebook action placeholder. It is intentionally not agent-ready until
+Wiii validates the exact live Composio action schema for the configured
+Facebook auth config.
+
 ## Lifecycle States
 
 Adapter V1 normalizes provider states into:
@@ -458,7 +482,8 @@ approval tokens and provider payloads must remain outside chat lifecycle data.
 ## Next Slices
 
 1. Add a curated Composio action catalog contract for one low-risk read-only
-   provider action.
+   provider action. Done for the disabled contract candidate; still needs live
+   schema verification before enablement.
 2. Bind Composio adapter `can_execute_actions` only for that curated read-only
    action and keep writes disabled.
 3. Add disconnect/delete/reconnect lifecycle controls behind the same policy.

--- a/docs/architecture/wiii-connect/README.md
+++ b/docs/architecture/wiii-connect/README.md
@@ -184,4 +184,5 @@ this repository.
    external provider catalog entries; frontend catalog state should converge on
    this projection.
 7. Add one low-risk read-only Composio action through the gateway before any
-   write/apply action.
+   write/apply action. A disabled read-only catalog candidate now exists; the
+   remaining work is live schema verification and adapter execution enablement.

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -153,7 +153,10 @@ agent-ready execution state. Wiii now also has an authenticated execution
 gateway preflight endpoint that fetches the stored org/user connection record,
 checks path/action/scope/evidence/adapter/audit policy, and appends a
 privacy-safe execution ledger record without calling Composio action execution.
-It still needs a curated action catalog, provider execution adapter enablement
-for one low-risk read-only action, disconnect/reconnect controls, and
-end-to-end acceptance against real Composio credentials before Composio actions
-can be enabled for real users.
+Wiii also has a curated action catalog contract with a disabled
+`FACEBOOK_GET_PAGE_PROFILE` read-only candidate, so future action exposure has a
+reviewable allowlist rather than a broad Composio tool dump. It still needs live
+Composio schema verification, provider execution adapter enablement for one
+low-risk read-only action, disconnect/reconnect controls, and end-to-end
+acceptance against real Composio credentials before Composio actions can be
+enabled for real users.

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -17,6 +17,7 @@ from app.engine.wiii_connect import (
     WiiiConnectExecutionRequest,
     WiiiConnectSessionStartRequest,
     WiiiConnectVaultSecretRef,
+    action_catalog_public_metadata,
     append_wiii_connect_callback_state,
     audit_ledger_status_public_metadata,
     build_audit_ledger_record,
@@ -331,6 +332,16 @@ async def list_wiii_connect_provider_connections(
         "provider": provider_result.to_public_metadata(),
         "storage": storage,
     }
+
+
+@router.get("/providers/{slug}/actions")
+async def list_wiii_connect_provider_actions(slug: str) -> dict[str, object]:
+    """Return the privacy-safe curated action catalog for a provider."""
+
+    entry = get_wiii_connect_provider_entry(slug)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="unknown_wiii_connect_provider")
+    return action_catalog_public_metadata(provider_slug=entry.slug)
 
 
 @router.post("/providers/{slug}/execution-decision")

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -14,6 +14,14 @@ from .adapter_v1 import (
     is_connection_baseline_ready,
     normalize_connection_state,
 )
+from .action_catalog import (
+    WIII_CONNECT_ACTION_CATALOG_VERSION,
+    WiiiConnectCuratedAction,
+    action_catalog_public_metadata,
+    action_catalog_summary_for_provider,
+    enabled_action_slugs_for_provider,
+    list_wiii_connect_curated_actions,
+)
 from .audit_ledger import (
     WIII_CONNECT_AUDIT_LEDGER_VERSION,
     WiiiConnectAuditLedgerRecord,
@@ -112,6 +120,7 @@ from .snapshot import (
 
 __all__ = [
     "WIII_CONNECT_ADAPTER_VERSION",
+    "WIII_CONNECT_ACTION_CATALOG_VERSION",
     "WIII_CONNECT_AUDIT_LEDGER_VERSION",
     "WIII_CONNECT_CALLBACK_CONTRACT_VERSION",
     "WIII_CONNECT_CALLBACK_STATE_PARAM",
@@ -126,6 +135,7 @@ __all__ = [
     "WiiiConnectAuthorizationUrlAuditEvent",
     "WiiiConnectAuthorizationUrlDecision",
     "WiiiConnectAuthorizationUrlRequest",
+    "WiiiConnectCuratedAction",
     "WiiiConnectAuditEvent",
     "WiiiConnectAuditLedgerRecord",
     "WiiiConnectCallbackAuditEvent",
@@ -161,6 +171,8 @@ __all__ = [
     "WiiiConnectionScopes",
     "WiiiConnectionSnapshot",
     "WiiiPathCapabilityRecord",
+    "action_catalog_public_metadata",
+    "action_catalog_summary_for_provider",
     "audit_ledger_status_public_metadata",
     "append_wiii_connect_callback_state",
     "begin_connection_session",
@@ -172,6 +184,7 @@ __all__ = [
     "decide_execution_gateway",
     "decide_authorization_url",
     "decide_vault_secret_write",
+    "enabled_action_slugs_for_provider",
     "build_composio_connect_enabled_entry",
     "build_composio_external_user_id",
     "build_composio_provider_managed_vault_capability",
@@ -182,6 +195,7 @@ __all__ = [
     "get_wiii_connect_provider_entry",
     "get_wiii_connect_persistent_storage",
     "is_connection_baseline_ready",
+    "list_wiii_connect_curated_actions",
     "list_wiii_connect_provider_registry",
     "list_composio_connected_accounts",
     "normalize_connection_state",

--- a/maritime-ai-service/app/engine/wiii_connect/action_catalog.py
+++ b/maritime-ai-service/app/engine/wiii_connect/action_catalog.py
@@ -1,0 +1,170 @@
+"""Curated Wiii Connect action catalog.
+
+The catalog is the review boundary between a connected external provider and
+the action schemas an agent may see. It intentionally stores only public action
+metadata and sanitized argument key names, not provider payload schemas.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .adapter_v1 import ActionMutation, ProviderKind, ScopeName
+
+
+WIII_CONNECT_ACTION_CATALOG_VERSION = "wiii_connect_action_catalog.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectCuratedAction:
+    """One reviewed external action candidate."""
+
+    slug: str
+    provider_slug: str
+    provider_kind: ProviderKind
+    label: str
+    mutation: ActionMutation = "read"
+    path: str = "external_app_action"
+    enabled: bool = False
+    requires_preview: bool = False
+    requires_approval: bool = False
+    required_scopes: tuple[ScopeName, ...] = ("read",)
+    argument_keys: tuple[str, ...] = ()
+    description: str = ""
+    source: str = "wiii_connect_action_catalog"
+    warnings: tuple[str, ...] = ()
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "version": WIII_CONNECT_ACTION_CATALOG_VERSION,
+            "slug": self.slug,
+            "provider_slug": self.provider_slug,
+            "provider_kind": self.provider_kind,
+            "label": self.label,
+            "mutation": self.mutation,
+            "path": self.path,
+            "enabled": self.enabled,
+            "requires_preview": self.requires_preview,
+            "requires_approval": self.requires_approval,
+            "required_scopes": list(self.required_scopes),
+            "argument_keys": [_safe_public_key(key) for key in self.argument_keys],
+            "description": self.description,
+            "source": self.source,
+            "warnings": list(self.warnings),
+        }
+
+
+_CURATED_ACTIONS: tuple[WiiiConnectCuratedAction, ...] = (
+    WiiiConnectCuratedAction(
+        slug="FACEBOOK_GET_PAGE_PROFILE",
+        provider_slug="facebook",
+        provider_kind="composio",
+        label="Read Facebook Page profile",
+        mutation="read",
+        enabled=False,
+        required_scopes=("read",),
+        argument_keys=("page_id",),
+        description=(
+            "Read-only candidate for verifying Composio execution after a real "
+            "Facebook auth-config and action schema are confirmed."
+        ),
+        warnings=("disabled_until_live_schema_verified",),
+    ),
+)
+
+
+def list_wiii_connect_curated_actions(
+    *,
+    provider_slug: str | None = None,
+    include_disabled: bool = True,
+) -> tuple[WiiiConnectCuratedAction, ...]:
+    """Return curated action metadata, optionally scoped to one provider."""
+
+    provider = _normalize_provider_slug(provider_slug)
+    actions = []
+    for action in _CURATED_ACTIONS:
+        if provider and action.provider_slug != provider:
+            continue
+        if not include_disabled and not action.enabled:
+            continue
+        actions.append(action)
+    return tuple(sorted(actions, key=lambda item: (item.provider_slug, item.slug)))
+
+
+def enabled_action_slugs_for_provider(provider_slug: str) -> tuple[str, ...]:
+    """Return action slugs that may enter gateway allowlists."""
+
+    return tuple(
+        action.slug
+        for action in list_wiii_connect_curated_actions(
+            provider_slug=provider_slug,
+            include_disabled=False,
+        )
+    )
+
+
+def action_catalog_summary_for_provider(provider_slug: str) -> dict[str, Any]:
+    """Return a privacy-safe catalog summary for one provider."""
+
+    actions = list_wiii_connect_curated_actions(provider_slug=provider_slug)
+    enabled = [action for action in actions if action.enabled]
+    read_only = [action for action in actions if action.mutation == "read"]
+    return {
+        "version": WIII_CONNECT_ACTION_CATALOG_VERSION,
+        "provider_slug": _normalize_provider_slug(provider_slug),
+        "catalog_action_count": len(actions),
+        "enabled_action_count": len(enabled),
+        "read_only_action_count": len(read_only),
+        "write_action_count": len(
+            [action for action in actions if action.mutation in {"write", "apply", "admin"}]
+        ),
+        "enabled_action_slugs": [action.slug for action in enabled],
+        "warnings": sorted({warning for action in actions for warning in action.warnings}),
+    }
+
+
+def action_catalog_public_metadata(
+    *,
+    provider_slug: str | None = None,
+    include_disabled: bool = True,
+) -> dict[str, Any]:
+    """Return the public action catalog projection."""
+
+    actions = list_wiii_connect_curated_actions(
+        provider_slug=provider_slug,
+        include_disabled=include_disabled,
+    )
+    return {
+        "version": WIII_CONNECT_ACTION_CATALOG_VERSION,
+        "provider_slug": _normalize_provider_slug(provider_slug) or None,
+        "action_count": len(actions),
+        "enabled_action_count": len([action for action in actions if action.enabled]),
+        "actions": [action.to_public_metadata() for action in actions],
+    }
+
+
+_SENSITIVE_KEY_MARKERS = ("token", "secret", "password", "credential", "key", "code")
+
+
+def _normalize_provider_slug(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_")
+
+
+def _safe_public_key(value: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if not normalized:
+        return "empty"
+    if any(marker in normalized for marker in _SENSITIVE_KEY_MARKERS):
+        return "redacted_sensitive_field"
+    return normalized[:80]
+
+
+__all__ = [
+    "WIII_CONNECT_ACTION_CATALOG_VERSION",
+    "WiiiConnectCuratedAction",
+    "action_catalog_public_metadata",
+    "action_catalog_summary_for_provider",
+    "enabled_action_slugs_for_provider",
+    "list_wiii_connect_curated_actions",
+]

--- a/maritime-ai-service/app/engine/wiii_connect/provider_registry.py
+++ b/maritime-ai-service/app/engine/wiii_connect/provider_registry.py
@@ -14,6 +14,7 @@ from .adapter_v1 import (
     ProviderKind,
     WiiiConnectProviderRegistryEntry,
 )
+from .action_catalog import action_catalog_summary_for_provider
 
 
 WIII_CONNECT_PROVIDER_REGISTRY_VERSION = "wiii_connect_provider_registry.v1"
@@ -178,11 +179,13 @@ def get_wiii_connect_provider_entry(
 def provider_registry_public_metadata() -> dict[str, object]:
     """Return the privacy-safe provider catalog projection for UI/API use."""
 
+    providers = []
+    for entry in list_wiii_connect_provider_registry():
+        metadata = entry.to_public_metadata()
+        metadata["action_catalog"] = action_catalog_summary_for_provider(entry.slug)
+        providers.append(metadata)
     return {
         "version": WIII_CONNECT_PROVIDER_REGISTRY_VERSION,
         "adapter_version": WIII_CONNECT_ADAPTER_VERSION,
-        "providers": [
-            entry.to_public_metadata()
-            for entry in list_wiii_connect_provider_registry()
-        ],
+        "providers": providers,
     }

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -676,6 +676,28 @@ async def test_wiii_connect_connections_api_lists_and_persists_safely(
 
 
 @pytest.mark.asyncio
+async def test_wiii_connect_actions_api_lists_curated_catalog_without_secrets(app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/wiii-connect/providers/facebook/actions")
+
+    assert response.status_code == 200
+    payload = response.json()
+    serialized = json.dumps(payload, sort_keys=True)
+    assert payload["version"] == "wiii_connect_action_catalog.v1"
+    assert payload["provider_slug"] == "facebook"
+    assert payload["action_count"] == 1
+    assert payload["enabled_action_count"] == 0
+    assert payload["actions"][0]["slug"] == "FACEBOOK_GET_PAGE_PROFILE"
+    assert payload["actions"][0]["enabled"] is False
+    assert "access_token" not in serialized
+    assert "refresh_token" not in serialized
+    assert "client_secret" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_wiii_connect_execution_decision_api_requires_auth(app):
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app),

--- a/maritime-ai-service/tests/unit/test_wiii_connect_action_catalog.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_action_catalog.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+
+
+def test_action_catalog_exposes_disabled_read_only_candidate_without_secrets():
+    from app.engine.wiii_connect.action_catalog import (
+        action_catalog_public_metadata,
+        action_catalog_summary_for_provider,
+        enabled_action_slugs_for_provider,
+    )
+
+    metadata = action_catalog_public_metadata(provider_slug="facebook")
+    summary = action_catalog_summary_for_provider("facebook")
+    serialized = json.dumps(metadata, sort_keys=True)
+
+    assert metadata["version"] == "wiii_connect_action_catalog.v1"
+    assert metadata["action_count"] == 1
+    assert metadata["enabled_action_count"] == 0
+    assert metadata["actions"][0]["slug"] == "FACEBOOK_GET_PAGE_PROFILE"
+    assert metadata["actions"][0]["mutation"] == "read"
+    assert metadata["actions"][0]["enabled"] is False
+    assert summary["catalog_action_count"] == 1
+    assert summary["enabled_action_count"] == 0
+    assert summary["read_only_action_count"] == 1
+    assert enabled_action_slugs_for_provider("facebook") == ()
+    assert "access_token" not in serialized
+    assert "refresh_token" not in serialized
+    assert "client_secret" not in serialized
+    assert "provider_payload" not in serialized
+
+
+def test_action_catalog_redacts_sensitive_argument_keys():
+    from app.engine.wiii_connect.action_catalog import WiiiConnectCuratedAction
+
+    action = WiiiConnectCuratedAction(
+        slug="TEST_READ",
+        provider_slug="internal",
+        provider_kind="composio",
+        label="Test read",
+        argument_keys=("page_id", "access_token", "client_secret"),
+    )
+    metadata = action.to_public_metadata()
+    serialized = json.dumps(metadata, sort_keys=True)
+
+    assert "page_id" in metadata["argument_keys"]
+    assert "redacted_sensitive_field" in metadata["argument_keys"]
+    assert "access_token" not in serialized
+    assert "client_secret" not in serialized

--- a/maritime-ai-service/tests/unit/test_wiii_connect_provider_registry.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_provider_registry.py
@@ -14,6 +14,8 @@ def test_provider_registry_exposes_disabled_composio_catalog_without_secrets():
 
     assert metadata["version"] == "wiii_connect_provider_registry.v1"
     assert by_slug["facebook"]["provider_kind"] == "composio"
+    assert by_slug["facebook"]["action_catalog"]["catalog_action_count"] == 1
+    assert by_slug["facebook"]["action_catalog"]["enabled_action_count"] == 0
     assert by_slug["gmail"]["enabled"] is False
     assert by_slug["gmail"]["agent_ready"] is False
     assert by_slug["github"]["requirements"] == [


### PR DESCRIPTION
## Summary
- Add a provider-neutral Wiii Connect curated action catalog contract.
- Expose a privacy-safe provider action catalog endpoint and provider registry summary.
- Add a disabled read-only Facebook candidate so future Composio action enablement has a reviewable allowlist instead of broad tool exposure.
- Update Adapter V1/OpenHuman audit docs with the current catalog state.

## Scope
- Backend Wiii Connect action catalog, API projection, tests, and docs.
- Candidate action remains disabled.
- No real Composio action execution is enabled.

## Non-Scope
- Live Composio schema verification.
- Provider execution network calls.
- Disconnect/reconnect UI.
- Frontend catalog rendering changes.

## Verification
- cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_action_catalog.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py -q --tb=short -> 41 passed.
- cd maritime-ai-service; python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py tests/unit/test_wiii_connect_action_catalog.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7 -> passed.
- git diff --check -> passed.

## Risk
- High-risk external action surface. The catalog is read-only metadata and keeps the candidate disabled until live schema and adapter execution are verified.

## Rollback
- Revert this PR. Existing provider registry, Connect Link, callback, connection-listing, and execution-decision paths remain fail-closed.

Closes #768