### PR TITLE
fix(connect): avoid new Connect Links during post-OAuth acceptance

### DIFF
--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -121,6 +121,11 @@ then rerun without printing the link:
 python scripts/wiii_connect_composio_acceptance.py --backend-url http://localhost:8080 --auth-mode dev-login --provider gmail --expect-connected --require-execution-ready
 ```
 
+Post-OAuth acceptance does not issue a new Connect Link when
+`--expect-connected`, `--require-execution-ready`, `--execute-readonly`, or
+`--disconnect` is set. Those phases verify the existing stored connection
+instead of starting another OAuth handoff.
+
 To execute the read-only action after the live Composio schema is known, pass
 arguments matching that schema:
 

--- a/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
@@ -483,7 +483,7 @@ class WiiiConnectComposioAcceptance:
                     "gateway fail-closed control",
                     self.check_gateway_blocks_missing_connection,
                 )
-                if not self.args.skip_connect_link:
+                if self.should_issue_connect_link():
                     self.run_check("connect link preflight", self.check_connect_link)
                 self.run_check("connection listing", self.check_connections)
                 if self.args.require_execution_ready or self.args.execute_readonly:
@@ -523,6 +523,18 @@ class WiiiConnectComposioAcceptance:
             "elapsed_seconds": round(float(elapsed), 3),
             "detail": redact_for_log(str(detail or "")),
         }
+
+    def should_issue_connect_link(self) -> bool:
+        """Issue Connect Links only during the initial connection phase."""
+
+        if self.args.skip_connect_link:
+            return False
+        return not (
+            self.args.expect_connected
+            or self.args.require_execution_ready
+            or self.args.execute_readonly
+            or self.args.disconnect
+        )
 
     def evidence_payload(self) -> dict[str, Any]:
         parsed_backend = urllib.parse.urlsplit(self.args.backend_url)

--- a/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
@@ -746,6 +746,187 @@ def test_readiness_report_only_does_not_run_live_connect_or_execute(monkeypatch)
     assert "complete_provider_oauth" in output
 
 
+def test_connect_phase_run_issues_connect_link(monkeypatch) -> None:
+    calls: list[str] = []
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="http://localhost:8080",
+            provider="gmail",
+            action="GMAIL_FETCH_EMAILS",
+            timeout=7.0,
+            org_id="",
+            readiness_report_only=False,
+            skip_connect_link=False,
+            expect_connected=False,
+            require_execution_ready=False,
+            execute_readonly=False,
+            disconnect=False,
+        )
+    )
+
+    monkeypatch.setattr(
+        harness,
+        "check_backend_health",
+        lambda: calls.append("health") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "authenticate",
+        lambda: calls.append("auth") or setattr(harness, "token", "token") or "auth",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_provider_registry",
+        lambda: calls.append("registry") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_adapter_readiness",
+        lambda: calls.append("adapter") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_storage_readiness",
+        lambda: calls.append("storage") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_audit_readiness",
+        lambda: calls.append("audit") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_curated_actions",
+        lambda: calls.append("actions") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_activation_ready_to_connect",
+        lambda: calls.append("connect_ready") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_gateway_blocks_missing_connection",
+        lambda: calls.append("gateway_block") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_connect_link",
+        lambda: calls.append("connect_link") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_connections",
+        lambda: calls.append("connections") or "ok",
+    )
+
+    assert harness.run() == 0
+
+    assert "connect_link" in calls
+
+
+def test_post_oauth_run_does_not_issue_new_connect_link(monkeypatch) -> None:
+    calls: list[str] = []
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="http://localhost:8080",
+            provider="gmail",
+            action="GMAIL_FETCH_EMAILS",
+            timeout=7.0,
+            org_id="",
+            readiness_report_only=False,
+            skip_connect_link=False,
+            expect_connected=True,
+            require_execution_ready=True,
+            execute_readonly=False,
+            disconnect=False,
+        )
+    )
+
+    def forbidden_connect_link() -> str:
+        raise AssertionError("post-OAuth acceptance must not create a new link")
+
+    monkeypatch.setattr(
+        harness,
+        "check_backend_health",
+        lambda: calls.append("health") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "authenticate",
+        lambda: calls.append("auth") or setattr(harness, "token", "token") or "auth",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_provider_registry",
+        lambda: calls.append("registry") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_adapter_readiness",
+        lambda: calls.append("adapter") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_storage_readiness",
+        lambda: calls.append("storage") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_audit_readiness",
+        lambda: calls.append("audit") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_curated_actions",
+        lambda: calls.append("actions") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_activation_ready_to_connect",
+        lambda: calls.append("connect_ready") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_gateway_blocks_missing_connection",
+        lambda: calls.append("gateway_block") or "ok",
+    )
+    monkeypatch.setattr(harness, "check_connect_link", forbidden_connect_link)
+    monkeypatch.setattr(
+        harness,
+        "check_connections",
+        lambda: calls.append("connections") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_activation_ready_to_execute",
+        lambda: calls.append("execute_ready") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_execution_gateway_allowed",
+        lambda: calls.append("gateway_allowed") or "ok",
+    )
+
+    assert harness.run() == 0
+
+    assert "connect_link" not in calls
+    assert calls == [
+        "health",
+        "auth",
+        "registry",
+        "adapter",
+        "storage",
+        "audit",
+        "actions",
+        "connect_ready",
+        "gateway_block",
+        "connections",
+        "execute_ready",
+        "gateway_allowed",
+    ]
+
+
 def test_check_record_redacts_connection_ref_query_strings() -> None:
     harness = acceptance.WiiiConnectComposioAcceptance(
         SimpleNamespace(connection_ref="", selected_connection_ref="")


### PR DESCRIPTION
Closes #831

## Summary
- skip Connect Link issuance automatically during post-OAuth acceptance phases (`--expect-connected`, `--require-execution-ready`, `--execute-readonly`, or `--disconnect`)
- preserve Connect Link issuance for the initial connect phase
- document the phase split in the Composio acceptance runbook

## Scope
- `maritime-ai-service/scripts/wiii_connect_composio_acceptance.py`
- `maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py`
- `docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md`

## Non-scope
- no runtime backend/API behavior changes
- no Composio credentials or environment changes
- no frontend behavior changes

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 25 passed
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_action_catalog.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_callback_state.py tests/unit/test_wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_snapshot.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/api/test_wiii_connect_api.py -q --tb=short` -> 109 passed
- `cd maritime-ai-service; python -m ruff check scripts/wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_composio_acceptance.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
Low-to-moderate. This changes only operator harness sequencing, but protects OAuth flow discipline by avoiding accidental extra Connect Link sessions during post-OAuth verification.

## Rollback
Revert this PR to restore the previous behavior where the harness issued Connect Link preflight unless `--skip-connect-link` was supplied.