### PR TITLE
Require connection-ref-only Composio acceptance input

### DIFF
--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -136,6 +136,8 @@ python scripts/wiii_connect_composio_acceptance.py --backend-url http://localhos
 If selecting a specific account manually, pass the opaque Wiii `connection_ref`
 returned by the connection list through `--connection-ref`; do not pass a raw
 provider connected-account ID.
+The acceptance harness intentionally does not accept a `--connection-id` alias;
+operator-selected accounts must use the `wcn_*` reference returned by Wiii.
 
 If the schema uses different argument names, do not change Wiii code blindly.
 Pass the live schema-compatible JSON through `--arguments-json` and record the

--- a/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
@@ -34,6 +34,7 @@ SCOPE_POLICY_VERSION = "wiii_connect_scope_policy.v1"
 TOKEN_ENV = "WIII_ACCEPTANCE_BEARER_TOKEN"
 TARGET_ENV = "WIII_ACCEPTANCE_TARGET_ENV"
 COMMIT_SHA_ENV = "WIII_ACCEPTANCE_COMMIT_SHA"
+PUBLIC_CONNECTION_REF_PREFIX = "wcn_"
 
 SENSITIVE_EXACT_KEYS = {
     "access_token",
@@ -180,6 +181,12 @@ def redact_for_log(value: Any) -> Any:
     return value
 
 
+def is_public_connection_ref(value: Any) -> bool:
+    return isinstance(value, str) and value.strip().startswith(
+        PUBLIC_CONNECTION_REF_PREFIX,
+    )
+
+
 def opaque_ref(value: str) -> str:
     if not value:
         return "missing"
@@ -211,12 +218,14 @@ def find_action(payload: dict[str, Any], action_slug: str) -> dict[str, Any]:
 
 def first_connected_connection(payload: dict[str, Any]) -> dict[str, Any] | None:
     for connection in payload.get("connections", []):
+        connection_ref = (
+            connection.get("connection_ref") if isinstance(connection, dict) else None
+        )
         if (
             isinstance(connection, dict)
             and connection.get("active") is True
             and connection.get("state") == "connected"
-            and isinstance(connection.get("connection_ref"), str)
-            and connection.get("connection_ref")
+            and is_public_connection_ref(connection_ref)
         ):
             return connection
     return None
@@ -989,6 +998,12 @@ class WiiiConnectComposioAcceptance:
                 "No connected account selected. Run with --expect-connected after OAuth "
                 "or pass --connection-ref explicitly."
             )
+        if not is_public_connection_ref(candidate):
+            raise AcceptanceFailure(
+                "Selected connection_ref is not a Wiii opaque ref. Pass the wcn_* "
+                "value returned by the backend connection list; do not pass raw "
+                "provider connection IDs."
+            )
         return candidate
 
 
@@ -1038,11 +1053,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--connection-ref",
         default="",
         help="Opaque Wiii connection_ref selected from the backend connection list.",
-    )
-    parser.add_argument(
-        "--connection-id",
-        dest="connection_ref",
-        help=argparse.SUPPRESS,
     )
     parser.add_argument("--argument-keys", default="")
     parser.add_argument("--arguments-json", default="{}")

--- a/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
@@ -111,6 +111,7 @@ def test_first_connected_connection_requires_opaque_connection_ref() -> None:
                 "connections": [
                     {
                         "connection_id": "ca_raw_only",
+                        "connection_ref": "ca_raw_only",
                         "state": "connected",
                         "active": True,
                     }
@@ -1016,14 +1017,23 @@ def test_connection_ref_for_action_requires_selected_or_explicit_connection() ->
     assert harness.connection_ref_for_action() == "wcn_live"
 
 
-def test_parser_prefers_connection_ref_and_keeps_legacy_alias() -> None:
+def test_connection_ref_for_action_rejects_raw_provider_connection_ids() -> None:
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(connection_ref="ca_raw_provider_id", selected_connection_ref="")
+    )
+
+    with pytest.raises(acceptance.AcceptanceFailure, match="not a Wiii opaque ref"):
+        harness.connection_ref_for_action()
+
+
+def test_parser_accepts_connection_ref_and_rejects_legacy_connection_id() -> None:
     parser = acceptance.build_parser()
 
     preferred = parser.parse_args(["--connection-ref", "wcn_live"])
-    legacy = parser.parse_args(["--connection-id", "wcn_legacy"])
     help_text = parser.format_help()
 
     assert preferred.connection_ref == "wcn_live"
-    assert legacy.connection_ref == "wcn_legacy"
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--connection-id", "wcn_legacy"])
     assert "--connection-ref" in help_text
     assert "--connection-id" not in help_text


### PR DESCRIPTION
## Summary
- remove the hidden `--connection-id` alias from the Wiii Connect Composio acceptance harness
- require selected/explicit harness connection refs to be Wiii opaque `wcn_*` refs before execute/disconnect phases
- update harness tests for raw-id rejection and parser behavior
- document that operators must use `--connection-ref`, not raw provider connected-account IDs

## Scope
- live Composio acceptance harness
- focused acceptance harness tests
- Composio acceptance runbook

## Non-scope
- no live Composio enablement
- no backend API behavior changes
- no frontend UI changes
- no secrets or environment changes

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 28 passed
- `cd maritime-ai-service; python -m pytest tests/unit/api/test_wiii_connect_api.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_callback_state.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_action_catalog.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/test_wiii_connect_snapshot.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_provider_adapters.py -q --tb=short` -> 112 passed
- `cd maritime-ai-service; python -m ruff check scripts\wiii_connect_composio_acceptance.py tests\unit\test_wiii_connect_composio_acceptance.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
- Low/intentional: operator scripts still using the hidden legacy `--connection-id` alias will now fail fast. This aligns the harness with Wiii's public `connection_ref` contract.

## Rollback
- Revert this PR to restore the hidden legacy parser alias and remove the early `wcn_*` validation.

Closes #837
Related #780