### PR TITLE
test(connect): require scope policy proof in Composio acceptance

### DIFF
--- a/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
@@ -30,6 +30,7 @@ DEFAULT_DEMO_EMAIL = "dev@localhost"
 DEFAULT_DEMO_NAME = "Dev User"
 DEFAULT_DEMO_ROLE = "admin"
 DEFAULT_EXPECTED_PLATFORM_ROLE = "platform_admin"
+SCOPE_POLICY_VERSION = "wiii_connect_scope_policy.v1"
 TOKEN_ENV = "WIII_ACCEPTANCE_BEARER_TOKEN"
 TARGET_ENV = "WIII_ACCEPTANCE_TARGET_ENV"
 COMMIT_SHA_ENV = "WIII_ACCEPTANCE_COMMIT_SHA"
@@ -306,6 +307,46 @@ def assert_activation_ready(
         f"{flag}={payload.get(flag)!r} status={payload.get('status')!r} "
         f"blockers={activation_blocker_summary(payload)}"
     )
+
+
+def assert_scope_policy_allowed(
+    payload: dict[str, Any],
+    *,
+    label: str,
+) -> str:
+    """Require Wiii-owned scope policy evidence before provider execution."""
+
+    gateway = payload.get("execution_gateway")
+    if gateway is None:
+        gateway = payload
+    if not isinstance(gateway, dict):
+        raise AcceptanceFailure(f"{label} omitted execution gateway evidence")
+    scope_policy = gateway.get("scope_policy")
+    if not isinstance(scope_policy, dict):
+        raise AcceptanceFailure(f"{label} omitted scope_policy evidence")
+    version = str(scope_policy.get("version") or "")
+    if version != SCOPE_POLICY_VERSION:
+        raise AcceptanceFailure(
+            f"{label} scope_policy version mismatch: version={version!r}"
+        )
+    if scope_policy.get("status") != "allowed" or scope_policy.get("reason") != "allowed":
+        raise AcceptanceFailure(
+            f"{label} scope policy not allowed: "
+            f"status={scope_policy.get('status')!r} reason={scope_policy.get('reason')!r}"
+        )
+    required_scopes = scope_policy.get("required_scopes")
+    allowed_scopes = scope_policy.get("allowed_scopes")
+    if not isinstance(required_scopes, list) or "read" not in required_scopes:
+        raise AcceptanceFailure(
+            f"{label} scope_policy missing required read scope: "
+            f"required_scopes={required_scopes!r}"
+        )
+    if not isinstance(allowed_scopes, list) or "read" not in allowed_scopes:
+        raise AcceptanceFailure(
+            f"{label} scope_policy does not allow read scope: "
+            f"allowed_scopes={allowed_scopes!r}"
+        )
+    return "scope_policy=allowed required_scopes=read"
 
 
 def normalize_provider(value: str) -> str:
@@ -769,7 +810,14 @@ class WiiiConnectComposioAcceptance:
             flag="ready_to_execute_readonly",
             label="read-only execution-ready",
         )
-        return f"ready_to_execute_readonly=true connection={opaque_ref(connection_ref)}"
+        scope_detail = assert_scope_policy_allowed(
+            payload,
+            label="activation readiness",
+        )
+        return (
+            "ready_to_execute_readonly=true "
+            f"{scope_detail} connection={opaque_ref(connection_ref)}"
+        )
 
     def check_activation_readiness_report(self) -> str:
         connection_ref = (self.args.connection_ref or "").strip()
@@ -856,7 +904,11 @@ class WiiiConnectComposioAcceptance:
             raise AcceptanceFailure(
                 f"Gateway did not allow read-only action: reason={payload.get('reason')!r}"
             )
-        return f"allowed connection={opaque_ref(connection_ref)}"
+        scope_detail = assert_scope_policy_allowed(
+            payload,
+            label="execution gateway",
+        )
+        return f"allowed {scope_detail} connection={opaque_ref(connection_ref)}"
 
     def check_readonly_execution(self) -> str:
         connection_ref = self.connection_ref_for_action()

--- a/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
@@ -23,6 +23,17 @@ assert SPEC.loader is not None
 SPEC.loader.exec_module(acceptance)
 
 
