### PR TITLE
Align Composio action candidates with current docs

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -327,10 +327,11 @@ never receives provider tokens or raw payloads.
 - currently performs preflight only. It does not call Composio action execution
   until a curated action catalog and provider execution adapter are enabled.
 
-The first catalog candidate is `FACEBOOK_GET_PAGE_PROFILE`, a disabled
-read-only Facebook action placeholder. It is intentionally not agent-ready until
-Wiii validates the exact live Composio action schema for the configured
-Facebook auth config.
+The first catalog candidate is `GMAIL_FETCH_EMAILS`, a disabled read-only Gmail
+action listed in current Composio docs. It is intentionally not agent-ready
+until Wiii validates the exact live Composio action schema for the configured
+Gmail auth config. Facebook remains a connection/catalog provider, but current
+Composio Facebook docs do not expose a ready Facebook action for Wiii to enable.
 
 ## Lifecycle States
 

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -154,9 +154,11 @@ gateway preflight endpoint that fetches the stored org/user connection record,
 checks path/action/scope/evidence/adapter/audit policy, and appends a
 privacy-safe execution ledger record without calling Composio action execution.
 Wiii also has a curated action catalog contract with a disabled
-`FACEBOOK_GET_PAGE_PROFILE` read-only candidate, so future action exposure has a
-reviewable allowlist rather than a broad Composio tool dump. It still needs live
-Composio schema verification, provider execution adapter enablement for one
-low-risk read-only action, disconnect/reconnect controls, and end-to-end
-acceptance against real Composio credentials before Composio actions can be
-enabled for real users.
+`GMAIL_FETCH_EMAILS` read-only candidate, so future action exposure has a
+reviewable allowlist rather than a broad Composio tool dump. This candidate was
+chosen because current Composio Gmail docs list it as an available tool, while
+current Facebook docs still describe Facebook actions as coming soon. Wiii still
+needs live Composio schema verification, provider execution adapter enablement
+for one low-risk read-only action, disconnect/reconnect controls, and
+end-to-end acceptance against real Composio credentials before Composio actions
+can be enabled for real users.

--- a/maritime-ai-service/app/engine/wiii_connect/action_catalog.py
+++ b/maritime-ai-service/app/engine/wiii_connect/action_catalog.py
@@ -57,19 +57,19 @@ class WiiiConnectCuratedAction:
 
 _CURATED_ACTIONS: tuple[WiiiConnectCuratedAction, ...] = (
     WiiiConnectCuratedAction(
-        slug="FACEBOOK_GET_PAGE_PROFILE",
-        provider_slug="facebook",
+        slug="GMAIL_FETCH_EMAILS",
+        provider_slug="gmail",
         provider_kind="composio",
-        label="Read Facebook Page profile",
+        label="Fetch Gmail emails",
         mutation="read",
         enabled=False,
         required_scopes=("read",),
-        argument_keys=("page_id",),
+        argument_keys=("query", "max_results"),
         description=(
-            "Read-only candidate for verifying Composio execution after a real "
-            "Facebook auth-config and action schema are confirmed."
+            "Read-only candidate listed in current Composio Gmail docs. Enable "
+            "only after a real Gmail auth-config and live tool schema are verified."
         ),
-        warnings=("disabled_until_live_schema_verified",),
+        warnings=("disabled_until_live_gmail_schema_verified",),
     ),
 )
 

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -681,16 +681,16 @@ async def test_wiii_connect_actions_api_lists_curated_catalog_without_secrets(ap
         transport=httpx.ASGITransport(app=app),
         base_url="http://test",
     ) as client:
-        response = await client.get("/wiii-connect/providers/facebook/actions")
+        response = await client.get("/wiii-connect/providers/gmail/actions")
 
     assert response.status_code == 200
     payload = response.json()
     serialized = json.dumps(payload, sort_keys=True)
     assert payload["version"] == "wiii_connect_action_catalog.v1"
