### PR TITLE
test(connect): add Composio readiness report

### DIFF
--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -70,6 +70,18 @@ The acceptance harness enforces the same projection automatically:
   activation readiness to report `ready_to_execute_readonly=true` for the
   selected connection before provider execution.
 
+Before secrets are available, operators can run a dry readiness report that
+does not issue a Connect Link, list provider accounts, execute provider actions,
+or disconnect anything:
+
+```powershell
+python scripts/wiii_connect_composio_acceptance.py --backend-url http://localhost:8080 --auth-mode dev-login --provider gmail --readiness-report-only
+```
+
+The report prints `ready_to_connect`, `ready_to_execute_readonly`, and failed
+activation gates with `required_next` hints. It is designed for preflight and
+environment setup; it is not a substitute for the live acceptance sequence.
+
 For local dev-login:
 
 ```powershell

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -211,6 +211,11 @@ The live acceptance harness now treats this projection as a required gate:
 `ready_to_connect=true` is required before Connect Link issuance, and
 `ready_to_execute_readonly=true` is required when operator acceptance asks for
 execution readiness or read-only provider execution.
+The same harness also has a dry readiness-report mode for setup work before
+real credentials are present. That mode calls only Wiii's activation-readiness
+projection, prints failed gates plus `required_next` hints, and deliberately
+does not issue Connect Links, list provider accounts, execute provider actions,
+or disconnect accounts.
 
 Remaining work before enabling Composio for real users: configure production
 Composio project credentials and auth config IDs, connect a live Gmail account,

--- a/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
@@ -232,6 +232,52 @@ def activation_blocker_summary(payload: dict[str, Any]) -> str:
     return ", ".join(blockers[:8]) or "none"
 
 
+def activation_readiness_report_lines(payload: dict[str, Any]) -> list[str]:
+    """Return a human-readable, redacted activation-readiness report."""
+
+    provider = _safe_report_text(payload.get("provider_slug") or "unknown")
+    status = _safe_report_text(payload.get("status") or "unknown")
+    lines = [
+        (
+            f"provider={provider} status={status} "
+            f"ready_to_connect={payload.get('ready_to_connect') is True} "
+            f"ready_to_execute_readonly={payload.get('ready_to_execute_readonly') is True}"
+        )
+    ]
+    gates = payload.get("gates")
+    if not isinstance(gates, list):
+        lines.append("blocked_gates=gates_missing")
+        return lines
+
+    blockers: list[str] = []
+    for gate in gates:
+        if not isinstance(gate, dict) or gate.get("ready") is True:
+            continue
+        key = _safe_report_text(gate.get("key") or "unknown")
+        reason = _safe_report_text(gate.get("reason") or "blocked")
+        required_next = gate.get("required_next")
+        if isinstance(required_next, list):
+            next_steps = ",".join(
+                _safe_report_text(item) for item in required_next[:5]
+            )
+        else:
+            next_steps = ""
+        suffix = f" next={next_steps}" if next_steps else ""
+        blockers.append(f"- {key}: {reason}{suffix}")
+    if blockers:
+        lines.append("blocked_gates:")
+        lines.extend(blockers[:12])
+    else:
+        lines.append("blocked_gates=none")
+    return lines
+
+
+def print_activation_readiness_report(payload: dict[str, Any]) -> None:
+    print("[REPORT] activation readiness")
+    for line in activation_readiness_report_lines(payload):
+        print(f"[REPORT] {line}")
+
+
 def assert_activation_ready(
     payload: dict[str, Any],
     *,
@@ -269,6 +315,18 @@ def _looks_sensitive_string(value: str) -> bool:
     if "wiii_state=" in lowered or "connected_account_id=" in lowered:
         return True
     return False
+
+
+def _safe_report_text(value: Any) -> str:
+    text = str(value or "").strip().replace(" ", "_")
+    if not text:
+        return "unknown"
+    if _looks_sensitive_string(text):
+        return "[redacted]"
+    lowered = text.lower()
+    if any(marker in lowered for marker in SENSITIVE_KEY_MARKERS):
+        return "[redacted]"
+    return text[:160]
 
 
 class WiiiConnectComposioAcceptance:
@@ -319,35 +377,44 @@ class WiiiConnectComposioAcceptance:
         self.run_check("backend health", self.check_backend_health)
         self.run_check("authentication", self.authenticate)
         if self.token:
-            self.run_check("provider registry", self.check_provider_registry)
-            self.run_check("adapter readiness", self.check_adapter_readiness)
-            self.run_check("storage readiness", self.check_storage_readiness)
-            self.run_check("audit readiness", self.check_audit_readiness)
-            self.run_check("curated actions", self.check_curated_actions)
-            self.run_check(
-                "activation readiness connect",
-                self.check_activation_ready_to_connect,
-            )
-            self.run_check(
-                "gateway fail-closed control",
-                self.check_gateway_blocks_missing_connection,
-            )
-            if not self.args.skip_connect_link:
-                self.run_check("connect link preflight", self.check_connect_link)
-            self.run_check("connection listing", self.check_connections)
-            if self.args.require_execution_ready or self.args.execute_readonly:
+            if self.args.readiness_report_only:
                 self.run_check(
-                    "activation readiness execution",
-                    self.check_activation_ready_to_execute,
+                    "activation readiness report",
+                    self.check_activation_readiness_report,
+                )
+            else:
+                self.run_check("provider registry", self.check_provider_registry)
+                self.run_check("adapter readiness", self.check_adapter_readiness)
+                self.run_check("storage readiness", self.check_storage_readiness)
+                self.run_check("audit readiness", self.check_audit_readiness)
+                self.run_check("curated actions", self.check_curated_actions)
+                self.run_check(
+                    "activation readiness connect",
+                    self.check_activation_ready_to_connect,
                 )
                 self.run_check(
-                    "execution gateway allowed",
-                    self.check_execution_gateway_allowed,
+                    "gateway fail-closed control",
+                    self.check_gateway_blocks_missing_connection,
                 )
-            if self.args.execute_readonly:
-                self.run_check("read-only provider execution", self.check_readonly_execution)
-            if self.args.disconnect:
-                self.run_check("backend-owned disconnect", self.check_disconnect)
+                if not self.args.skip_connect_link:
+                    self.run_check("connect link preflight", self.check_connect_link)
+                self.run_check("connection listing", self.check_connections)
+                if self.args.require_execution_ready or self.args.execute_readonly:
+                    self.run_check(
+                        "activation readiness execution",
+                        self.check_activation_ready_to_execute,
+                    )
+                    self.run_check(
+                        "execution gateway allowed",
+                        self.check_execution_gateway_allowed,
+                    )
+                if self.args.execute_readonly:
+                    self.run_check(
+                        "read-only provider execution",
+                        self.check_readonly_execution,
+                    )
+                if self.args.disconnect:
+                    self.run_check("backend-owned disconnect", self.check_disconnect)
 
         total = self.passed + self.failed
         print(f"\nResult: {self.passed}/{total} checks passed")
@@ -562,6 +629,12 @@ class WiiiConnectComposioAcceptance:
         )
         return f"ready_to_execute_readonly=true connection={opaque_ref(connection_id)}"
 
+    def check_activation_readiness_report(self) -> str:
+        connection_id = (self.args.connection_id or "").strip()
+        payload = self.activation_readiness_payload(connection_id=connection_id)
+        print_activation_readiness_report(payload)
+        return f"blockers={activation_blocker_summary(payload)}"
+
     def check_connect_link(self) -> str:
         payload = request_bytes(
             "POST",
@@ -748,6 +821,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_EXPECTED_PLATFORM_ROLE,
     )
     parser.add_argument("--skip-connect-link", action="store_true")
+    parser.add_argument(
+        "--readiness-report-only",
+        action="store_true",
+        help=(
+            "Fetch and print the redacted activation-readiness report, then stop. "
+            "Does not issue Connect Links, list provider accounts, execute, or disconnect."
+        ),
+    )
     parser.add_argument("--print-connect-url", action="store_true")
     parser.add_argument("--expect-connected", action="store_true")
     parser.add_argument("--require-execution-ready", action="store_true")

--- a/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import importlib.util
 import sys
 from pathlib import Path
@@ -128,6 +129,44 @@ def test_activation_readiness_helpers_report_blockers() -> None:
     )
 
 
+def test_activation_readiness_report_lines_are_redacted() -> None:
+    payload = {
+        "provider_slug": "gmail",
+        "status": "blocked",
+        "ready_to_connect": False,
+        "ready_to_execute_readonly": False,
+        "gates": [
+            {
+                "key": "provider_adapter",
+                "ready": False,
+                "reason": "missing_composio_api_key",
+                "required_next": [
+                    "configure_composio_adapter",
+                    "https://callback.example/?wiii_state=secret",
+                ],
+                "metadata": {"api_key": "secret-value"},
+            },
+            {
+                "key": "local_connection",
+                "ready": False,
+                "reason": "connection_missing",
+                "required_next": ["complete_provider_oauth"],
+            },
+        ],
+    }
+
+    report = "\n".join(acceptance.activation_readiness_report_lines(payload))
+
+    assert "provider=gmail" in report
+    assert "ready_to_connect=False" in report
+    assert "provider_adapter" in report
+    assert "configure_composio_adapter" in report
+    assert "local_connection: connection_missing" in report
+    assert "secret-value" not in report
+    assert "wiii_state=secret" not in report
+    assert "missing_composio_api_key" not in report
+
+
 def test_activation_readiness_payload_uses_backend_endpoint(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
@@ -173,6 +212,74 @@ def test_activation_readiness_payload_uses_backend_endpoint(monkeypatch) -> None
     assert "probe_database=true" in url
     assert "action_slug=GMAIL_FETCH_EMAILS" in url
     assert "connection_id=ca_live" in url
+
+
+def test_readiness_report_only_does_not_run_live_connect_or_execute(monkeypatch) -> None:
+    calls: list[str] = []
+    printed: list[str] = []
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="http://localhost:8080",
+            provider="gmail",
+            action="GMAIL_FETCH_EMAILS",
+            timeout=7.0,
+            org_id="",
+            readiness_report_only=True,
+            connection_id="",
+        )
+    )
+
+    def backend_health() -> str:
+        calls.append("health")
+        return "ok"
+
+    def authenticate() -> str:
+        calls.append("auth")
+        harness.token = "token"
+        return "bearer"
+
+    def report_payload(*, connection_id: str = ""):
+        calls.append(f"report:{connection_id or 'none'}")
+        return {
+            "provider_slug": "gmail",
+            "status": "blocked",
+            "ready_to_connect": False,
+            "ready_to_execute_readonly": False,
+            "gates": [
+                {
+                    "key": "local_connection",
+                    "ready": False,
+                    "reason": "connection_missing",
+                    "required_next": ["complete_provider_oauth"],
+                }
+            ],
+        }
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("live connect/execution path should not run")
+
+    monkeypatch.setattr(harness, "check_backend_health", backend_health)
+    monkeypatch.setattr(harness, "authenticate", authenticate)
+    monkeypatch.setattr(harness, "activation_readiness_payload", report_payload)
+    monkeypatch.setattr(harness, "check_connect_link", forbidden)
+    monkeypatch.setattr(harness, "check_connections", forbidden)
+    monkeypatch.setattr(harness, "check_execution_gateway_allowed", forbidden)
+    monkeypatch.setattr(harness, "check_readonly_execution", forbidden)
+    monkeypatch.setattr(harness, "check_disconnect", forbidden)
+    monkeypatch.setattr(
+        builtins,
+        "print",
+        lambda *values, **kwargs: printed.append(
+            " ".join(str(value) for value in values)
+        ),
+    )
+
+    assert harness.run() == 0
+
+    output = "\n".join(printed)
+    assert calls == ["health", "auth", "report:none"]
+    assert "[REPORT] activation readiness" in output
+    assert "complete_provider_oauth" in output
 
 
 def test_connection_id_for_action_requires_selected_or_explicit_connection() -> None:


### PR DESCRIPTION
Closes #787.

## Summary
- Add `--readiness-report-only` to the Wiii Connect Composio acceptance harness.
- The report calls only Wiii's activation-readiness projection, prints `ready_to_connect`, `ready_to_execute_readonly`, and failed gates with `required_next` hints, then stops.
- Update the Composio acceptance runbook and OpenHuman/Composio audit with the dry preflight flow.

## Scope
- Operator harness and docs only.
- Unit coverage for report redaction and proof that report-only mode does not enter live Connect Link/list/execute/disconnect checks.

## Non-Scope
- No credentials or environment files.
- No Composio provider-direct calls.
- No write/apply/admin action enablement.
- No chat runtime behavior changes.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 10 passed.
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_provider_adapters.py tests/unit/api/test_wiii_connect_api.py tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 52 passed.
- `cd maritime-ai-service; python -m ruff check scripts/wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_composio_acceptance.py --select=E9,F63,F7` -> passed.
- `cd maritime-ai-service; python scripts/wiii_connect_composio_acceptance.py --help` -> passed, shows `--readiness-report-only`.
- `git diff --check` -> passed.

## Risk
- Low runtime risk: this is an operator harness/docs change.
- Security focus: report output is redacted and the report-only path does not issue Connect Links, list provider accounts, execute provider actions, or disconnect accounts.

## Rollback
- Revert this commit. Backend runtime behavior remains unchanged.