### PR TITLE
test: add Composio acceptance evidence JSON

### DIFF
--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -82,6 +82,19 @@ The report prints `ready_to_connect`, `ready_to_execute_readonly`, and failed
 activation gates with `required_next` hints. It is designed for preflight and
 environment setup; it is not a substitute for the live acceptance sequence.
 
+For PR or issue evidence, write the optional sanitized JSON artifact to a local
+temporary path:
+
+```powershell
+python scripts/wiii_connect_composio_acceptance.py --backend-url http://localhost:8080 --auth-mode dev-login --provider gmail --readiness-report-only --target-env local --commit-sha <deployed-commit> --evidence-json "$env:TEMP\wiii-connect-composio-acceptance.json"
+```
+
+The JSON includes check names, pass/fail status, elapsed time, target label, and
+deployed commit. It intentionally strips bearer tokens, Connect URLs, callback
+state, raw connection IDs, vault references, and provider payloads. Do not commit
+generated evidence files; attach or summarize the sanitized output in the
+issue/PR when needed.
+
 For local dev-login:
 
 ```powershell

--- a/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
@@ -18,6 +18,8 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any, Callable
 
 
@@ -29,6 +31,8 @@ DEFAULT_DEMO_NAME = "Dev User"
 DEFAULT_DEMO_ROLE = "admin"
 DEFAULT_EXPECTED_PLATFORM_ROLE = "platform_admin"
 TOKEN_ENV = "WIII_ACCEPTANCE_BEARER_TOKEN"
+TARGET_ENV = "WIII_ACCEPTANCE_TARGET_ENV"
+COMMIT_SHA_ENV = "WIII_ACCEPTANCE_COMMIT_SHA"
 
 SENSITIVE_EXACT_KEYS = {
     "access_token",
@@ -226,8 +230,8 @@ def activation_blocker_summary(payload: dict[str, Any]) -> str:
     for gate in gates:
         if not isinstance(gate, dict) or gate.get("ready") is True:
             continue
-        key = str(gate.get("key") or "unknown")
-        reason = str(gate.get("reason") or "blocked")
+        key = _safe_report_text(gate.get("key") or "unknown")
+        reason = _safe_report_text(gate.get("reason") or "blocked")
         blockers.append(f"{key}:{reason}")
     return ", ".join(blockers[:8]) or "none"
 
@@ -336,6 +340,8 @@ class WiiiConnectComposioAcceptance:
         self.selected_connection_id = ""
         self.passed = 0
         self.failed = 0
+        self.started_at = datetime.now(UTC)
+        self.check_records: list[dict[str, Any]] = []
 
     def api_url(self, path: str) -> str:
         return join_url(self.args.backend_url, path)
@@ -361,14 +367,40 @@ class WiiiConnectComposioAcceptance:
             detail = func()
         except AcceptanceFailure as exc:
             self.failed += 1
+            elapsed = time.monotonic() - start
+            self.check_records.append(
+                self.check_record(
+                    name,
+                    status="failed",
+                    elapsed=elapsed,
+                    detail=str(exc),
+                )
+            )
             print(f"[FAIL] {name} - {exc}")
             return False
         except Exception as exc:  # pragma: no cover - defensive CLI boundary
             self.failed += 1
+            elapsed = time.monotonic() - start
+            self.check_records.append(
+                self.check_record(
+                    name,
+                    status="failed",
+                    elapsed=elapsed,
+                    detail=f"unexpected error: {exc}",
+                )
+            )
             print(f"[FAIL] {name} - unexpected error: {exc}")
             return False
         elapsed = time.monotonic() - start
         suffix = f" - {detail}" if detail else ""
+        self.check_records.append(
+            self.check_record(
+                name,
+                status="passed",
+                elapsed=elapsed,
+                detail=detail,
+            )
+        )
         print(f"[PASS] {name} ({elapsed:.1f}s){suffix}")
         self.passed += 1
         return True
@@ -418,7 +450,94 @@ class WiiiConnectComposioAcceptance:
 
         total = self.passed + self.failed
         print(f"\nResult: {self.passed}/{total} checks passed")
+        if getattr(self.args, "evidence_json", ""):
+            self.write_evidence_json()
         return 1 if self.failed else 0
+
+    def check_record(
+        self,
+        name: str,
+        *,
+        status: str,
+        elapsed: float,
+        detail: str,
+    ) -> dict[str, Any]:
+        return {
+            "name": str(name),
+            "status": status,
+            "elapsed_seconds": round(float(elapsed), 3),
+            "detail": redact_for_log(str(detail or "")),
+        }
+
+    def evidence_payload(self) -> dict[str, Any]:
+        parsed_backend = urllib.parse.urlsplit(self.args.backend_url)
+        backend_origin = ""
+        if parsed_backend.scheme and parsed_backend.netloc:
+            backend_origin = f"{parsed_backend.scheme}://{parsed_backend.netloc}"
+        return redact_for_log(
+            {
+                "schema": "wiii_connect_composio_acceptance_evidence.v1",
+                "generated_at": datetime.now(UTC).isoformat(),
+                "started_at": self.started_at.isoformat(),
+                "backend_origin": backend_origin or "[invalid_backend_url]",
+                "target_env": getattr(self.args, "target_env", "")
+                or os.environ.get(TARGET_ENV, "")
+                or "unspecified",
+                "commit_sha": getattr(self.args, "commit_sha", "")
+                or os.environ.get(COMMIT_SHA_ENV, "")
+                or "unspecified",
+                "provider": normalize_provider(self.args.provider),
+                "action": normalize_action(self.args.action),
+                "auth_mode": self.args.auth_mode,
+                "flags": {
+                    "readiness_report_only": bool(
+                        getattr(self.args, "readiness_report_only", False)
+                    ),
+                    "skip_connect_link": bool(
+                        getattr(self.args, "skip_connect_link", False)
+                    ),
+                    "print_connect_url": bool(
+                        getattr(self.args, "print_connect_url", False)
+                    ),
+                    "expect_connected": bool(
+                        getattr(self.args, "expect_connected", False)
+                    ),
+                    "require_execution_ready": bool(
+                        getattr(self.args, "require_execution_ready", False)
+                    ),
+                    "execute_readonly": bool(
+                        getattr(self.args, "execute_readonly", False)
+                    ),
+                    "disconnect": bool(getattr(self.args, "disconnect", False)),
+                    "explicit_connection_selected": bool(
+                        getattr(self.args, "connection_id", "")
+                    ),
+                    "arguments_present": bool(
+                        parse_json_argument_object(
+                            getattr(self.args, "arguments_json", "{}")
+                        )
+                    ),
+                },
+                "summary": {
+                    "passed": self.passed,
+                    "failed": self.failed,
+                    "total": self.passed + self.failed,
+                    "success": self.failed == 0,
+                },
+                "checks": self.check_records,
+            }
+        )
+
+    def write_evidence_json(self) -> None:
+        path = validate_evidence_path(getattr(self.args, "evidence_json", ""))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = self.evidence_payload()
+        path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+            + "\n",
+            encoding="utf-8",
+        )
+        print(f"[INFO] Wrote redacted evidence JSON: {path}")
 
     def check_backend_health(self) -> str:
         payload = request_bytes(
@@ -837,7 +956,51 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--connection-id", default="")
     parser.add_argument("--argument-keys", default="")
     parser.add_argument("--arguments-json", default="{}")
+    parser.add_argument(
+        "--target-env",
+        default="",
+        help=f"Optional target environment label for evidence JSON; env fallback {TARGET_ENV}.",
+    )
+    parser.add_argument(
+        "--commit-sha",
+        default="",
+        help=f"Optional deployed commit SHA for evidence JSON; env fallback {COMMIT_SHA_ENV}.",
+    )
+    parser.add_argument(
+        "--evidence-json",
+        default="",
+        help=(
+            "Write a sanitized JSON evidence artifact. Do not point this at "
+            ".env files, logs, screenshots, coverage, dist, or dependency folders."
+        ),
+    )
     return parser
+
+
+def validate_evidence_path(raw_path: str) -> Path:
+    text = str(raw_path or "").strip()
+    if not text:
+        raise AcceptanceFailure("--evidence-json path must not be empty")
+    path = Path(text).expanduser()
+    parts = [part.lower() for part in path.parts]
+    filename = path.name.lower()
+    blocked_parts = {
+        ".git",
+        ".env",
+        ".venv",
+        "node_modules",
+        "dist",
+        "dist-embed",
+        "coverage",
+        "__pycache__",
+    }
+    if filename.startswith(".env") or any(part in blocked_parts for part in parts):
+        raise AcceptanceFailure(
+            "--evidence-json path points at a forbidden local/secret/generated location"
+        )
+    if path.suffix.lower() != ".json":
+        raise AcceptanceFailure("--evidence-json path must end with .json")
+    return path
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -212,6 +213,148 @@ def test_activation_readiness_payload_uses_backend_endpoint(monkeypatch) -> None
     assert "probe_database=true" in url
     assert "action_slug=GMAIL_FETCH_EMAILS" in url
     assert "connection_id=ca_live" in url
+
+
+def test_validate_evidence_path_rejects_secret_and_generated_locations() -> None:
+    with pytest.raises(acceptance.AcceptanceFailure, match="forbidden"):
+        acceptance.validate_evidence_path(".env.composio.json")
+    with pytest.raises(acceptance.AcceptanceFailure, match="forbidden"):
+        acceptance.validate_evidence_path("coverage/wiii-connect.json")
+    with pytest.raises(acceptance.AcceptanceFailure, match="must end with .json"):
+        acceptance.validate_evidence_path("artifacts/wiii-connect.txt")
+
+    assert (
+        acceptance.validate_evidence_path("artifacts/wiii-connect/evidence.json").name
+        == "evidence.json"
+    )
+
+
+def test_evidence_payload_redacts_sensitive_details() -> None:
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="https://wiii.example.com/api?token=secret",
+            provider="gmail",
+            action="GMAIL_FETCH_EMAILS",
+            auth_mode="bearer",
+            target_env="staging",
+            commit_sha="abc1234",
+            readiness_report_only=False,
+            skip_connect_link=False,
+            print_connect_url=True,
+            expect_connected=True,
+            require_execution_ready=True,
+            execute_readonly=False,
+            disconnect=False,
+            connection_id="ca_secret",
+            arguments_json='{"max_results": 1}',
+        )
+    )
+    harness.passed = 1
+    harness.failed = 0
+    harness.check_records.append(
+        harness.check_record(
+            "connect link",
+            status="passed",
+            elapsed=0.2,
+            detail=(
+                "authorization_url=https://connect.example/callback"
+                "?wiii_state=secret connection_id=ca_secret"
+            ),
+        )
+    )
+
+    payload = harness.evidence_payload()
+    serialized = json.dumps(payload, sort_keys=True)
+
+    assert payload["schema"] == "wiii_connect_composio_acceptance_evidence.v1"
+    assert payload["backend_origin"] == "https://wiii.example.com"
+    assert payload["target_env"] == "staging"
+    assert payload["commit_sha"] == "abc1234"
+    assert payload["flags"]["explicit_connection_selected"] is True
+    assert payload["flags"]["arguments_present"] is True
+    assert "token=secret" not in serialized
+    assert "wiii_state=secret" not in serialized
+    assert "ca_secret" not in serialized
+    assert "authorization_url=" not in serialized
+
+
+def test_run_writes_redacted_evidence_json(monkeypatch, tmp_path) -> None:
+    calls: list[str] = []
+    printed: list[str] = []
+    evidence_path = tmp_path / "wiii-connect-evidence.json"
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="http://localhost:8080",
+            provider="gmail",
+            action="GMAIL_FETCH_EMAILS",
+            timeout=7.0,
+            org_id="",
+            readiness_report_only=True,
+            connection_id="",
+            auth_mode="bearer",
+            target_env="local",
+            commit_sha="abc1234",
+            evidence_json=str(evidence_path),
+        )
+    )
+
+    def backend_health() -> str:
+        calls.append("health")
+        return "ok"
+
+    def authenticate() -> str:
+        calls.append("auth")
+        harness.token = "secret-token"
+        return "bearer token"
+
+    def report_payload(*, connection_id: str = ""):
+        calls.append(f"report:{connection_id or 'none'}")
+        return {
+            "provider_slug": "gmail",
+            "status": "blocked",
+            "ready_to_connect": False,
+            "ready_to_execute_readonly": False,
+            "gates": [
+                {
+                    "key": "provider_adapter",
+                    "ready": False,
+                    "reason": "missing_composio_api_key",
+                    "required_next": [
+                        "configure_composio_adapter",
+                        "https://callback.example/?wiii_state=secret",
+                    ],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(harness, "check_backend_health", backend_health)
+    monkeypatch.setattr(harness, "authenticate", authenticate)
+    monkeypatch.setattr(harness, "activation_readiness_payload", report_payload)
+    monkeypatch.setattr(
+        builtins,
+        "print",
+        lambda *values, **kwargs: printed.append(
+            " ".join(str(value) for value in values)
+        ),
+    )
+
+    assert harness.run() == 0
+
+    payload = json.loads(evidence_path.read_text(encoding="utf-8"))
+    serialized = json.dumps(payload, sort_keys=True)
+    output = "\n".join(printed)
+
+    assert calls == ["health", "auth", "report:none"]
+    assert payload["summary"] == {"failed": 0, "passed": 3, "success": True, "total": 3}
+    assert [item["name"] for item in payload["checks"]] == [
+        "backend health",
+        "authentication",
+        "activation readiness report",
+    ]
+    assert "secret-token" not in serialized
+    assert "missing_composio_api_key" not in serialized
+    assert "wiii_state=secret" not in serialized
+    assert "Wrote redacted evidence JSON" in output
 
 
 def test_readiness_report_only_does_not_run_live_connect_or_execute(monkeypatch) -> None:


### PR DESCRIPTION
Summary:
- Adds optional `--evidence-json` output to the Wiii Connect Composio acceptance harness.
- Records check names/status/timing plus target env and deployed commit while redacting bearer tokens, Connect URLs, callback state, raw connection IDs, vault refs, and provider payloads.
- Documents the temporary evidence workflow in the Composio acceptance runbook.

Scope:
- `maritime-ai-service/scripts/wiii_connect_composio_acceptance.py`
- `maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py`
- `docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md`

Non-scope:
- No live Composio credentials, OAuth app setup, provider execution behavior, or production flags changed.
- No frontend UI changes.

Verification:
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 13 passed
- `cd maritime-ai-service; python -m ruff check scripts/wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_composio_acceptance.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed
- `cd maritime-ai-service; python scripts/wiii_connect_composio_acceptance.py --help` -> new evidence flags visible

Risk:
- Low runtime risk: this changes an operator harness and docs only.
- Main risk is accidental evidence leakage; tests cover redaction for token-like URLs, callback state, connection IDs, and API-key-shaped readiness reasons.

Rollback:
- Revert this PR to remove the evidence JSON option and return the runbook to stdout-only acceptance evidence.

Closes #793


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to generate sanitized acceptance check evidence reports in JSON format using the `--evidence-json` flag
  * Evidence captures check results, execution time, and deployment context while automatically redacting sensitive data (tokens, URLs, connection IDs)

* **Documentation**
  * Updated acceptance runbook with guidance on generating and managing evidence artifacts

* **Tests**
  * Added test coverage for evidence generation and data redaction functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/794?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->