### PR TITLE
fix(connect): auto-sync provider connections

### DIFF
--- a/wiii-desktop/src/__tests__/wiii-connect-page.test.tsx
+++ b/wiii-desktop/src/__tests__/wiii-connect-page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildWiiiConnectProviderCallbackUrl,
@@ -310,6 +310,117 @@ describe("WiiiConnectPage", () => {
     });
     expect(screen.queryByText("secret-api-key")).toBeNull();
     expect(screen.queryByText("api_key")).toBeNull();
+    expect(screen.queryByText("access_token")).toBeNull();
+  });
+
+  it("auto-syncs backend provider connections when a provider is selected", async () => {
+    mockFetchWiiiConnectProviders.mockResolvedValue({
+      version: "wiii_connect_provider_registry.v1",
+      adapter_version: "wiii_connect_adapter.v1",
+      providers: [
+        {
+          slug: "facebook",
+          label: "Facebook",
+          provider_kind: "composio",
+          auth_mode: "oauth2",
+          enabled: true,
+          agent_ready: false,
+          category: "social",
+          description: "Facebook provider from backend registry.",
+          requirements: ["curated_action_catalog"],
+          connect_requirements: ["provider_managed_vault_ref", "durable_audit_ledger"],
+          agent_ready_requirements: ["execution_gateway"],
+          action_count: 0,
+        },
+      ],
+    });
+    mockFetchWiiiConnectProviderConnections.mockResolvedValue({
+      version: "wiii_connect_connection_list.v1",
+      status: "ready",
+      reason: "listed",
+      provider_slug: "facebook",
+      provider_kind: "composio",
+      connection_count: 1,
+      connections: [
+        {
+          version: "wiii_connect_adapter.v1",
+          connection_ref: "wcn_public_1",
+          provider_slug: "facebook",
+          state: "connected",
+          active: true,
+          scopes: { read: true, write: false },
+          vault_ref_present: true,
+          account_label: "Wiii Facebook Page",
+          external_account_ref_present: true,
+          last_checked_at: "2026-05-28T00:00:00Z",
+          reason: "provider_listed",
+          warnings: [],
+        },
+      ],
+      provider: { status: "ready", access_token: "secret-token" },
+      storage: { persistent: true },
+    });
+    mockFetchWiiiConnectProviderActivationReadiness.mockResolvedValue({
+      version: "wiii_connect_activation_readiness.v1",
+      status: "blocked",
+      provider_slug: "facebook",
+      provider_kind: "composio",
+      ready_to_connect: true,
+      ready_to_execute_readonly: false,
+      gates: [
+        {
+          key: "local_connection",
+          ready: true,
+          reason: "ready",
+          required_next: [],
+        },
+        {
+          key: "execution_gateway",
+          ready: false,
+          reason: "provider_not_agent_ready",
+          required_next: ["enable_provider_agent_policy"],
+        },
+      ],
+      connection: {
+        present: true,
+        provider_slug: "facebook",
+        state: "connected",
+        active: true,
+        scopes: { read: true },
+        vault_ref_present: true,
+        reason: "ready",
+      },
+      execution_gateway: {
+        status: "blocked",
+        reason: "provider_not_agent_ready",
+      },
+      provider: { access_token: "secret-token" },
+      storage: { persistent: true },
+    });
+
+    const { container } = render(<WiiiConnectPage />);
+
+    expect(await screen.findByText("Registry backend")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Composio/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Facebook/i }));
+
+    expect(await screen.findByText("Connection thật")).toBeTruthy();
+    expect(screen.getAllByText("Wiii Facebook Page").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Đã kết nối").length).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(mockFetchWiiiConnectProviderConnections).toHaveBeenCalledWith("facebook", {
+        probeDatabase: true,
+      });
+    });
+    await waitFor(() => {
+      expect(mockFetchWiiiConnectProviderActivationReadiness).toHaveBeenCalledWith("facebook", {
+        actionSlug: "GMAIL_FETCH_EMAILS",
+        connectionRef: "wcn_public_1",
+        probeDatabase: true,
+      });
+    });
+    expect(container.textContent).not.toContain("wcn_public_1");
+    expect(container.textContent).not.toContain("secret-token");
     expect(screen.queryByText("access_token")).toBeNull();
   });
 

