### PR TITLE
docs: reconcile Wiii Connect adapter spec state

### DIFF
--- a/specs/730-wiii-connect-adapter-v1/plan.md
+++ b/specs/730-wiii-connect-adapter-v1/plan.md
@@ -10,12 +10,21 @@ Connect Adapter V1 contract. This slice adds deterministic policy objects and
 unit tests, while keeping real Composio OAuth/execution disabled until vault and
 runtime endpoints exist.
 
+Status update 2026-05-28: follow-up slices have implemented the runtime
+endpoints, provider-managed vault references, durable connection/audit storage,
+Composio Connect Link and callback boundary, activation readiness, read-only
+execution gateway, desktop Wiii Connect surface, and operator acceptance
+harness. Live Composio enablement is still pending #780 because it requires
+real Composio credentials, provider auth config IDs, and browser acceptance
+against a connected account.
+
 ## Technical Context
 
 **Language/Version**: Python 3.11+
 **Primary Dependencies**: FastAPI backend codebase, dataclasses, pytest
-**Storage**: None in this slice; future slices need persistent registry,
-connection records, vault references, and audit ledger.
+**Storage**: Adapter V1 now has durable connection records and audit ledger
+storage in `wiii_connect_connections` and `wiii_connect_audit_ledger`.
+Provider registry remains static backend configuration by design for V1.
 **Testing**: pytest unit tests
 **Target Platform**: Wiii backend service
 **Project Type**: backend contract and architecture docs

--- a/specs/730-wiii-connect-adapter-v1/spec.md
+++ b/specs/730-wiii-connect-adapter-v1/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `codex/730-audit-wiii-connect-adapter-v1`
 **Created**: 2026-05-27
-**Status**: Draft
+**Status**: Contract implemented; live Composio acceptance pending #780
 **Input**: User request to audit OpenHuman Connections/Composio and design Wiii
 Connect Adapter V1 before enabling real Composio execution.
 
@@ -114,6 +114,18 @@ paths and secret-like values are absent.
   values.
 - **SC-004**: Architecture docs explicitly state Composio is not enabled until
   vault, OAuth callback, scope policy, gateway, and audit ledger are in place.
+
+## Current Implementation Status
+
+As of 2026-05-28, Wiii has implemented the Adapter V1 contract, backend-owned
+provider registry, Composio adapter configuration boundary, provider-managed
+vault references, signed callback state, durable connection and audit storage,
+activation readiness projection, curated read-only action catalog, execution
+gateway, desktop Wiii Connect surface, and operator acceptance harness.
+
+The feature is not considered fully enabled for users until #780 proves the
+same flow with real Composio credentials, a Gmail auth config, a live connected
+account, sanitized harness output, and browser acceptance evidence.
 
 ## Assumptions
 

--- a/specs/730-wiii-connect-adapter-v1/tasks.md
+++ b/specs/730-wiii-connect-adapter-v1/tasks.md
@@ -2,6 +2,10 @@
 
 **Input**: Design documents from `specs/730-wiii-connect-adapter-v1/`
 **Prerequisites**: `plan.md`, `spec.md`
+**Status Update 2026-05-28**: Adapter V1 contract and Wiii-owned Composio
+control plane are implemented through follow-up slices. Live Composio
+acceptance remains pending in #780 because it requires real Composio
+credentials, a provider auth config, and a live connected account.
 
 ## Phase 1: Audit And Design
 
@@ -27,11 +31,48 @@
 
 ## Phase 4: Next Slices
 
-- [ ] T014 Add persistent provider registry API.
 - [x] T014 Add backend-owned static provider registry for disabled Composio catalog.
-- [x] T015 Add read-only provider registry API.
-- [ ] T016 Add persistent provider registry API.
-- [ ] T017 Add OAuth start/callback routes for disabled Composio adapter.
-- [ ] T018 Add vault integration or provider-managed secret reference storage.
-- [ ] T019 Add frontend connection modal using Wiii backend routes.
-- [ ] T020 Add browser acceptance for connect, poll, disconnect, gated scope, and denied execute cases.
+- [x] T015 Add read-only provider registry and action catalog APIs.
+- [x] T016 Decide persistent provider registry is out of scope for Adapter V1;
+      the static backend registry remains the source of truth until provider
+      onboarding needs runtime admin writes.
+- [x] T017 Add authenticated Composio Connect Link and callback routes behind
+      Wiii backend policy.
+- [x] T018 Add provider-managed vault reference storage and durable
+      connection/audit storage.
+- [x] T019 Add frontend Wiii Connect surface using Wiii backend routes for
+      provider registry, readiness, Connect Link, polling, and disconnect.
+- [x] T020 Add backend/operator acceptance harness for readiness, Connect Link,
+      connection polling, denied execute, optional read-only execute, and
+      disconnect checks.
+- [ ] T021 Run live Composio acceptance with real credentials, Gmail auth
+      config, and a connected account. Tracked by #780.
+- [ ] T022 Run browser acceptance against the live connected Gmail account and
+      confirm Wiii Connect shows connected/agent-ready state without raw
+      connection IDs, provider payloads, or secrets. Tracked by #780.
+
+## Current Evidence
+
+- Provider registry and API:
+  `maritime-ai-service/app/engine/wiii_connect/provider_registry.py`,
+  `maritime-ai-service/app/api/v1/wiii_connect.py`,
+  `tests/unit/api/test_wiii_connect_api.py`.
+- OAuth/session/callback boundary:
+  `maritime-ai-service/app/engine/wiii_connect/connection_sessions.py`,
+  `callback_state.py`, `callback_boundary.py`, and
+  `app/api/v1/wiii_connect.py`.
+- Vault and durable storage:
+  `maritime-ai-service/app/engine/wiii_connect/vault.py`,
+  `persistent_storage.py`, and
+  `alembic/versions/049_create_wiii_connect_storage.py`.
+- Scope policy, curated action catalog, and execution gateway:
+  `adapter_v1.py`, `action_catalog.py`, `execution_gateway.py`, and
+  `activation_readiness.py`.
+- Composio provider adapter:
+  `composio_adapter.py`.
+- Frontend Wiii Connect surface:
+  `wiii-desktop/src/components/connect/WiiiConnectPage.tsx` and
+  `wiii-desktop/src/__tests__/wiii-connect-page.test.tsx`.
+- Operator acceptance harness:
+  `maritime-ai-service/scripts/wiii_connect_composio_acceptance.py` and
+  `docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md`.


### PR DESCRIPTION
## Summary
- reconcile the Adapter V1 Spec Kit ledger with current Wiii Connect/Composio implementation evidence
- mark implemented OAuth, callback, provider-managed vault, durable storage, frontend Wiii Connect, and acceptance harness slices as complete
- keep live Composio credential/OAuth/browser acceptance explicitly pending in #780

## Scope
- specs/730-wiii-connect-adapter-v1/plan.md
- specs/730-wiii-connect-adapter-v1/spec.md
- specs/730-wiii-connect-adapter-v1/tasks.md

## Non-Scope
- no runtime behavior changes
- no Composio credentials or live OAuth setup
- no frontend/backend code changes

## Verification
- git diff --check
- docs/spec diff review

## Risk
Low runtime risk. The main risk is misstating implementation status; the task ledger now links each completed area to concrete source/test evidence and keeps #780 open for live acceptance.

## Rollback
Revert this docs/spec commit if any evidence mapping is inaccurate.

Closes #789