-    assert payload["provider_slug"] == "facebook"
+    assert payload["provider_slug"] == "gmail"
     assert payload["action_count"] == 1
     assert payload["enabled_action_count"] == 0
-    assert payload["actions"][0]["slug"] == "FACEBOOK_GET_PAGE_PROFILE"
+    assert payload["actions"][0]["slug"] == "GMAIL_FETCH_EMAILS"
     assert payload["actions"][0]["enabled"] is False
     assert "access_token" not in serialized
     assert "refresh_token" not in serialized

--- a/maritime-ai-service/tests/unit/test_wiii_connect_action_catalog.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_action_catalog.py
@@ -10,20 +10,20 @@ def test_action_catalog_exposes_disabled_read_only_candidate_without_secrets():
         enabled_action_slugs_for_provider,
     )
 
-    metadata = action_catalog_public_metadata(provider_slug="facebook")
-    summary = action_catalog_summary_for_provider("facebook")
+    metadata = action_catalog_public_metadata(provider_slug="gmail")
+    summary = action_catalog_summary_for_provider("gmail")
     serialized = json.dumps(metadata, sort_keys=True)
 
     assert metadata["version"] == "wiii_connect_action_catalog.v1"
     assert metadata["action_count"] == 1
     assert metadata["enabled_action_count"] == 0
-    assert metadata["actions"][0]["slug"] == "FACEBOOK_GET_PAGE_PROFILE"
+    assert metadata["actions"][0]["slug"] == "GMAIL_FETCH_EMAILS"
     assert metadata["actions"][0]["mutation"] == "read"
     assert metadata["actions"][0]["enabled"] is False
     assert summary["catalog_action_count"] == 1
     assert summary["enabled_action_count"] == 0
     assert summary["read_only_action_count"] == 1
-    assert enabled_action_slugs_for_provider("facebook") == ()
+    assert enabled_action_slugs_for_provider("gmail") == ()
     assert "access_token" not in serialized
     assert "refresh_token" not in serialized
     assert "client_secret" not in serialized

--- a/maritime-ai-service/tests/unit/test_wiii_connect_provider_registry.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_provider_registry.py
@@ -14,8 +14,9 @@ def test_provider_registry_exposes_disabled_composio_catalog_without_secrets():
 
     assert metadata["version"] == "wiii_connect_provider_registry.v1"
     assert by_slug["facebook"]["provider_kind"] == "composio"
-    assert by_slug["facebook"]["action_catalog"]["catalog_action_count"] == 1
-    assert by_slug["facebook"]["action_catalog"]["enabled_action_count"] == 0
+    assert by_slug["facebook"]["action_catalog"]["catalog_action_count"] == 0
+    assert by_slug["gmail"]["action_catalog"]["catalog_action_count"] == 1
+    assert by_slug["gmail"]["action_catalog"]["enabled_action_count"] == 0
     assert by_slug["gmail"]["enabled"] is False
     assert by_slug["gmail"]["agent_ready"] is False
     assert by_slug["github"]["requirements"] == [


### PR DESCRIPTION
## Summary
- Replace the disabled Facebook read-only action placeholder with disabled Gmail GMAIL_FETCH_EMAILS as the first real Composio action candidate.
- Document that current Composio Facebook docs show Facebook actions as coming soon, so Wiii should not present Facebook as action-ready.
- Update action catalog/API/registry tests.

## Scope
- Catalog metadata, docs, and focused tests only.
- No execution enablement and no Composio credentials.

## Verification
- cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_action_catalog.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/api/test_wiii_connect_api.py -q --tb=short -> 27 passed.
- cd maritime-ai-service; python -m ruff check app/engine/wiii_connect/action_catalog.py app/engine/wiii_connect/provider_registry.py app/api/v1/wiii_connect.py tests/unit/test_wiii_connect_action_catalog.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7 -> passed.
- git diff --check -> passed.

## Risk
- Low runtime risk; this is catalog/docs-only. It reduces product risk by avoiding a false Facebook action-ready signal.

## Rollback
- Revert this PR to restore prior candidate metadata.

Closes #770