### PR TITLE
security: use opaque Wiii Connect connection refs

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -126,7 +126,7 @@ authorization and connection-list endpoints for backend registry providers. It
 opens only backend-issued Connect Links, polls sanitized connection records
 through Wiii, and still keeps provider connection state separate from
 `agent_ready` execution state. The frontend never calls Composio directly and
-never receives provider tokens or raw payloads.
+never receives provider tokens, raw payloads, or raw provider connection IDs.
 
 The activation readiness endpoint is the single operator/UI preflight for a
 provider. It performs no provider network calls, creates no Connect Link, and
@@ -173,10 +173,12 @@ without guessing from logs.
 
 `WiiiConnectConnectionRecordV1`
 
-- provider slug, connection ID, normalized lifecycle state;
+- provider slug, opaque public `connection_ref`, normalized lifecycle state;
+- raw provider connection ID stays backend-internal for provider execute,
+  disconnect, and storage lookup;
 - granted scopes;
 - optional vault reference;
-- sanitized account label/reference only.
+- sanitized account label/reference presence only.
 
 `WiiiConnectExecutionRequest`
 

--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -160,6 +160,8 @@ Composio is ready to enable only when all of these are true:
   `connection_selection_required` as a failed policy proof;
 - Connect Link is issued by Wiii backend;
 - after OAuth, connection listing returns an active connected account;
+- connection listing returns an opaque `connection_ref`, not the raw provider
+  connected-account ID;
 - execution gateway allows the selected read-only action only for the stored
   org/user connection;
 - optional execution succeeds through `POST /api/v1/wiii-connect/providers/gmail/execute`;

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -246,6 +246,9 @@ raw provider payloads or connection IDs. Wiii now also has an authenticated exec
 gateway preflight endpoint that fetches the stored org/user connection record,
 checks path/action/scope/evidence/adapter/audit policy, and appends a
 privacy-safe execution ledger record without calling Composio action execution.
+Provider connection selection now uses an opaque Wiii `connection_ref` in
+frontend and harness requests; raw provider connected-account IDs remain
+backend-internal for Composio execute/disconnect calls.
 Wiii also has a curated action catalog contract with a
 `GMAIL_FETCH_EMAILS` read-only candidate, so future action exposure has a
 reviewable allowlist rather than a broad Composio tool dump. This candidate was
@@ -299,7 +302,8 @@ or disconnect accounts.
 
 Wiii now keeps the execution side stricter than the storage helper: execution
 readiness, execution-decision, and execute calls require an explicit selected
