### PR TITLE
feat(connect): add Composio activation readiness

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -106,6 +106,7 @@ POST /api/v1/wiii-connect/providers/{slug}/authorization-url
 GET  /api/v1/wiii-connect/providers/{slug}/connections
 DELETE /api/v1/wiii-connect/providers/{slug}/connections/{connection_id}
 GET  /api/v1/wiii-connect/providers/{slug}/actions
+GET  /api/v1/wiii-connect/providers/{slug}/activation-readiness
 POST /api/v1/wiii-connect/providers/{slug}/execution-decision
 POST /api/v1/wiii-connect/providers/{slug}/execute
 GET  /api/v1/wiii-connect/providers/{slug}/callback
@@ -126,6 +127,14 @@ opens only backend-issued Connect Links, polls sanitized connection records
 through Wiii, and still keeps provider connection state separate from
 `agent_ready` execution state. The frontend never calls Composio directly and
 never receives provider tokens or raw payloads.
+
+The activation readiness endpoint is the single operator/UI preflight for a
+provider. It performs no provider network calls, creates no Connect Link, and
+does not mutate local connection rows. It aggregates registry, provider adapter,
+provider-managed vault, durable storage, audit ledger, curated read-only action,
+local connection, and execution gateway state into one privacy-safe response so
+operators can see whether Wiii is ready to connect or execute a read-only action
+without guessing from logs.
 
 ## Core Entities
 

--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -49,6 +49,19 @@ Do not enable write/apply/admin actions in this phase.
 
 Run from `maritime-ai-service/`.
 
