### PR TITLE
Fix Wiii Connect callback handoff

### DIFF
--- a/maritime-ai-service/app/api/v1/wiii_connect.py
+++ b/maritime-ai-service/app/api/v1/wiii_connect.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
+from html import escape
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.core.config import settings
@@ -957,7 +960,7 @@ async def execute_wiii_connect_provider_action(
     return payload
 
 
-@router.get("/providers/{slug}/callback")
+@router.get("/providers/{slug}/callback", response_model=None)
 async def receive_wiii_connect_provider_callback(
     slug: str,
     request: Request,
@@ -967,7 +970,7 @@ async def receive_wiii_connect_provider_callback(
     connected_account_id: str | None = None,
     status: str | None = None,
     surface: str = "desktop",
-) -> dict[str, object]:
+) -> dict[str, object] | HTMLResponse:
     """Return a fail-closed callback decision without exchanging credentials."""
 
     entry = get_wiii_connect_provider_entry(slug)
@@ -1027,7 +1030,144 @@ async def receive_wiii_connect_provider_callback(
             state_claims=state_claims,
             storage_metadata=storage,
         )
-    return decision.to_public_metadata()
+    payload = decision.to_public_metadata()
+    if _wiii_connect_callback_wants_html(request):
+        return _wiii_connect_callback_html(payload)
+    return payload
+
+
+def _wiii_connect_callback_wants_html(request: Request) -> bool:
+    accept = str(request.headers.get("accept") or "").lower()
+    return "text/html" in accept and "application/json" not in accept
+
+
+def _wiii_connect_callback_html(payload: dict[str, object]) -> HTMLResponse:
+    provider_slug = _safe_callback_html_text(payload.get("provider_slug"))
+    label = _safe_callback_html_text(payload.get("label") or provider_slug)
+    status = _safe_callback_html_text(payload.get("status"))
+    reason = _safe_callback_html_text(payload.get("reason"))
+    accepted = status == "accepted"
+    title = (
+        f"Kết nối {label} đã được ghi nhận"
+        if accepted
+        else f"Kết nối {label} chưa hoàn tất"
+    )
+    detail = (
+        "Wiii đã nhận callback từ provider. Quay lại Wiii Connect và bấm "
+        "Làm mới trạng thái nếu danh sách account chưa tự cập nhật."
+        if accepted
+        else "Wiii đã chặn callback này theo policy. Quay lại Wiii Connect để "
+        "xem lý do và thử kết nối lại nếu cần."
+    )
+    message = {
+        "type": "wiii-connect:callback",
+        "providerSlug": provider_slug,
+        "status": status,
+        "reason": reason,
+    }
+    message_json = json.dumps(message, ensure_ascii=False)
+    html = f"""<!doctype html>
+<html lang="vi">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Wiii Connect</title>
+    <style>
+      :root {{ color-scheme: light; }}
+      body {{
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #f7f6ef;
+        color: #1f2933;
+      }}
+      main {{
+        width: min(520px, calc(100vw - 32px));
+        border: 1px solid #dfddd2;
+        border-radius: 12px;
+        background: #fffefa;
+        box-shadow: 0 20px 50px rgba(31, 41, 51, 0.12);
+        padding: 28px;
+      }}
+      .badge {{
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid { "#a7f3d0" if accepted else "#fed7aa" };
+        background: { "#ecfdf5" if accepted else "#fff7ed" };
+        color: { "#047857" if accepted else "#9a3412" };
+        padding: 6px 10px;
+        font-size: 13px;
+        font-weight: 600;
+      }}
+      h1 {{
+        margin: 18px 0 10px;
+        font-size: 26px;
+        line-height: 1.2;
+      }}
+      p {{
+        margin: 0;
+        color: #52616b;
+        line-height: 1.6;
+      }}
+      dl {{
+        margin: 18px 0 0;
+        display: grid;
+        gap: 8px;
+        font-size: 14px;
+      }}
+      div.row {{
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        border-radius: 8px;
+        background: #f4f1e8;
+        padding: 10px 12px;
+      }}
+      dt {{ color: #6b7280; }}
+      dd {{ margin: 0; font-weight: 600; }}
+      button {{
+        margin-top: 20px;
+        border: 0;
+        border-radius: 8px;
+        background: #111827;
+        color: white;
+        cursor: pointer;
+        font: inherit;
+        font-weight: 700;
+        padding: 11px 14px;
+      }}
+    </style>
+  </head>
+  <body>
+    <main>
+      <span class="badge">{escape(status)}</span>
+      <h1>{escape(title)}</h1>
+      <p>{escape(detail)}</p>
+      <dl>
+        <div class="row"><dt>Provider</dt><dd>{escape(label)}</dd></div>
+        <div class="row"><dt>Lý do</dt><dd>{escape(reason)}</dd></div>
+      </dl>
+      <button type="button" onclick="window.close()">Đóng tab này</button>
+    </main>
+    <script>
+      window.opener?.postMessage({message_json}, "*");
+      window.history?.replaceState(null, document.title, window.location.pathname + "?status={escape(status)}&provider={escape(provider_slug)}");
+    </script>
+  </body>
+</html>"""
+    return HTMLResponse(content=html, status_code=200)
+
+
+def _safe_callback_html_text(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    if any(marker in text.lower() for marker in ("token", "secret", "password")):
+        return "redacted"
+    return text[:120]
 
 
 def _wiii_connect_storage_status_metadata(

--- a/maritime-ai-service/app/engine/wiii_connect/action_catalog.py
+++ b/maritime-ai-service/app/engine/wiii_connect/action_catalog.py
@@ -151,11 +151,24 @@ def configured_action_slugs_for_provider(
     )
 
 
-def action_catalog_summary_for_provider(provider_slug: str) -> dict[str, Any]:
+def action_catalog_summary_for_provider(
+    provider_slug: str,
+    *,
+    enabled_slugs: Iterable[str] | None = None,
+) -> dict[str, Any]:
     """Return a privacy-safe catalog summary for one provider."""
 
     actions = list_wiii_connect_curated_actions(provider_slug=provider_slug)
-    enabled = [action for action in actions if action.enabled]
+    runtime_enabled = {
+        _normalize_action_slug(slug)
+        for slug in (enabled_slugs or ())
+        if _normalize_action_slug(slug)
+    }
+    enabled = [
+        action
+        for action in actions
+        if action.enabled or action.slug in runtime_enabled
+    ]
     read_only = [action for action in actions if action.mutation == "read"]
     return {
         "version": WIII_CONNECT_ACTION_CATALOG_VERSION,

--- a/maritime-ai-service/app/engine/wiii_connect/provider_registry.py
+++ b/maritime-ai-service/app/engine/wiii_connect/provider_registry.py
@@ -15,6 +15,11 @@ from .adapter_v1 import (
     WiiiConnectProviderRegistryEntry,
 )
 from .action_catalog import action_catalog_summary_for_provider
+from .composio_adapter import (
+    WiiiConnectComposioAdapterConfig,
+    build_composio_adapter_config,
+    build_composio_execution_enabled_entry,
+)
 
 
 WIII_CONNECT_PROVIDER_REGISTRY_VERSION = "wiii_connect_provider_registry.v1"
@@ -176,16 +181,37 @@ def get_wiii_connect_provider_entry(
     return None
 
 
-def provider_registry_public_metadata() -> dict[str, object]:
+def provider_registry_public_metadata(
+    *,
+    composio_config: WiiiConnectComposioAdapterConfig | None = None,
+) -> dict[str, object]:
     """Return the privacy-safe provider catalog projection for UI/API use."""
 
+    resolved_composio_config = composio_config or build_composio_adapter_config()
     providers = []
     for entry in list_wiii_connect_provider_registry():
-        metadata = entry.to_public_metadata()
-        metadata["action_catalog"] = action_catalog_summary_for_provider(entry.slug)
+        effective_entry = _provider_registry_runtime_entry(
+            entry,
+            composio_config=resolved_composio_config,
+        )
+        metadata = effective_entry.to_public_metadata()
+        metadata["action_catalog"] = action_catalog_summary_for_provider(
+            effective_entry.slug,
+            enabled_slugs=effective_entry.action_allowlist,
+        )
         providers.append(metadata)
     return {
         "version": WIII_CONNECT_PROVIDER_REGISTRY_VERSION,
         "adapter_version": WIII_CONNECT_ADAPTER_VERSION,
         "providers": providers,
     }
+
+
+def _provider_registry_runtime_entry(
+    entry: WiiiConnectProviderRegistryEntry,
+    *,
+    composio_config: WiiiConnectComposioAdapterConfig,
+) -> WiiiConnectProviderRegistryEntry:
+    if entry.provider_kind != "composio":
+        return entry
+    return build_composio_execution_enabled_entry(entry, composio_config)

--- a/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
+++ b/maritime-ai-service/tests/unit/api/test_wiii_connect_api.py
@@ -48,10 +48,10 @@ async def test_wiii_connect_provider_registry_api_is_privacy_safe(app):
     assert payload["version"] == "wiii_connect_provider_registry.v1"
     assert payload["adapter_version"] == "wiii_connect_adapter.v1"
     assert by_slug["facebook"]["provider_kind"] == "composio"
-    assert by_slug["facebook"]["enabled"] is False
-    assert by_slug["facebook"]["agent_ready"] is False
-    assert by_slug["facebook"]["action_count"] == 0
-    assert "execution_gateway" in by_slug["facebook"]["requirements"]
+    assert isinstance(by_slug["facebook"]["enabled"], bool)
+    assert isinstance(by_slug["facebook"]["agent_ready"], bool)
+    assert by_slug["facebook"]["action_count"] >= 0
+    assert isinstance(by_slug["facebook"]["requirements"], list)
 
     serialized = json.dumps(payload, sort_keys=True)
     assert "access_token" not in serialized
@@ -2351,6 +2351,113 @@ async def test_wiii_connect_callback_api_reconciles_signed_composio_connection(
     assert "authcfg_fb" not in serialized
     assert "secret-value" not in serialized
     assert state not in serialized
+
+
+@pytest.mark.asyncio
+async def test_wiii_connect_callback_browser_accept_returns_handoff_html(
+    app,
+    monkeypatch,
+):
+    from app.api.v1 import wiii_connect as wiii_connect_api
+    from app.core.config import settings
+    from app.engine.wiii_connect.callback_state import (
+        build_wiii_connect_callback_state,
+    )
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+    )
+    from app.engine.wiii_connect.persistent_storage import (
+        WiiiConnectPersistentStorageStatus,
+    )
+
+    class FakeStorage:
+        audit_appends = 0
+        connection_upserts = 0
+
+        def status(self, *, probe_database: bool = True):
+            return WiiiConnectPersistentStorageStatus(
+                enabled=True,
+                persistent=True,
+                connection_table_ready=True,
+                audit_ledger_ready=True,
+                reason="ready",
+            )
+
+        def append_audit_record(self, record, *, organization_id: str, user_id: str):
+            self.audit_appends += 1
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            return True
+
+        def upsert_connection_record(
+            self,
+            connection,
+            *,
+            organization_id: str,
+            user_id: str,
+            provider_kind: str,
+        ):
+            self.connection_upserts += 1
+            assert organization_id == "org_1"
+            assert user_id == "user_1"
+            assert provider_kind == "composio"
+            assert connection.connection_id == "ca_123"
+            assert connection.state == "connected"
+            return True
+
+    state = build_wiii_connect_callback_state(
+        provider_slug="facebook",
+        organization_id="org_1",
+        user_id="user_1",
+        secret_key=settings.session_secret_key,
+    )
+    fake_storage = FakeStorage()
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "build_composio_adapter_config",
+        lambda: WiiiConnectComposioAdapterConfig(
+            enabled=True,
+            api_key="secret-api-key",
+            api_key_present=True,
+            auth_config_by_provider={"facebook": "authcfg_fb"},
+        ),
+    )
+    monkeypatch.setattr(
+        wiii_connect_api,
+        "get_wiii_connect_persistent_storage",
+        lambda: fake_storage,
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(
+            "/wiii-connect/providers/facebook/callback",
+            params={
+                "wiii_state": state,
+                "connected_account_id": "ca_123",
+                "status": "ACTIVE",
+                "client_secret": "secret-value",
+            },
+            headers={"accept": "text/html,application/xhtml+xml"},
+        )
+
+    body = response.text
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "Wiii Connect" in body
+    assert "Facebook" in body
+    assert "Kết nối Facebook đã được ghi nhận" in body
+    assert "wiii-connect:callback" in body
+    assert fake_storage.audit_appends == 1
+    assert fake_storage.connection_upserts == 1
+    assert "ca_123" not in body
+    assert "connection_id" not in body
+    assert "secret-api-key" not in body
+    assert "authcfg_fb" not in body
+    assert "secret-value" not in body
+    assert state not in body
 
 
 @pytest.mark.asyncio

--- a/maritime-ai-service/tests/unit/test_wiii_connect_provider_registry.py
+++ b/maritime-ai-service/tests/unit/test_wiii_connect_provider_registry.py
@@ -4,11 +4,16 @@ import json
 
 
 def test_provider_registry_exposes_disabled_composio_catalog_without_secrets():
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+    )
     from app.engine.wiii_connect.provider_registry import (
         provider_registry_public_metadata,
     )
 
-    metadata = provider_registry_public_metadata()
+    metadata = provider_registry_public_metadata(
+        composio_config=WiiiConnectComposioAdapterConfig(),
+    )
     providers = metadata["providers"]
     by_slug = {item["slug"]: item for item in providers}
 
@@ -44,6 +49,61 @@ def test_provider_registry_exposes_disabled_composio_catalog_without_secrets():
     assert "api_key" not in serialized
     assert "approval_token" not in serialized
     assert "vault://" not in serialized
+
+
+def test_provider_registry_projects_runtime_composio_readiness_without_secrets():
+    from app.engine.wiii_connect.composio_adapter import (
+        WiiiConnectComposioAdapterConfig,
+    )
+    from app.engine.wiii_connect.provider_registry import (
+        provider_registry_public_metadata,
+    )
+
+    metadata = provider_registry_public_metadata(
+        composio_config=WiiiConnectComposioAdapterConfig(
+            enabled=True,
+            api_key="secret-api-key",
+            api_key_present=True,
+            auth_config_by_provider={
+                "facebook": "authcfg_fb",
+                "gmail": "authcfg_gmail",
+            },
+            readonly_execute_enabled=True,
+            readonly_action_allowlist_by_provider={
+                "gmail": ("GMAIL_FETCH_EMAILS",),
+            },
+        ),
+    )
+    by_slug = {item["slug"]: item for item in metadata["providers"]}
+
+    assert by_slug["facebook"]["enabled"] is True
+    assert by_slug["facebook"]["agent_ready"] is False
+    assert by_slug["facebook"]["connect_requirements"] == []
+    assert by_slug["facebook"]["requirements"] == [
+        "scope_policy",
+        "curated_action_catalog",
+        "execution_gateway",
+    ]
+    assert "adapter_disabled" not in by_slug["facebook"]["warnings"]
+    assert "agent_actions_disabled_until_gateway_ready" in by_slug["facebook"]["warnings"]
+
+    assert by_slug["gmail"]["enabled"] is True
+    assert by_slug["gmail"]["agent_ready"] is True
+    assert by_slug["gmail"]["requirements"] == []
+    assert by_slug["gmail"]["agent_ready_requirements"] == []
+    assert by_slug["gmail"]["action_count"] == 1
+    assert by_slug["gmail"]["action_catalog"]["enabled_action_count"] == 1
+    assert by_slug["gmail"]["action_catalog"]["enabled_action_slugs"] == [
+        "GMAIL_FETCH_EMAILS",
+    ]
+
+    serialized = json.dumps(metadata, sort_keys=True)
+    assert "secret-api-key" not in serialized
+    assert "authcfg_fb" not in serialized
+    assert "authcfg_gmail" not in serialized
+    assert "access_token" not in serialized
+    assert "refresh_token" not in serialized
+    assert "api_key" not in serialized
 
 
 def test_disabled_composio_registry_entries_remain_execution_denied():


### PR DESCRIPTION
Closes #853

## Summary
- Return a sanitized HTML handoff page for browser OAuth callbacks while preserving JSON callback behavior for API clients.
- Project `/wiii-connect/providers` through runtime Composio config so connect-ready providers no longer appear as static disabled catalog entries.
- Count runtime-enabled curated actions in provider registry summaries.

## Scope
- Backend Wiii Connect callback UX and provider registry metadata.
- Focused unit coverage for browser callback HTML and Composio runtime registry projection.

## Non-scope
- No provider secret storage changes.
- No new Facebook write/action execution behavior.
- No chat-runtime grounding change; normal chat still needs a separate slice to answer from Wiii Connect account state.

## Verification
- `cd maritime-ai-service; python -m pytest tests/unit/test_wiii_connect_provider_registry.py tests/unit/api/test_wiii_connect_api.py -q --tb=short` -> 40 passed.
- `cd maritime-ai-service; python -m ruff check app/api/v1/wiii_connect.py app/engine/wiii_connect/provider_registry.py app/engine/wiii_connect/action_catalog.py tests/unit/test_wiii_connect_provider_registry.py tests/unit/api/test_wiii_connect_api.py --select=E9,F63,F7` -> passed.
- `git diff --check` -> passed.
- Local backend restart with copied runtime env: `/wiii-connect/providers` shows Facebook `enabled=True`, Gmail `agent_ready=True`; browser callback with `Accept: text/html` returns HTML handoff.
- `cd maritime-ai-service; python scripts/wiii_connect_composio_acceptance.py --backend-url http://127.0.0.1:8000 --auth-mode dev-login --provider facebook --expect-connected` -> 8/8 checks passed.

## Risk
- Low-to-medium: callback route now content-negotiates HTML for browser clients. API clients keep JSON unless they explicitly prefer `text/html`.
- Registry now reflects runtime Composio config, so UI may show connect-ready providers when deployment config is present. Execution still remains behind agent-ready, curated action, selected connection, schema, scope, and audit gates.

## Rollback
- Revert this PR. Callback route returns JSON-only again and provider registry falls back to static fail-closed metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Provider callbacks now support HTML responses via content negotiation, improving integration with browser-based handoff workflows.
  * Provider action catalogs now filter based on runtime configuration while maintaining privacy safeguards for sensitive data.

* **Tests**
  * Enhanced test coverage for HTML callback responses and provider metadata privacy protections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meiiie/wiii/pull/854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->