### PR TITLE
test: block Wiii Connect evidence artifact paths

### DIFF
--- a/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
@@ -1001,6 +1001,8 @@ def validate_evidence_path(raw_path: str) -> Path:
         "dist",
         "dist-embed",
         "coverage",
+        "logs",
+        "screenshots",
         "__pycache__",
     }
     if filename.startswith(".env") or any(part in blocked_parts for part in parts):

--- a/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
@@ -299,6 +299,10 @@ def test_validate_evidence_path_rejects_secret_and_generated_locations() -> None
         acceptance.validate_evidence_path(".env.composio.json")
     with pytest.raises(acceptance.AcceptanceFailure, match="forbidden"):
         acceptance.validate_evidence_path("coverage/wiii-connect.json")
+    with pytest.raises(acceptance.AcceptanceFailure, match="forbidden"):
+        acceptance.validate_evidence_path("logs/wiii-connect/evidence.json")
+    with pytest.raises(acceptance.AcceptanceFailure, match="forbidden"):
+        acceptance.validate_evidence_path("screenshots/wiii-connect/evidence.json")
     with pytest.raises(acceptance.AcceptanceFailure, match="must end with .json"):
         acceptance.validate_evidence_path("artifacts/wiii-connect.txt")
 


### PR DESCRIPTION
Closes #807

## Summary
- blocks Composio acceptance evidence JSON paths under logs/ and screenshots/
- adds focused harness tests so CLI validation matches the runbook/help text

## Scope
- acceptance harness evidence path validation
- focused harness unit coverage

## Non-scope
- no live Composio credential enablement
- no backend OAuth/execution behavior change
- no evidence schema change

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 16 passed
- `cd maritime-ai-service; python -m ruff check scripts/wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_composio_acceptance.py --select=E9,F63,F7` -> pass
- `git diff --check main...HEAD` -> pass

## Risk
Low. CLI validation only; prevents evidence artifacts from being written into transient log/screenshot folders.

## Rollback
Revert this PR to restore prior evidence path validation.