### PR TITLE
fix: report selected Wiii Connect acceptance connection

### DIFF
--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -89,11 +89,11 @@ temporary path:
 python scripts/wiii_connect_composio_acceptance.py --backend-url http://localhost:8080 --auth-mode dev-login --provider gmail --readiness-report-only --target-env local --commit-sha <deployed-commit> --evidence-json "$env:TEMP\wiii-connect-composio-acceptance.json"
 ```
 
-The JSON includes check names, pass/fail status, elapsed time, target label, and
-deployed commit. It intentionally strips bearer tokens, Connect URLs, callback
-state, raw connection IDs, vault references, and provider payloads. Do not commit
-generated evidence files; attach or summarize the sanitized output in the
-issue/PR when needed.
+The JSON includes check names, pass/fail status, elapsed time, target label,
+deployed commit, and whether a connection was selected for action execution. It
+intentionally strips bearer tokens, Connect URLs, callback state, raw connection
+IDs, vault references, and provider payloads. Do not commit generated evidence
+files; attach or summarize the sanitized output in the issue/PR when needed.
 
 For local dev-login:
 

--- a/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
@@ -512,6 +512,10 @@ class WiiiConnectComposioAcceptance:
                     "explicit_connection_selected": bool(
                         getattr(self.args, "connection_id", "")
                     ),
+                    "connection_selected_for_action": bool(
+                        getattr(self.args, "connection_id", "")
+                        or self.selected_connection_id
+                    ),
                     "arguments_present": bool(
                         parse_json_argument_object(
                             getattr(self.args, "arguments_json", "{}")

--- a/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
@@ -350,11 +350,42 @@ def test_evidence_payload_redacts_sensitive_details() -> None:
     assert payload["target_env"] == "staging"
     assert payload["commit_sha"] == "abc1234"
     assert payload["flags"]["explicit_connection_selected"] is True
+    assert payload["flags"]["connection_selected_for_action"] is True
     assert payload["flags"]["arguments_present"] is True
     assert "token=secret" not in serialized
     assert "wiii_state=secret" not in serialized
     assert "ca_secret" not in serialized
     assert "authorization_url=" not in serialized
+
+
+def test_evidence_payload_marks_connection_selected_from_listing() -> None:
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="https://wiii.example.com",
+            provider="gmail",
+            action="GMAIL_FETCH_EMAILS",
+            auth_mode="bearer",
+            target_env="staging",
+            commit_sha="abc1234",
+            readiness_report_only=False,
+            skip_connect_link=False,
+            print_connect_url=False,
+            expect_connected=True,
+            require_execution_ready=True,
+            execute_readonly=True,
+            disconnect=False,
+            connection_id="",
+            arguments_json='{"max_results": 1}',
+        )
+    )
+    harness.selected_connection_id = "ca_selected_from_listing"
+
+    payload = harness.evidence_payload()
+    serialized = json.dumps(payload, sort_keys=True)
+
+    assert payload["flags"]["explicit_connection_selected"] is False
+    assert payload["flags"]["connection_selected_for_action"] is True
+    assert "ca_selected_from_listing" not in serialized
 
 
 def test_run_writes_redacted_evidence_json(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
Closes #805

## Summary
- adds `connection_selected_for_action` to sanitized Composio acceptance evidence
- keeps `explicit_connection_selected` limited to operator-provided `--connection-id`
- documents that evidence records whether a connection was selected without exposing raw IDs

## Scope
- Wiii Connect Composio acceptance harness metadata
- focused harness unit coverage
- acceptance runbook wording

## Non-scope
- no live Composio credential enablement
- no provider execution policy change
- no frontend runtime behavior change

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 16 passed
- `cd maritime-ai-service; python -m ruff check scripts/wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_composio_acceptance.py --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk
Low. This changes sanitized evidence metadata only. It should make live acceptance evidence clearer when the harness selects a connected account from listing after OAuth.

## Rollback
Revert this PR to remove the new evidence flag and test.