### PR TITLE
test(connect): require Composio activation readiness

### DIFF
--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -49,7 +49,7 @@ Do not enable write/apply/admin actions in this phase.
 
 Run from `maritime-ai-service/`.
 
-Before issuing a Connect Link, check activation readiness through Wiii:
+Before issuing a Connect Link manually, check activation readiness through Wiii:
 
 ```powershell
 curl -H "Authorization: Bearer <jwt>" "http://localhost:8080/api/v1/wiii-connect/providers/gmail/activation-readiness?probe_database=true"
@@ -61,6 +61,14 @@ IDs or secrets. `ready_to_connect=true` means Wiii has enough local policy,
 adapter, vault, storage, and audit readiness to issue a backend-owned Connect
 Link. `ready_to_execute_readonly=true` additionally requires a live stored
 connection and a runtime-enabled curated read-only action.
+
+The acceptance harness enforces the same projection automatically:
+
+- every run requires activation readiness to report `ready_to_connect=true`
+  before Connect Link issuance;
+- runs with `--require-execution-ready` or `--execute-readonly` also require
+  activation readiness to report `ready_to_execute_readonly=true` for the
+  selected connection before provider execution.
 
 For local dev-login:
 

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -207,6 +207,10 @@ This is the Wiii-side equivalent of the OpenHuman connection discipline: the UI
 and operators can see whether a provider is ready to connect and separately
 whether it is ready for read-only agent execution, while raw connection IDs,
 vault references, auth configs, API keys, and provider payloads remain hidden.
+The live acceptance harness now treats this projection as a required gate:
+`ready_to_connect=true` is required before Connect Link issuance, and
+`ready_to_execute_readonly=true` is required when operator acceptance asks for
+execution readiness or read-only provider execution.
 
 Remaining work before enabling Composio for real users: configure production
 Composio project credentials and auth config IDs, connect a live Gmail account,

--- a/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
@@ -216,6 +216,39 @@ def first_connected_connection(payload: dict[str, Any]) -> dict[str, Any] | None
     return None
 
 
+def activation_blocker_summary(payload: dict[str, Any]) -> str:
+    """Return a compact, redacted summary of failed activation gates."""
+
+    gates = payload.get("gates")
+    if not isinstance(gates, list):
+        return "gates_missing"
+    blockers: list[str] = []
+    for gate in gates:
+        if not isinstance(gate, dict) or gate.get("ready") is True:
+            continue
+        key = str(gate.get("key") or "unknown")
+        reason = str(gate.get("reason") or "blocked")
+        blockers.append(f"{key}:{reason}")
+    return ", ".join(blockers[:8]) or "none"
+
+
+def assert_activation_ready(
+    payload: dict[str, Any],
+    *,
+    flag: str,
+    label: str,
+) -> None:
+    """Fail closed unless one readiness flag is explicitly true."""
+
+    if payload.get(flag) is True:
+        return
+    raise AcceptanceFailure(
+        f"Activation readiness does not report {label}: "
+        f"{flag}={payload.get(flag)!r} status={payload.get('status')!r} "
+        f"blockers={activation_blocker_summary(payload)}"
+    )
+
+
 def normalize_provider(value: str) -> str:
     return str(value or "").strip().lower().replace("-", "_")
 
@@ -292,6 +325,10 @@ class WiiiConnectComposioAcceptance:
             self.run_check("audit readiness", self.check_audit_readiness)
             self.run_check("curated actions", self.check_curated_actions)
             self.run_check(
+                "activation readiness connect",
+                self.check_activation_ready_to_connect,
+            )
+            self.run_check(
                 "gateway fail-closed control",
                 self.check_gateway_blocks_missing_connection,
             )
@@ -299,6 +336,10 @@ class WiiiConnectComposioAcceptance:
                 self.run_check("connect link preflight", self.check_connect_link)
             self.run_check("connection listing", self.check_connections)
             if self.args.require_execution_ready or self.args.execute_readonly:
+                self.run_check(
+                    "activation readiness execution",
+                    self.check_activation_ready_to_execute,
+                )
                 self.run_check(
                     "execution gateway allowed",
                     self.check_execution_gateway_allowed,
@@ -476,6 +517,50 @@ class WiiiConnectComposioAcceptance:
         if payload.get("status") == "allowed":
             raise AcceptanceFailure("Gateway allowed execution without a connection")
         return f"blocked reason={payload.get('reason')}"
+
+    def activation_readiness_payload(
+        self,
+        *,
+        connection_id: str = "",
+    ) -> dict[str, Any]:
+        params = {
+            "probe_database": "true",
+            "action_slug": self.args.action,
+        }
+        if connection_id:
+            params["connection_id"] = connection_id
+        query = urllib.parse.urlencode(params)
+        return request_bytes(
+            "GET",
+            self.api_url(
+                f"/api/v1/wiii-connect/providers/{urllib.parse.quote(self.args.provider)}"
+                f"/activation-readiness?{query}"
+            ),
+            headers=self.auth_headers(),
+            timeout=self.args.timeout,
+        ).json()
+
+    def check_activation_ready_to_connect(self) -> str:
+        payload = self.activation_readiness_payload()
+        assert_activation_ready(
+            payload,
+            flag="ready_to_connect",
+            label="connect-ready",
+        )
+        return (
+            "ready_to_connect=true "
+            f"ready_to_execute_readonly={bool(payload.get('ready_to_execute_readonly'))}"
+        )
+
+    def check_activation_ready_to_execute(self) -> str:
+        connection_id = self.connection_id_for_action()
+        payload = self.activation_readiness_payload(connection_id=connection_id)
+        assert_activation_ready(
+            payload,
+            flag="ready_to_execute_readonly",
+            label="read-only execution-ready",
+        )
+        return f"ready_to_execute_readonly=true connection={opaque_ref(connection_id)}"
 
     def check_connect_link(self) -> str:
         payload = request_bytes(

--- a/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
@@ -97,6 +97,84 @@ def test_catalog_helpers_fail_closed_when_required_items_are_missing() -> None:
     assert acceptance.first_connected_connection({"connections": []}) is None
 
 
+def test_activation_readiness_helpers_report_blockers() -> None:
+    payload = {
+        "status": "blocked",
+        "ready_to_connect": False,
+        "gates": [
+            {"key": "provider_adapter", "ready": True, "reason": "ready"},
+            {
+                "key": "local_connection",
+                "ready": False,
+                "reason": "connection_missing",
+            },
+        ],
+    }
+
+    assert acceptance.activation_blocker_summary(payload) == (
+        "local_connection:connection_missing"
+    )
+    with pytest.raises(acceptance.AcceptanceFailure, match="ready_to_connect"):
+        acceptance.assert_activation_ready(
+            payload,
+            flag="ready_to_connect",
+            label="connect-ready",
+        )
+
+    acceptance.assert_activation_ready(
+        {"ready_to_connect": True},
+        flag="ready_to_connect",
+        label="connect-ready",
+    )
+
+
+def test_activation_readiness_payload_uses_backend_endpoint(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        def json(self):
+            return {
+                "ready_to_connect": True,
+                "ready_to_execute_readonly": False,
+                "gates": [],
+            }
+
+    def fake_request_bytes(method, url, *, headers=None, payload=None, timeout=15.0):
+        captured["method"] = method
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        captured["payload"] = payload
+        return FakeResponse()
+
+    monkeypatch.setattr(acceptance, "request_bytes", fake_request_bytes)
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="http://localhost:8080",
+            provider="gmail",
+            action="GMAIL_FETCH_EMAILS",
+            timeout=7.0,
+            org_id="",
+        )
+    )
+    harness.token = "token"
+
+    payload = harness.activation_readiness_payload(connection_id="ca_live")
+
+    assert payload["ready_to_connect"] is True
+    assert captured["method"] == "GET"
+    assert captured["headers"] == {"Authorization": "Bearer token"}
+    assert captured["payload"] is None
+    url = str(captured["url"])
+    assert url.startswith(
+        "http://localhost:8080/api/v1/wiii-connect/providers/gmail/"
+        "activation-readiness?"
+    )
+    assert "probe_database=true" in url
+    assert "action_slug=GMAIL_FETCH_EMAILS" in url
+    assert "connection_id=ca_live" in url
+
+
 def test_connection_id_for_action_requires_selected_or_explicit_connection() -> None:
     harness = acceptance.WiiiConnectComposioAcceptance(
         SimpleNamespace(connection_id="", selected_connection_id="")


### PR DESCRIPTION
Closes #785.

## Summary
- Require the Wiii Connect activation-readiness endpoint before the Composio acceptance harness issues a Connect Link.
- Require read-only execution readiness before harness runs execution-ready or read-only provider execution checks.
- Update the Composio acceptance runbook and OpenHuman/Composio audit note so the operator path matches the enforced harness behavior.

## Scope
- Backend operator harness only.
- Unit coverage for readiness blocker summaries and activation-readiness request construction.
- Documentation for operator acceptance gates.

## Non-Scope
- No production Composio credentials are added.
- No provider-direct API calls are added.
- No runtime chat/tool execution behavior changes.
- No frontend UI changes in this slice.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 8 passed.
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 50 passed.
- `cd maritime-ai-service; python -m ruff check scripts/wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_composio_acceptance.py --select=E9,F63,F7` -> passed.
- `cd maritime-ai-service; python scripts/wiii_connect_composio_acceptance.py --help` -> passed.
- `git diff --check` -> passed.

## Risk
- Low runtime risk: this is an operator acceptance harness/docs change.
- Intended stricter behavior: live acceptance now fails earlier if Wiii Connect is not activation-ready, rather than producing a misleading Connect Link/execution attempt.

## Rollback
- Revert this commit. Backend runtime behavior remains unchanged.