### PR TITLE
Add Wiii Connect lifecycle controls

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -542,7 +542,7 @@ approval tokens and provider payloads must remain outside chat lifecycle data.
    action and keep writes disabled. Done for the backend boundary; still needs
    real Composio credentials and acceptance against a live Gmail connection.
 3. Add disconnect/delete/reconnect lifecycle controls behind the same policy.
-   Backend disconnect is implemented; frontend controls and live-provider
-   acceptance are still pending.
+   Backend disconnect and desktop lifecycle controls are implemented; live
+   provider acceptance is still pending.
 4. Add browser acceptance for connect, denied execute, gated scope, and
    reconnect cases.

--- a/docs/architecture/wiii-connect/README.md
+++ b/docs/architecture/wiii-connect/README.md
@@ -188,5 +188,6 @@ this repository.
    write/apply action. The backend boundary now supports one curated Gmail
    read-only action behind config, schema verification, gateway, and audit; it
    also supports backend-owned disconnect that disables local Wiii state before
-   provider cleanup. The remaining work is live credential acceptance and
-   frontend disconnect/reconnect UX.
+   provider cleanup. The desktop Wiii Connect page can now call the backend
+   disconnect boundary and keep reconnect on the backend Connect Link path. The
+   remaining work is live credential acceptance.

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -160,7 +160,9 @@ calls Composio `connected_accounts` only through Wiii backend and upserts
 sanitized connection records. The desktop Wiii Connect page can now start a
 backend-owned Connect Link, open only backend-issued URLs, refresh/poll
 sanitized provider connection records, and show connection state separately from
-agent-ready execution state. Wiii now also has an authenticated execution
+agent-ready execution state. It can also request backend-owned disconnect for a
+provider connection and update the local UI state to disabled without exposing
+raw provider payloads or connection IDs. Wiii now also has an authenticated execution
 gateway preflight endpoint that fetches the stored org/user connection record,
 checks path/action/scope/evidence/adapter/audit policy, and appends a
 privacy-safe execution ledger record without calling Composio action execution.
@@ -193,6 +195,5 @@ during cleanup or eventual consistency windows.
 Remaining work before enabling Composio for real users: configure production
 Composio project credentials and auth config IDs, connect a live Gmail account,
 run browser/backend acceptance through Wiii's connect/list/execute/disconnect
-endpoints, add frontend disconnect/reconnect controls, and decide whether Wiii
-should keep using Composio as an adapter or graduate specific providers to
-Wiii-owned OAuth apps.
+endpoints, and decide whether Wiii should keep using Composio as an adapter or
+graduate specific providers to Wiii-owned OAuth apps.

--- a/wiii-desktop/src/__tests__/wiii-connect-page.test.tsx
+++ b/wiii-desktop/src/__tests__/wiii-connect-page.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildWiiiConnectProviderCallbackUrl,
   createWiiiConnectProviderAuthorizationUrl,
+  disconnectWiiiConnectProviderConnection,
   fetchWiiiConnectProviderConnections,
   fetchWiiiConnectProviders,
   startWiiiConnectProviderSession,