-connection id. They do not silently reuse the latest stored provider account.
+opaque connection reference. They do not silently reuse the latest stored
+provider account.
 This preserves the OpenHuman-style connection discipline while avoiding unsafe
 multi-account ambiguity once Composio is enabled with real users.
 

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -31,6 +31,7 @@ from app.engine.wiii_connect import (
     build_composio_provider_adapter_capability,
     build_wiii_connect_callback_state,
     begin_connection_session,
+    connection_ref_matches,
     create_composio_connect_link,
     decide_authorization_url,
     decide_execution_gateway,
@@ -78,6 +79,7 @@ class WiiiConnectExecutionDecisionBody(BaseModel):
 
     surface: str = "desktop"
     connection_id: str | None = None
+    connection_ref: str | None = None
     action_slug: str
     path: str = "external_app_action"
     mutation: str = "read"
@@ -169,6 +171,7 @@ async def get_wiii_connect_provider_connection_status(slug: str) -> dict[str, ob
 async def get_wiii_connect_provider_activation_readiness(
     slug: str,
     connection_id: str | None = None,
+    connection_ref: str | None = None,
     action_slug: str = "GMAIL_FETCH_EMAILS",
     probe_database: bool = True,
     current_user: AuthenticatedUser = Depends(require_auth),
@@ -196,7 +199,15 @@ async def get_wiii_connect_provider_activation_readiness(
         probe_database=probe_database,
     )
     storage_ready = _connection_storage_ready(storage)
-    safe_connection_id = _safe_provider_connection_id(connection_id)
+    selected_connection_ref = _safe_provider_connection_id(
+        connection_ref or connection_id,
+    )
+    safe_connection_id = _resolve_provider_connection_id(
+        storage,
+        current_user=current_user,
+        provider_slug=execution_entry.slug,
+        connection_ref_or_id=selected_connection_ref,
+    )
     _expire_stale_pending_connections(
         storage,
         current_user=current_user,
@@ -245,7 +256,7 @@ async def get_wiii_connect_provider_activation_readiness(
                 storage.get("persistent") and storage.get("audit_ledger_ready")
             ),
         },
-        connection_selection_required=not bool(safe_connection_id),
+        connection_selection_required=not bool(selected_connection_ref),
     )
     return build_activation_readiness_metadata(
         provider_slug=connect_entry.slug,
@@ -482,7 +493,13 @@ async def disconnect_wiii_connect_provider_connection(
     effective_entry = build_composio_connect_enabled_entry(entry, composio_config)
     adapter_capability = build_composio_provider_adapter_capability(composio_config)
     storage = _wiii_connect_storage_status_metadata(probe_database=True)
-    safe_connection_id = _safe_provider_connection_id(connection_id)
+    selected_connection_ref = _safe_provider_connection_id(connection_id)
+    safe_connection_id = _resolve_provider_connection_id(
+        storage,
+        current_user=current_user,
+        provider_slug=effective_entry.slug,
+        connection_ref_or_id=selected_connection_ref,
+    )
     if not _connection_storage_ready(storage):
         payload = _disconnect_payload(
             effective_entry,
@@ -681,7 +698,15 @@ async def decide_wiii_connect_provider_execution(
     effective_entry = build_composio_execution_enabled_entry(entry, composio_config)
     storage = _wiii_connect_storage_status_metadata(probe_database=True)
     storage_ready = _connection_storage_ready(storage)
-    safe_connection_id = _safe_provider_connection_id(body.connection_id)
+    selected_connection_ref = _safe_provider_connection_id(
+        body.connection_ref or body.connection_id,
+    )
+    safe_connection_id = _resolve_provider_connection_id(
+        storage,
+        current_user=current_user,
+        provider_slug=effective_entry.slug,
+        connection_ref_or_id=selected_connection_ref,
+    )
     _expire_stale_pending_connections(
         storage,
         current_user=current_user,
@@ -717,7 +742,7 @@ async def decide_wiii_connect_provider_execution(
         audit_ledger_metadata={
             "persistent": bool(storage.get("persistent") and storage.get("audit_ledger_ready")),
         },
-        connection_selection_required=not bool(safe_connection_id),
+        connection_selection_required=not bool(selected_connection_ref),
     )
     _append_execution_audit(
         gateway,
@@ -726,6 +751,7 @@ async def decide_wiii_connect_provider_execution(
         current_user=current_user,
         metadata={
             "surface": body.surface,
+            "connection_ref_present": bool(selected_connection_ref),
             "connection_id_present": bool(safe_connection_id),
             "connection_found": connection is not None,
             "storage": storage,
@@ -752,7 +778,15 @@ async def execute_wiii_connect_provider_action(
     effective_entry = build_composio_execution_enabled_entry(entry, composio_config)
     storage = _wiii_connect_storage_status_metadata(probe_database=True)
     storage_ready = _connection_storage_ready(storage)
-    safe_connection_id = _safe_provider_connection_id(body.connection_id)
+    selected_connection_ref = _safe_provider_connection_id(
+        body.connection_ref or body.connection_id,
+    )
+    safe_connection_id = _resolve_provider_connection_id(
+        storage,
+        current_user=current_user,
+        provider_slug=effective_entry.slug,
+        connection_ref_or_id=selected_connection_ref,
+    )
     _expire_stale_pending_connections(
         storage,
         current_user=current_user,
@@ -792,10 +826,11 @@ async def execute_wiii_connect_provider_action(
                 storage.get("persistent") and storage.get("audit_ledger_ready")
             ),
         },
-        connection_selection_required=not bool(safe_connection_id),
+        connection_selection_required=not bool(selected_connection_ref),
     )
     audit_base = {
         "surface": body.surface,
+        "connection_ref_present": bool(selected_connection_ref),
         "connection_id_present": bool(safe_connection_id),
         "connection_found": connection is not None,
         "storage": storage,
@@ -1347,6 +1382,38 @@ def _safe_provider_connection_id(value: str | None) -> str:
     if any(marker in text.lower() for marker in ("token", "secret", "password")):
         return ""
     return text[:160]
+
+
+def _resolve_provider_connection_id(
+    storage_metadata: dict[str, Any],
+    *,
+    current_user: AuthenticatedUser,
+    provider_slug: str,
+    connection_ref_or_id: str | None,
+) -> str:
+    """Resolve an opaque public connection ref inside one org/user boundary."""
+
+    candidate = _safe_provider_connection_id(connection_ref_or_id)
+    if not candidate:
+        return ""
+    if not candidate.startswith("wcn_"):
+        return candidate
+    if not _connection_storage_ready(storage_metadata):
+        return candidate
+
+    storage = get_wiii_connect_persistent_storage()
+    for connection in storage.list_connection_records(
+        organization_id=_wiii_connect_owner_organization_id(current_user),
+        user_id=current_user.user_id,
+        provider_slug=provider_slug,
+    ):
+        if connection_ref_matches(
+            provider_slug=connection.provider_slug,
+            connection_id=connection.connection_id,
+            candidate=candidate,
+        ):
+            return connection.connection_id
+    return candidate
 
 
 def _safe_action_slug(value: str) -> str:

--- a/maritime-ai-service/app/engine/wiii_connect/__init__.py
+++ b/maritime-ai-service/app/engine/wiii_connect/__init__.py
@@ -10,9 +10,11 @@ from .adapter_v1 import (
     WiiiConnectRequiredField,
     WiiiConnectScopeGrant,
     WiiiConnectVaultSecretRef,
+    connection_ref_matches,
     decide_external_execution,
     is_connection_baseline_ready,
     normalize_connection_state,
+    public_connection_ref,
 )
 from .action_catalog import (
     WIII_CONNECT_ACTION_CATALOG_VERSION,
@@ -220,6 +222,7 @@ __all__ = [
     "build_composio_external_user_id",
     "build_composio_provider_managed_vault_capability",
     "build_wiii_connect_callback_state",
+    "connection_ref_matches",
     "default_provider_adapter_capability",
     "default_persistent_storage_status_metadata",
     "default_wiii_connect_vault_capability",
@@ -233,6 +236,7 @@ __all__ = [
     "normalize_connection_state",
     "parse_composio_auth_config_map",
     "parse_composio_readonly_action_allowlist",
+    "public_connection_ref",
     "provider_adapter_status_public_metadata",
     "provider_callback_decision",
     "provider_callback_decision_for_entry",

--- a/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
+++ b/maritime-ai-service/app/engine/wiii_connect/adapter_v1.py
@@ -11,12 +11,14 @@ and carrying the required approval evidence before execution can proceed.
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Literal
 
 
 WIII_CONNECT_ADAPTER_VERSION = "wiii_connect_adapter.v1"
+WIII_CONNECT_PUBLIC_CONNECTION_REF_PREFIX = "wcn_"
 
 ProviderKind = Literal[
     "wiii_native",
@@ -238,17 +240,22 @@ class WiiiConnectConnectionRecordV1:
     def active(self) -> bool:
         return self.state == "connected"
 
+    @property
+    def connection_ref(self) -> str:
+        return public_connection_ref(self.provider_slug, self.connection_id)
+
     def to_public_metadata(self) -> dict[str, Any]:
         return {
             "version": WIII_CONNECT_ADAPTER_VERSION,
-            "connection_id": self.connection_id,
+            "connection_ref": self.connection_ref,
+            "connection_ref_present": bool(self.connection_ref),
             "provider_slug": self.provider_slug,
             "state": self.state,
             "active": self.active,
             "scopes": self.scopes.to_metadata(),
             "vault_ref_present": self.vault_ref is not None,
             "account_label": self.account_label,
-            "external_account_ref": self.external_account_ref,
+            "external_account_ref_present": bool(self.external_account_ref),
             "last_checked_at": self.last_checked_at,
             "reason": self.reason,
             "warnings": list(self.warnings),
@@ -347,6 +354,31 @@ def normalize_connection_state(status: str | None) -> ConnectionLifecycleState:
     if normalized == "DISABLED":
         return "disabled"
     return "disconnected"
+
+
+def public_connection_ref(provider_slug: str, connection_id: str) -> str:
+    """Return an opaque stable reference for UI/backend connection selection."""
+
+    provider = str(provider_slug or "").strip().lower().replace("-", "_")
+    raw_id = str(connection_id or "").strip()
+    if not provider or not raw_id:
+        return ""
+    digest = hashlib.sha256(f"{provider}:{raw_id}".encode("utf-8")).hexdigest()
+    return f"{WIII_CONNECT_PUBLIC_CONNECTION_REF_PREFIX}{digest[:24]}"
+
+
+def connection_ref_matches(
+    *,
+    provider_slug: str,
+    connection_id: str,
+    candidate: str,
+) -> bool:
+    """Return true when a public ref belongs to one provider connection id."""
+
+    normalized_candidate = str(candidate or "").strip()
+    if not normalized_candidate:
+        return False
+    return normalized_candidate == public_connection_ref(provider_slug, connection_id)
 
 
 def is_connection_baseline_ready(

--- a/maritime-ai-service/app/engine/wiii_connect/callback_boundary.py
+++ b/maritime-ai-service/app/engine/wiii_connect/callback_boundary.py
@@ -91,7 +91,7 @@ class WiiiConnectCallbackDecision:
     provider_kind: str
     auth_mode: str
     vault_ref_issued: bool = False
-    connection_id: str = ""
+    connection_ref: str = ""
     audit_event: WiiiConnectCallbackAuditEvent | None = None
 
     @property
@@ -108,7 +108,8 @@ class WiiiConnectCallbackDecision:
             "provider_kind": self.provider_kind,
             "auth_mode": self.auth_mode,
             "vault_ref_issued": self.vault_ref_issued,
-            "connection_id": self.connection_id,
+            "connection_ref": self.connection_ref,
+            "connection_ref_present": bool(self.connection_ref),
             "audit_event": (
                 self.audit_event.to_metadata() if self.audit_event is not None else None
             ),
@@ -163,7 +164,7 @@ def provider_callback_decision_for_entry(
         provider_kind=entry.provider_kind,
         auth_mode=entry.auth_mode,
         vault_ref_issued=status == "accepted",
-        connection_id="pending_connection_ref" if status == "accepted" else "",
+        connection_ref="pending_connection_ref" if status == "accepted" else "",
         audit_event=audit_event,
     )
 

--- a/maritime-ai-service/app/engine/wiii_connect/persistent_storage.py
+++ b/maritime-ai-service/app/engine/wiii_connect/persistent_storage.py
@@ -181,7 +181,6 @@ class WiiiConnectPersistentStorage:
         owner = _normalize_owner(organization_id=organization_id, user_id=user_id)
         if owner is None or not connection.connection_id or not connection.provider_slug:
             return False
-        metadata = connection.to_public_metadata()
         self._ensure_initialized()
         if self._session_factory is None:
             return False
@@ -224,22 +223,19 @@ class WiiiConnectPersistentStorage:
                         "provider_kind": str(provider_kind or "unknown").strip()
                         or "unknown",
                         "state": connection.state,
-                        "scopes": _json_dumps(metadata.get("scopes", {})),
+                        "scopes": _json_dumps(connection.scopes.to_metadata()),
                         "vault_ref": _json_dumps(
                             connection.vault_ref.to_public_metadata()
                             if connection.vault_ref is not None
                             else {}
                         ),
-                        "account_label": metadata.get("account_label") or None,
-                        "external_account_ref": (
-                            metadata.get("external_account_ref") or None
-                        ),
-                        "reason": metadata.get("reason") or None,
-                        "warnings": _json_dumps(metadata.get("warnings", [])),
+                        "account_label": connection.account_label or None,
+                        "external_account_ref": connection.external_account_ref
+                        or None,
+                        "reason": connection.reason or None,
+                        "warnings": _json_dumps(list(connection.warnings)),
                         "updated_at": datetime.now(UTC),
-                        "last_checked_at": _parse_datetime(
-                            metadata.get("last_checked_at")
-                        ),
+                        "last_checked_at": _parse_datetime(connection.last_checked_at),
                         "last_used_at": datetime.now(UTC)
                         if connection.active
                         else None,
@@ -303,40 +299,63 @@ class WiiiConnectPersistentStorage:
             logger.warning("Wiii Connect connection fetch failed: %s", exc)
             return None
 
-        if row is None:
-            return None
-        scopes = _decode_json_object(_row_value(row, "scopes"), default={})
-        vault_ref = _decode_json_object(_row_value(row, "vault_ref"), default={})
-        warnings = _decode_json_list(_row_value(row, "warnings"))
-        connection_id_value = str(_row_value(row, "id") or "").strip()
-        has_vault_ref = bool(vault_ref.get("vault_ref_present"))
-        return WiiiConnectConnectionRecordV1(
-            connection_id=connection_id_value,
-            provider_slug=str(_row_value(row, "provider_slug") or slug).strip(),
-            state=normalize_connection_state(str(_row_value(row, "state") or "")),
-            scopes=WiiiConnectScopeGrant(
-                read=bool(scopes.get("read")),
-                preview=bool(scopes.get("preview")),
-                write=bool(scopes.get("write")),
-                apply=bool(scopes.get("apply")),
-                admin=bool(scopes.get("admin")),
-            ),
-            vault_ref=(
-                WiiiConnectVaultSecretRef(
-                    provider_slug=slug,
-                    connection_id=connection_id_value,
-                    vault_key_id="stored_opaque_ref",
-                    secret_version=str(vault_ref.get("secret_version") or ""),
+        return _connection_record_from_row(row, fallback_provider_slug=slug)
+
+    def list_connection_records(
+        self,
+        *,
+        organization_id: str,
+        user_id: str,
+        provider_slug: str,
+        limit: int = 100,
+    ) -> tuple[WiiiConnectConnectionRecordV1, ...]:
+        """Fetch sanitized connection rows for resolving opaque public refs."""
+
+        owner = _normalize_owner(organization_id=organization_id, user_id=user_id)
+        slug = str(provider_slug or "").strip().lower().replace("-", "_")
+        if owner is None or not slug:
+            return ()
+        self._ensure_initialized()
+        if self._session_factory is None:
+            return ()
+
+        safe_limit = max(1, min(int(limit or 100), 500))
+        try:
+            with self._session_factory() as session:
+                result = session.execute(
+                    text(
+                        f"SELECT id, provider_slug, state, scopes, vault_ref, "
+                        f"account_label, external_account_ref, reason, warnings, "
+                        f"last_checked_at "
+                        f"FROM {self.CONNECTIONS_TABLE} "
+                        f"WHERE organization_id = :organization_id "
+                        f"AND user_id = :user_id "
+                        f"AND provider_slug = :provider_slug "
+                        f"ORDER BY updated_at DESC "
+                        f"LIMIT :limit"
+                    ),
+                    {
+                        "organization_id": owner["organization_id"],
+                        "user_id": owner["user_id"],
+                        "provider_slug": slug,
+                        "limit": safe_limit,
+                    },
                 )
-                if has_vault_ref
-                else None
-            ),
-            account_label=str(_row_value(row, "account_label") or ""),
-            external_account_ref=str(_row_value(row, "external_account_ref") or ""),
-            last_checked_at=_datetime_to_iso(_row_value(row, "last_checked_at")),
-            reason=str(_row_value(row, "reason") or ""),
-            warnings=tuple(warnings),
-        )
+                mappings = getattr(result, "mappings", None)
+                rows = mappings().all() if callable(mappings) else result.fetchall()
+        except Exception as exc:
+            if _is_missing_storage_table_error(exc):
+                logger.info("Wiii Connect connection storage unavailable; skipping list.")
+                return ()
+            logger.warning("Wiii Connect connection list failed: %s", exc)
+            return ()
+
+        records: list[WiiiConnectConnectionRecordV1] = []
+        for row in rows:
+            record = _connection_record_from_row(row, fallback_provider_slug=slug)
+            if record is not None:
+                records.append(record)
+        return tuple(records)
 
     def expire_stale_pending_connections(
         self,
@@ -447,6 +466,52 @@ def _fetch_mapping_row(result: Any) -> Any | None:
     if callable(fetchone):
         return fetchone()
     return None
+
+
+def _connection_record_from_row(
+    row: Any | None,
+    *,
+    fallback_provider_slug: str,
+) -> WiiiConnectConnectionRecordV1 | None:
+    if row is None:
+        return None
+    slug = str(fallback_provider_slug or "").strip().lower().replace("-", "_")
+    scopes = _decode_json_object(_row_value(row, "scopes"), default={})
+    vault_ref = _decode_json_object(_row_value(row, "vault_ref"), default={})
+    warnings = _decode_json_list(_row_value(row, "warnings"))
+    connection_id_value = str(_row_value(row, "id") or "").strip()
+    if not connection_id_value:
+        return None
+    provider_slug = str(_row_value(row, "provider_slug") or slug).strip()
+    normalized_provider = provider_slug.lower().replace("-", "_") or slug
+    has_vault_ref = bool(vault_ref.get("vault_ref_present"))
+    return WiiiConnectConnectionRecordV1(
+        connection_id=connection_id_value,
+        provider_slug=normalized_provider,
+        state=normalize_connection_state(str(_row_value(row, "state") or "")),
+        scopes=WiiiConnectScopeGrant(
+            read=bool(scopes.get("read")),
+            preview=bool(scopes.get("preview")),
+            write=bool(scopes.get("write")),
+            apply=bool(scopes.get("apply")),
+            admin=bool(scopes.get("admin")),
+        ),
+        vault_ref=(
+            WiiiConnectVaultSecretRef(
+                provider_slug=normalized_provider,
+                connection_id=connection_id_value,
+                vault_key_id="stored_opaque_ref",
+                secret_version=str(vault_ref.get("secret_version") or ""),
+            )
+            if has_vault_ref
+            else None
+        ),
+        account_label=str(_row_value(row, "account_label") or ""),
+        external_account_ref=str(_row_value(row, "external_account_ref") or ""),
+        last_checked_at=_datetime_to_iso(_row_value(row, "last_checked_at")),
+        reason=str(_row_value(row, "reason") or ""),
+        warnings=tuple(warnings),
+    )
 
 
 def _row_value(row: Any, key: str) -> Any:

--- a/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
@@ -213,8 +213,16 @@ def first_connected_connection(payload: dict[str, Any]) -> dict[str, Any] | None
             isinstance(connection, dict)
             and connection.get("active") is True
             and connection.get("state") == "connected"
-            and isinstance(connection.get("connection_id"), str)
-            and connection.get("connection_id")
+            and (
+                (
+                    isinstance(connection.get("connection_ref"), str)
+                    and connection.get("connection_ref")
+                )
+                or (
+                    isinstance(connection.get("connection_id"), str)
+                    and connection.get("connection_id")
+                )
+            )
         ):
             return connection
     return None
@@ -723,7 +731,7 @@ class WiiiConnectComposioAcceptance:
             "action_slug": self.args.action,
         }
         if connection_id:
-            params["connection_id"] = connection_id
+            params["connection_ref"] = connection_id
         query = urllib.parse.urlencode(params)
         return request_bytes(
             "GET",
@@ -815,7 +823,9 @@ class WiiiConnectComposioAcceptance:
             ):
                 raise AcceptanceFailure("No active connected account was returned")
             return "ready; no active account required for this run"
-        self.selected_connection_id = str(connection["connection_id"])
+        self.selected_connection_id = str(
+            connection.get("connection_ref") or connection.get("connection_id") or ""
+        )
         return f"active_connection={opaque_ref(self.selected_connection_id)}"
 
     def check_execution_gateway_allowed(self) -> str:
@@ -828,7 +838,7 @@ class WiiiConnectComposioAcceptance:
             headers=self.auth_headers(),
             payload={
                 "surface": "acceptance_harness",
-                "connection_id": connection_id,
+                "connection_ref": connection_id,
                 "action_slug": self.args.action,
                 "path": "external_app_action",
                 "mutation": "read",
@@ -852,7 +862,7 @@ class WiiiConnectComposioAcceptance:
             headers=self.auth_headers(),
             payload={
                 "surface": "acceptance_harness",
-                "connection_id": connection_id,
+                "connection_ref": connection_id,
                 "action_slug": self.args.action,
                 "path": "external_app_action",
                 "mutation": "read",

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -300,6 +300,7 @@ async def test_wiii_connect_activation_readiness_api_reports_ready_without_leaks
         WiiiConnectConnectionRecordV1,
         WiiiConnectScopeGrant,
         WiiiConnectVaultSecretRef,
+        public_connection_ref,
     )
     from app.engine.wiii_connect.composio_adapter import (
         WiiiConnectComposioAdapterConfig,
@@ -311,6 +312,7 @@ async def test_wiii_connect_activation_readiness_api_reports_ready_without_leaks
     class FakeStorage:
         fetches = 0
         expires = 0
+        lists = 0
 
         def status(self, *, probe_database: bool = True):
             assert probe_database is True
@@ -336,6 +338,26 @@ async def test_wiii_connect_activation_readiness_api_reports_ready_without_leaks
             assert provider_slug == "gmail"
             assert ttl_seconds >= 60
             return 1
+
+        def list_connection_records(
+            self,
+            *,
+            organization_id: str,
+            user_id: str,
+            provider_slug: str,
+        ):
+            self.lists += 1
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert provider_slug == "gmail"
+            return (
+                WiiiConnectConnectionRecordV1(
+                    connection_id="ca_active",
+                    provider_slug="gmail",
+                    state="connected",
+                    scopes=WiiiConnectScopeGrant(read=True),
+                ),
+            )
 
         def get_connection_record(
             self,
@@ -395,7 +417,7 @@ async def test_wiii_connect_activation_readiness_api_reports_ready_without_leaks
             "/wiii-connect/providers/gmail/activation-readiness",
             params={
                 "action_slug": "GMAIL_FETCH_EMAILS",
-                "connection_id": "ca_active",
+                "connection_ref": public_connection_ref("gmail", "ca_active"),
             },
         )
 
@@ -420,6 +442,7 @@ async def test_wiii_connect_activation_readiness_api_reports_ready_without_leaks
     assert gates["audit_ledger"]["ready"] is True
     assert gates["curated_readonly_action"]["ready"] is True
     assert gates["execution_gateway"]["ready"] is True
+    assert fake_storage.lists == 1
     assert fake_storage.fetches == 1
     assert fake_storage.expires == 1
     assert "ca_active" not in serialized
@@ -929,9 +952,11 @@ async def test_wiii_connect_connections_api_lists_and_persists_safely(
     assert payload["status"] == "ready"
     assert payload["reason"] == "ready"
     assert payload["connection_count"] == 1
-    assert payload["connections"][0]["connection_id"] == "ca_active"
+    assert payload["connections"][0]["connection_ref"].startswith("wcn_")
     assert payload["connections"][0]["state"] == "connected"
     assert fake_storage.upserts == 1
+    assert "ca_active" not in serialized
+    assert "connection_id" not in serialized
     assert "secret-api-key" not in serialized
     assert "authcfg_fb" not in serialized
     assert "access_token" not in serialized
@@ -2060,6 +2085,9 @@ async def test_wiii_connect_callback_api_reconciles_signed_composio_connection(
     assert payload["vault_ref_issued"] is True
     assert fake_storage.audit_appends == 1
     assert fake_storage.connection_upserts == 1
+    assert payload["connection_ref"] == "pending_connection_ref"
+    assert "connection_id" not in serialized
+    assert "ca_123" not in serialized
     assert "secret-api-key" not in serialized
     assert "authcfg_fb" not in serialized
     assert "secret-value" not in serialized

--- a/maritime-ai-service/tests/unit/test_wiii_connect_adapter_v1.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_adapter_v1.py
@@ -310,11 +310,14 @@ def test_public_metadata_does_not_expose_vault_key_or_raw_secret_values():
     vault_serialized = json.dumps(metadata["vault"], sort_keys=True)
 
     assert metadata["connection"]["vault_ref_present"] is True
+    assert metadata["connection"]["connection_ref"].startswith("wcn_")
     assert metadata["vault"]["vault_ref_present"] is True
     assert metadata["vault"]["connection_ref_present"] is True
     assert metadata["entry"]["required_fields"][0]["key"] == "client_secret"
     assert "oauth-token-secret" not in serialized
     assert "vault://tenant/private" not in serialized
+    assert "conn_1" not in serialized
+    assert "connection_id" not in serialized
     assert "conn_1" not in vault_serialized
     assert "connection_id" not in vault_serialized
 

--- a/maritime-ai-service/tests/unit/test_wiii_connect_callback_boundary.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_callback_boundary.py
@@ -102,7 +102,8 @@ def test_callback_requires_state_code_vault_and_adapter_before_accepting():
     assert missing_adapter.reason == "provider_adapter_not_bound"
     assert accepted.accepted is True
     assert accepted.vault_ref_issued is True
-    assert accepted.connection_id == "pending_connection_ref"
+    assert accepted.connection_ref == "pending_connection_ref"
+    assert "connection_id" not in accepted.to_public_metadata()
 
 
 def test_callback_accepts_vault_capability_without_boolean_override():

--- a/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
@@ -78,7 +78,7 @@ def test_catalog_helpers_find_adapter_provider_action_and_active_connection() ->
         {
             "connections": [
                 {"connection_id": "ca_old", "state": "disabled", "active": False},
-                {"connection_id": "ca_live", "state": "connected", "active": True},
+                {"connection_ref": "wcn_live", "state": "connected", "active": True},
             ]
         }
     )
@@ -86,7 +86,7 @@ def test_catalog_helpers_find_adapter_provider_action_and_active_connection() ->
     assert adapter["bound"] is True
     assert provider["provider_kind"] == "composio"
     assert action["mutation"] == "read"
-    assert connection["connection_id"] == "ca_live"
+    assert connection["connection_ref"] == "wcn_live"
 
 
 def test_catalog_helpers_fail_closed_when_required_items_are_missing() -> None:
@@ -212,7 +212,7 @@ def test_activation_readiness_payload_uses_backend_endpoint(monkeypatch) -> None
     )
     assert "probe_database=true" in url
     assert "action_slug=GMAIL_FETCH_EMAILS" in url
-    assert "connection_id=ca_live" in url
+    assert "connection_ref=ca_live" in url
 
 
 def test_gateway_fail_closed_check_requires_connection_selection_reason(

--- a/maritime-ai-service/tests/unit/test_wiii_connect_persistent_storage.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_persistent_storage.py
@@ -4,8 +4,9 @@ import json
 
 
 class _FakeResult:
-    def __init__(self, row=None, *, rowcount: int = 0):
+    def __init__(self, row=None, *, rows=None, rowcount: int = 0):
         self._row = row
+        self._rows = rows
         self.rowcount = rowcount
 
     def mappings(self):
@@ -14,10 +15,17 @@ class _FakeResult:
     def fetchone(self):
         return self._row
 
+    def all(self):
+        return list(self._rows if self._rows is not None else [self._row])
+
+    def fetchall(self):
+        return self.all()
+
 
 class _FakeSession:
-    def __init__(self, row=None, *, rowcount: int = 0):
+    def __init__(self, row=None, *, rows=None, rowcount: int = 0):
         self.row = row
+        self.rows = rows
         self.rowcount = rowcount
         self.executions = []
         self.commits = 0
@@ -35,7 +43,7 @@ class _FakeSession:
                 "params": dict(params or {}),
             }
         )
-        return _FakeResult(self.row, rowcount=self.rowcount)
+        return _FakeResult(self.row, rows=self.rows, rowcount=self.rowcount)
 
     def commit(self):
         self.commits += 1
@@ -189,6 +197,46 @@ def test_connection_fetch_rehydrates_sanitized_policy_record():
     assert record.to_public_metadata()["vault_ref_present"] is True
     assert "provider-managed://" not in serialized
     assert "oauth-token" not in serialized
+
+
+def test_connection_list_rehydrates_rows_for_opaque_ref_resolution():
+    from app.engine.wiii_connect.adapter_v1 import public_connection_ref
+    from app.engine.wiii_connect.persistent_storage import WiiiConnectPersistentStorage
+
+    session = _FakeSession(
+        rows=[
+            {
+                "id": "conn_1",
+                "provider_slug": "facebook",
+                "state": "ACTIVE",
+                "scopes": json.dumps({"read": True}),
+                "vault_ref": json.dumps(
+                    {"vault_ref_present": True, "secret_version": "provider_managed"}
+                ),
+                "account_label": "Wiii Page",
+                "external_account_ref": "page_1",
+                "reason": "provider_connection_list",
+                "warnings": json.dumps([]),
+                "last_checked_at": "2026-05-28T00:00:00+00:00",
+            }
+        ],
+    )
+    storage = WiiiConnectPersistentStorage(session_factory=lambda: session)
+
+    records = storage.list_connection_records(
+        organization_id="org_1",
+        user_id="user_1",
+        provider_slug="facebook",
+    )
+    public = records[0].to_public_metadata()
+    serialized = json.dumps(public, sort_keys=True)
+
+    assert len(records) == 1
+    assert records[0].connection_id == "conn_1"
+    assert public["connection_ref"] == public_connection_ref("facebook", "conn_1")
+    assert "conn_1" not in serialized
+    assert "page_1" not in serialized
+    assert "connection_id" not in serialized
 
 
 def test_persistent_storage_rejects_missing_owner_boundary():

--- a/maritime-ai-service/tests/unit/test_wiii_connect_provider_adapters.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_provider_adapters.py
@@ -318,9 +318,12 @@ async def test_composio_connection_list_client_filters_and_sanitizes_accounts():
     assert captured["api_key"] == "secret-api-key"
     assert result.ready is True
     assert public["connection_count"] == 2
-    assert public["connections"][0]["connection_id"] == "ca_active"
+    assert public["connections"][0]["connection_ref"].startswith("wcn_")
     assert public["connections"][0]["state"] == "connected"
     assert public["connections"][1]["state"] == "waiting"
+    assert "ca_active" not in serialized
+    assert "ca_pending" not in serialized
+    assert "connection_id" not in serialized
     assert "secret-api-key" not in serialized
     assert "secret-token" not in serialized
     assert "secret-cursor-value" not in serialized

--- a/wiii-desktop/src/__tests__/wiii-connect-page.test.tsx
+++ b/wiii-desktop/src/__tests__/wiii-connect-page.test.tsx
@@ -305,7 +305,7 @@ describe("WiiiConnectPage", () => {
     expect(screen.getByText("complete_provider_oauth")).toBeTruthy();
     expect(mockFetchWiiiConnectProviderActivationReadiness).toHaveBeenCalledWith("gmail", {
       actionSlug: "GMAIL_FETCH_EMAILS",
-      connectionId: undefined,
+      connectionRef: "",
       probeDatabase: true,
     });
     expect(screen.queryByText("secret-api-key")).toBeNull();
@@ -436,14 +436,14 @@ describe("WiiiConnectPage", () => {
       connections: [
         {
           version: "wiii_connect_adapter.v1",
-          connection_id: "conn_public_1",
+          connection_ref: "wcn_public_1",
           provider_slug: "facebook",
           state: "connected",
           active: true,
           scopes: { read: true, write: false },
           vault_ref_present: true,
           account_label: "Wiii Facebook Page",
-          external_account_ref: "fb_page_public",
+          external_account_ref_present: true,
           last_checked_at: "2026-05-28T00:00:00Z",
           reason: "provider_listed",
           warnings: [],
@@ -480,7 +480,7 @@ describe("WiiiConnectPage", () => {
     expect(await screen.findByText("Connection thật")).toBeTruthy();
     expect(screen.getAllByText("Wiii Facebook Page").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Đã kết nối").length).toBeGreaterThan(0);
-    expect(container.textContent).not.toContain("conn_public_1");
+    expect(container.textContent).not.toContain("wcn_public_1");
     expect(container.textContent).not.toContain("fb_page_public");
     expect(container.textContent).not.toContain("https://composio.example/connect/safe");
     expect(screen.queryByText("access_token")).toBeNull();
@@ -545,14 +545,14 @@ describe("WiiiConnectPage", () => {
       connections: [
         {
           version: "wiii_connect_adapter.v1",
-          connection_id: "conn_public_1",
+          connection_ref: "wcn_public_1",
           provider_slug: "facebook",
           state: "connected",
           active: true,
           scopes: { read: true, write: false },
           vault_ref_present: true,
           account_label: "Wiii Facebook Page",
-          external_account_ref: "fb_page_public",
+          external_account_ref_present: true,
           last_checked_at: "2026-05-28T00:00:00Z",
           reason: "provider_listed",
           warnings: [],
@@ -586,12 +586,12 @@ describe("WiiiConnectPage", () => {
 
     expect(mockDisconnectWiiiConnectProviderConnection).toHaveBeenCalledWith(
       "facebook",
-      "conn_public_1",
+      "wcn_public_1",
     );
     expect((await screen.findByTestId("wiii-connect-disconnect-status")).textContent).toContain("local");
     expect(screen.getByTestId("wiii-connect-disconnect-button").textContent?.toLowerCase()).toContain("ng");
     expect(screen.getAllByText("user_disconnect_requested").length).toBeGreaterThan(0);
-    expect(screen.queryByText("conn_public_1")).toBeNull();
+    expect(screen.queryByText("wcn_public_1")).toBeNull();
     expect(screen.queryByText("secret-token")).toBeNull();
     expect(screen.queryByText("access_token")).toBeNull();
 

--- a/wiii-desktop/src/api/types.ts
+++ b/wiii-desktop/src/api/types.ts
@@ -558,14 +558,16 @@ export interface WiiiConnectAuthorizationUrlDecision {
 
 export interface WiiiConnectProviderConnectionRecord {
   version: string;
-  connection_id: string;
+  connection_ref: string;
+  connection_ref_present?: boolean;
+  connection_id?: string;
   provider_slug: string;
   state: string;
   active?: boolean;
   scopes?: Record<string, boolean>;
   vault_ref_present?: boolean;
   account_label?: string;
-  external_account_ref?: string;
+  external_account_ref_present?: boolean;
   last_checked_at?: string | null;
   reason?: string;
   warnings?: string[];

--- a/wiii-desktop/src/api/wiii-connect.ts
+++ b/wiii-desktop/src/api/wiii-connect.ts
@@ -58,7 +58,7 @@ export async function fetchWiiiConnectProviderActivationReadiness(
   slug: string,
   options: {
     actionSlug?: string;
-    connectionId?: string;
+    connectionRef?: string;
     probeDatabase?: boolean;
   } = {},
 ): Promise<WiiiConnectActivationReadinessResponse> {
@@ -66,7 +66,7 @@ export async function fetchWiiiConnectProviderActivationReadiness(
     `/api/v1/wiii-connect/providers/${encodeURIComponent(slug)}/activation-readiness`,
     {
       action_slug: options.actionSlug ?? "GMAIL_FETCH_EMAILS",
-      connection_id: options.connectionId ?? "",
+      connection_ref: options.connectionRef ?? "",
       probe_database: options.probeDatabase === false ? "false" : "true",
     },
   );

--- a/wiii-desktop/src/components/connect/WiiiConnectPage.tsx
+++ b/wiii-desktop/src/components/connect/WiiiConnectPage.tsx
@@ -598,7 +598,9 @@ function providerConnectionSummary(
 ): string {
   if (!connection) return "Chưa có account";
   return compactText(
-    connection.account_label || connection.external_account_ref || connection.reason,
+    connection.account_label ||
+      (connection.external_account_ref_present ? "Provider account" : "") ||
+      connection.reason,
     "Đã có connection",
   );
 }
@@ -655,9 +657,15 @@ function responseWithLocallyDisabledConnection(
     reason,
     connection_count: Math.max(response.connection_count, 1),
     connections: response.connections.map((item) =>
-      item.connection_id === connection.connection_id ? disabled : item,
+      providerConnectionRef(item) === providerConnectionRef(connection) ? disabled : item,
     ),
   };
+}
+
+function providerConnectionRef(
+  connection: WiiiConnectProviderConnectionRecord | null | undefined,
+): string {
+  return connection?.connection_ref || connection?.connection_id || "";
 }
 
 function formatCount(value: unknown, label: string): string | null {
@@ -1128,7 +1136,7 @@ function ConnectionDetailPanel({
   const canDisconnectConnection =
     card.provider !== "wiii_native" &&
     card.registrySource === "backend" &&
-    Boolean(providerConnection?.connection_id) &&
+    Boolean(providerConnectionRef(providerConnection)) &&
     providerConnection?.state !== "disabled" &&
     Boolean(onDisconnectConnection);
 
@@ -1636,7 +1644,7 @@ function ConnectionCatalog({
     try {
       const response = await fetchWiiiConnectProviderActivationReadiness(slug, {
         actionSlug: "GMAIL_FETCH_EMAILS",
-        connectionId: selectedConnection?.connection_id,
+        connectionRef: providerConnectionRef(selectedConnection),
         probeDatabase: true,
       });
       setProviderReadinessStates((current) => ({
@@ -1768,7 +1776,7 @@ function ConnectionCatalog({
     try {
       const response = await disconnectWiiiConnectProviderConnection(
         slug,
-        connection.connection_id,
+        providerConnectionRef(connection),
       );
       setDisconnectStates((current) => ({
         ...current,


### PR DESCRIPTION
Closes #813

## Summary
- Replace public Wiii Connect provider connection selection with opaque `connection_ref` values instead of raw provider connected-account IDs.
- Resolve `connection_ref` server-side inside the authenticated organization/user/provider boundary for activation readiness, execution decision, execute, and disconnect paths while retaining legacy raw `connection_id` compatibility.
- Update the desktop Wiii Connect page, Composio acceptance harness, callback metadata, and docs/runbook to use opaque connection refs.

## Scope
- Backend Wiii Connect adapter/storage/API contract for public connection refs.
- Desktop Wiii Connect UI selection/disconnect/readiness calls.
- Acceptance harness and docs for the Composio live-readiness path.

## Non-Scope
- No live Composio production enablement.
- No new provider write/admin action exposure.
- No database migration or credential/vault backend change.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_callback_boundary.py tests/unit/api/test_wiii_connect_api.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 80 passed
- `cd wiii-desktop; npx vitest run src/__tests__/wiii-connect-page.test.tsx` -> 7 passed
- `cd wiii-desktop; npx tsc --noEmit` -> passed
- `cd maritime-ai-service; python -m ruff check app/engine/wiii_connect app/api/v1/wiii_connect.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/test_wiii_connect_composio_acceptance.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
- Medium: this touches provider connection selection and disconnect/execute lookup. Resolver fails closed when an opaque ref cannot be matched and legacy raw `connection_id` remains accepted for compatibility.

## Rollback
- Revert this PR. Composio live execution remains disabled by feature flags, so rollback does not require revoking provider credentials.