### PR TITLE
test(connect): require connection refs in Composio acceptance

### DIFF
--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -176,6 +176,8 @@ Composio is ready to enable only when all of these are true:
 - after OAuth, connection listing returns an active connected account;
 - connection listing returns an opaque `connection_ref`, not the raw provider
   connected-account ID;
+- the acceptance harness rejects active connected-account records that only
+  expose raw provider IDs without an opaque `connection_ref`;
 - backend Composio polling/listing filters the provider call to private
   connected accounts for the selected Wiii user and auth config;
 - execution gateway allows the selected read-only action only for the stored

--- a/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
@@ -215,16 +215,8 @@ def first_connected_connection(payload: dict[str, Any]) -> dict[str, Any] | None
             isinstance(connection, dict)
             and connection.get("active") is True
             and connection.get("state") == "connected"
-            and (
-                (
-                    isinstance(connection.get("connection_ref"), str)
-                    and connection.get("connection_ref")
-                )
-                or (
-                    isinstance(connection.get("connection_id"), str)
-                    and connection.get("connection_id")
-                )
-            )
+            and isinstance(connection.get("connection_ref"), str)
+            and connection.get("connection_ref")
         ):
             return connection
     return None
@@ -890,7 +882,7 @@ class WiiiConnectComposioAcceptance:
                 raise AcceptanceFailure("No active connected account was returned")
             return "ready; no active account required for this run"
         self.selected_connection_ref = str(
-            connection.get("connection_ref") or connection.get("connection_id") or ""
+            connection.get("connection_ref") or ""
         )
         return f"active_connection={opaque_ref(self.selected_connection_ref)}"
 

--- a/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
@@ -91,6 +91,7 @@ def test_catalog_helpers_find_adapter_provider_action_and_active_connection() ->
     connection = acceptance.first_connected_connection(
         {
             "connections": [
+                {"connection_id": "ca_raw", "state": "connected", "active": True},
                 {"connection_id": "ca_old", "state": "disabled", "active": False},
                 {"connection_ref": "wcn_live", "state": "connected", "active": True},
             ]
@@ -101,6 +102,23 @@ def test_catalog_helpers_find_adapter_provider_action_and_active_connection() ->
     assert provider["provider_kind"] == "composio"
     assert action["mutation"] == "read"
     assert connection["connection_ref"] == "wcn_live"
+
+
+def test_first_connected_connection_requires_opaque_connection_ref() -> None:
+    assert (
+        acceptance.first_connected_connection(
+            {
+                "connections": [
+                    {
+                        "connection_id": "ca_raw_only",
+                        "state": "connected",
+                        "active": True,
+                    }
+                ]
+            }
+        )
+        is None
+    )
 
 
 def test_catalog_helpers_fail_closed_when_required_items_are_missing() -> None:
@@ -499,6 +517,44 @@ def test_execution_gateway_allowed_rejects_blocked_scope_policy(monkeypatch) -> 
 
     with pytest.raises(acceptance.AcceptanceFailure, match="scope policy not allowed"):
         harness.check_execution_gateway_allowed()
+
+
+def test_connection_listing_rejects_raw_connection_id_fallback(monkeypatch) -> None:
+    class FakeResponse:
+        def json(self):
+            return {
+                "status": "ready",
+                "connections": [
+                    {
+                        "connection_id": "ca_raw_only",
+                        "state": "connected",
+                        "active": True,
+                    }
+                ],
+            }
+
+    def fake_request_bytes(method, url, *, headers=None, payload=None, timeout=15.0):
+        return FakeResponse()
+
+    monkeypatch.setattr(acceptance, "request_bytes", fake_request_bytes)
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="http://localhost:8080",
+            provider="gmail",
+            action="GMAIL_FETCH_EMAILS",
+            timeout=7.0,
+            org_id="",
+            expect_connected=True,
+            require_execution_ready=False,
+            execute_readonly=False,
+            disconnect=False,
+        )
+    )
+    harness.token = "token"
+
+    with pytest.raises(acceptance.AcceptanceFailure, match="No active connected"):
+        harness.check_connections()
+    assert harness.selected_connection_ref == ""
 
 
 def test_validate_evidence_path_rejects_secret_and_generated_locations() -> None:


### PR DESCRIPTION
Closes #833

## Summary
- require active connected-account records in the Composio acceptance harness to include an opaque `connection_ref`
- remove raw `connection_id` fallback when selecting a connection from the listing payload
- document that raw-only connected-account records fail acceptance

## Scope
- `maritime-ai-service/scripts/wiii_connect_composio_acceptance.py`
- `maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py`
- `docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md`

## Non-scope
- no backend runtime API behavior change
- no Composio credentials or environment changes
- no UI changes

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 27 passed
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_action_catalog.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_callback_state.py tests/unit/test_wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/test_wiii_connect_provider_adapters.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_snapshot.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/api/test_wiii_connect_api.py -q --tb=short` -> 111 passed
- `cd maritime-ai-service; python -m ruff check scripts/wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_composio_acceptance.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
Low. This tightens only the live acceptance harness. It can make live acceptance fail earlier if the backend omits the required opaque connection reference, which is intended.

## Rollback
Revert this PR to restore raw provider `connection_id` fallback selection in the acceptance harness.