### PR TITLE
fix(connect): reflect provider execution readiness

### DIFF
--- a/wiii-desktop/src/__tests__/wiii-connect-page.test.tsx
+++ b/wiii-desktop/src/__tests__/wiii-connect-page.test.tsx
@@ -424,6 +424,122 @@ describe("WiiiConnectPage", () => {
     expect(screen.queryByText("access_token")).toBeNull();
   });
 
+  it("reflects backend read-only execution readiness on provider cards", async () => {
+    mockFetchWiiiConnectProviders.mockResolvedValue({
+      version: "wiii_connect_provider_registry.v1",
+      adapter_version: "wiii_connect_adapter.v1",
+      providers: [
+        {
+          slug: "gmail",
+          label: "Gmail",
+          provider_kind: "composio",
+          auth_mode: "oauth2",
+          enabled: true,
+          agent_ready: false,
+          category: "productivity",
+          description: "Gmail provider from backend registry.",
+          requirements: ["scope_policy", "execution_gateway"],
+          connect_requirements: ["provider_managed_vault_ref"],
+          agent_ready_requirements: ["curated_readonly_action", "execution_gateway"],
+          action_count: 0,
+        },
+      ],
+    });
+    mockFetchWiiiConnectProviderConnections.mockResolvedValue({
+      version: "wiii_connect_connection_list.v1",
+      status: "ready",
+      reason: "listed",
+      provider_slug: "gmail",
+      provider_kind: "composio",
+      connection_count: 1,
+      connections: [
+        {
+          version: "wiii_connect_adapter.v1",
+          connection_ref: "wcn_live_gmail_1",
+          provider_slug: "gmail",
+          state: "connected",
+          active: true,
+          scopes: { read: true, write: false },
+          vault_ref_present: true,
+          account_label: "Wiii Gmail Account",
+          external_account_ref_present: true,
+          last_checked_at: "2026-05-28T00:00:00Z",
+          reason: "provider_listed",
+          warnings: [],
+        },
+      ],
+      provider: { status: "ready", refresh_token: "secret-refresh-token" },
+      storage: { persistent: true },
+    });
+    mockFetchWiiiConnectProviderActivationReadiness.mockResolvedValue({
+      version: "wiii_connect_activation_readiness.v1",
+      status: "ready",
+      provider_slug: "gmail",
+      provider_kind: "composio",
+      ready_to_connect: true,
+      ready_to_execute_readonly: true,
+      gates: [
+        {
+          key: "local_connection",
+          ready: true,
+          reason: "ready",
+          required_next: [],
+        },
+        {
+          key: "curated_readonly_action",
+          ready: true,
+          reason: "ready",
+          required_next: [],
+        },
+        {
+          key: "execution_gateway",
+          ready: true,
+          reason: "allowed",
+          required_next: [],
+        },
+      ],
+      action: {
+        action_slug: "GMAIL_FETCH_EMAILS",
+        api_key: "secret-action-key",
+      },
+      connection: {
+        present: true,
+        provider_slug: "gmail",
+        state: "connected",
+        active: true,
+        scopes: { read: true },
+        vault_ref_present: true,
+        reason: "ready",
+      },
+      execution_gateway: {
+        status: "allowed",
+        reason: "readonly_action_allowed",
+      },
+      provider: { refresh_token: "secret-refresh-token" },
+      storage: { persistent: true },
+    });
+
+    const { container } = render(<WiiiConnectPage />);
+
+    expect(await screen.findByText("Registry backend")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Composio/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Gmail/i }));
+
+    expect(await screen.findByText("Read-only sẵn sàng")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Read-only action đã qua scope policy và execution gateway; mutation/write vẫn bị chặn ngoài allowlist.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getAllByText("allowed").length).toBeGreaterThan(0);
+    expect(container.textContent?.replace(/\s+/g, "")).toContain("Agent-readyCó");
+    expect(container.textContent).not.toContain("wcn_live_gmail_1");
+    expect(container.textContent).not.toContain("secret-refresh-token");
+    expect(container.textContent).not.toContain("secret-action-key");
+    expect(screen.queryByText("refresh_token")).toBeNull();
+    expect(screen.queryByText("api_key")).toBeNull();
+  });
+
   it("requests backend session decision for backend registry providers", async () => {
     mockFetchWiiiConnectProviders.mockResolvedValue({
       version: "wiii_connect_provider_registry.v1",

--- a/wiii-desktop/src/components/connect/WiiiConnectPage.tsx
+++ b/wiii-desktop/src/components/connect/WiiiConnectPage.tsx
@@ -926,6 +926,7 @@ function buildNativeCatalogCards(
 function buildExternalCatalogCards(
   providerRegistry: WiiiConnectProviderRegistryEntry[] | null,
   providerConnectionLists: Record<string, ProviderConnectionListState> = {},
+  providerReadinessStates: Record<string, ProviderActivationReadinessState> = {},
 ): CatalogCard[] {
   const definitions =
     registryEntriesToExternalDefinitions(providerRegistry) ?? externalCatalogDefinitions;
@@ -940,7 +941,10 @@ function buildExternalCatalogCards(
       : connectionResponse?.status === "blocked"
         ? "Bị chặn"
         : "Chưa nối";
+    const readiness = providerReadinessStates[definition.id]?.response;
+    const agentReady = Boolean(readiness?.ready_to_execute_readonly);
     const reason = connectionResponse?.reason;
+    const statusDetail = externalAgentStatusDetail(fromBackend, readiness);
     return {
       id: `${definition.provider}-${definition.id}`,
       providerSlug: definition.id,
@@ -953,29 +957,26 @@ function buildExternalCatalogCards(
       icon: definition.icon,
       tone,
       status: connectionStatus,
-      statusDetail: fromBackend
-        ? "Backend registry đã khai báo provider này; agent action vẫn bị khóa cho đến khi có scope, policy và audit."
-        : "Wiii chưa có adapter, vault và permission gate cho kết nối này.",
-      agentReady: false,
+      statusDetail,
+      agentReady,
       connected: tone === "ok",
       registrySource: definition.source ?? "local",
       detailRows: [
         ["Provider", providerKindLabels[definition.provider] ?? definition.provider],
         ["Nguồn", fromBackend ? "Backend registry" : "Local fallback"],
         ["Auth", compactText(definition.authMode, "Chưa khai báo")],
-        ["Action", definition.actionCount != null ? `${definition.actionCount}` : "Chưa khai báo"],
+        ["Action", externalActionSummary(readiness, definition.actionCount)],
         ["Trạng thái", connectionStatus],
         ["Account", providerConnectionSummary(providerConnection)],
         ["Vault ref", providerConnection?.vault_ref_present ? "Có" : "Chưa"],
         ["Scope", providerConnection ? scopeSummary(providerConnection.scopes) : "Chưa"],
-        ["Agent-ready", "Chưa"],
-        ["Mutation", "Bị chặn cho đến khi có curated action và execution gateway"],
+        ["Agent-ready", agentReady ? "Có" : "Chưa"],
+        ["Gateway", readinessGatewayStatus(readiness)],
+        ["Mutation", "Write vẫn bị chặn ngoài allowlist"],
         ...(reason ? ([["Lý do", compactText(reason)]] as Array<[string, string]>) : []),
       ],
       requirements: definition.requirements,
-      disabledReason: fromBackend
-        ? "Provider có trong registry backend. Kết nối account được phép khi backend cấp URL; action vẫn fail-closed."
-        : "Cần thiết kế adapter/vault/policy trước khi bật Connect.",
+      disabledReason: fromBackend ? statusDetail : "Cần thiết kế adapter/vault/policy trước khi bật Connect.",
     };
   });
 }
@@ -985,10 +986,11 @@ function buildConnectionCatalogCards(
   fallbackModel: CapabilityStatusViewModel,
   providerRegistry: WiiiConnectProviderRegistryEntry[] | null,
   providerConnectionLists: Record<string, ProviderConnectionListState> = {},
+  providerReadinessStates: Record<string, ProviderActivationReadinessState> = {},
 ): CatalogCard[] {
   return [
     ...buildNativeCatalogCards(snapshot, fallbackModel),
-    ...buildExternalCatalogCards(providerRegistry, providerConnectionLists),
+    ...buildExternalCatalogCards(providerRegistry, providerConnectionLists, providerReadinessStates),
   ];
 }
 
@@ -1045,6 +1047,52 @@ function activationReadinessTone(
 
 function readinessBooleanLabel(value: boolean | undefined): string {
   return value ? "Sẵn sàng" : "Chưa sẵn sàng";
+}
+
+function readinessGateReady(
+  readiness: WiiiConnectActivationReadinessResponse | undefined,
+  key: string,
+): boolean {
+  return Boolean(readiness?.gates?.some((gate) => gate.key === key && gate.ready));
+}
+
+function readinessGatewayStatus(
+  readiness: WiiiConnectActivationReadinessResponse | undefined,
+): string {
+  return compactText(readiness?.execution_gateway?.status, "Chưa đánh giá");
+}
+
+function externalActionSummary(
+  readiness: WiiiConnectActivationReadinessResponse | undefined,
+  actionCount: number | undefined,
+): string {
+  if (readiness?.ready_to_execute_readonly || readinessGateReady(readiness, "curated_readonly_action")) {
+    return "Read-only sẵn sàng";
+  }
+  if (actionCount != null) return `${actionCount}`;
+  return "Chưa khai báo";
+}
+
+function externalAgentStatusDetail(
+  fromBackend: boolean,
+  readiness: WiiiConnectActivationReadinessResponse | undefined,
+): string {
+  if (!fromBackend) {
+    return "Wiii chưa có adapter, vault và permission gate cho kết nối này.";
+  }
+  if (readiness?.ready_to_execute_readonly) {
+    return "Read-only action đã qua scope policy và execution gateway; mutation/write vẫn bị chặn ngoài allowlist.";
+  }
+  if (readiness?.ready_to_connect) {
+    return "Backend đã sẵn sàng cấp Connect Link; agent action vẫn chờ account, scope policy và execution gateway.";
+  }
+  return "Backend registry đã khai báo provider này; agent action vẫn bị khóa cho đến khi có scope, policy và audit.";
+}
+
+function externalControlLabel(card: CatalogCard): string {
+  if (card.agentReady) return "Read-only";
+  if (card.connected) return "Chờ policy";
+  return "Fail-closed";
 }
 
 function readinessGateLabel(key: string): string {
@@ -1607,8 +1655,15 @@ function ConnectionCatalog({
   }, []);
 
   const cards = useMemo(
-    () => buildConnectionCatalogCards(snapshot, fallbackModel, providerRegistry, providerConnectionLists),
-    [snapshot, fallbackModel, providerRegistry, providerConnectionLists],
+    () =>
+      buildConnectionCatalogCards(
+        snapshot,
+        fallbackModel,
+        providerRegistry,
+        providerConnectionLists,
+        providerReadinessStates,
+      ),
+    [snapshot, fallbackModel, providerRegistry, providerConnectionLists, providerReadinessStates],
   );
 
   const normalizedQuery = query.trim().toLowerCase();
@@ -2015,7 +2070,7 @@ function ConnectionCatalog({
                   <div className="min-w-0 rounded-md bg-surface-secondary px-2 py-2">
                     <div className="text-text-tertiary">Điều khiển</div>
                     <div className="mt-0.5 truncate font-medium text-text">
-                      {card.connected ? "Theo policy" : "Fail-closed"}
+                      {externalControlLabel(card)}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
Wiii Connect provider cards now reflect backend activation readiness instead of only registry/connection-list state. When activation readiness reports `ready_to_execute_readonly=true`, the selected provider surface shows agent read-only readiness, gateway state, and read-only action availability while keeping mutation/write fail-closed outside the allowlist.

## Linked Work
Refs #847

## Naming and Traceability

- Branch name: `codex/847-fix-connect-execution-ready-ui`
- Branch follows `docs/operations/WIII_GITHUB_GOVERNANCE.md`: yes
- PR title follows Conventional Commit style and is suitable for squash merge: yes
- Issue id is present in branch name or documented reason for exception: yes, #847

## Scope

- In scope: Wiii Connect catalog/detail readiness derivation for backend providers; focused frontend test coverage for read-only execution readiness and secret/ref redaction.
- Out of scope: backend Composio policy, OAuth setup, vault storage, LMS mutation paths, provider registry contents.

## Ownership and Coordination

- PR owner: Codex
- Agents involved: Codex
- Owned paths: `wiii-desktop/src/components/connect/WiiiConnectPage.tsx`, `wiii-desktop/src/__tests__/wiii-connect-page.test.tsx`
- Out-of-scope paths: backend runtime, docs, generated build output
- Conflict risk: low; scoped frontend state projection
- Merge decision owner: maintainer/admin

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation/governance
- [ ] Test-only
- [ ] Build/CI/dependency
- [ ] Security/auth/privacy
- [ ] Database/migration
- [ ] Breaking change

## Risk Checklist

- [x] No unrelated dirty worktree changes were staged.
- [x] No secrets, tokens, private data, or local-only files are committed.
- [x] PR is within the reviewability gate, or a maintainer-approved bypass rationale is documented.
- [x] Multi-agent file ownership was declared when more than one agent contributed.
- [x] CodeRabbit findings are resolved, deferred with rationale, or explicitly not applicable.
- [x] Codex Review was requested for high-risk changes, or explicitly marked not required with rationale.
- [x] Auth, tenant isolation, memory, and user identity behavior were considered.
- [x] Feature flags and default behavior were considered.
- [x] Database migrations are included or explicitly not required.
- [x] Rollback path is clear.

## Verification

```text
Command: cd wiii-desktop; npx vitest run src/__tests__/wiii-connect-page.test.tsx
Result: passed, 1 file / 9 tests
```

```text
Command: cd wiii-desktop; npx tsc --noEmit
Result: passed
```

```text
Command: cd wiii-desktop; npm run build:embed
Result: passed; Vite emitted existing chunk-size/dynamic-import warnings
```

```text
Command: git diff --check
Result: passed
```

```text
Command: Playwright browser smoke against http://127.0.0.1:1420 with Wiii Connect provider/readiness routes mocked to `ready_to_execute_readonly=true`
Result: passed; card/detail showed account, Agent-ready, read-only readiness, gateway allowed; no `wcn_*` refs or token/secret markers rendered; console errors 0
```

## UI Evidence

Browser smoke on localhost verified the Wiii Connect Gmail card/detail renders connected account, Agent-ready/read-only readiness, gateway allowed, and redacts connection refs/secrets. A screenshot is not attached because the check used deterministic Playwright assertions against the rendered DOM.

## Deployment Notes

- Environment/config changes: none
- Migration/backfill steps: none
- Monitoring/logs to watch: Wiii Connect provider card/detail copy; ensure connected providers no longer show stale `Agent-ready Chưa` when activation readiness is read-only ready
- Rollback: revert this PR; backend activation readiness behavior is unchanged

## Reviewer Focus

- Critical paths: `buildExternalCatalogCards` readiness derivation, selected provider detail rows, redaction expectations
- Edge cases: connected account but gateway blocked; connect-ready but no account; local fallback providers
- Known limitations: live local backend may still show fail-closed if the active dev user has no provider connection
- Codex Review focus: frontend state projection only; no backend auth/vault mutation in this PR