+def allowed_read_scope_policy() -> dict[str, object]:
+    return {
+        "version": acceptance.SCOPE_POLICY_VERSION,
+        "status": "allowed",
+        "reason": "allowed",
+        "provider_slug": "gmail",
+        "required_scopes": ["read"],
+        "allowed_scopes": ["read"],
+    }
+
+
 def test_join_url_handles_slashes() -> None:
     assert acceptance.join_url("http://localhost:8080/", "/api/v1/health") == (
         "http://localhost:8080/api/v1/health"
@@ -133,6 +144,49 @@ def test_activation_readiness_helpers_report_blockers() -> None:
     )
 
 
+def test_scope_policy_helper_requires_allowed_read_policy() -> None:
+    assert acceptance.assert_scope_policy_allowed(
+        {
+            "execution_gateway": {
+                "status": "allowed",
+                "scope_policy": allowed_read_scope_policy(),
+            }
+        },
+        label="activation readiness",
+    ) == "scope_policy=allowed required_scopes=read"
+
+    with pytest.raises(acceptance.AcceptanceFailure, match="scope_policy evidence"):
+        acceptance.assert_scope_policy_allowed(
+            {"execution_gateway": {"status": "allowed"}},
+            label="activation readiness",
+        )
+
+    with pytest.raises(acceptance.AcceptanceFailure, match="scope policy not allowed"):
+        acceptance.assert_scope_policy_allowed(
+            {
+                "status": "blocked",
+                "scope_policy": {
+                    **allowed_read_scope_policy(),
+                    "status": "blocked",
+                    "reason": "scope_policy_denied",
+                },
+            },
+            label="execution gateway",
+        )
+
+    with pytest.raises(acceptance.AcceptanceFailure, match="missing required read"):
+        acceptance.assert_scope_policy_allowed(
+            {
+                "status": "allowed",
+                "scope_policy": {
+                    **allowed_read_scope_policy(),
+                    "required_scopes": ["write"],
+                },
+            },
+            label="execution gateway",
+        )
+
+
 def test_activation_readiness_report_lines_are_redacted() -> None:
     payload = {
         "provider_slug": "gmail",
@@ -218,6 +272,73 @@ def test_activation_readiness_payload_uses_backend_endpoint(monkeypatch) -> None
     assert "connection_ref=wcn_live" in url
 
 
+def test_activation_ready_to_execute_requires_scope_policy_proof(
+    monkeypatch,
+) -> None:
+    class FakeResponse:
+        def json(self):
+            return {
+                "status": "ready",
+                "ready_to_execute_readonly": True,
+                "execution_gateway": {
+                    "status": "allowed",
+                    "scope_policy": allowed_read_scope_policy(),
+                },
+            }
+
+    def fake_request_bytes(method, url, *, headers=None, payload=None, timeout=15.0):
+        return FakeResponse()
+
+    monkeypatch.setattr(acceptance, "request_bytes", fake_request_bytes)
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="http://localhost:8080",
+            provider="gmail",
+            action="GMAIL_FETCH_EMAILS",
+            timeout=7.0,
+            org_id="",
+            connection_ref="wcn_live",
+        )
+    )
+    harness.token = "token"
+
+    detail = harness.check_activation_ready_to_execute()
+
+    assert "ready_to_execute_readonly=true" in detail
+    assert "scope_policy=allowed" in detail
+
+
+def test_activation_ready_to_execute_rejects_missing_scope_policy(
+    monkeypatch,
+) -> None:
+    class FakeResponse:
+        def json(self):
+            return {
+                "status": "ready",
+                "ready_to_execute_readonly": True,
+                "execution_gateway": {"status": "allowed"},
+            }
+
+    def fake_request_bytes(method, url, *, headers=None, payload=None, timeout=15.0):
+        return FakeResponse()
+
+    monkeypatch.setattr(acceptance, "request_bytes", fake_request_bytes)
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="http://localhost:8080",
+            provider="gmail",
+            action="GMAIL_FETCH_EMAILS",
+            timeout=7.0,
+            org_id="",
+            connection_ref="wcn_live",
+        )
+    )
+    harness.token = "token"
+
+    with pytest.raises(acceptance.AcceptanceFailure, match="scope_policy evidence"):
+        harness.check_activation_ready_to_execute()
+
+
 def test_gateway_fail_closed_check_requires_connection_selection_reason(
     monkeypatch,
 ) -> None:
@@ -295,6 +416,89 @@ def test_gateway_fail_closed_check_rejects_generic_block_reason(monkeypatch) -> 
         match="explicit connection selection",
     ):
         harness.check_gateway_blocks_missing_connection()
+
+
+def test_execution_gateway_allowed_requires_scope_policy_proof(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        def json(self):
+            return {
+                "status": "allowed",
+                "reason": "allowed",
+                "scope_policy": allowed_read_scope_policy(),
+            }
+
+    def fake_request_bytes(method, url, *, headers=None, payload=None, timeout=15.0):
+        captured["method"] = method
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["payload"] = payload
+        return FakeResponse()
+
+    monkeypatch.setattr(acceptance, "request_bytes", fake_request_bytes)
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="http://localhost:8080",
+            provider="gmail",
+            action="GMAIL_FETCH_EMAILS",
+            timeout=7.0,
+            org_id="",
+            connection_ref="wcn_live",
+            argument_keys="",
+            arguments_json='{"query": "from:me"}',
+        )
+    )
+    harness.token = "token"
+
+    detail = harness.check_execution_gateway_allowed()
+
+    assert "allowed scope_policy=allowed" in detail
+    assert captured["method"] == "POST"
+    assert captured["headers"] == {"Authorization": "Bearer token"}
+    assert captured["payload"] == {
+        "surface": "acceptance_harness",
+        "connection_ref": "wcn_live",
+        "action_slug": "GMAIL_FETCH_EMAILS",
+        "path": "external_app_action",
+        "mutation": "read",
+        "argument_keys": ["query"],
+    }
+
+
+def test_execution_gateway_allowed_rejects_blocked_scope_policy(monkeypatch) -> None:
+    class FakeResponse:
+        def json(self):
+            return {
+                "status": "allowed",
+                "reason": "allowed",
+                "scope_policy": {
+                    **allowed_read_scope_policy(),
+                    "status": "blocked",
+                    "reason": "scope_policy_denied",
+                },
+            }
+
+    def fake_request_bytes(method, url, *, headers=None, payload=None, timeout=15.0):
+        return FakeResponse()
+
+    monkeypatch.setattr(acceptance, "request_bytes", fake_request_bytes)
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="http://localhost:8080",
+            provider="gmail",
+            action="GMAIL_FETCH_EMAILS",
+            timeout=7.0,
+            org_id="",
+            connection_ref="wcn_live",
+            argument_keys="",
+            arguments_json="{}",
+        )
+    )
+    harness.token = "token"
+
+    with pytest.raises(acceptance.AcceptanceFailure, match="scope policy not allowed"):
+        harness.check_execution_gateway_allowed()
 
 
 def test_validate_evidence_path_rejects_secret_and_generated_locations() -> None:


### PR DESCRIPTION
Closes #825

## Summary
- make the Composio acceptance harness require Wiii-owned `scope_policy` proof for execution readiness and execution gateway allow decisions
- fail closed when scope policy metadata is missing, version-mismatched, blocked, or does not grant the required read scope
- add focused unit coverage for nested activation-readiness payloads and direct execution-decision payloads

## Scope
- `maritime-ai-service/scripts/wiii_connect_composio_acceptance.py`
- `maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py`

## Non-scope
- no live Composio OAuth execution in this PR
- no provider registry, vault, OAuth callback, or frontend UI behavior changes
- no changes to local/prod secrets or environment files

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 23 passed
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_action_catalog.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_callback_state.py tests/unit/test_wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_snapshot.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/api/test_wiii_connect_api.py -q --tb=short` -> 107 passed
- `cd maritime-ai-service; python -m ruff check scripts/wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_composio_acceptance.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
Low. This only tightens acceptance validation. It can make a Composio acceptance run fail earlier if the backend omits Wiii scope-policy evidence, which is intended for production safety.

## Rollback
Revert this PR to restore the previous looser harness behavior. Runtime backend behavior is unchanged.