### PR TITLE
docs: clarify Wiii Connect public connection refs

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -104,7 +104,7 @@ GET  /api/v1/wiii-connect/providers/{slug}/status
 POST /api/v1/wiii-connect/providers/{slug}/sessions
 POST /api/v1/wiii-connect/providers/{slug}/authorization-url
 GET  /api/v1/wiii-connect/providers/{slug}/connections
-DELETE /api/v1/wiii-connect/providers/{slug}/connections/{connection_id}
+DELETE /api/v1/wiii-connect/providers/{slug}/connections/{connection_ref}
 GET  /api/v1/wiii-connect/providers/{slug}/actions
 GET  /api/v1/wiii-connect/providers/{slug}/activation-readiness
 POST /api/v1/wiii-connect/providers/{slug}/execution-decision
@@ -377,8 +377,8 @@ without guessing from logs.
   approval token values, Composio API keys, or provider response bodies;
 - remains the required preflight boundary for both execution-decision and real
   execution routes. The execute route may call Composio only after this gateway
-  returns `allowed`, the live schema check passes, and started/succeeded/failed
-  audit records can be appended.
+  returns `allowed`, the live schema check passes, required schema argument
+  keys are present, and started/succeeded/failed audit records can be appended.
 
 The first catalog candidate is `GMAIL_FETCH_EMAILS`, a disabled read-only Gmail
 action listed in current Composio docs. It is intentionally not agent-ready
@@ -420,7 +420,7 @@ and requires all of:
 2. provider registry entry is marked agent-ready;
 3. live connection belongs to the same provider slug;
 4. live connection state is `connected`;
-5. the caller selected an explicit stored connection id for execution;
+5. the caller selected an explicit opaque `connection_ref` for execution;
 6. runtime path and action are allowed by the gateway.
 
 This follows the useful OpenHuman pattern while keeping Wiii's stronger LMS,
@@ -534,7 +534,8 @@ Before real Composio OAuth is enabled:
   `POST /api/v1/wiii-connect/providers/{slug}/execute`, not direct Composio
   calls from frontend or chat;
 - read-only Composio execution must verify the live tool schema before the
-  provider call and append privacy-safe started plus completion audit events;
+  provider call, block if required schema argument keys are missing, and append
+  privacy-safe started plus completion audit events when execution proceeds;
 - durable persistence must bind every connection/audit write to a Wiii
   organization and user boundary;
 - frontend may receive connect URLs and state labels, not tokens;
@@ -564,7 +565,7 @@ approval tokens and provider payloads must remain outside chat lifecycle data.
 
 1. Add a curated Composio action catalog contract for one low-risk read-only
    provider action. Done for the disabled contract candidate; still needs live
-   schema verification before enablement.
+   acceptance with real credentials before rollout.
 2. Bind Composio adapter `can_execute_actions` only for that curated read-only
    action and keep writes disabled. Done for the backend boundary; still needs
    real Composio credentials and acceptance against a live Gmail connection.

--- a/docs/architecture/wiii-connect/README.md
+++ b/docs/architecture/wiii-connect/README.md
@@ -186,11 +186,12 @@ this repository.
    this projection.
 7. Add one low-risk read-only Composio action through the gateway before any
    write/apply action. The backend boundary now supports one curated Gmail
-   read-only action behind config, schema verification, gateway, and audit; it
-   also supports backend-owned disconnect that disables local Wiii state before
-   provider cleanup. The desktop Wiii Connect page can now call the backend
-   disconnect boundary and keep reconnect on the backend Connect Link path. The
-   operator acceptance harness now exists in
+   read-only action behind config, schema verification, required-argument
+   gating, gateway, and audit; it also supports backend-owned disconnect that
+   disables local Wiii state before provider cleanup. The desktop Wiii Connect
+   page can now call the backend disconnect boundary through opaque
+   `connection_ref` values and keep reconnect on the backend Connect Link path.
+   The operator acceptance harness now exists in
    `maritime-ai-service/scripts/wiii_connect_composio_acceptance.py`; the
    remaining work is running it with real Composio credentials and a live Gmail
    connection before rollout.

--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -155,7 +155,8 @@ Composio is ready to enable only when all of these are true:
 - provider registry returns Gmail as a Composio provider;
 - curated actions include only the intended read-only action;
 - execution gateway blocks a missing-connection execution request;
-- execution gateway blocks execution when no explicit connection id is selected;
+- execution gateway blocks execution when no explicit opaque `connection_ref` is
+  selected;
 - the acceptance harness treats any missing-selection deny reason other than
   `connection_selection_required` as a failed policy proof;
 - Connect Link is issued by Wiii backend;
@@ -177,7 +178,7 @@ Common blocked reasons:
 |---|---|
 | `provider_adapter_not_configured` | Missing Composio API key or auth config map. |
 | `audit_ledger_not_persistent` | Migration or database connection is missing. |
-| `connection_selection_required` | The caller has not selected a stored provider connection id for execution. |
+| `connection_selection_required` | The caller has not selected a stored opaque `connection_ref` for execution. |
 | `connection_missing` | OAuth has not completed or the selected connection does not belong to this org/user. |
 | `provider_not_agent_ready` | Read-only action execution is not enabled for the curated allowlist. |
 | `missing_required_arguments` | Live schema verification succeeded, but the request is missing required argument keys. |


### PR DESCRIPTION
Closes #817

## Summary
- Align Wiii Connect architecture and Composio acceptance docs with the public opaque `connection_ref` contract.
- Clarify that required-argument gating happens after live schema verification and before Composio execution.
- Remove remaining public/operator wording that implied raw provider connection IDs should be selected.

## Scope
- Docs only: Wiii Connect architecture README/design and Composio acceptance runbook.

## Non-Scope
- No runtime behavior change.
- No live Composio enablement.
- No frontend redesign.

## Verification
- rg public connection-id wording in Wiii Connect docs -> no matches
- `git diff --check` -> passed

## Risk
- Low docs-only change. Risk is mostly operator clarity on a security-sensitive provider connection surface.

## Rollback
- Revert this docs PR.
