### PR TITLE
fix: validate Wiii Connect callback state first

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -514,9 +514,10 @@ Before real Composio OAuth is enabled:
 - disabled providers must return a blocked decision with missing requirements;
 - missing connection requirements block OAuth/session start, while missing
   agent-ready requirements only block tool/action exposure;
-- callback handling must stay blocked until signed state validation,
-  provider-managed connection reference or code presence, vault storage, and
-  provider adapter exchange are ready;
+- callback handling must validate Wiii-owned signed state before trusting
+  provider error/status fields, and must stay blocked until signed state
+  validation, provider-managed connection reference or code presence, vault
+  storage, and provider adapter exchange are ready;
 - callback/webhook handling must bind provider account to Wiii org/user;
 - credential material must be stored in an encrypted vault or provider-managed
   backend secret store;

--- a/maritime-ai-service/app/engine/wiii_connect/callback_boundary.py
+++ b/maritime-ai-service/app/engine/wiii_connect/callback_boundary.py
@@ -177,12 +177,12 @@ def _callback_reason(
 ) -> CallbackDecisionReason:
     if not entry.enabled:
         return "provider_disabled"
-    if request.error_present:
-        return "provider_error"
     if not request.state_present:
         return "missing_state"
     if not request.state_valid:
         return "invalid_state"
+    if request.error_present:
+        return "provider_error"
     if not request.code_present and not request.connection_ref_present:
         return "missing_code"
     if not request.connection_ref_present:

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -1769,6 +1769,197 @@ async def test_wiii_connect_callback_api_blocks_and_redacts_oauth_values(app):
 
 
 @pytest.mark.asyncio
+async def test_wiii_connect_callback_api_validates_state_before_provider_error(
+    app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+    )
+    from app.engine.wiii_connect.persistent_storage import (
+        WiiiConnectPersistentStorageStatus,
+    )
+
+    class FakeStorage:
+        audit_appends = 0
+        connection_upserts = 0
+
+        def status(self, *, probe_database: bool = True):
+            return WiiiConnectPersistentStorageStatus(
+                enabled=True,
+                persistent=True,
+                connection_table_ready=True,
+                audit_ledger_ready=True,
+                reason="ready",
+            )
+
+        def append_audit_record(self, *args, **kwargs):
+            self.audit_appends += 1
+            raise AssertionError("invalid state must not append tenant audit")
+
+        def upsert_connection_record(self, *args, **kwargs):
+            self.connection_upserts += 1
+            raise AssertionError("invalid state must not upsert connection")
+
+    fake_storage = FakeStorage()
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "build_composio_adapter_config",
+        lambda: WiiiConnectComposioAdapterConfig(
+            enabled=True,
+            api_key="secret-api-key",
+            api_key_present=True,
+            auth_config_by_provider={"facebook": "authcfg_fb"},
+        ),
+    )
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        lambda: fake_storage,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        missing_state = await client.get(
+            "/wiii-connect/providers/facebook/callback",
+            params={
+                "error": "access_denied",
+                "connected_account_id": "ca_secret",
+            },
+        )
+        invalid_state = await client.get(
+            "/wiii-connect/providers/facebook/callback",
+            params={
+                "wiii_state": "tampered-state",
+                "error": "access_denied",
+                "connected_account_id": "ca_secret",
+            },
+        )
+
+    missing_payload = missing_state.json()
+    invalid_payload = invalid_state.json()
+    serialized = json.dumps(
+        {
+            "missing": missing_payload,
+            "invalid": invalid_payload,
+        },
+        sort_keys=True,
+    )
+
+    assert missing_state.status_code == 200
+    assert invalid_state.status_code == 200
+    assert missing_payload["status"] == "blocked"
+    assert missing_payload["reason"] == "missing_state"
+    assert invalid_payload["status"] == "blocked"
+    assert invalid_payload["reason"] == "invalid_state"
+    assert fake_storage.audit_appends == 0
+    assert fake_storage.connection_upserts == 0
+    assert "access_denied" not in serialized
+    assert "tampered-state" not in serialized
+    assert "ca_secret" not in serialized
+    assert "secret-api-key" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_callback_api_blocks_valid_state_provider_error(
+    app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+    from app.core.config import settings
+    from app.engine.wiii_connect.callback_state import (
+        build_wiii_connect_callback_state,
+    )
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+    )
+    from app.engine.wiii_connect.persistent_storage import (
+        WiiiConnectPersistentStorageStatus,
+    )
+
+    class FakeStorage:
+        audit_appends = 0
+        connection_upserts = 0
+
+        def status(self, *, probe_database: bool = True):
+            return WiiiConnectPersistentStorageStatus(
+                enabled=True,
+                persistent=True,
+                connection_table_ready=True,
+                audit_ledger_ready=True,
+                reason="ready",
+            )
+
+        def append_audit_record(self, record, *, organization_id: str, user_id: str):
+            self.audit_appends += 1
+            metadata = record.to_public_metadata()["metadata"]
+            serialized = json.dumps(metadata, sort_keys=True)
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert metadata["state"]["valid"] is True
+            assert "access_denied" not in serialized
+            assert "secret-state-value" not in serialized
+            return True
+
+        def upsert_connection_record(self, *args, **kwargs):
+            self.connection_upserts += 1
+            raise AssertionError("provider error must not upsert connection")
+
+    state = build_wiii_connect_callback_state(
+        provider_slug="facebook",
+        organization_id="org_1",
+        user_id="user_1",
+        secret_key=settings.session_secret_key,
+    )
+    fake_storage = FakeStorage()
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "build_composio_adapter_config",
+        lambda: WiiiConnectComposioAdapterConfig(
+            enabled=True,
+            api_key="secret-api-key",
+            api_key_present=True,
+            auth_config_by_provider={"facebook": "authcfg_fb"},
+        ),
+    )
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        lambda: fake_storage,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/wiii-connect/providers/facebook/callback",
+            params={
+                "wiii_state": state,
+                "error": "access_denied",
+                "connected_account_id": "ca_secret",
+            },
+        )
+
+    payload = response.json()
+    serialized = json.dumps(payload, sort_keys=True)
+
+    assert response.status_code == 200
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "provider_error"
+    assert payload["vault_ref_issued"] is False
+    assert fake_storage.audit_appends == 1
+    assert fake_storage.connection_upserts == 0
+    assert "access_denied" not in serialized
+    assert "ca_secret" not in serialized
+    assert state not in serialized
+    assert "secret-api-key" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_wiii_connect_callback_api_reconciles_signed_composio_connection(
     app,
     monkeypatch,


### PR DESCRIPTION
Closes #801

## Summary
- validate Wiii-owned signed callback state before honoring provider error/status fields
- keep missing/tampered state from creating tenant audit records or connection upserts
- document the Wiii Connect callback state-first OAuth boundary

## Scope
- Wiii Connect callback decision ordering
- Wiii Connect callback API unit coverage
- Wiii Connect Adapter V1 docs

## Non-scope
- no live Composio credential enablement
- no frontend UI changes
- no vault schema or migration changes

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/api/test_wiii_connect_api.py tests/unit/test_wiii_connect_provider_adapters.py -q --tb=short` -> 47 passed
- `cd maritime-ai-service; python -m ruff check app/engine/wiii_connect/callback_boundary.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk
Low-to-medium. This changes OAuth callback denial precedence for Wiii Connect. Provider errors with missing/tampered Wiii state now surface as state failures and skip tenant audit/upsert, which is stricter and safer for Composio/OAuth rollout.

## Rollback
Revert this PR to restore prior callback reason ordering and remove the added state-first tests/docs.