@@ -16,6 +17,7 @@ import { useUIStore } from "@/stores/ui-store";
 vi.mock("@/api/wiii-connect", () => ({
   buildWiiiConnectProviderCallbackUrl: vi.fn(),
   createWiiiConnectProviderAuthorizationUrl: vi.fn(),
+  disconnectWiiiConnectProviderConnection: vi.fn(),
   fetchWiiiConnectProviderConnections: vi.fn(),
   fetchWiiiConnectProviders: vi.fn(),
   startWiiiConnectProviderSession: vi.fn(),
@@ -27,6 +29,7 @@ vi.mock("@tauri-apps/plugin-shell", () => ({
 
 const mockBuildWiiiConnectProviderCallbackUrl = vi.mocked(buildWiiiConnectProviderCallbackUrl);
 const mockCreateWiiiConnectProviderAuthorizationUrl = vi.mocked(createWiiiConnectProviderAuthorizationUrl);
+const mockDisconnectWiiiConnectProviderConnection = vi.mocked(disconnectWiiiConnectProviderConnection);
 const mockFetchWiiiConnectProviderConnections = vi.mocked(fetchWiiiConnectProviderConnections);
 const mockFetchWiiiConnectProviders = vi.mocked(fetchWiiiConnectProviders);
 const mockStartWiiiConnectProviderSession = vi.mocked(startWiiiConnectProviderSession);
@@ -39,6 +42,8 @@ describe("WiiiConnectPage", () => {
     mockBuildWiiiConnectProviderCallbackUrl.mockReturnValue("http://localhost:8080/api/v1/wiii-connect/providers/facebook/callback");
     mockCreateWiiiConnectProviderAuthorizationUrl.mockReset();
     mockCreateWiiiConnectProviderAuthorizationUrl.mockRejectedValue(new Error("offline"));
+    mockDisconnectWiiiConnectProviderConnection.mockReset();
+    mockDisconnectWiiiConnectProviderConnection.mockRejectedValue(new Error("offline"));
     mockFetchWiiiConnectProviderConnections.mockReset();
     mockFetchWiiiConnectProviderConnections.mockRejectedValue(new Error("offline"));
     mockStartWiiiConnectProviderSession.mockReset();
@@ -385,6 +390,115 @@ describe("WiiiConnectPage", () => {
     expect(screen.getAllByText("Đã kết nối").length).toBeGreaterThan(0);
     expect(screen.queryByText("access_token")).toBeNull();
     expect(screen.queryByText("secret-value")).toBeNull();
+
+    openSpy.mockRestore();
+  });
+
+  it("disconnects a provider connection through Wiii backend and keeps payloads sanitized", async () => {
+    mockFetchWiiiConnectProviders.mockResolvedValue({
+      version: "wiii_connect_provider_registry.v1",
+      adapter_version: "wiii_connect_adapter.v1",
+      providers: [
+        {
+          slug: "facebook",
+          label: "Facebook",
+          provider_kind: "composio",
+          auth_mode: "oauth2",
+          enabled: true,
+          agent_ready: false,
+          category: "social",
+          description: "Facebook provider from backend registry.",
+          requirements: ["curated_action_catalog"],
+          connect_requirements: ["provider_managed_vault_ref", "durable_audit_ledger"],
+          agent_ready_requirements: ["execution_gateway"],
+          action_count: 0,
+        },
+      ],
+    });
+    mockCreateWiiiConnectProviderAuthorizationUrl.mockResolvedValue({
+      version: "wiii_connect_provider_adapter.v1",
+      status: "ready",
+      reason: "authorization_url_issued",
+      provider_slug: "facebook",
+      label: "Facebook",
+      provider_kind: "composio",
+      auth_mode: "oauth2",
+      authorization_url: "https://composio.example/connect/safe",
+      adapter: {
+        version: "wiii_connect_provider_adapter.v1",
+        provider_kind: "composio",
+        adapter_name: "composio",
+        bound: true,
+        configured: true,
+        can_create_authorization_url: true,
+        can_exchange_callback: true,
+        can_execute_actions: false,
+        authorization_ready: true,
+        reason: "configured",
+        warnings: [],
+      },
+      required_next: [],
+      audit_event: null,
+    });
+    mockFetchWiiiConnectProviderConnections.mockResolvedValue({
+      version: "wiii_connect_connection_list.v1",
+      status: "ready",
+      reason: "listed",
+      provider_slug: "facebook",
+      provider_kind: "composio",
+      connection_count: 1,
+      connections: [
+        {
+          version: "wiii_connect_adapter.v1",
+          connection_id: "conn_public_1",
+          provider_slug: "facebook",
+          state: "connected",
+          active: true,
+          scopes: { read: true, write: false },
+          vault_ref_present: true,
+          account_label: "Wiii Facebook Page",
+          external_account_ref: "fb_page_public",
+          last_checked_at: "2026-05-28T00:00:00Z",
+          reason: "provider_listed",
+          warnings: [],
+        },
+      ],
+      provider: { status: "ready", access_token: "secret-token" },
+      storage: { persistent: true },
+    });
+    mockDisconnectWiiiConnectProviderConnection.mockResolvedValue({
+      version: "wiii_connect_disconnect.v1",
+      status: "succeeded",
+      reason: "ready",
+      provider_slug: "facebook",
+      provider_kind: "composio",
+      connection_present: true,
+      local_disabled: true,
+      provider: { status: "succeeded", connection_ref_present: true },
+      storage: { persistent: true },
+    });
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(<WiiiConnectPage />);
+
+    expect(await screen.findByText("Registry backend")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Composio/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Facebook/i }));
+    fireEvent.click(screen.getByRole("button", { name: /qua Wiii$/ }));
+    expect((await screen.findAllByText("Wiii Facebook Page")).length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByTestId("wiii-connect-disconnect-button"));
+
+    expect(mockDisconnectWiiiConnectProviderConnection).toHaveBeenCalledWith(
+      "facebook",
+      "conn_public_1",
+    );
+    expect((await screen.findByTestId("wiii-connect-disconnect-status")).textContent).toContain("local");
+    expect(screen.getByTestId("wiii-connect-disconnect-button").textContent?.toLowerCase()).toContain("ng");
+    expect(screen.getAllByText("user_disconnect_requested").length).toBeGreaterThan(0);
+    expect(screen.queryByText("conn_public_1")).toBeNull();
+    expect(screen.queryByText("secret-token")).toBeNull();
+    expect(screen.queryByText("access_token")).toBeNull();
 
     openSpy.mockRestore();
   });

--- a/wiii-desktop/src/api/types.ts
+++ b/wiii-desktop/src/api/types.ts
@@ -583,6 +583,18 @@ export interface WiiiConnectProviderConnectionListResponse {
   storage?: Record<string, unknown> | null;
 }
 
+export interface WiiiConnectProviderDisconnectResponse {
+  version: string;
+  status: "blocked" | "succeeded" | "failed" | string;
+  reason: string;
+  provider_slug: string;
+  provider_kind: string;
+  connection_present: boolean;
+  local_disabled: boolean;
+  provider?: Record<string, unknown> | null;
+  storage?: Record<string, unknown> | null;
+}
+
 export interface SSEChatLifecycleEvent {
   schema_version: string;
   event_name: string;

--- a/wiii-desktop/src/api/wiii-connect.ts
+++ b/wiii-desktop/src/api/wiii-connect.ts
@@ -3,6 +3,7 @@ import type {
   WiiiConnectAuthorizationUrlDecision,
   WiiiConnectProviderConnectionListResponse,
   WiiiConnectProviderConnectionStatus,
+  WiiiConnectProviderDisconnectResponse,
   WiiiConnectProviderRegistryResponse,
   WiiiConnectSessionStartBody,
   WiiiConnectSessionStartDecision,
@@ -49,6 +50,15 @@ export async function fetchWiiiConnectProviderConnections(
     {
       probe_database: options.probeDatabase === false ? "false" : "true",
     },
+  );
+}
+
+export async function disconnectWiiiConnectProviderConnection(
+  slug: string,
+  connectionId: string,
+): Promise<WiiiConnectProviderDisconnectResponse> {
+  return getClient().delete<WiiiConnectProviderDisconnectResponse>(
+    `/api/v1/wiii-connect/providers/${encodeURIComponent(slug)}/connections/${encodeURIComponent(connectionId)}`,
   );
 }
 

--- a/wiii-desktop/src/components/connect/WiiiConnectPage.tsx
+++ b/wiii-desktop/src/components/connect/WiiiConnectPage.tsx
@@ -22,6 +22,7 @@ import {
   Route,
   Search,
   Server,
+  Unplug,
   Workflow,
   type LucideIcon,
   XCircle,
@@ -30,6 +31,7 @@ import type {
   WiiiConnectAuthorizationUrlDecision,
   WiiiConnectProviderConnectionListResponse,
   WiiiConnectProviderConnectionRecord,
+  WiiiConnectProviderDisconnectResponse,
   WiiiConnectProviderRegistryEntry,
   WiiiConnectSessionStartDecision,
   WiiiConnectRuntimeConnection,
@@ -39,6 +41,7 @@ import type {
 import {
   buildWiiiConnectProviderCallbackUrl,
   createWiiiConnectProviderAuthorizationUrl,
+  disconnectWiiiConnectProviderConnection,
   fetchWiiiConnectProviderConnections,
   fetchWiiiConnectProviders,
   startWiiiConnectProviderSession,
@@ -119,6 +122,13 @@ interface ProviderConnectionListState {
   loading: boolean;
   error?: string;
   lastFetchedAt?: string;
+}
+
+interface ProviderDisconnectState {
+  response?: WiiiConnectProviderDisconnectResponse;
+  loading: boolean;
+  error?: string;
+  lastUpdatedAt?: string;
 }
 
 const tabs: FullPageTab[] = [
@@ -589,6 +599,57 @@ function compactText(value: unknown, fallback = "Chưa có"): string {
   return text.length > 72 ? `${text.slice(0, 69)}...` : text;
 }
 
+function disconnectResultTone(
+  response: WiiiConnectProviderDisconnectResponse | undefined,
+): CapabilityStatusTone {
+  if (!response) return "off";
+  if (response.local_disabled) return "ok";
+  if (response.status === "blocked") return "warn";
+  return response.status === "failed" ? "warn" : "off";
+}
+
+function locallyDisabledConnection(
+  connection: WiiiConnectProviderConnectionRecord,
+  reason = "user_disconnect_requested",
+): WiiiConnectProviderConnectionRecord {
+  return {
+    ...connection,
+    state: "disabled",
+    active: false,
+    scopes: {},
+    reason,
+    warnings: Array.from(new Set([...(connection.warnings ?? []), "disconnected_by_user"])),
+  };
+}
+
+function responseWithLocallyDisabledConnection(
+  response: WiiiConnectProviderConnectionListResponse | undefined,
+  connection: WiiiConnectProviderConnectionRecord,
+  reason = "user_disconnect_requested",
+): WiiiConnectProviderConnectionListResponse {
+  const disabled = locallyDisabledConnection(connection, reason);
+  if (!response) {
+    return {
+      version: "wiii_connect_connection_list.v1",
+      status: "ready",
+      reason,
+      provider_slug: connection.provider_slug,
+      provider_kind: "composio",
+      connection_count: 1,
+      connections: [disabled],
+    };
+  }
+  return {
+    ...response,
+    status: "ready",
+    reason,
+    connection_count: Math.max(response.connection_count, 1),
+    connections: response.connections.map((item) =>
+      item.connection_id === connection.connection_id ? disabled : item,
+    ),
+  };
+}
+
 function formatCount(value: unknown, label: string): string | null {
   if (typeof value !== "number") return null;
   return `${value} ${label}`;
@@ -961,24 +1022,31 @@ function ConnectionDetailPanel({
   authorizationDecision,
   sessionLoading,
   authorizationLoading,
+  disconnectState,
   sessionError,
   authorizationError,
   connectionList,
   onRequestSession,
   onRequestAuthorization,
   onRefreshConnections,
+  onDisconnectConnection,
 }: {
   card: CatalogCard | null;
   sessionDecision?: WiiiConnectSessionStartDecision;
   authorizationDecision?: WiiiConnectAuthorizationUrlDecision;
   sessionLoading?: boolean;
   authorizationLoading?: boolean;
+  disconnectState?: ProviderDisconnectState;
   sessionError?: string;
   authorizationError?: string;
   connectionList?: ProviderConnectionListState;
   onRequestSession?: (card: CatalogCard) => Promise<void>;
   onRequestAuthorization?: (card: CatalogCard) => Promise<void>;
   onRefreshConnections?: (card: CatalogCard) => Promise<unknown>;
+  onDisconnectConnection?: (
+    card: CatalogCard,
+    connection: WiiiConnectProviderConnectionRecord,
+  ) => Promise<void>;
 }) {
   if (!card) {
     return (
@@ -1002,6 +1070,12 @@ function ConnectionDetailPanel({
     card.registrySource === "backend" &&
     Boolean(onRefreshConnections);
   const providerConnection = primaryProviderConnection(connectionList?.response);
+  const canDisconnectConnection =
+    card.provider !== "wiii_native" &&
+    card.registrySource === "backend" &&
+    Boolean(providerConnection?.connection_id) &&
+    providerConnection?.state !== "disabled" &&
+    Boolean(onDisconnectConnection);
 
   return (
     <aside className="rounded-lg border border-[var(--border)] bg-surface p-4">
@@ -1176,6 +1250,49 @@ function ConnectionDetailPanel({
         </div>
       )}
 
+      {disconnectState?.response && (
+        <div className="mt-4 rounded-md border border-[var(--border)] bg-surface-secondary px-3 py-3">
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <div className="text-xs font-semibold uppercase text-text-tertiary">
+              Ngắt kết nối
+            </div>
+            <span data-testid="wiii-connect-disconnect-status">
+              <StatusPill tone={disconnectResultTone(disconnectState.response)}>
+                {disconnectState.response.local_disabled ? "Đã khóa local" : disconnectState.response.status}
+              </StatusPill>
+            </span>
+          </div>
+          <dl className="grid gap-2 text-xs">
+            <div>
+              <dt className="text-text-tertiary">Lý do</dt>
+              <dd className="mt-0.5 font-medium text-text">
+                {disconnectState.response.reason}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-text-tertiary">Provider cleanup</dt>
+              <dd className="mt-0.5 font-medium text-text">
+                {disconnectState.response.status === "succeeded" ? "Đã gửi yêu cầu" : "Chờ xử lý"}
+              </dd>
+            </div>
+            {disconnectState.lastUpdatedAt && (
+              <div>
+                <dt className="text-text-tertiary">Cập nhật</dt>
+                <dd className="mt-0.5 font-medium text-text">
+                  {formatDateTime(disconnectState.lastUpdatedAt)}
+                </dd>
+              </div>
+            )}
+          </dl>
+        </div>
+      )}
+
+      {disconnectState?.error && (
+        <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          {disconnectState.error}
+        </div>
+      )}
+
       <div className="mt-4 flex flex-wrap gap-2">
         <button
           type="button"
@@ -1221,6 +1338,33 @@ function ConnectionDetailPanel({
             aria-hidden="true"
           />
           Làm mới trạng thái
+        </button>
+
+        <button
+          type="button"
+          data-testid="wiii-connect-disconnect-button"
+          disabled={!canDisconnectConnection || disconnectState?.loading}
+          onClick={() => {
+            if (canDisconnectConnection && providerConnection) {
+              void onDisconnectConnection?.(card, providerConnection);
+            }
+          }}
+          className={`inline-flex h-9 items-center justify-center gap-2 rounded-md border px-3 text-sm font-medium ${
+            canDisconnectConnection
+              ? "border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100"
+              : "border-[var(--border)] bg-surface-secondary text-text-tertiary"
+          }`}
+        >
+          {disconnectState?.loading ? (
+            <Loader2 size={14} className="animate-spin" aria-hidden="true" />
+          ) : (
+            <Unplug size={14} aria-hidden="true" />
+          )}
+          {disconnectState?.loading
+            ? "Đang ngắt..."
+            : providerConnection?.state === "disabled"
+              ? "Đã ngắt"
+              : "Ngắt kết nối"}
         </button>
 
         <button
@@ -1272,6 +1416,9 @@ function ConnectionCatalog({
   const [authorizationLoadingSlug, setAuthorizationLoadingSlug] = useState<string | null>(null);
   const [providerConnectionLists, setProviderConnectionLists] = useState<
     Record<string, ProviderConnectionListState>
+  >({});
+  const [disconnectStates, setDisconnectStates] = useState<
+    Record<string, ProviderDisconnectState>
   >({});
   const connectionPollTokenRef = useRef(0);
 
@@ -1366,6 +1513,62 @@ function ConnectionCatalog({
         },
       }));
       return null;
+    }
+  };
+
+  const disconnectProviderConnection = async (
+    card: CatalogCard,
+    connection: WiiiConnectProviderConnectionRecord,
+  ) => {
+    if (card.provider === "wiii_native" || card.registrySource !== "backend") return;
+    const slug = card.providerSlug;
+    connectionPollTokenRef.current += 1;
+    setDisconnectStates((current) => ({
+      ...current,
+      [slug]: {
+        ...current[slug],
+        loading: true,
+        error: undefined,
+      },
+    }));
+    try {
+      const response = await disconnectWiiiConnectProviderConnection(
+        slug,
+        connection.connection_id,
+      );
+      setDisconnectStates((current) => ({
+        ...current,
+        [slug]: {
+          response,
+          loading: false,
+          lastUpdatedAt: new Date().toISOString(),
+        },
+      }));
+      if (response.local_disabled) {
+        setProviderConnectionLists((current) => ({
+          ...current,
+          [slug]: {
+            ...current[slug],
+            response: responseWithLocallyDisabledConnection(
+              current[slug]?.response,
+              connection,
+              "user_disconnect_requested",
+            ),
+            loading: false,
+            lastFetchedAt: new Date().toISOString(),
+          },
+        }));
+      }
+    } catch {
+      setDisconnectStates((current) => ({
+        ...current,
+        [slug]: {
+          ...current[slug],
+          loading: false,
+          error: "Không thể ngắt kết nối từ backend.",
+          lastUpdatedAt: new Date().toISOString(),
+        },
+      }));
     }
   };
 
@@ -1571,12 +1774,14 @@ function ConnectionCatalog({
           authorizationDecision={selectedCard ? authorizationDecisions[selectedCard.providerSlug] : undefined}
           sessionLoading={selectedCard ? sessionLoadingSlug === selectedCard.providerSlug : false}
           authorizationLoading={selectedCard ? authorizationLoadingSlug === selectedCard.providerSlug : false}
+          disconnectState={selectedCard ? disconnectStates[selectedCard.providerSlug] : undefined}
           sessionError={selectedCard ? sessionErrors[selectedCard.providerSlug] : undefined}
           authorizationError={selectedCard ? authorizationErrors[selectedCard.providerSlug] : undefined}
           connectionList={selectedCard ? providerConnectionLists[selectedCard.providerSlug] : undefined}
           onRequestSession={requestSessionDecision}
           onRequestAuthorization={requestAuthorizationUrl}
           onRefreshConnections={refreshProviderConnections}
+          onDisconnectConnection={disconnectProviderConnection}
         />
       </div>
     </section>


### PR DESCRIPTION
Closes #776

## Summary
- Add desktop Wiii Connect API typing/client for backend provider disconnect.
- Add provider lifecycle controls in the Wiii Connect detail panel: connect/reconnect stays on backend Connect Link, refresh reads backend connection state, and disconnect calls the backend policy endpoint.
- Update local UI state to disabled after backend confirms `local_disabled`, without rendering provider tokens/raw payloads/connection IDs.
- Update Wiii Connect/OpenHuman/Composio docs so frontend lifecycle controls are no longer listed as pending.

## Scope
- `wiii-desktop` Wiii Connect page, API types/client, and focused page tests.
- Docs status updates for the Wiii Connect Adapter V1 lifecycle.

## Non-Scope
- No production Composio credentials or auth config IDs.
- No live Gmail/Facebook acceptance in this PR.
- No write/apply provider actions and no native Meta/Gmail OAuth app.

## Verification
- `cd wiii-desktop; npx vitest run src/__tests__/wiii-connect-page.test.tsx` -> 6 passed
- `cd wiii-desktop; npx tsc --noEmit` -> passed
- `cd wiii-desktop; npm run build:embed` -> passed
- `git diff --check` -> clean

## Visual Evidence
- No browser screenshot captured in this session because no browser MCP was available after tool discovery. The lifecycle interaction is covered by React Testing Library and the embed production build.

## Risk
- Touches frontend provider lifecycle controls but all provider actions still route through Wiii backend policy endpoints.
- Disconnect only calls the backend endpoint for backend registry providers with a concrete connection record.
- UI intentionally keeps connection IDs and provider secrets out of rendered text.

## Rollback
- Revert this PR to remove the desktop lifecycle controls and API client addition.
- Backend connect/list/execute/disconnect boundaries from prior PRs remain intact; this PR only adds the desktop control surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added provider connection disconnect capability to the desktop Wiii Connect page, enabling users to disconnect backend-managed provider connections with real-time status updates.

* **Documentation**
  * Updated architecture and audit documentation to reflect completed backend disconnect and desktop lifecycle controls implementation.

* **Tests**
  * Added test coverage for the new provider disconnect functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->