### PR TITLE
Require opaque refs for Wiii Connect execution selection

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -133,6 +133,10 @@ opens only backend-issued Connect Links, polls sanitized connection records
 through Wiii, and still keeps provider connection state separate from
 `agent_ready` execution state. The frontend never calls Composio directly and
 never receives provider tokens, raw payloads, or raw provider connection IDs.
+Activation, execution-decision, execute, and disconnect surfaces must select an
+account with Wiii's opaque `connection_ref` (`wcn_*`). Raw provider connected
+account IDs are backend-internal only and are treated as "no selected
+connection" if they appear in public request bodies or paths.
 
 The activation readiness endpoint is the single operator/UI preflight for a
 provider. It performs no provider network calls, creates no Connect Link, and

--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -200,7 +200,7 @@ async def get_wiii_connect_provider_activation_readiness(
         probe_database=probe_database,
     )
     storage_ready = _connection_storage_ready(storage)
-    selected_connection_ref = _safe_provider_connection_id(
+    selected_connection_ref = _safe_public_connection_ref(
         connection_ref or connection_id,
     )
     safe_connection_id = _resolve_provider_connection_id(
@@ -495,7 +495,7 @@ async def disconnect_wiii_connect_provider_connection(
     effective_entry = build_composio_connect_enabled_entry(entry, composio_config)
     adapter_capability = build_composio_provider_adapter_capability(composio_config)
     storage = _wiii_connect_storage_status_metadata(probe_database=True)
-    selected_connection_ref = _safe_provider_connection_id(connection_ref)
+    selected_connection_ref = _safe_public_connection_ref(connection_ref)
     safe_connection_id = _resolve_provider_connection_id(
         storage,
         current_user=current_user,
@@ -700,7 +700,7 @@ async def decide_wiii_connect_provider_execution(
     effective_entry = build_composio_execution_enabled_entry(entry, composio_config)
     storage = _wiii_connect_storage_status_metadata(probe_database=True)
     storage_ready = _connection_storage_ready(storage)
-    selected_connection_ref = _safe_provider_connection_id(
+    selected_connection_ref = _safe_public_connection_ref(
         body.connection_ref or body.connection_id,
     )
     safe_connection_id = _resolve_provider_connection_id(
@@ -781,7 +781,7 @@ async def execute_wiii_connect_provider_action(
     effective_entry = build_composio_execution_enabled_entry(entry, composio_config)
     storage = _wiii_connect_storage_status_metadata(probe_database=True)
     storage_ready = _connection_storage_ready(storage)
-    selected_connection_ref = _safe_provider_connection_id(
+    selected_connection_ref = _safe_public_connection_ref(
         body.connection_ref or body.connection_id,
     )
     safe_connection_id = _resolve_provider_connection_id(
@@ -1417,6 +1417,13 @@ def _safe_provider_connection_id(value: str | None) -> str:
     return text[:160]
 
 
+def _safe_public_connection_ref(value: str | None) -> str:
+    candidate = _safe_provider_connection_id(value)
+    if candidate.startswith("wcn_"):
+        return candidate
+    return ""
+
+
 def _resolve_provider_connection_id(
     storage_metadata: dict[str, Any],
     *,
@@ -1430,7 +1437,7 @@ def _resolve_provider_connection_id(
     if not candidate:
         return ""
     if not candidate.startswith("wcn_"):
-        return candidate
+        return ""
     if not _connection_storage_ready(storage_metadata):
         return candidate
 

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -1297,6 +1297,7 @@ async def test_wiii_connect_execution_decision_api_audits_fail_closed(
     from app.engine.wiii_connect.adapter_v1 import (
         WiiiConnectConnectionRecordV1,
         WiiiConnectScopeGrant,
+        public_connection_ref,
     )
     from app.engine.wiii_connect.composio_adapter import (
         WiiiConnectComposioAdapterConfig,
@@ -1308,6 +1309,7 @@ async def test_wiii_connect_execution_decision_api_audits_fail_closed(
     class FakeStorage:
         audit_appends = 0
         fetches = 0
+        lists = 0
 
         def status(self, *, probe_database: bool = True):
             return WiiiConnectPersistentStorageStatus(
@@ -1317,6 +1319,27 @@ async def test_wiii_connect_execution_decision_api_audits_fail_closed(
                 audit_ledger_ready=True,
                 reason="ready",
             )
+
+        def list_connection_records(
+            self,
+            *,
+            organization_id: str,
+            user_id: str,
+            provider_slug: str,
+        ):
+            self.lists += 1
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert provider_slug == "facebook"
+            return [
+                WiiiConnectConnectionRecordV1(
+                    connection_id="ca_active",
+                    provider_slug="facebook",
+                    state="connected",
+                    scopes=WiiiConnectScopeGrant(read=True, write=True),
+                    reason="provider_connection_list",
+                ),
+            ]
 
         def get_connection_record(
             self,
@@ -1377,7 +1400,7 @@ async def test_wiii_connect_execution_decision_api_audits_fail_closed(
             "/wiii-connect/providers/facebook/execution-decision",
             json={
                 "surface": "desktop",
-                "connection_id": "ca_active",
+                "connection_ref": public_connection_ref("facebook", "ca_active"),
                 "action_slug": "FACEBOOK_GET_PAGE",
                 "path": "external_app_action",
                 "mutation": "read",
@@ -1394,6 +1417,7 @@ async def test_wiii_connect_execution_decision_api_audits_fail_closed(
     assert payload["reason"] == "provider_not_agent_ready"
     assert payload["connection_present"] is True
     assert payload["adapter"]["can_execute_actions"] is False
+    assert fake_storage.lists == 1
     assert fake_storage.fetches == 1
     assert fake_storage.audit_appends == 1
     assert "secret-api-key" not in serialized
@@ -1418,6 +1442,7 @@ async def test_wiii_connect_execution_decision_requires_selected_connection(
     class FakeStorage:
         audit_appends = 0
         fetches = 0
+        lists = 0
 
         def status(self, *, probe_database: bool = True):
             return WiiiConnectPersistentStorageStatus(
@@ -1476,6 +1501,7 @@ async def test_wiii_connect_execution_decision_requires_selected_connection(
             "/wiii-connect/providers/gmail/execution-decision",
             json={
                 "surface": "desktop",
+                "connection_id": "ca_active",
                 "action_slug": "GMAIL_FETCH_EMAILS",
                 "path": "external_app_action",
                 "mutation": "read",
@@ -1492,6 +1518,7 @@ async def test_wiii_connect_execution_decision_requires_selected_connection(
     assert "select_provider_connection" in payload["required_next"]
     assert fake_storage.fetches == 0
     assert fake_storage.audit_appends == 1
+    assert "ca_active" not in serialized
     assert "secret-api-key" not in serialized
     assert "authcfg_gmail" not in serialized
     assert "access_token" not in serialized
@@ -1506,6 +1533,7 @@ async def test_wiii_connect_execute_api_runs_readonly_composio_action_safely(
     from app.engine.wiii_connect.adapter_v1 import (
         WiiiConnectConnectionRecordV1,
         WiiiConnectScopeGrant,
+        public_connection_ref,
     )
     from app.engine.wiii_connect.composio_adapter import (
         WiiiConnectComposioAdapterConfig,
@@ -1519,6 +1547,7 @@ async def test_wiii_connect_execute_api_runs_readonly_composio_action_safely(
     class FakeStorage:
         audit_appends = 0
         fetches = 0
+        lists = 0
 
         def status(self, *, probe_database: bool = True):
             return WiiiConnectPersistentStorageStatus(
@@ -1528,6 +1557,27 @@ async def test_wiii_connect_execute_api_runs_readonly_composio_action_safely(
                 audit_ledger_ready=True,
                 reason="ready",
             )
+
+        def list_connection_records(
+            self,
+            *,
+            organization_id: str,
+            user_id: str,
+            provider_slug: str,
+        ):
+            self.lists += 1
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert provider_slug == "gmail"
+            return [
+                WiiiConnectConnectionRecordV1(
+                    connection_id="ca_active",
+                    provider_slug="gmail",
+                    state="connected",
+                    scopes=WiiiConnectScopeGrant(read=True),
+                    reason="provider_connection_list",
+                ),
+            ]
 
         def get_connection_record(
             self,
@@ -1626,7 +1676,7 @@ async def test_wiii_connect_execute_api_runs_readonly_composio_action_safely(
             "/wiii-connect/providers/gmail/execute",
             json={
                 "surface": "desktop",
-                "connection_id": "ca_active",
+                "connection_ref": public_connection_ref("gmail", "ca_active"),
                 "action_slug": "GMAIL_FETCH_EMAILS",
                 "path": "external_app_action",
                 "mutation": "read",
@@ -1646,6 +1696,7 @@ async def test_wiii_connect_execute_api_runs_readonly_composio_action_safely(
     assert payload["schema"]["status"] == "ready"
     assert payload["execution"]["status"] == "succeeded"
     assert payload["execution"]["log_id_present"] is True
+    assert fake_storage.lists == 1
     assert fake_storage.fetches == 1
     assert fake_storage.audit_appends == 2
     assert "client-secret" not in serialized
@@ -1664,6 +1715,7 @@ async def test_wiii_connect_execute_blocks_missing_required_schema_arguments(
     from app.engine.wiii_connect.adapter_v1 import (
         WiiiConnectConnectionRecordV1,
         WiiiConnectScopeGrant,
+        public_connection_ref,
     )
     from app.engine.wiii_connect.composio_adapter import (
         WiiiConnectComposioAdapterConfig,
@@ -1676,6 +1728,7 @@ async def test_wiii_connect_execute_blocks_missing_required_schema_arguments(
     class FakeStorage:
         audit_appends = 0
         fetches = 0
+        lists = 0
 
         def status(self, *, probe_database: bool = True):
             return WiiiConnectPersistentStorageStatus(
@@ -1685,6 +1738,27 @@ async def test_wiii_connect_execute_blocks_missing_required_schema_arguments(
                 audit_ledger_ready=True,
                 reason="ready",
             )
+
+        def list_connection_records(
+            self,
+            *,
+            organization_id: str,
+            user_id: str,
+            provider_slug: str,
+        ):
+            self.lists += 1
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert provider_slug == "gmail"
+            return [
+                WiiiConnectConnectionRecordV1(
+                    connection_id="ca_active",
+                    provider_slug="gmail",
+                    state="connected",
+                    scopes=WiiiConnectScopeGrant(read=True),
+                    reason="provider_connection_list",
+                ),
+            ]
 
         def get_connection_record(
             self,
@@ -1775,7 +1849,7 @@ async def test_wiii_connect_execute_blocks_missing_required_schema_arguments(
             "/wiii-connect/providers/gmail/execute",
             json={
                 "surface": "desktop",
-                "connection_id": "ca_active",
+                "connection_ref": public_connection_ref("gmail", "ca_active"),
                 "action_slug": "GMAIL_FETCH_EMAILS",
                 "path": "external_app_action",
                 "mutation": "read",
@@ -1795,6 +1869,7 @@ async def test_wiii_connect_execute_blocks_missing_required_schema_arguments(
     assert payload["schema"]["status"] == "ready"
     assert payload["execution"] is None
     assert payload["missing_argument_keys"] == ["query", "redacted_sensitive_field"]
+    assert fake_storage.lists == 1
     assert fake_storage.fetches == 1
     assert fake_storage.audit_appends == 1
     assert "client-secret" not in serialized
@@ -1889,6 +1964,7 @@ async def test_wiii_connect_execute_requires_selected_connection_before_provider
             "/wiii-connect/providers/gmail/execute",
             json={
                 "surface": "desktop",
+                "connection_id": "ca_active",
                 "action_slug": "GMAIL_FETCH_EMAILS",
                 "path": "external_app_action",
                 "mutation": "read",
@@ -1910,6 +1986,7 @@ async def test_wiii_connect_execute_requires_selected_connection_before_provider
     assert "select_provider_connection" in payload["required_next"]
     assert fake_storage.fetches == 0
     assert fake_storage.audit_appends == 1
+    assert "ca_active" not in serialized
     assert "client-secret" not in serialized
     assert "access_token" not in serialized
     assert "secret-api-key" not in serialized


### PR DESCRIPTION
## Summary
- require public activation, execution-decision, execute, and disconnect selection to use Wiii opaque `connection_ref` values
- reject raw provider connected-account IDs before storage resolution/provider execution
- update Wiii Connect API tests so happy paths use `connection_ref` and raw `connection_id` payloads fail closed
- document the public/private connection-id boundary in Adapter V1 design

## Scope
- Wiii Connect FastAPI boundary
- Wiii Connect API unit coverage
- Wiii Connect architecture doc

## Non-scope
- no live Composio credential setup
- no provider OAuth app changes
- no frontend UI changes
- no schema/migration changes

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/api/test_wiii_connect_api.py -q --tb=short` -> 35 passed
- `cd maritime-ai-service; python -m pytest tests/unit/api/test_wiii_connect_api.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_callback_state.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_action_catalog.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/test_wiii_connect_snapshot.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_provider_adapters.py -q --tb=short` -> 111 passed
- `cd maritime-ai-service; python -m ruff check app\api\v1\wiii_connect.py tests\unit\api\test_wiii_connect_api.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
- Medium: public callers still sending raw provider connection IDs will now receive `connection_selection_required`/connection missing behavior instead of silently resolving.
- This is intentional for the Composio/Wiii Connect privacy boundary; UI/operator surfaces must first list connections and pass the opaque Wiii `connection_ref`.

## Rollback
- Revert this PR to restore legacy raw `connection_id` acceptance on public selection surfaces.

Closes #835

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified connection reference handling requirements across activation, execution, and disconnect operations.

* **Bug Fixes**
  * Strengthened validation of connection references to ensure only properly formatted identifiers are accepted in API requests.

* **Tests**
  * Updated unit tests to validate stricter connection reference enforcement and prevent unintended data leaks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->