### PR TITLE
test: assert Wiii Connect UI hides provider identifiers

### DIFF
--- a/wiii-desktop/src/__tests__/wiii-connect-page.test.tsx
+++ b/wiii-desktop/src/__tests__/wiii-connect-page.test.tsx
@@ -454,7 +454,7 @@ describe("WiiiConnectPage", () => {
     });
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 
-    render(<WiiiConnectPage />);
+    const { container } = render(<WiiiConnectPage />);
 
     expect(await screen.findByText("Registry backend")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: /Composio/i }));
@@ -480,6 +480,9 @@ describe("WiiiConnectPage", () => {
     expect(await screen.findByText("Connection thật")).toBeTruthy();
     expect(screen.getAllByText("Wiii Facebook Page").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Đã kết nối").length).toBeGreaterThan(0);
+    expect(container.textContent).not.toContain("conn_public_1");
+    expect(container.textContent).not.toContain("fb_page_public");
+    expect(container.textContent).not.toContain("https://composio.example/connect/safe");
     expect(screen.queryByText("access_token")).toBeNull();
     expect(screen.queryByText("secret-value")).toBeNull();
 


### PR DESCRIPTION
Closes #803

## Summary
- adds frontend regression coverage proving Wiii Connect can use backend-owned provider connection data without rendering raw provider identifiers
- asserts raw `connection_id`, external account ref, and backend-issued Connect Link URL stay out of visible UI text

## Scope
- Wiii Connect page unit test only

## Non-scope
- no runtime UI behavior changes
- no backend OAuth/policy changes
- no live Composio credential enablement

## Verification
- `cd wiii-desktop; npx vitest run src/__tests__/wiii-connect-page.test.tsx` -> 7 passed
- `git diff --check` -> pass

## Visual Evidence
Not applicable: test-only privacy regression coverage; rendered UI behavior is unchanged.

## Risk
Low. This is a test-only addition, but it protects a live Composio acceptance invariant.

## Rollback
Revert this PR to remove the additional frontend regression assertions.