### PR TITLE
fix(backend): gate Wiii Connect execute on required schema args

### DIFF
--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -164,6 +164,8 @@ Composio is ready to enable only when all of these are true:
   connected-account ID;
 - execution gateway allows the selected read-only action only for the stored
   org/user connection;
+- execute blocks before calling Composio when live schema verification reports
+  missing required argument keys;
 - optional execution succeeds through `POST /api/v1/wiii-connect/providers/gmail/execute`;
 - optional disconnect disables local Wiii state and completes provider cleanup.
 
@@ -178,6 +180,7 @@ Common blocked reasons:
 | `connection_selection_required` | The caller has not selected a stored provider connection id for execution. |
 | `connection_missing` | OAuth has not completed or the selected connection does not belong to this org/user. |
 | `provider_not_agent_ready` | Read-only action execution is not enabled for the curated allowlist. |
+| `missing_required_arguments` | Live schema verification succeeded, but the request is missing required argument keys. |
 | `action_not_allowed` | The action is not in Wiii's curated catalog for that provider. |
 | `missing_scope` | The stored connection lacks the required scope grant. |
 | `tool_schema_not_found` | Composio's live schema does not match the curated action/provider. |

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -878,6 +878,35 @@ async def execute_wiii_connect_provider_action(
         payload["execution"] = None
         return payload
 
+    missing_argument_keys = _missing_required_argument_keys(
+        required_keys=schema.required_argument_keys,
+        arguments=body.arguments,
+    )
+    if missing_argument_keys:
+        _append_execution_stage_audit(
+            gateway,
+            request,
+            storage,
+            current_user=current_user,
+            status="blocked",
+            reason="missing_required_arguments",
+            metadata={
+                **audit_base,
+                "stage": "schema",
+                "schema": schema.to_public_metadata(),
+                "missing_required_arguments": list(missing_argument_keys),
+            },
+        )
+        payload = gateway.to_public_metadata()
+        payload["status"] = "blocked"
+        payload["reason"] = "missing_required_arguments"
+        payload["provider_slug"] = effective_entry.slug
+        payload["storage"] = storage
+        payload["schema"] = schema.to_public_metadata()
+        payload["execution"] = None
+        payload["missing_argument_keys"] = list(missing_argument_keys)
+        return payload
+
     _append_execution_stage_audit(
         gateway,
         request,
@@ -1438,6 +1467,33 @@ def _safe_argument_keys(values: list[str]) -> list[str]:
         if key:
             result.append(key[:120])
     return result
+
+
+def _missing_required_argument_keys(
+    *,
+    required_keys: tuple[str, ...],
+    arguments: dict[str, Any],
+) -> tuple[str, ...]:
+    provided = {str(key or "").strip() for key in (arguments or {}).keys()}
+    missing: list[str] = []
+    for raw_key in required_keys:
+        key = str(raw_key or "").strip()
+        if not key or key in provided:
+            continue
+        safe_key = _safe_public_argument_key(key)
+        if safe_key not in missing:
+            missing.append(safe_key)
+    return tuple(missing[:50])
+
+
+def _safe_public_argument_key(value: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if not normalized:
+        return "empty"
+    sensitive_markers = ("token", "secret", "password", "credential", "key", "code")
+    if any(marker in normalized for marker in sensitive_markers):
+        return "redacted_sensitive_field"
+    return normalized[:80]
 
 
 def _safe_public_id(value: str | None) -> str | None:

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -1624,6 +1624,156 @@ async def test_wiii_connect_execute_api_runs_readonly_composio_action_safely(
 
 
 @pytest.mark.asyncio
+async def test_wiii_connect_execute_blocks_missing_required_schema_arguments(
+    authenticated_app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+    from app.engine.wiii_connect.adapter_v1 import (
+        WiiiConnectConnectionRecordV1,
+        WiiiConnectScopeGrant,
+    )
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+        WiiiConnectComposioToolSchemaResult,
+    )
+    from app.engine.wiii_connect.persistent_storage import (
+        WiiiConnectPersistentStorageStatus,
+    )
+
+    class FakeStorage:
+        audit_appends = 0
+        fetches = 0
+
+        def status(self, *, probe_database: bool = True):
+            return WiiiConnectPersistentStorageStatus(
+                enabled=True,
+                persistent=True,
+                connection_table_ready=True,
+                audit_ledger_ready=True,
+                reason="ready",
+            )
+
+        def get_connection_record(
+            self,
+            *,
+            organization_id: str,
+            user_id: str,
+            provider_slug: str,
+            connection_id: str | None = None,
+        ):
+            self.fetches += 1
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert provider_slug == "gmail"
+            assert connection_id == "ca_active"
+            return WiiiConnectConnectionRecordV1(
+                connection_id="ca_active",
+                provider_slug="gmail",
+                state="connected",
+                scopes=WiiiConnectScopeGrant(read=True),
+                reason="provider_connection_list",
+            )
+
+        def append_audit_record(self, record, *, organization_id: str, user_id: str):
+            self.audit_appends += 1
+            metadata = record.to_public_metadata()["metadata"]
+            serialized = json.dumps(record.to_public_metadata(), sort_keys=True)
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert metadata["stage"] == "schema"
+            assert metadata["missing_required_arguments"] == [
+                "query",
+                "redacted_sensitive_field",
+            ]
+            assert metadata["request"]["action_slug"] == "GMAIL_FETCH_EMAILS"
+            assert "client-secret" not in serialized
+            assert "private subject" not in serialized
+            assert "access_token" not in serialized
+            assert "api_key" not in serialized
+            return True
+
+    fake_storage = FakeStorage()
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "build_composio_adapter_config",
+        lambda: WiiiConnectComposioAdapterConfig(
+            enabled=True,
+            api_key="secret-api-key",
+            api_key_present=True,
+            auth_config_by_provider={"gmail": "authcfg_gmail"},
+            readonly_execute_enabled=True,
+            readonly_action_allowlist_by_provider={
+                "gmail": ("GMAIL_FETCH_EMAILS",),
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        lambda: fake_storage,
+    )
+
+    async def fake_schema(**kwargs):
+        assert kwargs["provider_slug"] == "gmail"
+        assert kwargs["action_slug"] == "GMAIL_FETCH_EMAILS"
+        return WiiiConnectComposioToolSchemaResult(
+            ready=True,
+            provider_slug="gmail",
+            action_slug="GMAIL_FETCH_EMAILS",
+            reason="ready",
+            schema_present=True,
+            argument_keys=("query",),
+            required_argument_keys=("query", "access_token"),
+        )
+
+    async def fake_execute(**kwargs):
+        raise AssertionError(
+            "provider execution must not run with missing required arguments",
+        )
+
+    monkeypatch.setattr(wiii_connect_api, "verify_composio_tool_schema", fake_schema)
+    monkeypatch.setattr(wiii_connect_api, "execute_composio_tool", fake_execute)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=authenticated_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/wiii-connect/providers/gmail/execute",
+            json={
+                "surface": "desktop",
+                "connection_id": "ca_active",
+                "action_slug": "GMAIL_FETCH_EMAILS",
+                "path": "external_app_action",
+                "mutation": "read",
+                "arguments": {
+                    "api_key": "client-secret",
+                    "subject": "private subject",
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    serialized = json.dumps(payload, sort_keys=True)
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "missing_required_arguments"
+    assert payload["decision"]["outcome"] == "allowed"
+    assert payload["schema"]["status"] == "ready"
+    assert payload["execution"] is None
+    assert payload["missing_argument_keys"] == ["query", "redacted_sensitive_field"]
+    assert fake_storage.fetches == 1
+    assert fake_storage.audit_appends == 1
+    assert "client-secret" not in serialized
+    assert "private subject" not in serialized
+    assert "access_token" not in serialized
+    assert "api_key" not in serialized
+    assert "secret-api-key" not in serialized
+    assert "authcfg_gmail" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_wiii_connect_execute_requires_selected_connection_before_provider_call(
     authenticated_app,
     monkeypatch,


### PR DESCRIPTION
Closes #815

## Summary
- Block Wiii Connect read-only execution before calling Composio when live schema verification reports missing required argument keys.
- Audit the schema-stage block with sanitized missing argument names and without raw argument values, API keys, provider payloads, or raw connection IDs.
- Document the new `missing_required_arguments` live-acceptance failure mode.

## Scope
- Backend Wiii Connect `/providers/{slug}/execute` schema gate.
- Focused API regression coverage.
- Composio acceptance runbook pass/failure criteria.

## Non-Scope
- No live Composio enablement.
- No write/admin action exposure.
- No frontend UI redesign.
- No database migration.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/api/test_wiii_connect_api.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 64 passed
- `cd maritime-ai-service; python -m ruff check app/api/v1/wiii_connect.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
- Medium: touches the provider execution boundary. Behavior is intentionally stricter: schema-ready but argument-incomplete requests fail closed before external provider calls.

## Rollback
- Revert this PR. Composio live execution remains disabled by default via feature flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * API now performs preflight validation to ensure all required schema arguments are provided before execution.
  * Requests missing required arguments are blocked with a "missing_required_arguments" status, including details about which keys are missing (with sensitive values redacted for safety).

* **Documentation**
  * Updated operational runbook to document new schema argument validation behavior and pass/failure criteria.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/816?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->