### PR TITLE
Support Facebook connect-only Composio acceptance

### DIFF
--- a/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
+++ b/docs/operations/WIII_CONNECT_COMPOSIO_ACCEPTANCE_RUNBOOK.md
@@ -50,6 +50,18 @@ wiii_connect_audit_ledger
 
 Do not enable write/apply/admin actions in this phase.
 
+For Facebook connection-only acceptance, include the Facebook auth config in the
+same map instead of enabling a Facebook action:
+
+```text
+composio_auth_config_map={"facebook":"<Composio Facebook auth_config_id>"}
+```
+
+Facebook currently has no curated Wiii action catalog entry. Use it to prove
+Connect Link, OAuth callback, connection listing, and disconnect only; do not
+use it to execute Facebook actions until a reviewed action, scope policy,
+preview/approval rule, and gateway test exist.
+
 ## Acceptance Sequence
 
 Run from `maritime-ai-service/`.
@@ -107,6 +119,12 @@ For local dev-login:
 python scripts/wiii_connect_composio_acceptance.py --backend-url http://localhost:8080 --auth-mode dev-login --provider gmail --print-connect-url
 ```
 
+For Facebook connection-only local dev-login:
+
+```powershell
+python scripts/wiii_connect_composio_acceptance.py --backend-url http://localhost:8080 --auth-mode dev-login --provider facebook --print-connect-url
+```
+
 For staging or production with a JWT:
 
 ```powershell
@@ -119,6 +137,12 @@ then rerun without printing the link:
 
 ```powershell
 python scripts/wiii_connect_composio_acceptance.py --backend-url http://localhost:8080 --auth-mode dev-login --provider gmail --expect-connected --require-execution-ready
+```
+
+For Facebook connection-only, rerun without execution readiness:
+
+```powershell
+python scripts/wiii_connect_composio_acceptance.py --backend-url http://localhost:8080 --auth-mode dev-login --provider facebook --expect-connected
 ```
 
 Post-OAuth acceptance does not issue a new Connect Link when
@@ -188,6 +212,12 @@ Composio is ready to enable only when all of these are true:
   missing required argument keys;
 - optional execution succeeds through `POST /api/v1/wiii-connect/providers/gmail/execute`;
 - optional disconnect disables local Wiii state and completes provider cleanup.
+
+For provider connection-only acceptance, such as Facebook before action curation,
+the execution-specific criteria above do not apply. The pass criteria are:
+adapter, storage, audit, `ready_to_connect=true`, backend-issued Connect Link,
+active connected-account listing, opaque `connection_ref`, private-account
+provider polling, and optional backend-owned disconnect.
 
 ## Failure Interpretation
 

--- a/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/scripts/wiii_connect_composio_acceptance.py
@@ -475,19 +475,20 @@ class WiiiConnectComposioAcceptance:
                 self.run_check("adapter readiness", self.check_adapter_readiness)
                 self.run_check("storage readiness", self.check_storage_readiness)
                 self.run_check("audit readiness", self.check_audit_readiness)
-                self.run_check("curated actions", self.check_curated_actions)
                 self.run_check(
                     "activation readiness connect",
                     self.check_activation_ready_to_connect,
                 )
-                self.run_check(
-                    "gateway fail-closed control",
-                    self.check_gateway_blocks_missing_connection,
-                )
+                if self.should_check_execution_policy():
+                    self.run_check("curated actions", self.check_curated_actions)
+                    self.run_check(
+                        "gateway fail-closed control",
+                        self.check_gateway_blocks_missing_connection,
+                    )
                 if self.should_issue_connect_link():
                     self.run_check("connect link preflight", self.check_connect_link)
                 self.run_check("connection listing", self.check_connections)
-                if self.args.require_execution_ready or self.args.execute_readonly:
+                if self.should_check_execution_policy():
                     self.run_check(
                         "activation readiness execution",
                         self.check_activation_ready_to_execute,
@@ -536,6 +537,11 @@ class WiiiConnectComposioAcceptance:
             or self.args.execute_readonly
             or self.args.disconnect
         )
+
+    def should_check_execution_policy(self) -> bool:
+        """Run action/gateway checks only for read-only execution acceptance."""
+
+        return bool(self.args.require_execution_ready or self.args.execute_readonly)
 
     def evidence_payload(self) -> dict[str, Any]:
         parsed_backend = urllib.parse.urlsplit(self.args.backend_url)