--- a/wiii-desktop/src/components/connect/WiiiConnectPage.tsx
+++ b/wiii-desktop/src/components/connect/WiiiConnectPage.tsx
@@ -1678,14 +1678,29 @@ function ConnectionCatalog({
     ) {
       return;
     }
-    const state = providerReadinessStates[selectedCard.providerSlug];
-    if (state?.loading || state?.response || state?.error) return;
+    const slug = selectedCard.providerSlug;
+    const connectionState = providerConnectionLists[slug];
+    if (connectionState?.loading) return;
+    if (!connectionState?.response && !connectionState?.error) {
+      void refreshProviderConnections(selectedCard).then((response) => {
+        if (!response) void refreshActivationReadiness(selectedCard);
+      });
+      return;
+    }
+    const readinessState = providerReadinessStates[slug];
+    if (readinessState?.loading || readinessState?.response || readinessState?.error) return;
     void refreshActivationReadiness(selectedCard);
   }, [
     selectedCard?.id,
     selectedCard?.provider,
     selectedCard?.providerSlug,
     selectedCard?.registrySource,
+    providerConnectionLists[selectedCard?.providerSlug ?? ""]?.loading,
+    providerConnectionLists[selectedCard?.providerSlug ?? ""]?.response,
+    providerConnectionLists[selectedCard?.providerSlug ?? ""]?.error,
+    providerReadinessStates[selectedCard?.providerSlug ?? ""]?.loading,
+    providerReadinessStates[selectedCard?.providerSlug ?? ""]?.response,
+    providerReadinessStates[selectedCard?.providerSlug ?? ""]?.error,
   ]);
 
   const requestSessionDecision = async (card: CatalogCard) => {


### PR DESCRIPTION
## Summary
- Auto-refresh backend provider connection lists when a Wiii Connect catalog card is selected.
- Defer activation readiness until the connection list refresh completes, so readiness probes use the selected opaque connection ref instead of an empty ref.
- Add focused coverage that Facebook renders as connected without manual refresh while keeping connection refs and token-like payloads out of the DOM.

Fixes #843.

## Scope
- `wiii-desktop/src/components/connect/WiiiConnectPage.tsx`
- `wiii-desktop/src/__tests__/wiii-connect-page.test.tsx`

## Non-Scope
- No backend OAuth/Composio changes.
- No provider action execution enablement.
- No Facebook write/post flow.
- No secrets, environment files, migrations, or generated assets.

## Verification
- `cd wiii-desktop; npx vitest run src/__tests__/wiii-connect-page.test.tsx` -> passed, 8 tests.
- `cd wiii-desktop; npx tsc --noEmit` -> passed.
- `git diff --check` -> passed.
- Browser smoke against local backend/frontend -> selected Composio/Facebook without clicking refresh; UI requested `/providers/facebook/connections`, then readiness with the opaque connection ref, with 0 empty-ref readiness requests. Facebook catalog card rendered `Đã kết nối`.

## Visual Evidence
- Browser smoke used Playwright DOM/network verification instead of a committed screenshot because the visual change is a state label refresh and local screenshots are temporary artifacts.

## Risk
- Frontend-only state timing change. Main risk is extra provider status requests or stale readiness after a provider selection.
- Action execution remains fail-closed; this does not enable Facebook posting or provider mutations.

## Rollback
- Revert this PR to restore manual-refresh-only provider connection state. Backend connection records, Composio OAuth state, and database schema are unaffected.

## Reviewer Focus
- Confirm the effect cannot loop and does not issue readiness before connection refresh finishes.
- Confirm no provider secrets, connection refs, or authorization URLs render in the Wiii Connect page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backend provider connections now automatically synchronize when a provider is selected, with improved coordination of connection and readiness status data retrieval for more efficient and reliable operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->