### PR TITLE
security(connect): pin Composio listing to private accounts

### DIFF
--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -171,6 +171,8 @@ Composio is ready to enable only when all of these are true:
 - after OAuth, connection listing returns an active connected account;
 - connection listing returns an opaque `connection_ref`, not the raw provider
   connected-account ID;
+- backend Composio polling/listing filters the provider call to private
+  connected accounts for the selected Wiii user and auth config;
 - execution gateway allows the selected read-only action only for the stored
   org/user connection;
 - execute blocks before calling Composio when live schema verification reports

--- a/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
+++ b/docs/operations/WIII_OPENHUMAN_COMPOSIO_SOURCE_AUDIT_2026-05-28.md
@@ -242,11 +242,12 @@ probe, Composio adapter configuration status, an authenticated Connect Link
 client path that calls Composio only after policy preflight passes, signed
 callback state, and callback reconciliation into durable Wiii connection
 records. It also has an authenticated connection-listing/polling boundary that
-calls Composio `connected_accounts` only through Wiii backend and upserts
-sanitized connection records. The desktop Wiii Connect page can now start a
-backend-owned Connect Link, open only backend-issued URLs, refresh/poll
-sanitized provider connection records, and show connection state separately from
-agent-ready execution state. It can also request backend-owned disconnect for a
+calls Composio `connected_accounts` only through Wiii backend, filters listing
+to private connected accounts for the selected Wiii user/auth config, and
+upserts sanitized connection records. The desktop Wiii Connect page can now
+start a backend-owned Connect Link, open only backend-issued URLs, refresh/poll
+sanitized provider connection records, and show connection state separately
+from agent-ready execution state. It can also request backend-owned disconnect for a
 provider connection and update the local UI state to disabled without exposing
 raw provider payloads or connection IDs. Wiii now also has an authenticated execution
 gateway preflight endpoint that fetches the stored org/user connection record,

--- a/maritime-ai-service/app/engine/wiii_connect/composio_adapter.py
+++ b/maritime-ai-service/app/engine/wiii_connect/composio_adapter.py
@@ -638,6 +638,7 @@ async def list_composio_connected_accounts(
     params: list[tuple[str, str | int]] = [
         ("user_ids", user_id),
         ("auth_config_ids", auth_config_id),
+        ("account_type", "PRIVATE"),
         ("limit", max(1, min(int(limit or 50), 100))),
     ]
     client_created = http_client is None

--- a/maritime-ai-service/tests/unit/test_wiii_connect_provider_adapters.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_provider_adapters.py
@@ -315,6 +315,7 @@ async def test_composio_connection_list_client_filters_and_sanitizes_accounts():
     )
     assert "user_ids=wiii_user_hash" in captured["url"]
     assert "auth_config_ids=authcfg_fb" in captured["url"]
+    assert "account_type=PRIVATE" in captured["url"]
     assert captured["api_key"] == "secret-api-key"
     assert result.ready is True
     assert public["connection_count"] == 2


### PR DESCRIPTION
Closes #829

## Summary
- make Composio connected-account polling/listing request `account_type=PRIVATE` explicitly
- update focused adapter coverage to assert the private-account filter is sent with user/auth-config filters
- document the private-account listing invariant in the Composio acceptance runbook/source audit

## Scope
- `maritime-ai-service/app/engine/wiii_connect/composio_adapter.py`
- `maritime-ai-service/tests/unit/test_wiii_connect_provider_adapters.py`
- Wiii Connect Composio docs/runbook

## Non-scope
- no Composio credentials or environment changes
- no OAuth, execute, disconnect, UI, or database changes
- no shared-account support in this rollout

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_provider_adapters.py -q --tb=short` -> 14 passed
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_action_catalog.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_callback_state.py tests/unit/test_wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_snapshot.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/api/test_wiii_connect_api.py -q --tb=short` -> 107 passed
- `cd maritime-ai-service; python -m ruff check app/engine/wiii_connect/composio_adapter.py tests/unit/test_wiii_connect_provider_adapters.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
Low. This narrows provider listing behavior to private accounts. It is security-relevant because live Composio rollout should not depend on provider defaults for shared-account exclusion.

## Rollback
Revert this PR to remove the explicit `account_type=PRIVATE` query parameter and rely on Composio defaults again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated acceptance runbook to verify backend filters connected accounts to private user accounts during polling/listing operations.
  * Updated architecture documentation to clarify connected account filtering behavior and sanitization processes.

* **Tests**
  * Enhanced tests to confirm private account filtering is correctly applied in backend operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->