### PR TITLE
security: redact Wiii Connect vault connection refs

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -167,6 +167,8 @@ without guessing from logs.
 
 - opaque pointer to credentials;
 - never serializes secret values or vault paths to public metadata;
+- public metadata reports only provider slug, connection-reference presence, and
+  secret-version labels, never raw provider connection IDs;
 - lets UI and runtime know that a vault reference exists without exposing it.
 
 `WiiiConnectConnectionRecordV1`

--- a/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
+++ b/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
@@ -213,7 +213,7 @@ class WiiiConnectVaultSecretRef:
     def to_public_metadata(self) -> dict[str, Any]:
         return {
             "provider_slug": self.provider_slug,
-            "connection_id": self.connection_id,
+            "connection_ref_present": bool(self.connection_id),
             "vault_ref_present": bool(self.vault_key_id),
             "secret_version": self.secret_version,
         }
@@ -324,7 +324,7 @@ class WiiiConnectAuditEvent:
             "version": WIII_CONNECT_ADAPTER_VERSION,
             "stage": self.stage,
             "created_at": self.created_at,
-            "connection_id": self.connection_id,
+            "connection_ref_present": bool(self.connection_id),
             "request": self.request.to_audit_metadata(),
             "decision": self.decision.to_metadata(),
         }

--- a/maritime-ai-service/app/engine/wiii_connect/vault.py
+++ b/maritime-ai-service/app/engine/wiii_connect/vault.py
@@ -82,7 +82,7 @@ class WiiiConnectVaultSecretWriteRequest:
     def to_audit_metadata(self) -> dict[str, Any]:
         return {
             "provider_slug": self.provider_slug,
-            "connection_id": self.connection_id,
+            "connection_ref_present": bool(self.connection_id),
             "secret_kind": self.secret_kind,
             "secret_material_present": self.secret_material_present,
             "metadata_keys": [_safe_metadata_key(key) for key in self.metadata_keys],
@@ -129,7 +129,7 @@ class WiiiConnectVaultSecretWriteDecision:
             "status": self.status,
             "reason": self.reason,
             "provider_slug": self.provider_slug,
-            "connection_id": self.connection_id,
+            "connection_ref_present": bool(self.connection_id),
             "secret_kind": self.secret_kind,
             "vault_ref": (
                 self.vault_ref.to_public_metadata() if self.vault_ref is not None else None

--- a/maritime-ai-service/tests/unit/test_wiii_connect_adapter_v1.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_adapter_v1.py
@@ -307,9 +307,47 @@ def test_public_metadata_does_not_expose_vault_key_or_raw_secret_values():
         "vault": connection.vault_ref.to_public_metadata(),
     }
     serialized = json.dumps(metadata, sort_keys=True)
+    vault_serialized = json.dumps(metadata["vault"], sort_keys=True)
 
     assert metadata["connection"]["vault_ref_present"] is True
     assert metadata["vault"]["vault_ref_present"] is True
+    assert metadata["vault"]["connection_ref_present"] is True
     assert metadata["entry"]["required_fields"][0]["key"] == "client_secret"
     assert "oauth-token-secret" not in serialized
     assert "vault://tenant/private" not in serialized
+    assert "conn_1" not in vault_serialized
+    assert "connection_id" not in vault_serialized
+
+
+def test_execution_audit_event_reports_connection_presence_only():
+    from app.engine.wiii_connect.adapter_v1 import (
+        WiiiConnectAuditEvent,
+        WiiiConnectExecutionDecision,
+        WiiiConnectExecutionRequest,
+    )
+
+    request = WiiiConnectExecutionRequest(
+        provider_slug="gmail",
+        action_slug="GMAIL_FETCH_EMAILS",
+        path="external_app_action",
+    )
+    decision = WiiiConnectExecutionDecision(
+        outcome="allowed",
+        reason="allowed",
+        provider_slug="gmail",
+        action_slug="GMAIL_FETCH_EMAILS",
+        path="external_app_action",
+    )
+    event = WiiiConnectAuditEvent(
+        stage="started",
+        request=request,
+        decision=decision,
+        connection_id="ca_secret_provider_ref",
+    )
+
+    metadata = event.to_metadata()
+    serialized = json.dumps(metadata, sort_keys=True)
+
+    assert metadata["connection_ref_present"] is True
+    assert "ca_secret_provider_ref" not in serialized
+    assert "connection_id" not in serialized

--- a/maritime-ai-service/tests/unit/test_wiii_connect_persistent_storage.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_persistent_storage.py
@@ -142,7 +142,10 @@ def test_connection_upsert_stores_only_public_vault_ref_metadata():
     assert scopes["read"] is True
     assert scopes["write"] is True
     assert vault_ref["vault_ref_present"] is True
+    assert vault_ref["connection_ref_present"] is True
     assert vault_ref["secret_version"] == "v1"
+    assert "conn_1" not in json.dumps(vault_ref, sort_keys=True)
+    assert "connection_id" not in vault_ref
     assert "oauth-token-secret" not in serialized
     assert "vault://tenant/private" not in serialized
     assert session.commits == 1

--- a/maritime-ai-service/tests/unit/test_wiii_connect_vault_audit.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_vault_audit.py
@@ -51,9 +51,12 @@ def test_vault_write_decision_blocks_disabled_provider_and_redacts_keys():
 
     assert decision.ready is False
     assert metadata["reason"] == "provider_disabled"
+    assert metadata["connection_ref_present"] is True
     assert metadata["vault_ref"] is None
     assert "redacted_sensitive_field" in serialized
     assert "account_id" in serialized
+    assert "conn_1" not in serialized
+    assert "connection_id" not in serialized
     assert "access_token" not in serialized
     assert "refresh_token" not in serialized
     assert "secret-value" not in serialized
@@ -97,8 +100,12 @@ def test_vault_write_decision_issues_only_opaque_ref_when_ready():
 
     assert decision.ready is True
     assert metadata["reason"] == "ready_to_store"
+    assert metadata["connection_ref_present"] is True
     assert metadata["vault_ref"]["vault_ref_present"] is True
+    assert metadata["vault_ref"]["connection_ref_present"] is True
     assert metadata["vault_ref"]["secret_version"] == "pending"
+    assert "conn_1" not in serialized
+    assert "connection_id" not in serialized
     assert "tenant_1/composio/internal_test/conn_1/oauth_token" not in serialized
 
 


### PR DESCRIPTION
Closes #809

## Summary
- replaces raw provider connection IDs in vault public metadata and vault audit request metadata with connection-ref presence flags
- replaces the generic execution audit event raw connection id with a presence flag
- documents the vault-ref public metadata contract and adds focused redaction tests

## Scope
- Wiii Connect adapter/vault metadata contracts
- focused backend tests for vault, audit, and storage redaction
- Adapter V1 design doc clarification

## Non-scope
- no live Composio credential enablement
- no OAuth provider behavior change
- no frontend connection selection flow change
- no database schema change

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_vault_audit.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_persistent_storage.py -q --tb=short` -> 17 passed
- `cd maritime-ai-service; python -m ruff check app/engine/wiii_connect/adapter_v1.py app/engine/wiii_connect/vault.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_persistent_storage.py --select=E9,F63,F7` -> pass
- `git diff --check` -> pass

## Risk
Low to medium. This is security/privacy hardening on metadata shape. Internal connection records still keep IDs for authenticated selection and provider calls; public/audit helper metadata now exposes only presence booleans.

## Rollback
Revert this PR to restore the previous raw connection-id fields in these helper metadata shapes if a downstream consumer unexpectedly depends on them.