### PR TITLE
security: redact Wiii Connect connection refs in evidence

### DIFF
--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -97,8 +97,9 @@ python scripts/wiii_connect_composio_acceptance.py --backend-url http://localhos
 The JSON includes check names, pass/fail status, elapsed time, target label,
 deployed commit, and whether a connection was selected for action execution. It
 intentionally strips bearer tokens, Connect URLs, callback state, raw connection
-IDs, vault references, and provider payloads. Do not commit generated evidence
-files; attach or summarize the sanitized output in the issue/PR when needed.
+IDs, opaque connection refs, vault references, and provider payloads. Do not
+commit generated evidence files; attach or summarize the sanitized output in
+the issue/PR when needed.
 
 For local dev-login:
 

--- a/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
@@ -42,6 +42,7 @@ SENSITIVE_EXACT_KEYS = {
     "code",
     "connected_account_id",
     "connection_id",
+    "connection_ref",
     "credential",
     "password",
     "redirect_url",
@@ -324,7 +325,12 @@ def _looks_sensitive_string(value: str) -> bool:
         return True
     if "access_token=" in lowered or "refresh_token=" in lowered:
         return True
-    if "wiii_state=" in lowered or "connected_account_id=" in lowered:
+    if (
+        "wiii_state=" in lowered
+        or "connected_account_id=" in lowered
+        or "connection_ref=" in lowered
+        or "connection_id=" in lowered
+    ):
         return True
     return False
 

--- a/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
@@ -41,6 +41,7 @@ def test_redact_for_log_removes_tokens_urls_and_connection_ids() -> None:
     payload = {
         "authorization_url": "https://connect.example/callback?wiii_state=abc",
         "connection_id": "ca_secret_123",
+        "connection_ref": "wcn_public_ref",
         "nested": {
             "access_token": "secret-token",
             "safe": "visible",
@@ -53,11 +54,13 @@ def test_redact_for_log_removes_tokens_urls_and_connection_ids() -> None:
 
     assert redacted["authorization_url"] == "[redacted]"
     assert redacted["connection_id"] == "[redacted]"
+    assert redacted["connection_ref"] == "[redacted]"
     assert redacted["nested"]["access_token"] == "[redacted]"
     assert redacted["nested"]["items"][0]["vault_key_id"] == "[redacted]"
     assert redacted["nested"]["safe"] == "visible"
     assert "secret-token" not in serialized
     assert "ca_secret_123" not in serialized
+    assert "wcn_public_ref" not in serialized
     assert "provider-managed://composio" not in serialized
 
 
@@ -537,6 +540,27 @@ def test_readiness_report_only_does_not_run_live_connect_or_execute(monkeypatch)
     assert calls == ["health", "auth", "report:none"]
     assert "[REPORT] activation readiness" in output
     assert "complete_provider_oauth" in output
+
+
+def test_check_record_redacts_connection_ref_query_strings() -> None:
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(connection_ref="", selected_connection_ref="")
+    )
+
+    record = harness.check_record(
+        "activation readiness",
+        status="failed",
+        elapsed=0.1,
+        detail=(
+            "GET http://localhost:8080/api/v1/wiii-connect/providers/gmail/"
+            "activation-readiness?connection_ref=wcn_public_ref failed"
+        ),
+    )
+    serialized = json.dumps(record, sort_keys=True)
+
+    assert record["detail"] == "[redacted]"
+    assert "wcn_public_ref" not in serialized
+    assert "connection_ref=" not in serialized
 
 
 def test_connection_ref_for_action_requires_selected_or_explicit_connection() -> None:


### PR DESCRIPTION
Closes #821

## Summary
- Redact `connection_ref` dictionary keys in the live Composio acceptance harness evidence/log projection.
- Redact strings that contain `connection_ref=` or `connection_id=` query snippets before they reach evidence JSON.
- Update the runbook to state that opaque connection refs are stripped from sanitized evidence.

## Scope
- Acceptance harness redaction only.
- Focused harness tests and runbook wording.

## Non-Scope
- No backend runtime behavior change.
- No live Composio enablement.
- No frontend change.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 18 passed
- `cd maritime-ai-service; python -m ruff check scripts/wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_composio_acceptance.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
- Low. This is stricter redaction for live acceptance artifacts. It preserves boolean evidence flags such as `explicit_connection_ref_selected`.

## Rollback
- Revert this PR. No data migration or credential rollback required.