--- a/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_composio_acceptance.py
@@ -854,7 +854,9 @@ def test_connect_phase_run_issues_connect_link(monkeypatch) -> None:
     monkeypatch.setattr(
         harness,
         "check_curated_actions",
-        lambda: calls.append("actions") or "ok",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("connect-only acceptance should not require actions")
+        ),
     )
     monkeypatch.setattr(
         harness,
@@ -864,7 +866,9 @@ def test_connect_phase_run_issues_connect_link(monkeypatch) -> None:
     monkeypatch.setattr(
         harness,
         "check_gateway_blocks_missing_connection",
-        lambda: calls.append("gateway_block") or "ok",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("connect-only acceptance should not require execution policy")
+        ),
     )
     monkeypatch.setattr(
         harness,
@@ -880,6 +884,112 @@ def test_connect_phase_run_issues_connect_link(monkeypatch) -> None:
     assert harness.run() == 0
 
     assert "connect_link" in calls
+    assert calls == [
+        "health",
+        "auth",
+        "registry",
+        "adapter",
+        "storage",
+        "audit",
+        "connect_ready",
+        "connect_link",
+        "connections",
+    ]
+
+
+def test_facebook_connect_only_run_does_not_require_curated_actions(
+    monkeypatch,
+) -> None:
+    calls: list[str] = []
+    harness = acceptance.WiiiConnectComposioAcceptance(
+        SimpleNamespace(
+            backend_url="http://localhost:8080",
+            provider="facebook",
+            action="GMAIL_FETCH_EMAILS",
+            timeout=7.0,
+            org_id="",
+            readiness_report_only=False,
+            skip_connect_link=False,
+            expect_connected=False,
+            require_execution_ready=False,
+            execute_readonly=False,
+            disconnect=False,
+        )
+    )
+
+    monkeypatch.setattr(
+        harness,
+        "check_backend_health",
+        lambda: calls.append("health") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "authenticate",
+        lambda: calls.append("auth") or setattr(harness, "token", "token") or "auth",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_provider_registry",
+        lambda: calls.append("registry") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_adapter_readiness",
+        lambda: calls.append("adapter") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_storage_readiness",
+        lambda: calls.append("storage") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_audit_readiness",
+        lambda: calls.append("audit") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_curated_actions",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("facebook connect-only should not require an action")
+        ),
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_gateway_blocks_missing_connection",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("facebook connect-only should not check execution gateway")
+        ),
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_activation_ready_to_connect",
+        lambda: calls.append("connect_ready") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_connect_link",
+        lambda: calls.append("connect_link") or "ok",
+    )
+    monkeypatch.setattr(
+        harness,
+        "check_connections",
+        lambda: calls.append("connections") or "ok",
+    )
+
+    assert harness.run() == 0
+
+    assert calls == [
+        "health",
+        "auth",
+        "registry",
+        "adapter",
+        "storage",
+        "audit",
+        "connect_ready",
+        "connect_link",
+        "connections",
+    ]
 
 
 def test_post_oauth_run_does_not_issue_new_connect_link(monkeypatch) -> None:
@@ -975,8 +1085,8 @@ def test_post_oauth_run_does_not_issue_new_connect_link(monkeypatch) -> None:
         "adapter",
         "storage",
         "audit",
-        "actions",
         "connect_ready",
+        "actions",
         "gateway_block",
         "connections",
         "execute_ready",


### PR DESCRIPTION
## Summary
- split the Composio acceptance harness into connect-only and execution acceptance lanes
- skip curated action/gateway execution checks unless `--require-execution-ready` or `--execute-readonly` is requested
- add regression coverage for Facebook connect-only acceptance without a curated action
- document Facebook connect-only commands and explicitly keep Facebook actions disabled until reviewed policy exists

## Scope
- Wiii Connect Composio acceptance harness
- focused harness tests
- Composio acceptance runbook

## Non-scope
- no live Composio credentials or provider enablement
- no Facebook action execution
- no backend API behavior changes
- no frontend UI changes

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_composio_acceptance.py -q --tb=short` -> 29 passed
- `cd maritime-ai-service; python -m pytest tests/unit/api/test_wiii_connect_api.py tests/unit/test_wiii_connect_persistent_storage.py tests/unit/test_wiii_connect_connection_sessions.py tests/unit/test_wiii_connect_composio_acceptance.py tests/unit/test_wiii_connect_callback_state.py tests/unit/test_wiii_connect_callback_boundary.py tests/unit/test_wiii_connect_adapter_v1.py tests/unit/test_wiii_connect_action_catalog.py tests/unit/test_wiii_connect_vault_audit.py tests/unit/test_wiii_connect_snapshot.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/test_wiii_connect_provider_adapters.py -q --tb=short` -> 113 passed
- `cd maritime-ai-service; python -m ruff check scripts\wiii_connect_composio_acceptance.py tests\unit\test_wiii_connect_composio_acceptance.py --select=E9,F63,F7` -> passed
- `git diff --check` -> passed

## Risk
- Low/intentional: connect-only runs no longer prove execution gateway behavior. Operators must use `--require-execution-ready` / `--execute-readonly` for Gmail read-only execution acceptance.
- Facebook remains connection-only until a curated action, scope policy, preview/approval rule, and gateway tests exist.

## Rollback
- Revert this PR to restore the previous Gmail/action-centric harness behavior.

Closes #841
Related #780
