### PR TITLE
fix(backend): rename Wiii Connect public selection refs

### DIFF
--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -127,6 +127,10 @@ arguments matching that schema:
 python scripts/wiii_connect_composio_acceptance.py --backend-url http://localhost:8080 --auth-mode dev-login --provider gmail --expect-connected --require-execution-ready --execute-readonly --arguments-json '{"max_results":1}'
 ```
 
+If selecting a specific account manually, pass the opaque Wiii `connection_ref`
+returned by the connection list through `--connection-ref`; do not pass a raw
+provider connected-account ID.
+
 If the schema uses different argument names, do not change Wiii code blindly.
 Pass the live schema-compatible JSON through `--arguments-json` and record the
 accepted shape in the PR or release note.

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -476,10 +476,10 @@ async def list_wiii_connect_provider_connections(
     }
 
 
-@router.delete("/providers/{slug}/connections/{connection_id}")
+@router.delete("/providers/{slug}/connections/{connection_ref}")
 async def disconnect_wiii_connect_provider_connection(
     slug: str,
-    connection_id: str,
+    connection_ref: str,
     body: WiiiConnectDisconnectBody | None = None,
     current_user: AuthenticatedUser = Depends(require_auth),
 ) -> dict[str, object]:
@@ -493,7 +493,7 @@ async def disconnect_wiii_connect_provider_connection(
     effective_entry = build_composio_connect_enabled_entry(entry, composio_config)
     adapter_capability = build_composio_provider_adapter_capability(composio_config)
     storage = _wiii_connect_storage_status_metadata(probe_database=True)
-    selected_connection_ref = _safe_provider_connection_id(connection_id)
+    selected_connection_ref = _safe_provider_connection_id(connection_ref)
     safe_connection_id = _resolve_provider_connection_id(
         storage,
         current_user=current_user,

--- a/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
@@ -345,7 +345,7 @@ class WiiiConnectComposioAcceptance:
     def __init__(self, args: argparse.Namespace) -> None:
         self.args = args
         self.token = ""
-        self.selected_connection_id = ""
+        self.selected_connection_ref = ""
         self.passed = 0
         self.failed = 0
         self.started_at = datetime.now(UTC)
@@ -517,12 +517,12 @@ class WiiiConnectComposioAcceptance:
                         getattr(self.args, "execute_readonly", False)
                     ),
                     "disconnect": bool(getattr(self.args, "disconnect", False)),
-                    "explicit_connection_selected": bool(
-                        getattr(self.args, "connection_id", "")
+                    "explicit_connection_ref_selected": bool(
+                        getattr(self.args, "connection_ref", "")
                     ),
                     "connection_selected_for_action": bool(
-                        getattr(self.args, "connection_id", "")
-                        or self.selected_connection_id
+                        getattr(self.args, "connection_ref", "")
+                        or self.selected_connection_ref
                     ),
                     "arguments_present": bool(
                         parse_json_argument_object(
@@ -724,14 +724,14 @@ class WiiiConnectComposioAcceptance:
     def activation_readiness_payload(
         self,
         *,
-        connection_id: str = "",
+        connection_ref: str = "",
     ) -> dict[str, Any]:
         params = {
             "probe_database": "true",
             "action_slug": self.args.action,
         }
-        if connection_id:
-            params["connection_ref"] = connection_id
+        if connection_ref:
+            params["connection_ref"] = connection_ref
         query = urllib.parse.urlencode(params)
         return request_bytes(
             "GET",
@@ -756,18 +756,18 @@ class WiiiConnectComposioAcceptance:
         )
 
     def check_activation_ready_to_execute(self) -> str:
-        connection_id = self.connection_id_for_action()
-        payload = self.activation_readiness_payload(connection_id=connection_id)
+        connection_ref = self.connection_ref_for_action()
+        payload = self.activation_readiness_payload(connection_ref=connection_ref)
         assert_activation_ready(
             payload,
             flag="ready_to_execute_readonly",
             label="read-only execution-ready",
         )
-        return f"ready_to_execute_readonly=true connection={opaque_ref(connection_id)}"
+        return f"ready_to_execute_readonly=true connection={opaque_ref(connection_ref)}"
 
     def check_activation_readiness_report(self) -> str:
-        connection_id = (self.args.connection_id or "").strip()
-        payload = self.activation_readiness_payload(connection_id=connection_id)
+        connection_ref = (self.args.connection_ref or "").strip()
+        payload = self.activation_readiness_payload(connection_ref=connection_ref)
         print_activation_readiness_report(payload)
         return f"blockers={activation_blocker_summary(payload)}"
 
@@ -823,13 +823,13 @@ class WiiiConnectComposioAcceptance:
             ):
                 raise AcceptanceFailure("No active connected account was returned")
             return "ready; no active account required for this run"
-        self.selected_connection_id = str(
+        self.selected_connection_ref = str(
             connection.get("connection_ref") or connection.get("connection_id") or ""
         )
-        return f"active_connection={opaque_ref(self.selected_connection_id)}"
+        return f"active_connection={opaque_ref(self.selected_connection_ref)}"
 
     def check_execution_gateway_allowed(self) -> str:
-        connection_id = self.connection_id_for_action()
+        connection_ref = self.connection_ref_for_action()
         payload = request_bytes(
             "POST",
             self.api_url(
@@ -838,7 +838,7 @@ class WiiiConnectComposioAcceptance:
             headers=self.auth_headers(),
             payload={
                 "surface": "acceptance_harness",
-                "connection_ref": connection_id,
+                "connection_ref": connection_ref,
                 "action_slug": self.args.action,
                 "path": "external_app_action",
                 "mutation": "read",
@@ -850,10 +850,10 @@ class WiiiConnectComposioAcceptance:
             raise AcceptanceFailure(
                 f"Gateway did not allow read-only action: reason={payload.get('reason')!r}"
             )
-        return f"allowed connection={opaque_ref(connection_id)}"
+        return f"allowed connection={opaque_ref(connection_ref)}"
 
     def check_readonly_execution(self) -> str:
-        connection_id = self.connection_id_for_action()
+        connection_ref = self.connection_ref_for_action()
         payload = request_bytes(
             "POST",
             self.api_url(
@@ -862,7 +862,7 @@ class WiiiConnectComposioAcceptance:
             headers=self.auth_headers(),
             payload={
                 "surface": "acceptance_harness",
-                "connection_ref": connection_id,
+                "connection_ref": connection_ref,
                 "action_slug": self.args.action,
                 "path": "external_app_action",
                 "mutation": "read",
@@ -886,12 +886,12 @@ class WiiiConnectComposioAcceptance:
         return f"succeeded data_keys={execution.get('data_keys', [])}"
 
     def check_disconnect(self) -> str:
-        connection_id = self.connection_id_for_action()
+        connection_ref = self.connection_ref_for_action()
         payload = request_bytes(
             "DELETE",
             self.api_url(
                 f"/api/v1/wiii-connect/providers/{urllib.parse.quote(self.args.provider)}"
-                f"/connections/{urllib.parse.quote(connection_id)}"
+                f"/connections/{urllib.parse.quote(connection_ref)}"
             ),
             headers=self.auth_headers(),
             payload={"surface": "acceptance_harness"},
@@ -906,7 +906,7 @@ class WiiiConnectComposioAcceptance:
             raise AcceptanceFailure(
                 f"Provider disconnect did not succeed: {json_for_log(payload)}"
             )
-        return f"local_disabled=true connection={opaque_ref(connection_id)}"
+        return f"local_disabled=true connection={opaque_ref(connection_ref)}"
 
     def argument_keys(self) -> list[str]:
         if self.args.argument_keys:
@@ -920,12 +920,12 @@ class WiiiConnectComposioAcceptance:
     def arguments(self) -> dict[str, Any]:
         return parse_json_argument_object(self.args.arguments_json)
 
-    def connection_id_for_action(self) -> str:
-        candidate = (self.args.connection_id or self.selected_connection_id).strip()
+    def connection_ref_for_action(self) -> str:
+        candidate = (self.args.connection_ref or self.selected_connection_ref).strip()
         if not candidate:
             raise AcceptanceFailure(
                 "No connected account selected. Run with --expect-connected after OAuth "
-                "or pass --connection-id explicitly."
+                "or pass --connection-ref explicitly."
             )
         return candidate
 
@@ -972,7 +972,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--require-execution-ready", action="store_true")
     parser.add_argument("--execute-readonly", action="store_true")
     parser.add_argument("--disconnect", action="store_true")
-    parser.add_argument("--connection-id", default="")
+    parser.add_argument(
+        "--connection-ref",
+        default="",
+        help="Opaque Wiii connection_ref selected from the backend connection list.",
+    )
+    parser.add_argument(
+        "--connection-id",
+        dest="connection_ref",
+        help=argparse.SUPPRESS,
+    )
     parser.add_argument("--argument-keys", default="")
     parser.add_argument("--arguments-json", default="{}")
     parser.add_argument(

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -1069,10 +1069,18 @@ async def test_wiii_connect_disconnect_api_requires_auth(app):
         base_url="http://test",
     ) as client:
         response = await client.delete(
-            "/wiii-connect/providers/gmail/connections/ca_active",
+            "/wiii-connect/providers/gmail/connections/wcn_public_ref",
         )
 
     assert response.status_code == 401
+
+
+def test_wiii_connect_openapi_names_disconnect_path_connection_ref(app):
+    schema = app.openapi()
+    paths = schema["paths"]
+
+    assert "/wiii-connect/providers/{slug}/connections/{connection_ref}" in paths
+    assert "/wiii-connect/providers/{slug}/connections/{connection_id}" not in paths
 
 
 @pytest.mark.asyncio
@@ -1084,6 +1092,7 @@ async def test_wiii_connect_disconnect_api_disables_local_before_provider_delete
     from app.engine.wiii_connect.adapter_v1 import (
         WiiiConnectConnectionRecordV1,
         WiiiConnectScopeGrant,
+        public_connection_ref,
     )
     from app.engine.wiii_connect.composio_adapter import (
         WiiiConnectComposioAdapterConfig,
@@ -1096,6 +1105,7 @@ async def test_wiii_connect_disconnect_api_disables_local_before_provider_delete
     class FakeStorage:
         audit_appends = 0
         fetches = 0
+        lists = 0
         upserts = 0
 
         def status(self, *, probe_database: bool = True):
@@ -1126,6 +1136,26 @@ async def test_wiii_connect_disconnect_api_disables_local_before_provider_delete
                 state="connected",
                 scopes=WiiiConnectScopeGrant(read=True),
                 reason="provider_connection_list",
+            )
+
+        def list_connection_records(
+            self,
+            *,
+            organization_id: str,
+            user_id: str,
+            provider_slug: str,
+        ):
+            self.lists += 1
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert provider_slug == "gmail"
+            return (
+                WiiiConnectConnectionRecordV1(
+                    connection_id="ca_active",
+                    provider_slug="gmail",
+                    state="connected",
+                    scopes=WiiiConnectScopeGrant(read=True),
+                ),
             )
 
         def upsert_connection_record(
@@ -1199,7 +1229,8 @@ async def test_wiii_connect_disconnect_api_disables_local_before_provider_delete
     ) as client:
         response = await client.request(
             "DELETE",
-            "/wiii-connect/providers/gmail/connections/ca_active",
+            "/wiii-connect/providers/gmail/connections/"
+            f"{public_connection_ref('gmail', 'ca_active')}",
             json={"surface": "desktop"},
         )
 
@@ -1212,6 +1243,7 @@ async def test_wiii_connect_disconnect_api_disables_local_before_provider_delete
     assert payload["connection_present"] is True
     assert payload["local_disabled"] is True
     assert payload["provider"]["provider_success"] is True
+    assert fake_storage.lists == 1
     assert fake_storage.fetches == 1
     assert fake_storage.upserts == 1
     assert fake_storage.audit_appends == 2

--- a/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
@@ -199,7 +199,7 @@ def test_activation_readiness_payload_uses_backend_endpoint(monkeypatch) -> None
     )
     harness.token = "token"
 
-    payload = harness.activation_readiness_payload(connection_id="ca_live")
+    payload = harness.activation_readiness_payload(connection_ref="wcn_live")
 
     assert payload["ready_to_connect"] is True
     assert captured["method"] == "GET"
@@ -212,7 +212,7 @@ def test_activation_readiness_payload_uses_backend_endpoint(monkeypatch) -> None
     )
     assert "probe_database=true" in url
     assert "action_slug=GMAIL_FETCH_EMAILS" in url
-    assert "connection_ref=ca_live" in url
+    assert "connection_ref=wcn_live" in url
 
 
 def test_gateway_fail_closed_check_requires_connection_selection_reason(
@@ -328,7 +328,7 @@ def test_evidence_payload_redacts_sensitive_details() -> None:
             require_execution_ready=True,
             execute_readonly=False,
             disconnect=False,
-            connection_id="ca_secret",
+            connection_ref="wcn_secret",
             arguments_json='{"max_results": 1}',
         )
     )
@@ -341,7 +341,7 @@ def test_evidence_payload_redacts_sensitive_details() -> None:
             elapsed=0.2,
             detail=(
                 "authorization_url=https://connect.example/callback"
-                "?wiii_state=secret connection_id=ca_secret"
+                "?wiii_state=secret connection_ref=wcn_secret"
             ),
         )
     )
@@ -353,12 +353,12 @@ def test_evidence_payload_redacts_sensitive_details() -> None:
     assert payload["backend_origin"] == "https://wiii.example.com"
     assert payload["target_env"] == "staging"
     assert payload["commit_sha"] == "abc1234"
-    assert payload["flags"]["explicit_connection_selected"] is True
+    assert payload["flags"]["explicit_connection_ref_selected"] is True
     assert payload["flags"]["connection_selected_for_action"] is True
     assert payload["flags"]["arguments_present"] is True
     assert "token=secret" not in serialized
     assert "wiii_state=secret" not in serialized
-    assert "ca_secret" not in serialized
+    assert "wcn_secret" not in serialized
     assert "authorization_url=" not in serialized
 
 
@@ -378,18 +378,18 @@ def test_evidence_payload_marks_connection_selected_from_listing() -> None:
             require_execution_ready=True,
             execute_readonly=True,
             disconnect=False,
-            connection_id="",
+            connection_ref="",
             arguments_json='{"max_results": 1}',
         )
     )
-    harness.selected_connection_id = "ca_selected_from_listing"
+    harness.selected_connection_ref = "wcn_selected_from_listing"
 
     payload = harness.evidence_payload()
     serialized = json.dumps(payload, sort_keys=True)
 
-    assert payload["flags"]["explicit_connection_selected"] is False
+    assert payload["flags"]["explicit_connection_ref_selected"] is False
     assert payload["flags"]["connection_selected_for_action"] is True
-    assert "ca_selected_from_listing" not in serialized
+    assert "wcn_selected_from_listing" not in serialized
 
 
 def test_run_writes_redacted_evidence_json(monkeypatch, tmp_path) -> None:
@@ -404,7 +404,7 @@ def test_run_writes_redacted_evidence_json(monkeypatch, tmp_path) -> None:
             timeout=7.0,
             org_id="",
             readiness_report_only=True,
-            connection_id="",
+            connection_ref="",
             auth_mode="bearer",
             target_env="local",
             commit_sha="abc1234",
@@ -421,8 +421,8 @@ def test_run_writes_redacted_evidence_json(monkeypatch, tmp_path) -> None:
         harness.token = "secret-token"
         return "bearer token"
 
-    def report_payload(*, connection_id: str = ""):
-        calls.append(f"report:{connection_id or 'none'}")
+    def report_payload(*, connection_ref: str = ""):
+        calls.append(f"report:{connection_ref or 'none'}")
         return {
             "provider_slug": "gmail",
             "status": "blocked",
@@ -482,7 +482,7 @@ def test_readiness_report_only_does_not_run_live_connect_or_execute(monkeypatch)
             timeout=7.0,
             org_id="",
             readiness_report_only=True,
-            connection_id="",
+            connection_ref="",
         )
     )
 
@@ -495,8 +495,8 @@ def test_readiness_report_only_does_not_run_live_connect_or_execute(monkeypatch)
         harness.token = "token"
         return "bearer"
 
-    def report_payload(*, connection_id: str = ""):
-        calls.append(f"report:{connection_id or 'none'}")
+    def report_payload(*, connection_ref: str = ""):
+        calls.append(f"report:{connection_ref or 'none'}")
         return {
             "provider_slug": "gmail",
             "status": "blocked",
@@ -539,13 +539,26 @@ def test_readiness_report_only_does_not_run_live_connect_or_execute(monkeypatch)
     assert "complete_provider_oauth" in output
 
 
-def test_connection_id_for_action_requires_selected_or_explicit_connection() -> None:
+def test_connection_ref_for_action_requires_selected_or_explicit_connection() -> None:
     harness = acceptance.WiiiConnectComposioAcceptance(
-        SimpleNamespace(connection_id="", selected_connection_id="")
+        SimpleNamespace(connection_ref="", selected_connection_ref="")
     )
 
     with pytest.raises(acceptance.AcceptanceFailure, match="No connected account"):
-        harness.connection_id_for_action()
+        harness.connection_ref_for_action()
 
-    harness.selected_connection_id = "ca_live"
-    assert harness.connection_id_for_action() == "ca_live"
+    harness.selected_connection_ref = "wcn_live"
+    assert harness.connection_ref_for_action() == "wcn_live"
+
+
+def test_parser_prefers_connection_ref_and_keeps_legacy_alias() -> None:
+    parser = acceptance.build_parser()
+
+    preferred = parser.parse_args(["--connection-ref", "wcn_live"])
+    legacy = parser.parse_args(["--connection-id", "wcn_legacy"])
+    help_text = parser.format_help()
+
+    assert preferred.connection_ref == "wcn_live"
+    assert legacy.connection_ref == "wcn_legacy"
+    assert "--connection-ref" in help_text
+    assert "--connection-id" not in help_text


### PR DESCRIPTION
Closes #819

## Summary
- Rename the public Wiii Connect disconnect path parameter from `{connection_id}` to `{connection_ref}` while keeping the URL shape unchanged.
- Update the live Composio acceptance harness to prefer `--connection-ref` and evidence key `explicit_connection_ref_selected`.
- Keep hidden legacy `--connection-id` parser alias for backward compatibility.
- Document that manual selection should use the opaque Wiii `connection_ref`, not a raw provider connected-account ID.

## Scope
- Backend OpenAPI/path parameter naming for disconnect.
- Acceptance harness CLI/evidence naming.
- Focused backend and harness tests.
- Acceptance runbook wording.

## Non-Scope
- No live Composio enablement.
- No provider API behavior change.
- No database migration.
- No frontend redesign.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/api/test_wiii_connect_api.py tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 52 passed
- `cd maritime-ai-service; python -m ruff check app/api/v1/wiii_connect.py scripts/wiii_connect_composio_acceptance.py tests/unit/api/test_wiii_connect_api.py tests/unit/test_wiii_connect_composio_acceptance.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
- Low-to-medium public contract cleanup. Runtime URL shape remains unchanged, and legacy harness `--connection-id` still parses into the new `connection_ref` field.

## Rollback
- Revert this PR. No data migration or credential rollback required.
