### PR TITLE
test: assert Wiii Connect connection-selection acceptance

### DIFF
--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -148,6 +148,8 @@ Composio is ready to enable only when all of these are true:
 - curated actions include only the intended read-only action;
 - execution gateway blocks a missing-connection execution request;
 - execution gateway blocks execution when no explicit connection id is selected;
+- the acceptance harness treats any missing-selection deny reason other than
+  `connection_selection_required` as a failed policy proof;
 - Connect Link is issued by Wiii backend;
 - after OAuth, connection listing returns an active connected account;
 - execution gateway allows the selected read-only action only for the stored

--- a/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
@@ -702,6 +702,11 @@ class WiiiConnectComposioAcceptance:
         ).json()
         if payload.get("status") == "allowed":
             raise AcceptanceFailure("Gateway allowed execution without a connection")
+        if payload.get("reason") != "connection_selection_required":
+            raise AcceptanceFailure(
+                "Gateway did not enforce explicit connection selection: "
+                f"reason={payload.get('reason')!r}"
+            )
         return f"blocked reason={payload.get('reason')}"
 
     def activation_readiness_payload(

--- a/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
@@ -215,6 +215,85 @@ def test_activation_readiness_payload_uses_backend_endpoint(monkeypatch) -> None
     assert "connection_id=ca_live" in url
 
 
+def test_gateway_fail_closed_check_requires_connection_selection_reason(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        def json(self):
+            return {
+                "status": "blocked",
+                "reason": "connection_selection_required",
+            }
+
+    def fake_request_bytes(method, url, *, headers=None, payload=None, timeout=15.0):
+        captured["method"] = method
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["payload"] = payload
+        return FakeResponse()
+
+    monkeypatch.setattr(acceptance, "request_bytes", fake_request_bytes)
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="http://localhost:8080",
+            provider="gmail",
+            action="GMAIL_FETCH_EMAILS",
+            timeout=7.0,
+            org_id="",
+            argument_keys="query,access_token",
+            arguments_json="{}",
+        )
+    )
+    harness.token = "token"
+
+    detail = harness.check_gateway_blocks_missing_connection()
+
+    assert detail == "blocked reason=connection_selection_required"
+    assert captured["method"] == "POST"
+    assert captured["headers"] == {"Authorization": "Bearer token"}
+    assert captured["payload"] == {
+        "surface": "acceptance_harness",
+        "action_slug": "GMAIL_FETCH_EMAILS",
+        "path": "external_app_action",
+        "mutation": "read",
+        "argument_keys": ["query", "access_token"],
+    }
+
+
+def test_gateway_fail_closed_check_rejects_generic_block_reason(monkeypatch) -> None:
+    class FakeResponse:
+        def json(self):
+            return {
+                "status": "blocked",
+                "reason": "connection_missing",
+            }
+
+    def fake_request_bytes(method, url, *, headers=None, payload=None, timeout=15.0):
+        return FakeResponse()
+
+    monkeypatch.setattr(acceptance, "request_bytes", fake_request_bytes)
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="http://localhost:8080",
+            provider="gmail",
+            action="GMAIL_FETCH_EMAILS",
+            timeout=7.0,
+            org_id="",
+            argument_keys="",
+            arguments_json='{"query": "from:me"}',
+        )
+    )
+    harness.token = "token"
+
+    with pytest.raises(
+        acceptance.AcceptanceFailure,
+        match="explicit connection selection",
+    ):
+        harness.check_gateway_blocks_missing_connection()
+
+
 def test_validate_evidence_path_rejects_secret_and_generated_locations() -> None:
     with pytest.raises(acceptance.AcceptanceFailure, match="forbidden"):
         acceptance.validate_evidence_path(".env.composio.json")


### PR DESCRIPTION
## Summary
- require the Composio acceptance harness to prove the exact connection_selection_required deny reason for missing selected connection ids
- add focused tests for the expected deny reason and for rejecting generic blocked reasons
- document the stricter pass criterion in the Composio acceptance runbook

## Scope
- Wiii Connect Composio acceptance harness
- Focused harness unit tests
- Acceptance runbook wording

## Non-Scope
- No production runtime behavior change
- No live Composio OAuth credentials or account setup
- No frontend UI changes

## Verification
- PASS: cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short -> 15 passed
- PASS: cd maritime-ai-service; python -m ruff check scripts/wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_composio_acceptance.py --select=E9,F63,F7`n- PASS: git diff --check`n
## Risk
Low. This tightens the operator acceptance proof. A backend regression that still blocks execution but no longer enforces explicit connection selection will now fail acceptance, which is intended.

## Rollback
Revert this PR to restore the previous generic blocked-state harness check.

Closes #797