### PR TITLE
Align Wiii Connect execution docs with connection_ref

### DIFF
--- a/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
+++ b/docs/architecture/wiii-connect/ADAPTER_V1_DESIGN.md
@@ -487,9 +487,10 @@ Wiii must not expose Composio's broad meta-tools directly to normal chat. The
 path governor selects the product path first. Only then may a scoped integration
 agent receive curated action schemas for the selected provider.
 
-Execution preflight and execution calls must pass an explicit Wiii connection
-id. They must not fall back to the latest stored account for a provider. This
-keeps multi-account integrations deterministic and matches the source-audited
+Execution preflight and execution calls must pass an explicit Wiii opaque
+`connection_ref` (`wcn_*`). They must not accept raw provider connected-account
+IDs or fall back to the latest stored account for a provider. This keeps
+multi-account integrations deterministic and matches the source-audited
 OpenHuman/Composio pattern where connection state is visible first, then a
 specific connected account is chosen before tools run.
 


### PR DESCRIPTION
## Summary
- replace stale Adapter V1 wording that said execution calls pass a Wiii connection id
- clarify that execution preflight/execute calls must pass an opaque `connection_ref` (`wcn_*`) and must not accept raw provider connected-account IDs

## Scope
- Wiii Connect Adapter V1 architecture wording only

## Non-scope
- no runtime code changes
- no harness changes
- no frontend changes

## Verification
- targeted stale wording search over Wiii Connect docs -> no matches
- `git diff --check` -> passed

## Risk
- Low: documentation-only alignment with the already-merged connection_ref runtime and harness contract.

## Rollback
- Revert this PR to restore the previous wording.

Closes #839
Related #780