+Before issuing a Connect Link, check activation readiness through Wiii:
+
+```powershell
+curl -H "Authorization: Bearer <jwt>" "http://localhost:8080/api/v1/wiii-connect/providers/gmail/activation-readiness?probe_database=true"
+```
+
+The response must be treated as the operator preflight. It does not contact
+Composio, does not create an OAuth session, and does not expose raw connection
+IDs or secrets. `ready_to_connect=true` means Wiii has enough local policy,
+adapter, vault, storage, and audit readiness to issue a backend-owned Connect
+Link. `ready_to_execute_readonly=true` additionally requires a live stored
+connection and a runtime-enabled curated read-only action.
+
 For local dev-login:
 
 ```powershell
@@ -96,6 +109,8 @@ Composio is ready to enable only when all of these are true:
 - adapter readiness reports `authorization_ready=true`;
 - storage readiness reports persistent connection and audit tables;
 - audit readiness reports `persistent=true`;
+- activation readiness reports `ready_to_connect=true` before OAuth and
+  `ready_to_execute_readonly=true` after OAuth plus action allowlist;
 - provider registry returns Gmail as a Composio provider;
 - curated actions include only the intended read-only action;
 - execution gateway blocks a missing-connection execution request;

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -199,6 +199,15 @@ missing-connection denial, backend-owned Connect Link creation, sanitized
 connection listing, optional read-only execution, and optional backend-owned
 disconnect without calling Composio directly from the harness.
 
+Wiii also exposes a single authenticated activation-readiness projection for a
+provider. It aggregates registry, Composio adapter, provider-managed vault,
+durable storage, audit ledger, curated read-only action, stored connection, and
+execution gateway state without contacting Composio or issuing a Connect Link.
+This is the Wiii-side equivalent of the OpenHuman connection discipline: the UI
+and operators can see whether a provider is ready to connect and separately
+whether it is ready for read-only agent execution, while raw connection IDs,
+vault references, auth configs, API keys, and provider payloads remain hidden.
+
 Remaining work before enabling Composio for real users: configure production
 Composio project credentials and auth config IDs, connect a live Gmail account,
 run the acceptance harness plus browser acceptance through Wiii's

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -20,6 +20,7 @@ from app.engine.wiii_connect import (
     action_catalog_public_metadata,
     append_wiii_connect_callback_state,
     audit_ledger_status_public_metadata,
+    build_activation_readiness_metadata,
     build_audit_ledger_record,
     build_composio_adapter_config,
     build_composio_connect_enabled_entry,
@@ -37,6 +38,7 @@ from app.engine.wiii_connect import (
     get_wiii_connect_provider_entry,
     get_wiii_connect_persistent_storage,
     execute_composio_tool,
+    get_wiii_connect_curated_action,
     list_composio_connected_accounts,
     normalize_connection_state,
     provider_adapter_status_public_metadata,
@@ -160,6 +162,95 @@ async def get_wiii_connect_provider_connection_status(slug: str) -> dict[str, ob
     if status is None:
         raise HTTPException(status_code=404, detail="unknown_wiii_connect_provider")
     return status.to_public_metadata()
+
+
+@router.get("/providers/{slug}/activation-readiness")
+async def get_wiii_connect_provider_activation_readiness(
+    slug: str,
+    connection_id: str | None = None,
+    action_slug: str = "GMAIL_FETCH_EMAILS",
+    probe_database: bool = True,
+    current_user: AuthenticatedUser = Depends(require_auth),
+) -> dict[str, object]:
+    """Return one privacy-safe readiness projection for enabling a provider.
+
+    This endpoint performs no provider network calls and does not issue Connect
+    Links. It only aggregates local Wiii Connect policy, storage, action, and
+    connection readiness for the authenticated org/user boundary.
+    """
+
+    entry = get_wiii_connect_provider_entry(slug)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="unknown_wiii_connect_provider")
+
+    action = _safe_action_slug(action_slug)
+    composio_config = build_composio_adapter_config()
+    connect_entry = build_composio_connect_enabled_entry(entry, composio_config)
+    execution_entry = build_composio_execution_enabled_entry(entry, composio_config)
+    adapter_capability = build_composio_provider_adapter_capability(composio_config)
+    vault_capability = build_composio_provider_managed_vault_capability(
+        composio_config,
+    )
+    storage = _wiii_connect_storage_status_metadata(
+        probe_database=probe_database,
+    )
+    storage_ready = _connection_storage_ready(storage)
+    connection = (
+        get_wiii_connect_persistent_storage().get_connection_record(
+            organization_id=_wiii_connect_owner_organization_id(current_user),
+            user_id=current_user.user_id,
+            provider_slug=execution_entry.slug,
+            connection_id=_safe_provider_connection_id(connection_id),
+        )
+        if storage_ready
+        else None
+    )
+    curated_action = get_wiii_connect_curated_action(execution_entry.slug, action)
+    runtime_enabled_actions = (
+        composio_config.readonly_action_slugs_for_provider(execution_entry.slug)
+        if composio_config.readonly_execute_enabled
+        else ()
+    )
+    action_runtime_enabled = bool(
+        curated_action is not None and curated_action.slug in runtime_enabled_actions
+    )
+    request = WiiiConnectExecutionRequest(
+        provider_slug=execution_entry.slug,
+        action_slug=action,
+        path=curated_action.path
+        if curated_action is not None
+        else "external_app_action",
+        mutation=curated_action.mutation if curated_action is not None else "read",
+        preview_evidence_required=bool(
+            curated_action.requires_preview if curated_action is not None else False
+        ),
+        argument_keys=tuple(
+            curated_action.argument_keys if curated_action is not None else ()
+        ),
+    )
+    gateway = decide_execution_gateway(
+        execution_entry,
+        connection,
+        request,
+        adapter_capability=adapter_capability,
+        audit_ledger_metadata={
+            "persistent": bool(
+                storage.get("persistent") and storage.get("audit_ledger_ready")
+            ),
+        },
+    )
+    return build_activation_readiness_metadata(
+        provider_slug=connect_entry.slug,
+        connect_entry=connect_entry,
+        execution_entry=execution_entry,
+        adapter_capability=adapter_capability,
+        vault_capability=vault_capability,
+        storage_metadata=storage,
+        action=curated_action,
+        action_runtime_enabled=action_runtime_enabled,
+        connection=connection,
+        execution_gateway=gateway,
+    )
 
 
 @router.post("/providers/{slug}/sessions")

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -24,6 +24,11 @@ from .action_catalog import (
     get_wiii_connect_curated_action,
     list_wiii_connect_curated_actions,
 )
+from .activation_readiness import (
+    WIII_CONNECT_ACTIVATION_READINESS_VERSION,
+    WiiiConnectActivationGate,
+    build_activation_readiness_metadata,
+)
 from .audit_ledger import (
     WIII_CONNECT_AUDIT_LEDGER_VERSION,
     WiiiConnectAuditLedgerRecord,
@@ -133,6 +138,7 @@ from .snapshot import (
 
 __all__ = [
     "WIII_CONNECT_ADAPTER_VERSION",
+    "WIII_CONNECT_ACTIVATION_READINESS_VERSION",
     "WIII_CONNECT_ACTION_CATALOG_VERSION",
     "WIII_CONNECT_AUDIT_LEDGER_VERSION",
     "WIII_CONNECT_CALLBACK_CONTRACT_VERSION",
@@ -149,6 +155,7 @@ __all__ = [
     "WIII_CONNECT_SESSION_CONTRACT_VERSION",
     "WIII_CONNECT_VAULT_CONTRACT_VERSION",
     "WiiiConnectAuthorizationUrlAuditEvent",
+    "WiiiConnectActivationGate",
     "WiiiConnectAuthorizationUrlDecision",
     "WiiiConnectAuthorizationUrlRequest",
     "WiiiConnectCuratedAction",
@@ -196,6 +203,7 @@ __all__ = [
     "append_wiii_connect_callback_state",
     "begin_connection_session",
     "build_composio_adapter_config",
+    "build_activation_readiness_metadata",
     "build_composio_execution_enabled_entry",
     "build_composio_provider_adapter_capability",
     "build_wiii_connect_snapshot",

--- a/maritime-ai-service/app/engine/wiii_connect/activation_readiness.py
+++ b/maritime-ai-service/app/engine/wiii_connect/activation_readiness.py
@@ -1,0 +1,426 @@
+"""Wiii Connect activation readiness projection.
+
+This module aggregates existing Wiii Connect gates into one privacy-safe
+operator/UI contract. It performs no provider network calls and must not create
+authorization sessions, issue Connect Links, mutate connection rows, or expose
+provider secrets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .action_catalog import WiiiConnectCuratedAction
+from .adapter_v1 import (
+    WiiiConnectConnectionRecordV1,
+    WiiiConnectProviderRegistryEntry,
+)
+from .execution_gateway import WiiiConnectExecutionGatewayDecision
+from .provider_adapters import WiiiConnectProviderAdapterCapability
+from .vault import WiiiConnectVaultCapability
+
+
+WIII_CONNECT_ACTIVATION_READINESS_VERSION = "wiii_connect_activation_readiness.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class WiiiConnectActivationGate:
+    """One activation gate in the external-provider readiness ladder."""
+
+    key: str
+    ready: bool
+    reason: str = "ready"
+    required_next: tuple[str, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_public_metadata(self) -> dict[str, Any]:
+        return {
+            "key": _safe_key(self.key),
+            "ready": self.ready,
+            "reason": _safe_reason(self.reason),
+            "required_next": [_safe_key(value) for value in self.required_next],
+            "metadata": _safe_metadata(self.metadata),
+        }
+
+
+def build_activation_readiness_metadata(
+    *,
+    provider_slug: str,
+    connect_entry: WiiiConnectProviderRegistryEntry | None,
+    execution_entry: WiiiConnectProviderRegistryEntry | None,
+    adapter_capability: WiiiConnectProviderAdapterCapability,
+    vault_capability: WiiiConnectVaultCapability,
+    storage_metadata: dict[str, Any],
+    action: WiiiConnectCuratedAction | None,
+    action_runtime_enabled: bool,
+    connection: WiiiConnectConnectionRecordV1 | None,
+    execution_gateway: WiiiConnectExecutionGatewayDecision | None,
+) -> dict[str, Any]:
+    """Return a single privacy-safe readiness projection for one provider."""
+
+    provider_registered = connect_entry is not None
+    provider_kind = (
+        connect_entry.provider_kind
+        if connect_entry is not None
+        else adapter_capability.provider_kind
+    )
+    storage_ready = _storage_ready(storage_metadata)
+    audit_ready = bool(
+        storage_metadata.get("persistent")
+        and storage_metadata.get("audit_ledger_ready")
+    )
+    action_ready = bool(action is not None and action_runtime_enabled)
+    connection_ready = bool(connection is not None and connection.active)
+    gateway_allowed = bool(execution_gateway is not None and execution_gateway.allowed)
+    ready_to_connect = bool(
+        provider_registered
+        and connect_entry is not None
+        and connect_entry.enabled
+        and adapter_capability.authorization_ready
+        and vault_capability.can_store_external_secret
+        and storage_ready
+        and audit_ready
+    )
+    ready_to_execute_readonly = bool(
+        ready_to_connect
+        and action_ready
+        and connection_ready
+        and gateway_allowed
+    )
+    gates = (
+        _provider_gate(connect_entry),
+        _adapter_gate(adapter_capability),
+        _vault_gate(vault_capability),
+        _storage_gate(storage_metadata),
+        _audit_gate(storage_metadata),
+        _connect_policy_gate(connect_entry),
+        _action_gate(action, runtime_enabled=action_runtime_enabled),
+        _connection_gate(connection),
+        _execution_gateway_gate(execution_gateway),
+    )
+    return {
+        "version": WIII_CONNECT_ACTIVATION_READINESS_VERSION,
+        "status": "ready" if ready_to_execute_readonly else "blocked",
+        "provider_slug": _safe_key(provider_slug),
+        "provider_kind": provider_kind,
+        "ready_to_connect": ready_to_connect,
+        "ready_to_execute_readonly": ready_to_execute_readonly,
+        "gates": [gate.to_public_metadata() for gate in gates],
+        "provider": connect_entry.to_public_metadata() if connect_entry else None,
+        "execution_provider": (
+            execution_entry.to_public_metadata() if execution_entry else None
+        ),
+        "adapter": adapter_capability.to_public_metadata(),
+        "vault": vault_capability.to_public_metadata(),
+        "storage": _safe_storage_metadata(storage_metadata),
+        "action": _action_metadata(action, runtime_enabled=action_runtime_enabled),
+        "connection": _connection_metadata(connection),
+        "execution_gateway": (
+            execution_gateway.to_public_metadata() if execution_gateway else None
+        ),
+    }
+
+
+def _provider_gate(
+    entry: WiiiConnectProviderRegistryEntry | None,
+) -> WiiiConnectActivationGate:
+    if entry is None:
+        return WiiiConnectActivationGate(
+            key="provider_registered",
+            ready=False,
+            reason="unknown_provider",
+            required_next=("register_provider",),
+        )
+    if entry.provider_kind != "composio":
+        return WiiiConnectActivationGate(
+            key="provider_registered",
+            ready=False,
+            reason="provider_kind_not_composio",
+            required_next=("select_composio_provider",),
+            metadata={"provider_kind": entry.provider_kind},
+        )
+    return WiiiConnectActivationGate(
+        key="provider_registered",
+        ready=True,
+        metadata={"provider_kind": entry.provider_kind},
+    )
+
+
+def _adapter_gate(
+    capability: WiiiConnectProviderAdapterCapability,
+) -> WiiiConnectActivationGate:
+    return WiiiConnectActivationGate(
+        key="provider_adapter",
+        ready=capability.authorization_ready,
+        reason=capability.reason,
+        required_next=()
+        if capability.authorization_ready
+        else ("configure_composio_adapter",),
+        metadata={
+            "bound": capability.bound,
+            "configured": capability.configured,
+            "can_create_authorization_url": capability.can_create_authorization_url,
+            "can_execute_actions": capability.can_execute_actions,
+        },
+    )
+
+
+def _vault_gate(capability: WiiiConnectVaultCapability) -> WiiiConnectActivationGate:
+    return WiiiConnectActivationGate(
+        key="vault",
+        ready=capability.can_store_external_secret,
+        reason=capability.reason,
+        required_next=()
+        if capability.can_store_external_secret
+        else ("configure_provider_managed_vault",),
+        metadata={
+            "backend": capability.backend,
+            "provider_managed": capability.provider_managed,
+        },
+    )
+
+
+def _storage_gate(storage: dict[str, Any]) -> WiiiConnectActivationGate:
+    ready = _storage_ready(storage)
+    return WiiiConnectActivationGate(
+        key="persistent_storage",
+        ready=ready,
+        reason=str(storage.get("reason") or ("ready" if ready else "storage_not_ready")),
+        required_next=() if ready else ("apply_wiii_connect_storage_migration",),
+        metadata={
+            "persistent": bool(storage.get("persistent")),
+            "connection_table_ready": bool(storage.get("connection_table_ready")),
+            "audit_ledger_ready": bool(storage.get("audit_ledger_ready")),
+        },
+    )
+
+
+def _audit_gate(storage: dict[str, Any]) -> WiiiConnectActivationGate:
+    ready = bool(storage.get("persistent") and storage.get("audit_ledger_ready"))
+    return WiiiConnectActivationGate(
+        key="audit_ledger",
+        ready=ready,
+        reason=str(storage.get("reason") or ("ready" if ready else "audit_not_ready")),
+        required_next=() if ready else ("configure_persistent_audit_ledger",),
+        metadata={
+            "persistent": bool(storage.get("persistent")),
+            "audit_ledger_ready": bool(storage.get("audit_ledger_ready")),
+        },
+    )
+
+
+def _connect_policy_gate(
+    entry: WiiiConnectProviderRegistryEntry | None,
+) -> WiiiConnectActivationGate:
+    ready = bool(entry is not None and entry.enabled)
+    return WiiiConnectActivationGate(
+        key="connect_policy",
+        ready=ready,
+        reason="ready" if ready else "provider_disabled",
+        required_next=() if ready else ("enable_connect_policy",),
+        metadata={
+            "agent_ready": bool(entry.agent_ready) if entry is not None else False,
+            "connect_requirements": list(entry.connection_requirements())
+            if entry is not None
+            else [],
+            "agent_ready_requirements": list(entry.agent_ready_requirements)
+            if entry is not None
+            else [],
+        },
+    )
+
+
+def _action_gate(
+    action: WiiiConnectCuratedAction | None,
+    *,
+    runtime_enabled: bool,
+) -> WiiiConnectActivationGate:
+    if action is None:
+        return WiiiConnectActivationGate(
+            key="curated_readonly_action",
+            ready=False,
+            reason="action_not_curated",
+            required_next=("curate_readonly_action",),
+        )
+    ready = bool(action.mutation == "read" and runtime_enabled)
+    reason = "ready" if ready else "action_not_runtime_enabled"
+    required_next = () if ready else ("enable_readonly_action_allowlist",)
+    return WiiiConnectActivationGate(
+        key="curated_readonly_action",
+        ready=ready,
+        reason=reason,
+        required_next=required_next,
+        metadata={
+            "action_slug": action.slug,
+            "mutation": action.mutation,
+            "runtime_enabled": runtime_enabled,
+            "requires_preview": action.requires_preview,
+            "requires_approval": action.requires_approval,
+        },
+    )
+
+
+def _connection_gate(
+    connection: WiiiConnectConnectionRecordV1 | None,
+) -> WiiiConnectActivationGate:
+    if connection is None:
+        return WiiiConnectActivationGate(
+            key="local_connection",
+            ready=False,
+            reason="connection_missing",
+            required_next=("complete_provider_oauth",),
+        )
+    ready = connection.active
+    return WiiiConnectActivationGate(
+        key="local_connection",
+        ready=ready,
+        reason="ready" if ready else "connection_not_connected",
+        required_next=() if ready else ("refresh_or_reconnect_provider_account",),
+        metadata=_connection_metadata(connection),
+    )
+
+
+def _execution_gateway_gate(
+    gateway: WiiiConnectExecutionGatewayDecision | None,
+) -> WiiiConnectActivationGate:
+    if gateway is None:
+        return WiiiConnectActivationGate(
+            key="execution_gateway",
+            ready=False,
+            reason="gateway_not_evaluated",
+            required_next=("evaluate_execution_gateway",),
+        )
+    return WiiiConnectActivationGate(
+        key="execution_gateway",
+        ready=gateway.allowed,
+        reason=gateway.reason,
+        required_next=gateway.required_next,
+        metadata={
+            "connection_present": gateway.connection_present,
+            "audit_persistent": gateway.audit_persistent,
+        },
+    )
+
+
+def _storage_ready(storage: dict[str, Any]) -> bool:
+    return bool(
+        storage.get("persistent")
+        and storage.get("connection_table_ready")
+        and storage.get("audit_ledger_ready")
+    )
+
+
+def _action_metadata(
+    action: WiiiConnectCuratedAction | None,
+    *,
+    runtime_enabled: bool,
+) -> dict[str, Any] | None:
+    if action is None:
+        return None
+    metadata = action.to_public_metadata()
+    metadata["runtime_enabled"] = runtime_enabled
+    return _safe_metadata(metadata)
+
+
+def _connection_metadata(
+    connection: WiiiConnectConnectionRecordV1 | None,
+) -> dict[str, Any]:
+    if connection is None:
+        return {
+            "present": False,
+            "state": "missing",
+            "active": False,
+            "vault_ref_present": False,
+            "scopes": {},
+            "reason": "connection_missing",
+            "warnings": [],
+        }
+    return {
+        "present": True,
+        "provider_slug": _safe_key(connection.provider_slug),
+        "state": connection.state,
+        "active": connection.active,
+        "scopes": connection.scopes.to_metadata(),
+        "vault_ref_present": connection.vault_ref is not None,
+        "account_label_present": bool(connection.account_label),
+        "external_account_ref_present": bool(connection.external_account_ref),
+        "last_checked_at_present": bool(connection.last_checked_at),
+        "reason": _safe_reason(connection.reason),
+        "warnings": [_safe_reason(warning) for warning in connection.warnings],
+    }
+
+
+def _safe_storage_metadata(storage: dict[str, Any]) -> dict[str, Any]:
+    allowed = {
+        "version",
+        "enabled",
+        "persistent",
+        "backend",
+        "connection_table_ready",
+        "audit_ledger_ready",
+        "reason",
+        "warnings",
+    }
+    return {
+        key: _safe_metadata(value)
+        for key, value in storage.items()
+        if key in allowed
+    }
+
+
+_SENSITIVE_KEY_MARKERS = (
+    "token",
+    "secret",
+    "password",
+    "credential",
+    "api_key",
+    "client_key",
+    "private_key",
+    "authorization_code",
+    "oauth_code",
+)
+
+
+def _safe_metadata(value: Any) -> Any:
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for raw_key, raw_value in value.items():
+            key = _safe_key(raw_key)
+            if any(marker in key.lower() for marker in _SENSITIVE_KEY_MARKERS):
+                result["redacted_sensitive_field"] = "[redacted]"
+                continue
+            result[key] = _safe_metadata(raw_value)
+        return result
+    if isinstance(value, list):
+        return [_safe_metadata(item) for item in value]
+    if isinstance(value, tuple):
+        return [_safe_metadata(item) for item in value]
+    if isinstance(value, str):
+        return _safe_text(value)
+    return value
+
+
+def _safe_key(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_")[:120] or "unknown"
+
+
+def _safe_reason(value: Any) -> str:
+    text = str(value or "").strip().lower().replace("-", "_")
+    if any(marker in text for marker in _SENSITIVE_KEY_MARKERS):
+        return "redacted_sensitive_value"
+    return text[:160] or "ready"
+
+
+def _safe_text(value: Any) -> str:
+    text = str(value or "").strip()
+    if any(marker in text.lower() for marker in _SENSITIVE_KEY_MARKERS):
+        return "redacted_sensitive_value"
+    return text[:240]
+
+
+__all__ = [
+    "WIII_CONNECT_ACTIVATION_READINESS_VERSION",
+    "WiiiConnectActivationGate",
+    "build_activation_readiness_metadata",
+]

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -254,6 +254,168 @@ async def test_wiii_connect_provider_status_api_is_fail_closed(app):
 
 
 @pytest.mark.asyncio
+async def test_wiii_connect_activation_readiness_api_fails_closed_without_config(
+    authenticated_app,
+):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=authenticated_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/wiii-connect/providers/gmail/activation-readiness",
+            params={"probe_database": "false"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    gates = {gate["key"]: gate for gate in payload["gates"]}
+    serialized = json.dumps(payload, sort_keys=True)
+
+    assert payload["version"] == "wiii_connect_activation_readiness.v1"
+    assert payload["status"] == "blocked"
+    assert payload["provider_slug"] == "gmail"
+    assert payload["ready_to_connect"] is False
+    assert payload["ready_to_execute_readonly"] is False
+    assert gates["provider_registered"]["ready"] is True
+    assert gates["provider_adapter"]["ready"] is False
+    assert gates["persistent_storage"]["ready"] is False
+    assert gates["curated_readonly_action"]["ready"] is False
+    assert gates["local_connection"]["reason"] == "connection_missing"
+    assert payload["connection"]["present"] is False
+    assert "access_token" not in serialized
+    assert "refresh_token" not in serialized
+    assert "api_key" not in serialized
+    assert "approval_token" not in serialized
+    assert "authcfg" not in serialized
+    assert "vault://" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_activation_readiness_api_reports_ready_without_leaks(
+    authenticated_app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+    from app.engine.wiii_connect.adapter_v1 import (
+        WiiiConnectConnectionRecordV1,
+        WiiiConnectScopeGrant,
+        WiiiConnectVaultSecretRef,
+    )
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+    )
+    from app.engine.wiii_connect.persistent_storage import (
+        WiiiConnectPersistentStorageStatus,
+    )
+
+    class FakeStorage:
+        fetches = 0
+
+        def status(self, *, probe_database: bool = True):
+            assert probe_database is True
+            return WiiiConnectPersistentStorageStatus(
+                enabled=True,
+                persistent=True,
+                connection_table_ready=True,
+                audit_ledger_ready=True,
+                reason="ready",
+            )
+
+        def get_connection_record(
+            self,
+            *,
+            organization_id: str,
+            user_id: str,
+            provider_slug: str,
+            connection_id: str | None = None,
+        ):
+            self.fetches += 1
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert provider_slug == "gmail"
+            assert connection_id == "ca_active"
+            return WiiiConnectConnectionRecordV1(
+                connection_id="ca_active",
+                provider_slug="gmail",
+                state="connected",
+                scopes=WiiiConnectScopeGrant(read=True),
+                vault_ref=WiiiConnectVaultSecretRef(
+                    provider_slug="gmail",
+                    connection_id="ca_active",
+                    vault_key_id="provider-managed://composio/ca_active",
+                    secret_version="provider_managed",
+                ),
+                account_label="private-user@example.test",
+                external_account_ref="acct_private",
+                reason="provider_connection_list",
+            )
+
+    fake_storage = FakeStorage()
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "build_composio_adapter_config",
+        lambda: WiiiConnectComposioAdapterConfig(
+            enabled=True,
+            api_key="secret-api-key",
+            api_key_present=True,
+            auth_config_by_provider={"gmail": "authcfg_gmail"},
+            readonly_execute_enabled=True,
+            readonly_action_allowlist_by_provider={
+                "gmail": ("GMAIL_FETCH_EMAILS",),
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        lambda: fake_storage,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=authenticated_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/wiii-connect/providers/gmail/activation-readiness",
+            params={
+                "action_slug": "GMAIL_FETCH_EMAILS",
+                "connection_id": "ca_active",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    gates = {gate["key"]: gate for gate in payload["gates"]}
+    serialized = json.dumps(payload, sort_keys=True)
+
+    assert payload["status"] == "ready"
+    assert payload["provider_slug"] == "gmail"
+    assert payload["ready_to_connect"] is True
+    assert payload["ready_to_execute_readonly"] is True
+    assert payload["action"]["slug"] == "GMAIL_FETCH_EMAILS"
+    assert payload["action"]["runtime_enabled"] is True
+    assert payload["connection"]["present"] is True
+    assert payload["connection"]["active"] is True
+    assert payload["connection"]["vault_ref_present"] is True
+    assert payload["execution_gateway"]["status"] == "allowed"
+    assert gates["provider_adapter"]["ready"] is True
+    assert gates["vault"]["ready"] is True
+    assert gates["persistent_storage"]["ready"] is True
+    assert gates["audit_ledger"]["ready"] is True
+    assert gates["curated_readonly_action"]["ready"] is True
+    assert gates["execution_gateway"]["ready"] is True
+    assert fake_storage.fetches == 1
+    assert "ca_active" not in serialized
+    assert "secret-api-key" not in serialized
+    assert "authcfg_gmail" not in serialized
+    assert "provider-managed://" not in serialized
+    assert "private-user@example.test" not in serialized
+    assert "acct_private" not in serialized
+    assert "access_token" not in serialized
+    assert "api_key" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_wiii_connect_session_start_api_blocks_without_leaking_secrets(app):
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app),


### PR DESCRIPTION
Closes #781.\n\n## Summary\n- Add an authenticated Wiii Connect activation-readiness projection for Composio-backed providers.\n- Aggregate provider registry, adapter, provider-managed vault, storage, audit ledger, curated read-only action, local connection, and execution gateway gates without contacting Composio or mutating state.\n- Document the preflight in Adapter V1 docs, the Composio acceptance runbook, and the OpenHuman/Composio source audit.\n\n## Scope\n- Backend Wiii Connect readiness contract and API endpoint.\n- API tests for fail-closed and ready/no-leak paths.\n- Operator docs for acceptance preflight.\n\n## Non-scope\n- No Composio credentials or production auth config changes.\n- No live OAuth or live Gmail execution.\n- No frontend dashboard changes in this slice.\n\n## Verification\n- python -m pytest tests/unit/api/test_wiii_connect_api.py -q --tb=short -> 28 passed.\n- python -m pytest tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short -> 20 passed.\n- python -m pytest tests/unit/api/test_wiii_connect_api.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short -> 48 passed.\n- python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7 -> passed.\n- git diff --cached --check -> passed before commit.\n\n## Risk\n- Low runtime risk: endpoint is authenticated, performs no provider network calls, creates no Connect Link, and does not mutate connection rows.\n- Main risk is an overly strict gate causing readiness to remain blocked; output lists required next steps for diagnosis.\n\n## Rollback\n- Revert commit 3552bce3 to remove the endpoint, readiness contract, tests, and docs. Existing Wiii Connect connect/list/execute/disconnect paths are unchanged.