### PR TITLE
Require explicit Wiii Connect connection selection

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -416,7 +416,8 @@ and requires all of:
 2. provider registry entry is marked agent-ready;
 3. live connection belongs to the same provider slug;
 4. live connection state is `connected`;
-5. runtime path and action are allowed by the gateway.
+5. the caller selected an explicit stored connection id for execution;
+6. runtime path and action are allowed by the gateway.
 
 This follows the useful OpenHuman pattern while keeping Wiii's stronger LMS,
 tenant, and host-action safety boundary.
@@ -427,6 +428,7 @@ The gateway denies by default. Current reason codes:
 
 - `provider_disabled`
 - `provider_not_agent_ready`
+- `connection_selection_required`
 - `connection_missing`
 - `connection_provider_mismatch`
 - `connection_not_connected`
@@ -464,6 +466,12 @@ Composio execute
 Wiii must not expose Composio's broad meta-tools directly to normal chat. The
 path governor selects the product path first. Only then may a scoped integration
 agent receive curated action schemas for the selected provider.
+
+Execution preflight and execution calls must pass an explicit Wiii connection
+id. They must not fall back to the latest stored account for a provider. This
+keeps multi-account integrations deterministic and matches the source-audited
+OpenHuman/Composio pattern where connection state is visible first, then a
+specific connected account is chosen before tools run.
 
 ## OAuth And Vault Requirements
 

--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -147,6 +147,7 @@ Composio is ready to enable only when all of these are true:
 - provider registry returns Gmail as a Composio provider;
 - curated actions include only the intended read-only action;
 - execution gateway blocks a missing-connection execution request;
+- execution gateway blocks execution when no explicit connection id is selected;
 - Connect Link is issued by Wiii backend;
 - after OAuth, connection listing returns an active connected account;
 - execution gateway allows the selected read-only action only for the stored
@@ -162,6 +163,7 @@ Common blocked reasons:
 |---|---|
 | `provider_adapter_not_configured` | Missing Composio API key or auth config map. |
 | `audit_ledger_not_persistent` | Migration or database connection is missing. |
+| `connection_selection_required` | The caller has not selected a stored provider connection id for execution. |
 | `connection_missing` | OAuth has not completed or the selected connection does not belong to this org/user. |
 | `provider_not_agent_ready` | Read-only action execution is not enabled for the curated allowlist. |
 | `action_not_allowed` | The action is not in Wiii's curated catalog for that provider. |

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -297,6 +297,12 @@ projection, prints failed gates plus `required_next` hints, and deliberately
 does not issue Connect Links, list provider accounts, execute provider actions,
 or disconnect accounts.
 
+Wiii now keeps the execution side stricter than the storage helper: execution
+readiness, execution-decision, and execute calls require an explicit selected
+connection id. They do not silently reuse the latest stored provider account.
+This preserves the OpenHuman-style connection discipline while avoiding unsafe
+multi-account ambiguity once Composio is enabled with real users.
+
 Remaining work before enabling Composio for real users: configure production
 Composio project credentials and auth config IDs, connect a live Gmail account,
 run the acceptance harness plus browser acceptance through Wiii's

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -195,14 +195,15 @@ async def get_wiii_connect_provider_activation_readiness(
         probe_database=probe_database,
     )
     storage_ready = _connection_storage_ready(storage)
+    safe_connection_id = _safe_provider_connection_id(connection_id)
     connection = (
         get_wiii_connect_persistent_storage().get_connection_record(
             organization_id=_wiii_connect_owner_organization_id(current_user),
             user_id=current_user.user_id,
             provider_slug=execution_entry.slug,
-            connection_id=_safe_provider_connection_id(connection_id),
+            connection_id=safe_connection_id,
         )
-        if storage_ready
+        if storage_ready and safe_connection_id
         else None
     )
     curated_action = get_wiii_connect_curated_action(execution_entry.slug, action)
@@ -238,6 +239,7 @@ async def get_wiii_connect_provider_activation_readiness(
                 storage.get("persistent") and storage.get("audit_ledger_ready")
             ),
         },
