### PR TITLE
docs: add Wiii Connect Composio env examples

### DIFF
--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -35,6 +35,11 @@ enable_wiii_connect_composio_readonly_execute=true
 composio_readonly_action_allowlist={"gmail":["GMAIL_FETCH_EMAILS"]}
 ```
 
+The committed `.env.example` files use uppercase environment variable names for
+operator convention. The backend settings loader is case-insensitive, so those
+uppercase names map to the lowercase settings shown above. Never place real
+Composio API keys or auth config IDs in committed example files.
+
 The database must also have migration `049_create_wiii_connect_storage.py`
 applied so these tables exist:
 

--- a/maritime-ai-service/.env.example
+++ b/maritime-ai-service/.env.example
@@ -182,6 +182,21 @@ CORS_ORIGINS=["http://localhost:3000","http://localhost:8080"]
 # ENABLE_MCP_CLIENT=false             # Connect to external MCP servers
 # MCP_SERVER_CONFIGS=[]               # JSON array of MCP server configs
 
+# =============================================================================
+# WIII CONNECT - COMPOSIO ADAPTER (DISABLED BY DEFAULT)
+# =============================================================================
+# Keep these disabled until issue #780 live acceptance passes with real
+# backend deployment secrets, a Composio auth config, and a test OAuth account.
+ENABLE_WIII_CONNECT_COMPOSIO=false
+# COMPOSIO_API_KEY=composio-project-api-key
+COMPOSIO_BASE_URL=https://backend.composio.dev
+COMPOSIO_API_VERSION=v3.1
+# Provider slug -> Composio auth_config_id. Do not commit real auth config IDs.
+COMPOSIO_AUTH_CONFIG_MAP={"gmail":"replace-with-composio-gmail-auth-config-id"}
+ENABLE_WIII_CONNECT_COMPOSIO_READONLY_EXECUTE=false
+# Curated read-only actions only. Do not enable write/apply/admin actions here.
+COMPOSIO_READONLY_ACTION_ALLOWLIST={"gmail":["GMAIL_FETCH_EMAILS"]}
+
 # Dedicated privileged sandbox runtime (OpenSandbox)
 # ENABLE_PRIVILEGED_SANDBOX=false
 # SANDBOX_PROVIDER=opensandbox

--- a/maritime-ai-service/.env.production.example
+++ b/maritime-ai-service/.env.production.example
@@ -17,10 +17,10 @@ API_KEY=your-secure-api-key-here
 LMS_API_KEY=your-lms-api-key-here
 
 # --- REQUIRED: Security ---
-JWT_SECRET_KEY=generate-a-random-256-bit-key-here
+JWT_SECRET_KEY=change-me
 JWT_ALGORITHM=HS256
 JWT_EXPIRE_MINUTES=15
-SESSION_SECRET_KEY=generate-a-random-session-secret-here
+SESSION_SECRET_KEY=change-me
 CORS_ORIGINS=["https://your-domain.com"]
 
 # --- Rate Limiting ---
@@ -29,20 +29,20 @@ RATE_LIMIT_WINDOW_SECONDS=60
 
 # --- REQUIRED: Database Passwords (change from defaults!) ---
 POSTGRES_USER=wiii
-POSTGRES_PASSWORD=change-this-strong-password
+POSTGRES_PASSWORD=change-me
 POSTGRES_DB=wiii_ai
 # Production: connect via socket or internal hostname, not localhost:5433
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
-DATABASE_URL=postgresql+asyncpg://wiii:change-this-strong-password@postgres:5432/wiii_ai
+DATABASE_URL=postgresql+asyncpg://wiii:change-me@postgres:5432/wiii_ai
 
 NEO4J_USER=neo4j
 NEO4J_USERNAME=neo4j
-NEO4J_PASSWORD=change-this-strong-password
+NEO4J_PASSWORD=change-me
 NEO4J_URI=bolt://neo4j:7687
 
 MINIO_ACCESS_KEY=wiii
-MINIO_SECRET_KEY=change-this-strong-password
+MINIO_SECRET_KEY=change-me
 MINIO_BUCKET=wiii-docs
 MINIO_ENDPOINT=minio:9000
 MINIO_SECURE=false
@@ -102,6 +102,19 @@ VALKEY_URL=redis://valkey:6379/0
 RESEND_API_KEY=
 MAGIC_LINK_BASE_URL=https://your-domain.com
 MAGIC_LINK_FROM_EMAIL=Wiii <noreply@your-domain.com>
+
+# --- Optional: Wiii Connect Composio Adapter ---
+# Keep disabled until issue #780 live acceptance passes with real backend
+# deployment secrets, a Composio auth config, and a test OAuth account.
+ENABLE_WIII_CONNECT_COMPOSIO=false
+# COMPOSIO_API_KEY=composio-project-api-key
+COMPOSIO_BASE_URL=https://backend.composio.dev
+COMPOSIO_API_VERSION=v3.1
+# Provider slug -> Composio auth_config_id. Do not commit real auth config IDs.
+COMPOSIO_AUTH_CONFIG_MAP={"gmail":"replace-with-composio-gmail-auth-config-id"}
+ENABLE_WIII_CONNECT_COMPOSIO_READONLY_EXECUTE=false
+# Curated read-only actions only. Do not enable write/apply/admin actions here.
+COMPOSIO_READONLY_ACTION_ALLOWLIST={"gmail":["GMAIL_FETCH_EMAILS"]}
 
 # --- Logging & Observability ---
 LOG_LEVEL=INFO


### PR DESCRIPTION
Closes #811

## Summary
- adds disabled-by-default Wiii Connect/Composio placeholders to local and production env examples
- documents the exact Composio adapter settings operators need before issue #780 live acceptance
- clarifies that uppercase env examples map to lowercase settings through the case-insensitive backend loader

## Scope
- maritime-ai-service/.env.example`n- maritime-ai-service/.env.production.example`n- docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md`n
## Non-scope
- no live Composio credential setup
- no .env, .env.local, .env.production, or deployment secret changes
- no runtime behavior change

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_provider_adapters.py -q --tb=short` -> 14 passed
- `git diff --check` -> pass
- searched changed examples/runbook for the previously shared Xiaomi token pattern; none found

## Risk
Low. Docs/example-only operator enablement. The main risk is accidental secret exposure; this PR contains placeholders only and keeps Composio disabled by default.

## Rollback
Revert this PR to remove the example env block and runbook note if the operator config contract changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified environment variable naming conventions and security best practices in operational runbook.

* **Chores**
  * Updated environment configuration examples with Composio adapter settings (disabled by default).
  * Updated credential placeholder values in production configuration template.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/812?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->