### PR TITLE
docs(connect): refresh OpenHuman audit provenance

### DIFF
--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -60,17 +60,23 @@ Sources:
 
 ## OpenHuman Source Findings
 
-Audited local reference clone:
+Audited external reference clone:
 
 ```text
-.Codex/external/reference-systems/openhuman
+../_reference_research/openhuman
 ```
 
-Reference clone commit inspected for the Composio source pass:
+Reference clone commit inspected for the current Composio source pass:
 
 ```text
-77c15cb
+6736467
 ```
+
+This clone is intentionally outside the Wiii repository and is not a committed
+artifact. Earlier exploratory clones under local agent folders such as
+`.Codex/` are not canonical Wiii source inputs. The canonical Wiii evidence is
+this audit document plus the Wiii Connect contracts and tests in the main
+repository.
 
 Important source files:
 

--- a/docs/operations/WIII_OPENHUMAN_REFERENCE_AUDIT_2026-05-26.md
+++ b/docs/operations/WIII_OPENHUMAN_REFERENCE_AUDIT_2026-05-26.md
@@ -25,19 +25,25 @@ without reading raw prompts or uploaded documents.
 
 ## Source Snapshot
 
-External code was inspected from the ignored local research workspace:
+External code was originally inspected from an ignored local research
+workspace. The current refreshed OpenHuman reference clone used for later
+Composio/Connections audit work is kept outside the Wiii repository:
 
 ```text
-.Codex/external/reference-systems/openhuman
+../_reference_research/openhuman
 ```
+
+Do not treat legacy `.Codex/` exploratory folders as canonical Wiii source
+inputs or committed artifacts.
 
 | Field | Value |
 |---|---|
 | Remote | `https://github.com/tinyhumansai/openhuman.git` |
-| Inspected commit | `0e4729e7f2214f2fed3e23fb8d352018c0393fb3` |
-| Commit date | `2026-05-25T23:33:40+05:30` |
-| Commit title | `test(memory): serialize tests that drive the process-global memory client (#2649)` |
-| Local checkout note | Local worktree remained at `5e31d3e00dd7972d81b52b4d537d6925ec318ee3`; latest files were read through `origin/main:<path>` without resetting the clone. |
+| Original inspected commit | `0e4729e7f2214f2fed3e23fb8d352018c0393fb3` |
+| Original commit date | `2026-05-25T23:33:40+05:30` |
+| Original commit title | `test(memory): serialize tests that drive the process-global memory client (#2649)` |
+| Refreshed local commit for 2026-05-28 Composio pass | `6736467` |
+| Local checkout note | Later Composio/Connections checks use the external `_reference_research/openhuman` clone without vendoring it into Wiii. |
 | Clone mode | shallow, sparse, no submodules |
 
 Primary OpenHuman areas reviewed:

--- a/docs/operations/WIII_REFERENCE_SYSTEMS_AUDIT_2026-05-25.md
+++ b/docs/operations/WIII_REFERENCE_SYSTEMS_AUDIT_2026-05-25.md
@@ -19,20 +19,22 @@ audit. It is not an endorsement to copy architecture wholesale.
 
 ## Local Research Workspace
 
-External reference repositories are cloned outside tracked Wiii source:
+External reference repositories are cloned outside tracked Wiii source. The
+current durable refresh location for OpenHuman is:
 
 ```text
-.Codex/external/reference-systems/
+../_reference_research/openhuman
 ```
 
-This path is intentionally ignored by `.gitignore` through the existing
-`.Codex/` rule. Do not vendor external repositories into Wiii history.
+Older exploratory clones under `.Codex/external/reference-systems/` were local
+scratch space and are not canonical Wiii source inputs. Do not vendor external
+repositories into Wiii history.
 
-Current local clones:
+Reference entries recorded during the original audit and refreshed where noted:
 
 | Project | Local path | Remote | Local HEAD | Clone mode | Why it is first-class |
 |---|---|---|---|---|---|
-| OpenHuman | `.Codex/external/reference-systems/openhuman` | `https://github.com/tinyhumansai/openhuman.git` | `5e31d3e` | shallow, sparse, no submodules | living memory, local-first knowledge vault, typed integrations, background context ingestion, personal-agent UX |
+| OpenHuman | `../_reference_research/openhuman` | `https://github.com/tinyhumansai/openhuman.git` | `6736467` | shallow, sparse, no submodules | living memory, local-first knowledge vault, typed integrations, background context ingestion, personal-agent UX |
 | OpenClaw | `.Codex/external/reference-systems/openclaw` | `https://github.com/openclaw/openclaw.git` | `d967760` | shallow, sparse | gateway control plane, multi-channel routing, operator commands, session isolation, tool permission defaults, trace/doctor UX |
 | Understand-Anything | `.Codex/external/reference-systems/understand-anything` | `https://github.com/Lum1104/Understand-Anything.git` | `470cc01` | shallow | system-comprehension harness, deterministic source inventory, import-map extraction, semantic batching, local architecture graph/dashboard |
 


### PR DESCRIPTION
Closes #827

## Summary
- refresh OpenHuman audit provenance to point at the current external reference clone `../_reference_research/openhuman`
- record current inspected OpenHuman commit `6736467` for the Composio/Connections source pass
- clarify that legacy `.Codex/` exploratory clones are not canonical Wiii source inputs or committed artifacts

## Scope
- `docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md`
- `docs/operations/WIII_OPENHUMAN_REFERENCE_AUDIT_2026-05-26.md`
- `docs/operations/WIII_REFERENCE_SYSTEMS_AUDIT_2026-05-25.md`

## Non-scope
- no runtime behavior changes
- no Composio configuration or secrets
- no external reference clone files committed

## Verification
- `git diff --check` -> passed
- targeted provenance search for the stale OpenHuman `.Codex` path and old commit -> no matches

## Risk
Low. Docs-only provenance cleanup. Relevant to security/review traceability for future Composio enablement.

## Rollback
Revert this PR to restore the previous audit provenance wording.