+        connection_selection_required=not bool(safe_connection_id),
     )
     return build_activation_readiness_metadata(
         provider_slug=connect_entry.slug,
@@ -659,14 +661,15 @@ async def decide_wiii_connect_provider_execution(
     effective_entry = build_composio_execution_enabled_entry(entry, composio_config)
     storage = _wiii_connect_storage_status_metadata(probe_database=True)
     storage_ready = _connection_storage_ready(storage)
+    safe_connection_id = _safe_provider_connection_id(body.connection_id)
     connection = (
         get_wiii_connect_persistent_storage().get_connection_record(
             organization_id=_wiii_connect_owner_organization_id(current_user),
             user_id=current_user.user_id,
             provider_slug=effective_entry.slug,
-            connection_id=body.connection_id,
+            connection_id=safe_connection_id,
         )
-        if storage_ready
+        if storage_ready and safe_connection_id
         else None
     )
     request = WiiiConnectExecutionRequest(
@@ -689,6 +692,7 @@ async def decide_wiii_connect_provider_execution(
         audit_ledger_metadata={
             "persistent": bool(storage.get("persistent") and storage.get("audit_ledger_ready")),
         },
+        connection_selection_required=not bool(safe_connection_id),
     )
     _append_execution_audit(
         gateway,
@@ -697,7 +701,7 @@ async def decide_wiii_connect_provider_execution(
         current_user=current_user,
         metadata={
             "surface": body.surface,
-            "connection_id_present": bool(body.connection_id),
+            "connection_id_present": bool(safe_connection_id),
             "connection_found": connection is not None,
             "storage": storage,
         },
@@ -723,14 +727,15 @@ async def execute_wiii_connect_provider_action(
     effective_entry = build_composio_execution_enabled_entry(entry, composio_config)
     storage = _wiii_connect_storage_status_metadata(probe_database=True)
     storage_ready = _connection_storage_ready(storage)
+    safe_connection_id = _safe_provider_connection_id(body.connection_id)
     connection = (
         get_wiii_connect_persistent_storage().get_connection_record(
             organization_id=_wiii_connect_owner_organization_id(current_user),
             user_id=current_user.user_id,
             provider_slug=effective_entry.slug,
-            connection_id=body.connection_id,
+            connection_id=safe_connection_id,
         )
-        if storage_ready
+        if storage_ready and safe_connection_id
         else None
     )
     request = WiiiConnectExecutionRequest(
@@ -757,10 +762,11 @@ async def execute_wiii_connect_provider_action(
                 storage.get("persistent") and storage.get("audit_ledger_ready")
             ),
         },
+        connection_selection_required=not bool(safe_connection_id),
     )
     audit_base = {
         "surface": body.surface,
-        "connection_id_present": bool(body.connection_id),
+        "connection_id_present": bool(safe_connection_id),
         "connection_found": connection is not None,
         "storage": storage,
     }

--- a/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
+++ b/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
@@ -47,6 +47,7 @@ ExecutionDenyReason = Literal[
     "provider_adapter_not_configured",
     "provider_adapter_cannot_execute",
     "audit_ledger_not_persistent",
+    "connection_selection_required",
     "connection_missing",
     "connection_provider_mismatch",
     "connection_not_connected",

--- a/maritime-ai-service/app/engine/wiii_connect/execution_gateway.py
+++ b/maritime-ai-service/app/engine/wiii_connect/execution_gateway.py
@@ -76,6 +76,7 @@ def decide_execution_gateway(
     adapter_capability: WiiiConnectProviderAdapterCapability | None = None,
     audit_ledger_metadata: dict[str, Any] | None = None,
     require_persistent_audit: bool = True,
+    connection_selection_required: bool = False,
 ) -> WiiiConnectExecutionGatewayDecision:
     """Return the fail-closed decision before a provider action may run."""
 
@@ -84,7 +85,11 @@ def decide_execution_gateway(
     )
     audit_persistent = bool((audit_ledger_metadata or {}).get("persistent"))
 
-    base = decide_external_execution(entry, connection, request)
+    base = (
+        _gateway_deny(entry, request, "connection_selection_required")
+        if connection_selection_required
+        else decide_external_execution(entry, connection, request)
+    )
     if not base.allowed:
         return WiiiConnectExecutionGatewayDecision(
             decision=base,
@@ -151,6 +156,7 @@ def _required_next_for_reason(reason: str) -> tuple[str, ...]:
         "provider_adapter_not_configured": ("configure_provider_adapter",),
         "provider_adapter_cannot_execute": ("implement_provider_action_adapter",),
         "audit_ledger_not_persistent": ("configure_persistent_audit_ledger",),
+        "connection_selection_required": ("select_provider_connection",),
         "connection_missing": ("connect_provider_account",),
         "connection_provider_mismatch": ("select_matching_connection",),
         "connection_not_connected": ("refresh_or_reconnect_provider_account",),

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -416,6 +416,86 @@ async def test_wiii_connect_activation_readiness_api_reports_ready_without_leaks
 
 
 @pytest.mark.asyncio
+async def test_wiii_connect_activation_readiness_requires_selected_connection(
+    authenticated_app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+    )
+    from app.engine.wiii_connect.persistent_storage import (
+        WiiiConnectPersistentStorageStatus,
+    )
+
+    class FakeStorage:
+        fetches = 0
+
+        def status(self, *, probe_database: bool = True):
+            assert probe_database is True
+            return WiiiConnectPersistentStorageStatus(
+                enabled=True,
+                persistent=True,
+                connection_table_ready=True,
+                audit_ledger_ready=True,
+                reason="ready",
+            )
+
+        def get_connection_record(self, **kwargs):
+            self.fetches += 1
+            raise AssertionError("readiness must not select latest connection")
+
+    fake_storage = FakeStorage()
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "build_composio_adapter_config",
+        lambda: WiiiConnectComposioAdapterConfig(
+            enabled=True,
+            api_key="secret-api-key",
+            api_key_present=True,
+            auth_config_by_provider={"gmail": "authcfg_gmail"},
+            readonly_execute_enabled=True,
+            readonly_action_allowlist_by_provider={
+                "gmail": ("GMAIL_FETCH_EMAILS",),
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        lambda: fake_storage,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=authenticated_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/wiii-connect/providers/gmail/activation-readiness",
+            params={"action_slug": "GMAIL_FETCH_EMAILS"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    gates = {gate["key"]: gate for gate in payload["gates"]}
+    serialized = json.dumps(payload, sort_keys=True)
+
+    assert payload["status"] == "blocked"
+    assert payload["ready_to_connect"] is True
+    assert payload["ready_to_execute_readonly"] is False
+    assert payload["connection"]["present"] is False
+    assert payload["execution_gateway"]["reason"] == "connection_selection_required"
+    assert (
+        "select_provider_connection" in payload["execution_gateway"]["required_next"]
+    )
+    assert gates["local_connection"]["reason"] == "connection_missing"
+    assert gates["execution_gateway"]["reason"] == "connection_selection_required"
+    assert fake_storage.fetches == 0
+    assert "secret-api-key" not in serialized
+    assert "authcfg_gmail" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_wiii_connect_session_start_api_blocks_without_leaking_secrets(app):
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=app),
@@ -1249,6 +1329,101 @@ async def test_wiii_connect_execution_decision_api_audits_fail_closed(
 
 
 @pytest.mark.asyncio
+async def test_wiii_connect_execution_decision_requires_selected_connection(
+    authenticated_app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+    )
+    from app.engine.wiii_connect.persistent_storage import (
+        WiiiConnectPersistentStorageStatus,
+    )
+
+    class FakeStorage:
+        audit_appends = 0
+        fetches = 0
+
+        def status(self, *, probe_database: bool = True):
+            return WiiiConnectPersistentStorageStatus(
+                enabled=True,
+                persistent=True,
+                connection_table_ready=True,
+                audit_ledger_ready=True,
+                reason="ready",
+            )
+
+        def get_connection_record(self, **kwargs):
+            self.fetches += 1
+            raise AssertionError(
+                "execution preflight must not select latest connection",
+            )
+
+        def append_audit_record(self, record, *, organization_id: str, user_id: str):
+            self.audit_appends += 1
+            metadata = record.to_public_metadata()["metadata"]
+            serialized = json.dumps(record.to_public_metadata(), sort_keys=True)
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert metadata["connection_id_present"] is False
+            assert metadata["connection_found"] is False
+            assert metadata["request"]["action_slug"] == "GMAIL_FETCH_EMAILS"
+            assert "secret-api-key" not in serialized
+            assert "access_token" not in serialized
+            return True
+
+    fake_storage = FakeStorage()
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "build_composio_adapter_config",
+        lambda: WiiiConnectComposioAdapterConfig(
+            enabled=True,
+            api_key="secret-api-key",
+            api_key_present=True,
+            auth_config_by_provider={"gmail": "authcfg_gmail"},
+            readonly_execute_enabled=True,
+            readonly_action_allowlist_by_provider={
+                "gmail": ("GMAIL_FETCH_EMAILS",),
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        lambda: fake_storage,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=authenticated_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/wiii-connect/providers/gmail/execution-decision",
+            json={
+                "surface": "desktop",
+                "action_slug": "GMAIL_FETCH_EMAILS",
+                "path": "external_app_action",
+                "mutation": "read",
+                "argument_keys": ["query", "access_token"],
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    serialized = json.dumps(payload, sort_keys=True)
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "connection_selection_required"
+    assert payload["connection_present"] is False
+    assert "select_provider_connection" in payload["required_next"]
+    assert fake_storage.fetches == 0
+    assert fake_storage.audit_appends == 1
+    assert "secret-api-key" not in serialized
+    assert "authcfg_gmail" not in serialized
+    assert "access_token" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_wiii_connect_execute_api_runs_readonly_composio_action_safely(
     authenticated_app,
     monkeypatch,
@@ -1404,6 +1579,116 @@ async def test_wiii_connect_execute_api_runs_readonly_composio_action_safely(
     assert "private subject" not in serialized
     assert "secret-api-key" not in serialized
     assert "authcfg_gmail" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_execute_requires_selected_connection_before_provider_call(
+    authenticated_app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+    )
+    from app.engine.wiii_connect.persistent_storage import (
+        WiiiConnectPersistentStorageStatus,
+    )
+
+    class FakeStorage:
+        audit_appends = 0
+        fetches = 0
+
+        def status(self, *, probe_database: bool = True):
+            return WiiiConnectPersistentStorageStatus(
+                enabled=True,
+                persistent=True,
+                connection_table_ready=True,
+                audit_ledger_ready=True,
+                reason="ready",
+            )
+
+        def get_connection_record(self, **kwargs):
+            self.fetches += 1
+            raise AssertionError("execute must not select latest connection")
+
+        def append_audit_record(self, record, *, organization_id: str, user_id: str):
+            self.audit_appends += 1
+            metadata = record.to_public_metadata()["metadata"]
+            serialized = json.dumps(record.to_public_metadata(), sort_keys=True)
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert metadata["stage"] == "gateway"
+            assert metadata["connection_id_present"] is False
+            assert metadata["connection_found"] is False
+            assert metadata["request"]["action_slug"] == "GMAIL_FETCH_EMAILS"
+            assert "client-secret" not in serialized
+            assert "access_token" not in serialized
+            return True
+
+    fake_storage = FakeStorage()
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "build_composio_adapter_config",
+        lambda: WiiiConnectComposioAdapterConfig(
+            enabled=True,
+            api_key="secret-api-key",
+            api_key_present=True,
+            auth_config_by_provider={"gmail": "authcfg_gmail"},
+            readonly_execute_enabled=True,
+            readonly_action_allowlist_by_provider={
+                "gmail": ("GMAIL_FETCH_EMAILS",),
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        lambda: fake_storage,
+    )
+
+    async def fake_schema(**kwargs):
+        raise AssertionError("schema probe must not run without selected connection")
+
+    async def fake_execute(**kwargs):
+        raise AssertionError(
+            "provider execution must not run without selected connection",
+        )
+
+    monkeypatch.setattr(wiii_connect_api, "verify_composio_tool_schema", fake_schema)
+    monkeypatch.setattr(wiii_connect_api, "execute_composio_tool", fake_execute)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=authenticated_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/wiii-connect/providers/gmail/execute",
+            json={
+                "surface": "desktop",
+                "action_slug": "GMAIL_FETCH_EMAILS",
+                "path": "external_app_action",
+                "mutation": "read",
+                "arguments": {
+                    "query": "from:me",
+                    "access_token": "client-secret",
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    serialized = json.dumps(payload, sort_keys=True)
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "connection_selection_required"
+    assert payload["connection_present"] is False
+    assert payload["schema"] is None
+    assert payload["execution"] is None
+    assert "select_provider_connection" in payload["required_next"]
+    assert fake_storage.fetches == 0
+    assert fake_storage.audit_appends == 1
+    assert "client-secret" not in serialized
+    assert "access_token" not in serialized
+    assert "secret-api-key" not in serialized
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- require an explicit selected Wiii Connect connection id before activation execution readiness, execution-decision, or execute can proceed
- add a dedicated \connection_selection_required\ gateway denial with \select_provider_connection\ next-step guidance
- add API coverage proving Wiii does not fall back to the latest stored connection and does not call Composio schema/execute without a selected account
- document the explicit-selection contract in the Wiii Connect adapter/runbook/OpenHuman audit docs

## Scope
- Backend Wiii Connect gateway policy and API behavior
- Wiii Connect API unit tests
- Wiii Connect documentation/runbooks

## Non-Scope
- Live Composio OAuth credentials, auth config IDs, or provider account setup
- New providers beyond the existing Composio/Gmail acceptance path
- Frontend Connect dashboard changes

## Verification
- PASS: \cd maritime-ai-service; python -m pytest tests/unit/api/test_wiii_connect_api.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short\ -> 58 passed
- PASS: \cd maritime-ai-service; python -m ruff check app/ --select=E9,F63,F7\`n- PASS: \git diff --check\`n- TIMEOUT: \cd maritime-ai-service; $env:PYTHONIOENCODING='utf-8'; python -m pytest tests/unit/ -p no:capture --tb=short -q\ timed out after 364s without failure output

## Risk
Low-to-medium. This tightens execution fail-closed behavior. Existing callers that omitted \connection_id\ for execution will now receive \connection_selection_required\ instead of implicitly using the latest stored account.

## Rollback
Revert this PR to restore previous gateway behavior. No migrations or persistent data shape changes are included.

Closes #795