### PR TITLE
Harden live lookup tool UX and source contracts

### DIFF
--- a/maritime-ai-service/app/engine/multi_agent/direct_final_synthesis_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_final_synthesis_runtime.py
@@ -47,6 +47,10 @@ _LIVE_LOOKUP_TOOL_NAMES = {
     "web_search",
     "tool_search_news",
     "search_news",
+    "tool_search_legal",
+    "search_legal",
+    "tool_search_maritime",
+    "search_maritime",
     "tool_fetch_url",
     "fetch_url",
     "tool_current_datetime",
@@ -58,7 +62,7 @@ _LIVE_LOOKUP_TOOL_NAMES = {
 
 def _has_live_lookup_tool(tool_names: list[str]) -> bool:
     return any(
-        str(name or "").strip() in _LIVE_LOOKUP_TOOL_NAMES
+        str(name or "").strip().lower() in _LIVE_LOOKUP_TOOL_NAMES
         for name in tool_names
     )
 

--- a/maritime-ai-service/app/engine/multi_agent/direct_final_synthesis_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_final_synthesis_runtime.py
@@ -14,6 +14,7 @@ from app.engine.multi_agent.direct_reasoning import (
     _infer_direct_thinking_mode,
 )
 from app.engine.multi_agent.direct_tool_message_runtime import (
+    build_system_instruction_message,
     build_user_instruction_message,
 )
 from app.engine.multi_agent.state import AgentState
@@ -41,6 +42,48 @@ def extract_direct_visible_text(content: Any) -> str:
         return str(content or "").strip()
 
 
+_LIVE_LOOKUP_TOOL_NAMES = {
+    "tool_web_search",
+    "web_search",
+    "tool_search_news",
+    "search_news",
+    "tool_fetch_url",
+    "fetch_url",
+    "tool_current_datetime",
+    "current_datetime",
+    "tool_current_weather",
+    "current_weather",
+}
+
+
+def _has_live_lookup_tool(tool_names: list[str]) -> bool:
+    return any(
+        str(name or "").strip() in _LIVE_LOOKUP_TOOL_NAMES
+        for name in tool_names
+    )
+
+
+def build_direct_live_lookup_system_guard(tool_names: list[str]) -> str:
+    """Return a system-level guard for evidence-only live lookup synthesis."""
+    if not _has_live_lookup_tool(tool_names):
+        return ""
+    return (
+        "SYSTEM live lookup guard: answer only from tool evidence collected in "
+        "this turn. Do not use stored memory, inferred emotions, relationship "
+        "history, occupation, maritime/campus context, or user background unless "
+        "the user explicitly asked for that context in the current message. "
+        "Do not say the user is sad, worried, interested in ports, or preparing "
+        "for something unless the current user message says so. Do not inject "
+        "Wiii lore, Bong, pet stories, bedtime advice, kaomoji, or decorative "
+        "playful asides into factual lookup answers unless explicitly requested. "
+        "Do not ask personal follow-up questions about where the user is, what "
+        "they are doing, whether they are studying late, or whether they are at "
+        "home. "
+        "Keep the answer concise, natural, and professional; the UI already "
+        "renders source links."
+    )
+
+
 def build_direct_final_synthesis_instruction(
     query: str,
     state: AgentState,
@@ -56,6 +99,18 @@ def build_direct_final_synthesis_instruction(
         "Hay tong hop ngay thanh cau tra loi cuoi cung bang tieng Viet, "
         "dua tren cac ket qua cong cu da co."
     )
+    if _has_live_lookup_tool(tool_names):
+        base += (
+            " Voi luot tra cuu web/thoi gian/thoi tiet, chi tra loi tu bang chung "
+            "cong cu trong luot nay; khong chen ky uc, cam xuc, moi quan he, "
+            "nghe nghiep, hang hai, truong lop, hay suy dien ve nguoi dung neu "
+            "user khong hoi truc tiep. Khong chen lore Wiii, Bong, chuyen thu "
+            "cung, loi khuyen di ngu, kaomoji, hay aside vui dua vao cau tra "
+            "cuu su kien. Khong hoi nguoc chuyen ca nhan nhu user dang o dau, "
+            "dang lam gi, co hoc khuya hay dang o nha khong. Uu tien 1-2 doan "
+            "gon, tu nhien, chuyen nghiep; khong "
+            "can lap lai danh sach link vi UI da co the nguon."
+        )
 
     if thinking_mode == "analytical_market":
         return (
@@ -120,6 +175,14 @@ async def run_direct_final_synthesis(
         if event.get("type") == "call"
     ]
     synthesis_messages = list(messages)
+    live_lookup_guard = build_direct_live_lookup_system_guard(synthesis_tool_names)
+    if live_lookup_guard:
+        synthesis_messages.append(
+            build_system_instruction_message(
+                live_lookup_guard,
+                native_tool_messages=native_tool_messages,
+            )
+        )
     synthesis_messages.append(
         build_user_instruction_message(
             build_direct_final_synthesis_instruction(

--- a/maritime-ai-service/app/engine/multi_agent/direct_forced_web_search_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_forced_web_search_runtime.py
@@ -8,6 +8,9 @@ from typing import Any, Awaitable, Callable
 from app.engine.multi_agent.direct_search_synthesis_fallback import (
     build_search_template_fallback,
 )
+from app.engine.multi_agent.direct_tool_sources import (
+    extract_source_infos_from_tool_result,
+)
 from app.engine.multi_agent.direct_tool_message_runtime import (
     build_assistant_message,
 )
@@ -116,6 +119,15 @@ async def execute_forced_web_search_shortcut(
             "node": "direct",
         }
     )
+    sources = extract_source_infos_from_tool_result(forced_search_tool_name, result)
+    if sources:
+        await push_event(
+            {
+                "type": "sources",
+                "content": sources,
+                "node": "direct",
+            }
+        )
     tool_call_events.append(
         {
             "type": "result",

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_operational_fast_paths.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_operational_fast_paths.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import re
 
 from app.engine.multi_agent.direct_intent import _normalize_for_intent
+from app.engine.multi_agent.direct_web_search_policy import (
+    _looks_explicit_web_search_query,
+)
 from app.engine.multi_agent.direct_reasoning import _is_codebase_analysis_query
 from app.engine.multi_agent.direct_session_memory_runtime import (
     _with_requested_response_marker,
@@ -43,12 +46,14 @@ def _strip_dsml_residue(text: str) -> str:
 
 def _is_explicit_web_search_turn_for_direct(query: str, state: AgentState | None = None) -> bool:
     folded = _fold_direct_text(query)
-    if "@web-search" in folded or "@web_search" in folded or "search the web" in folded:
+    if (
+        "@web-search" in folded
+        or "@web_search" in folded
+        or "search the web" in folded
+        or _looks_explicit_web_search_query(query)
+    ):
         return True
     if isinstance(state, dict):
-        routing = state.get("routing_metadata") if isinstance(state.get("routing_metadata"), dict) else {}
-        if str(routing.get("intent") or "").strip().lower() == "web_search":
-            return True
         if "web-search" in _force_skills_from_state(state):
             return True
     return False

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_response_cleanup.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_response_cleanup.py
@@ -30,6 +30,10 @@ _LIVE_LOOKUP_TOOL_NAMES = {
     "web_search",
     "tool_search_news",
     "search_news",
+    "tool_search_legal",
+    "search_legal",
+    "tool_search_maritime",
+    "search_maritime",
     "tool_fetch_url",
     "fetch_url",
     "tool_current_datetime",
@@ -52,7 +56,7 @@ _LIVE_LOOKUP_KAOMOJI_RE = re.compile(
 
 def _has_live_lookup_event(tool_call_events: list[dict[str, Any]]) -> bool:
     return any(
-        str(event.get("name") or "").strip() in _LIVE_LOOKUP_TOOL_NAMES
+        str(event.get("name") or "").strip().lower() in _LIVE_LOOKUP_TOOL_NAMES
         for event in tool_call_events or []
         if event.get("type") in {"call", "result"}
     )
@@ -72,10 +76,6 @@ def _query_allows_personal_context(query: str) -> bool:
             "cam xuc",
             "ve toi",
             "ve minh",
-            "cang bien",
-            "cang thong minh",
-            "hang hai",
-            "truong",
             "cong viec cua toi",
             "cong viec cua minh",
         )
@@ -114,10 +114,6 @@ def strip_live_lookup_inferred_personal_context(
         "ban dang lo",
         "minh lo",
         "toi lo",
-        "quan tam den cang",
-        "cang thong minh",
-        "cang bien",
-        "truong dai hoc hang hai",
         "chuan bi gi do",
         "bong",
         "bong ao",

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_response_cleanup.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_response_cleanup.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+import re
 from typing import Any, Callable
 
 from app.engine.multi_agent.state import AgentState
+from app.engine.multi_agent.direct_text_utils import _fold_direct_text
 
 
 @dataclass(slots=True)
@@ -21,6 +23,178 @@ class DirectNodeSourceFallback:
     response: str
     tools_used: list[Any]
     engaged: bool
+
+
+_LIVE_LOOKUP_TOOL_NAMES = {
+    "tool_web_search",
+    "web_search",
+    "tool_search_news",
+    "search_news",
+    "tool_fetch_url",
+    "fetch_url",
+    "tool_current_datetime",
+    "current_datetime",
+    "tool_current_weather",
+    "current_weather",
+}
+
+_LIVE_LOOKUP_DECORATIVE_SYMBOL_RE = re.compile(
+    "["
+    "\U0001f300-\U0001faff"
+    "\u2600-\u27bf"
+    "\ufe0f"
+    "]"
+)
+_LIVE_LOOKUP_KAOMOJI_RE = re.compile(
+    r"\s*\([^A-Za-z0-9\s)]*[\u02c3\u02c2\u02f6\u2565\ufe4f\u203f][^)]*\)"
+)
+
+
+def _has_live_lookup_event(tool_call_events: list[dict[str, Any]]) -> bool:
+    return any(
+        str(event.get("name") or "").strip() in _LIVE_LOOKUP_TOOL_NAMES
+        for event in tool_call_events or []
+        if event.get("type") in {"call", "result"}
+    )
+
+
+def _query_allows_personal_context(query: str) -> bool:
+    folded = _fold_direct_text(query)
+    return any(
+        marker in folded
+        for marker in (
+            "toi dang",
+            "minh dang",
+            "toi buon",
+            "minh buon",
+            "lo lang",
+            "tam trang",
+            "cam xuc",
+            "ve toi",
+            "ve minh",
+            "cang bien",
+            "cang thong minh",
+            "hang hai",
+            "truong",
+            "cong viec cua toi",
+            "cong viec cua minh",
+        )
+    )
+
+
+def strip_live_lookup_inferred_personal_context(
+    response: str,
+    *,
+    query: str,
+    tool_call_events: list[dict[str, Any]],
+) -> str:
+    """Remove memory/persona bleed from live lookup answers.
+
+    Live weather/news/web lookups should answer the current factual request.
+    Stored memories and relationship context can still be useful elsewhere, but
+    here they often create false claims like "you are sad" or unrelated
+    maritime/campus framing.
+    """
+
+    if (
+        not response
+        or not _has_live_lookup_event(tool_call_events)
+        or _query_allows_personal_context(query)
+    ):
+        return response
+
+    folded_markers = (
+        "minh biet cau dang",
+        "minh hieu cau dang",
+        "toi biet ban dang",
+        "toi hieu ban dang",
+        "cau dang buon",
+        "ban dang buon",
+        "cau dang lo",
+        "ban dang lo",
+        "minh lo",
+        "toi lo",
+        "quan tam den cang",
+        "cang thong minh",
+        "cang bien",
+        "truong dai hoc hang hai",
+        "chuan bi gi do",
+        "bong",
+        "bong ao",
+        "bong cua minh",
+        "meo bong",
+        "meo ao",
+        "ke chuyen meo",
+        "ke chuyen bong",
+        "cuon tron trong chan",
+        "nghe nhac nhe",
+        "uong tra",
+        "o nha nghi ngoi",
+        "dung thuc khuya",
+        "thuc khuya qua",
+        "cau dang hoc khuya",
+        "ban dang hoc khuya",
+        "dang hoc khuya",
+        "hoc khuya",
+        "dang hoc bai",
+        "hoc bai",
+        "cau dang o nha",
+        "ban dang o nha",
+        "dang o nha",
+        "o nha hay di dau",
+        "di dau khuya",
+        "khuya vay",
+        "ngu khong ngon",
+        "buon ngu",
+        "de met",
+        "met lam",
+        "nghi mot chut",
+    )
+    followup_markers = (
+        "neu cau muon",
+        "neu ban muon",
+        "co gi can minh",
+        "minh co the giup",
+        "minh co the tao",
+        "minh co the ve",
+        "minh co the lam",
+        "minh co the gui",
+        "minh co meo",
+    )
+    parts = re.split(r"(?<=[.!?…])\s+", str(response))
+    kept: list[str] = []
+    for part in parts:
+        folded = _fold_direct_text(part)
+        if any(marker in folded for marker in folded_markers):
+            continue
+        if any(marker in folded for marker in followup_markers):
+            continue
+        kept.append(part)
+    deduped: list[str] = []
+    previous_folded = ""
+    for item in kept:
+        stripped = item.strip()
+        if not stripped:
+            continue
+        folded = _fold_direct_text(stripped)
+        if folded and folded == previous_folded:
+            continue
+        deduped.append(stripped)
+        previous_folded = folded
+
+    cleaned = " ".join(deduped).strip()
+    cleaned = _LIVE_LOOKUP_DECORATIVE_SYMBOL_RE.sub("", cleaned)
+    cleaned = _LIVE_LOOKUP_KAOMOJI_RE.sub("", cleaned)
+    cleaned = re.sub(r"\b(cậu|bạn)\s+ơi[~～]*[,!]*\s*", "", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"[~～]+", "", cleaned)
+    cleaned = re.sub(r"\s+([,.;:!?])", r"\1", cleaned)
+    paragraphs = [item.strip() for item in re.split(r"\n{2,}", cleaned) if item.strip()]
+    if len(paragraphs) >= 2:
+        first = _fold_direct_text(paragraphs[0])
+        second = _fold_direct_text(paragraphs[1])
+        if first and second.startswith(first):
+            cleaned = "\n\n".join(paragraphs[1:])
+    return cleaned or response
 
 
 def clean_direct_node_llm_response(
@@ -54,6 +228,11 @@ def clean_direct_node_llm_response(
     cleaned_response = sanitize_wiii_house_text(cleaned_response, query=query)
     cleaned_response = strip_direct_inline_private_asides(cleaned_response)
     cleaned_response = strip_dsml_residue(cleaned_response).strip()
+    cleaned_response = strip_live_lookup_inferred_personal_context(
+        cleaned_response,
+        query=query,
+        tool_call_events=tool_call_events,
+    )
 
     if is_identity_turn:
         cleaned_response = compact_basic_identity_answer(cleaned_response, query=query)

--- a/maritime-ai-service/app/engine/multi_agent/direct_node_tool_selection.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_node_tool_selection.py
@@ -130,12 +130,6 @@ def select_direct_node_tools(
     # Phase F5 (2026-05-06): explicit @-mention tool binding is a user choice,
     # so required tools must survive recommender pruning and force tool choice.
     force_skills = _force_skills_from_state(state)
-    if routing_intent == "web_search":
-        force_skills.add("web-search")
-        merged_force_skills = sorted(force_skills)
-        state["force_skills"] = merged_force_skills
-        ctx["force_skills"] = merged_force_skills
-
     force_required_tools: list[str] = []
     if "wiii-pointy" in force_skills:
         pointy_required = ["tool_pointy_show", "tool_pointy_inventory"]
@@ -151,6 +145,19 @@ def select_direct_node_tools(
         force_tools = True
         logger_obj.info("[DIRECT] Force-bound via @-mention: required=%s", force_required_tools)
 
+    routing_required_tools: list[str] = []
+    if (
+        routing_intent == "web_search"
+        and "web-search" not in force_skills
+        and _turn_path_allows_tool_name(state, "tool_web_search")
+    ):
+        routing_required_tools.append("tool_web_search")
+        force_tools = True
+        logger_obj.info(
+            "[DIRECT] Required via routing intent: required=%s",
+            routing_required_tools,
+        )
+
     try:
         from app.engine.skills.skill_recommender import select_runtime_tools
 
@@ -162,6 +169,9 @@ def select_direct_node_tools(
         ):
             must_include_names.append(_DOC_PREVIEW_HOST_ACTION_TOOL)
         for tool_name in force_required_tools:
+            if tool_name not in must_include_names:
+                must_include_names.append(tool_name)
+        for tool_name in routing_required_tools:
             if tool_name not in must_include_names:
                 must_include_names.append(tool_name)
 

--- a/maritime-ai-service/app/engine/multi_agent/direct_response_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_response_runtime.py
@@ -35,7 +35,36 @@ def _flatten_message_content(value) -> str:
     return str(value or "").strip()
 
 
+def _message_role(message) -> str:
+    if isinstance(message, dict):
+        role = message.get("role") or message.get("type") or ""
+    else:
+        role = (
+            getattr(message, "role", None)
+            or getattr(message, "type", None)
+            or message.__class__.__name__
+        )
+    normalized = str(role or "").strip().lower()
+    if normalized in {"human", "humanmessage"}:
+        return "user"
+    if normalized in {"ai", "aimessage", "assistant"}:
+        return "assistant"
+    if normalized in {"tool", "toolmessage"}:
+        return "tool"
+    return normalized
+
+
 def _extract_last_query(messages: list) -> str:
+    for message in reversed(messages or []):
+        if _message_role(message) != "user":
+            continue
+        if isinstance(message, dict):
+            content = _flatten_message_content(message.get("content", ""))
+        else:
+            content = _flatten_message_content(getattr(message, "content", ""))
+        if content:
+            return content
+
     for message in reversed(messages or []):
         if isinstance(message, dict):
             content = _flatten_message_content(message.get("content", ""))

--- a/maritime-ai-service/app/engine/multi_agent/direct_search_synthesis_fallback.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_search_synthesis_fallback.py
@@ -304,9 +304,8 @@ def _format_outro(hit_count: int) -> str:
             "hơn nhé."
         )
     return (
-        "\n\n_Lưu ý: AI synthesizer tạm chậm — mình tổng hợp trực tiếp từ "
-        "kết quả tra cứu để bạn không phải chờ. Bấm vào tên nguồn để đọc "
-        "chi tiết._"
+        "\n\n_Nguồn: tổng hợp trực tiếp từ kết quả tra cứu web. "
+        "Bấm vào tên nguồn để mở chi tiết._"
     )
 
 

--- a/maritime-ai-service/app/engine/multi_agent/direct_search_template_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_search_template_runtime.py
@@ -14,6 +14,7 @@ from app.engine.multi_agent.direct_tool_message_runtime import (
 from app.engine.multi_agent.direct_web_search_policy import (
     _force_skills_for_turn,
     _has_search_tool_result,
+    _is_weather_lookup_query,
     _should_return_search_template_after_tool_round,
 )
 
@@ -29,6 +30,8 @@ def build_direct_post_tool_search_template_response(
 ) -> Any | None:
     """Return a source-backed search template when another LLM round is wasteful."""
     log = logger_obj or logging.getLogger(__name__)
+    if _is_weather_lookup_query(query):
+        return None
     forced_web_search = "web-search" in _force_skills_for_turn(
         state
     ) and _has_search_tool_result(tool_call_events)

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_dispatch_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_dispatch_runtime.py
@@ -10,6 +10,9 @@ from typing import Any
 from pydantic import ValidationError
 
 from app.engine.multi_agent.tool_event_sanitizer import sanitize_tool_args_for_event
+from app.engine.multi_agent.direct_tool_sources import (
+    extract_source_infos_from_tool_result,
+)
 from app.engine.multi_agent.tool_policy_session import (
     tool_policy_denial_message,
     tool_policy_session_from_state,
@@ -211,6 +214,15 @@ async def dispatch_direct_tool_call(
             "node": "direct",
         }
     )
+    sources = extract_source_infos_from_tool_result(tool_name, result)
+    if sources:
+        await push_event(
+            {
+                "type": "sources",
+                "content": sources,
+                "node": "direct",
+            }
+        )
     return DirectToolDispatchResult(
         tool_call_id=tool_call_id,
         tool_name=tool_name,

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_message_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_message_runtime.py
@@ -38,6 +38,22 @@ def build_user_instruction_message(
     return Message(role="user", content=content)
 
 
+def build_system_instruction_message(
+    content: str,
+    *,
+    native_tool_messages: bool,
+) -> Any:
+    """Create a system instruction message for runtime-only guardrails."""
+    if native_tool_messages:
+        from app.engine.native_chat_runtime import make_system_message
+
+        return make_system_message(content)
+
+    from app.engine.messages import Message
+
+    return Message(role="system", content=content)
+
+
 def build_assistant_message(
     content: str,
     *,

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_round_execution_runtime.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_round_execution_runtime.py
@@ -18,6 +18,13 @@ ProcessDirectToolPostDispatch = Callable[..., Awaitable[Any]]
 EmitVisualCommitEvents = Callable[..., Awaitable[None]]
 
 
+_WEB_SEARCH_TOOL_NAMES = {"tool_web_search", "web_search"}
+_WEATHER_SEARCH_FANOUT_SKIP_RESULT = (
+    "Additional weather web search was not executed because the previous "
+    "source-backed web search already contains enough live weather evidence."
+)
+
+
 @dataclass(frozen=True)
 class DirectToolRoundExecution:
     """State emitted by one direct tool round."""
@@ -25,6 +32,46 @@ class DirectToolRoundExecution:
     round_tool_names: list[str]
     round_cue: str
     visual_emitted_any: bool
+
+
+def _tool_call_name(tool_call: dict[str, Any]) -> str:
+    return str(tool_call.get("name", "") or "").strip()
+
+
+def _turn_path_name(state: AgentState) -> str:
+    if not isinstance(state, dict):
+        return ""
+    decision = state.get("_turn_path_decision")
+    if not isinstance(decision, dict):
+        return ""
+    return str(decision.get("path") or "").strip().lower()
+
+
+def _is_weather_lookup_turn(query: str, state: AgentState) -> bool:
+    try:
+        from app.engine.multi_agent.direct_intent import _needs_weather_lookup
+
+        if not _needs_weather_lookup(query):
+            return False
+    except Exception:  # noqa: BLE001
+        return False
+
+    path = _turn_path_name(state)
+    return path in {"weather_lookup", "web_search"}
+
+
+def _should_skip_weather_search_fanout(
+    *,
+    tool_call: dict[str, Any],
+    query: str,
+    state: AgentState,
+    executed_web_search_count: int,
+) -> bool:
+    if not _is_weather_lookup_turn(query, state):
+        return False
+    if _tool_call_name(tool_call).lower() not in _WEB_SEARCH_TOOL_NAMES:
+        return False
+    return executed_web_search_count >= 1
 
 
 async def execute_direct_tool_round(
@@ -75,7 +122,42 @@ async def execute_direct_tool_round(
     active_visual_session_ids = collect_active_visual_session_ids(state)
 
     next_visual_emitted_any = visual_emitted_any
+    executed_web_search_count = 0
     for tool_call in normalized_tool_calls:
+        if _should_skip_weather_search_fanout(
+            tool_call=tool_call,
+            query=query,
+            state=state,
+            executed_web_search_count=executed_web_search_count,
+        ):
+            tool_call_id = str(tool_call.get("id") or f"tc_{tool_round}")
+            tool_name = _tool_call_name(tool_call) or "tool_web_search"
+            logger_obj.info(
+                "[DIRECT] Skipping duplicate weather web search tool=%s id=%s",
+                tool_name,
+                tool_call_id,
+            )
+            tool_call_events.append(
+                {
+                    "type": "result",
+                    "name": tool_name,
+                    "result": _WEATHER_SEARCH_FANOUT_SKIP_RESULT,
+                    "id": tool_call_id,
+                    "policy": {
+                        "skipped": True,
+                        "reason": "weather_search_fanout_limited",
+                    },
+                }
+            )
+            messages.append(
+                build_tool_result_message(
+                    _WEATHER_SEARCH_FANOUT_SKIP_RESULT,
+                    tool_call_id=tool_call_id,
+                    native_tool_messages=native_tool_messages,
+                )
+            )
+            continue
+
         dispatch_result = await dispatch_direct_tool_call(
             tool_call=tool_call,
             tool_round=tool_round,
@@ -92,6 +174,13 @@ async def execute_direct_tool_round(
             summarize_tool_result_for_stream=summarize_tool_result_for_stream,
             logger_obj=logger_obj,
         )
+        dispatch_result_text = str(dispatch_result.result or "").strip()
+        if (
+            dispatch_result.tool_name.strip().lower() in _WEB_SEARCH_TOOL_NAMES
+            and dispatch_result_text
+            and dispatch_result_text != "Tool unavailable"
+        ):
+            executed_web_search_count += 1
         post_dispatch = await process_direct_tool_post_dispatch(
             tool_name=dispatch_result.tool_name,
             tool_args=dispatch_result.tool_args or {},

--- a/maritime-ai-service/app/engine/multi_agent/direct_tool_sources.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_tool_sources.py
@@ -1,0 +1,215 @@
+"""Source extraction for direct tool results.
+
+Direct web-search tools return markdown-ish text because the full result still
+needs to go back to the model. The UI, however, needs structured source items
+so search feels like an evidence-gathering step instead of a raw tool dump.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+
+_BLOCK_SEPARATOR_PATTERN = re.compile(r"\n\s*---\s*\n")
+_MARKDOWN_TITLE_PATTERN = re.compile(r"^\s*\*\*(.+?)\*\*", re.MULTILINE)
+_URL_LINE_PATTERN = re.compile(r"^\s*URL:\s*(https?://\S+)", re.IGNORECASE | re.MULTILINE)
+_MARKDOWN_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\((https?://[^\s)]+)\)")
+_URL_PATTERN = re.compile(r"https?://[^\s)>\]}\"']+")
+
+_SOURCE_BACKED_TOOL_MARKERS = (
+    "web_search",
+    "search_news",
+    "search_legal",
+    "search_maritime",
+)
+
+
+def is_source_backed_tool_name(tool_name: str) -> bool:
+    lowered = str(tool_name or "").strip().lower()
+    return any(marker in lowered for marker in _SOURCE_BACKED_TOOL_MARKERS)
+
+
+def extract_source_infos_from_tool_result(
+    tool_name: str,
+    result: Any,
+    *,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Return public web sources from a direct search tool result."""
+
+    if not is_source_backed_tool_name(tool_name):
+        return []
+    text = str(result or "").strip()
+    if not text:
+        return []
+
+    sources: list[dict[str, Any]] = []
+    seen_urls: set[str] = set()
+
+    def add(title: str, url: str, content: str = "") -> None:
+        cleaned_url = _clean_url(url)
+        if not cleaned_url or cleaned_url in seen_urls or len(sources) >= limit:
+            return
+        seen_urls.add(cleaned_url)
+        safe_title = _clean_title(title) or _host_label(cleaned_url)
+        safe_content = _clean_content(content) or cleaned_url
+        sources.append(
+            {
+                "title": safe_title[:220],
+                "content": safe_content[:700],
+                "url": cleaned_url,
+                "source_type": "web",
+            }
+        )
+
+    parsed = _parse_json(text)
+    if parsed is not None:
+        for item in _iter_json_source_items(parsed):
+            add(
+                str(item.get("title") or ""),
+                str(item.get("url") or item.get("href") or item.get("link") or ""),
+                str(
+                    item.get("snippet")
+                    or item.get("body")
+                    or item.get("summary")
+                    or item.get("content")
+                    or ""
+                ),
+            )
+            if len(sources) >= limit:
+                return sources
+
+    for block in _split_result_blocks(text):
+        url = _extract_block_url(block)
+        if not url:
+            continue
+        title = _extract_block_title(block) or _host_label(url)
+        add(title, url, _extract_block_snippet(block, title))
+        if len(sources) >= limit:
+            return sources
+
+    for match in _MARKDOWN_LINK_PATTERN.finditer(text):
+        add(match.group(1), match.group(2))
+        if len(sources) >= limit:
+            return sources
+
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    for index, line in enumerate(lines):
+        match = _URL_PATTERN.search(line)
+        if not match:
+            continue
+        url = match.group(0)
+        title = ""
+        if index > 0 and not _URL_PATTERN.search(lines[index - 1]):
+            title = lines[index - 1]
+        add(title, url)
+        if len(sources) >= limit:
+            return sources
+
+    return sources
+
+
+def _parse_json(text: str) -> Any | None:
+    if not text or text[0] not in "[{":
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+def _iter_json_source_items(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, dict)]
+    if not isinstance(value, dict):
+        return []
+    for key in ("results", "items", "sources", "data"):
+        item = value.get(key)
+        if isinstance(item, list):
+            return [entry for entry in item if isinstance(entry, dict)]
+    if any(key in value for key in ("url", "href", "link")):
+        return [value]
+    return []
+
+
+def _split_result_blocks(text: str) -> list[str]:
+    blocks = [
+        block.strip()
+        for block in _BLOCK_SEPARATOR_PATTERN.split(text)
+        if block.strip()
+    ]
+    if blocks:
+        return blocks
+    return [text.strip()] if text.strip() else []
+
+
+def _extract_block_url(block: str) -> str:
+    line_match = _URL_LINE_PATTERN.search(block)
+    if line_match:
+        return _clean_url(line_match.group(1))
+    generic_match = _URL_PATTERN.search(block)
+    return _clean_url(generic_match.group(0)) if generic_match else ""
+
+
+def _extract_block_title(block: str) -> str:
+    title_match = _MARKDOWN_TITLE_PATTERN.search(block)
+    if title_match:
+        return _clean_title(title_match.group(1))
+    for line in block.splitlines():
+        cleaned = _clean_title(line)
+        if cleaned and not _URL_PATTERN.search(cleaned) and not cleaned.lower().startswith("url:"):
+            return cleaned
+    return ""
+
+
+def _extract_block_snippet(block: str, title: str) -> str:
+    snippets: list[str] = []
+    title_seen = False
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if not title_seen and title and title in line:
+            title_seen = True
+            continue
+        if _URL_PATTERN.search(line) or line.lower().startswith("url:"):
+            continue
+        snippets.append(line)
+        if len(" ".join(snippets)) >= 700:
+            break
+    return _clean_content(" ".join(snippets))
+
+
+def _clean_title(value: str) -> str:
+    return (
+        str(value or "")
+        .strip()
+        .strip("-*•· ")
+        .replace("**", "")
+        .strip()
+    )
+
+
+def _clean_content(value: str) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip())
+
+
+def _clean_url(value: str) -> str:
+    return str(value or "").strip().rstrip(".,;:)>]}'\"")
+
+
+def _host_label(url: str) -> str:
+    try:
+        host = urlparse(url).netloc.replace("www.", "")
+    except Exception:
+        host = ""
+    return host or "Web source"
+
+
+__all__ = [
+    "extract_source_infos_from_tool_result",
+    "is_source_backed_tool_name",
+]

--- a/maritime-ai-service/app/engine/multi_agent/direct_web_search_policy.py
+++ b/maritime-ai-service/app/engine/multi_agent/direct_web_search_policy.py
@@ -84,6 +84,24 @@ def _strip_vietnamese_discourse_prefix(text: str) -> str:
     return cleaned
 
 
+def _strip_vietnamese_polite_suffix(text: str) -> str:
+    """Remove request politeness that hurts search recall but carries no topic."""
+
+    cleaned = str(text or "").strip()
+    suffix_pattern = re.compile(
+        r"(?i)(?:"
+        r"\s+(?:cho|giúp|giup)\s+(?:mình|minh|tôi|toi|em|anh|chị|chi|mình\s+nhé|minh\s+nhe)"
+        r"|\s+(?:cho|giúp|giup)\s+(?:mình|minh)?"
+        r"|\s+(?:nhé|nhe|nha|ạ|a)\s*"
+        r")\s*[.!?]*$"
+    )
+    previous = None
+    while cleaned and previous != cleaned:
+        previous = cleaned
+        cleaned = suffix_pattern.sub("", cleaned).strip()
+    return cleaned
+
+
 def _looks_explicit_web_search_query(query: str) -> bool:
     folded = _fold_tool_round_text(query)
     if not folded:
@@ -116,6 +134,15 @@ def _is_search_tool_name(name: str) -> bool:
     }
 
 
+def _is_weather_lookup_query(query: str) -> bool:
+    try:
+        from app.engine.multi_agent.direct_intent import _needs_weather_lookup
+
+        return bool(_needs_weather_lookup(query))
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _prefer_official_query_for_known_docs(args: Any, user_query: str) -> dict:
     normalized_args = dict(args or {}) if isinstance(args, dict) else {}
     current_query = str(normalized_args.get("query") or normalized_args.get("q") or "")
@@ -136,10 +163,9 @@ def _should_return_search_template_after_tool_round(
 ) -> bool:
     if not _has_search_tool_result(tool_call_events):
         return False
-    routing_meta = state.get("routing_metadata") if isinstance(state, dict) else {}
-    routing_intent = str((routing_meta or {}).get("intent") or "").strip().lower()
-    explicit_web = routing_intent == "web_search" or _looks_explicit_web_search_query(query)
-    if not explicit_web:
+    if _is_weather_lookup_query(query):
+        return False
+    if not _looks_explicit_web_search_query(query):
         return False
     search_result_chars = sum(
         len(str(event.get("result") or ""))
@@ -154,11 +180,8 @@ def _should_return_search_template_after_tool_round(
 
 
 def _is_explicit_web_search_turn(query: str, state: AgentState | None) -> bool:
-    routing_meta = state.get("routing_metadata") if isinstance(state, dict) else {}
-    routing_intent = str((routing_meta or {}).get("intent") or "").strip().lower()
     return (
         "web-search" in _force_skills_for_turn(state)
-        or routing_intent == "web_search"
         or _looks_explicit_web_search_query(query)
     )
 
@@ -169,6 +192,8 @@ def _should_use_search_template_for_empty_response(
     state: AgentState | None,
     tool_call_events: list[dict],
 ) -> bool:
+    if _is_weather_lookup_query(query):
+        return False
     return (
         _is_explicit_web_search_turn(query, state)
         and _has_search_tool_result(tool_call_events)
@@ -185,5 +210,6 @@ def _clean_forced_web_search_query(query: str) -> str:
         text,
         maxsplit=1,
     )[0].strip()
+    text = _strip_vietnamese_polite_suffix(text)
     text = text.strip(" .:-–—")
     return text or str(query or "").strip()

--- a/maritime-ai-service/app/engine/multi_agent/graph_stream_surface.py
+++ b/maritime-ai-service/app/engine/multi_agent/graph_stream_surface.py
@@ -22,6 +22,7 @@ from app.engine.multi_agent.stream_utils import (
     create_emotion_event,
     create_pointy_action_event,
     create_preview_event,
+    create_sources_event,
     create_status_event,
     create_thinking_delta_event,
     create_thinking_end_event,
@@ -74,6 +75,9 @@ async def _convert_bus_event_impl(event: dict) -> StreamEvent:
             tool_call_id=tc.get("id", ""),
             node=node,
         )
+    if etype == "sources":
+        sources = event.get("content", [])
+        return await create_sources_event(sources if isinstance(sources, list) else [])
     if etype == "answer_delta":
         return await create_answer_event(event.get("content", ""))
     if etype == "thinking_start":

--- a/maritime-ai-service/app/engine/multi_agent/tool_collection.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_collection.py
@@ -94,6 +94,13 @@ def _needs_weather_lookup(query: str) -> bool:
     return _load_attr("app.engine.multi_agent.direct_intent", "_needs_weather_lookup")(query)
 
 
+def _weather_provider_configured() -> bool:
+    return bool(
+        getattr(settings, "living_agent_enable_weather", False)
+        and str(getattr(settings, "living_agent_weather_api_key", "") or "").strip()
+    )
+
+
 def _needs_datetime(query: str) -> bool:
     return _load_attr("app.engine.multi_agent.direct_intent", "_needs_datetime")(query)
 
@@ -751,6 +758,8 @@ def _resolve_direct_turn_path_decision(
         or host_ui_navigation
         or _safe_intent_flag(_needs_pointy, query)
     )
+    needs_weather_lookup = _safe_intent_flag(_needs_weather_lookup, query)
+    weather_uses_web_fallback = needs_weather_lookup and not _weather_provider_configured()
     signals = TurnPathSignals(
         normalized_query=normalized_query,
         routing_intent=_routing_intent(state),
@@ -769,8 +778,10 @@ def _resolve_direct_turn_path_decision(
             query,
             state,
         ),
-        needs_weather_lookup=_safe_intent_flag(_needs_weather_lookup, query),
-        needs_web_search=_safe_intent_flag(_needs_web_search, query),
+        needs_weather_lookup=needs_weather_lookup and not weather_uses_web_fallback,
+        needs_web_search=(
+            _safe_intent_flag(_needs_web_search, query) or weather_uses_web_fallback
+        ),
         needs_datetime=_safe_intent_flag(_needs_datetime, query),
         needs_news_search=_safe_intent_flag(_needs_news_search, query),
         needs_legal_search=_safe_intent_flag(_needs_legal_search, query),
@@ -1605,7 +1616,17 @@ def _direct_required_tool_names(query: str, user_role: str = "student") -> list[
     visual_decision = resolve_visual_intent(query)
 
     if _needs_weather_lookup(query):
-        required.append("tool_current_weather")
+        if _weather_provider_configured():
+            required.extend(
+                [
+                    "tool_current_weather",
+                    "tool_web_search",
+                    "tool_fetch_url",
+                    "tool_current_datetime",
+                ]
+            )
+        else:
+            required.append("tool_web_search")
     if _needs_datetime(query):
         required.append("tool_current_datetime")
     if _needs_news_search(query):

--- a/maritime-ai-service/app/engine/multi_agent/tool_collection.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_collection.py
@@ -1621,7 +1621,6 @@ def _direct_required_tool_names(query: str, user_role: str = "student") -> list[
                 [
                     "tool_current_weather",
                     "tool_web_search",
-                    "tool_fetch_url",
                     "tool_current_datetime",
                 ]
             )

--- a/maritime-ai-service/app/engine/multi_agent/tool_collection.py
+++ b/maritime-ai-service/app/engine/multi_agent/tool_collection.py
@@ -778,7 +778,7 @@ def _resolve_direct_turn_path_decision(
             query,
             state,
         ),
-        needs_weather_lookup=needs_weather_lookup and not weather_uses_web_fallback,
+        needs_weather_lookup=needs_weather_lookup,
         needs_web_search=(
             _safe_intent_flag(_needs_web_search, query) or weather_uses_web_fallback
         ),
@@ -1078,7 +1078,7 @@ def _collect_direct_tools(query: str, user_role: str = "student", state: Optiona
             tool_web_search,
             tool_fetch_url,
         ]
-        if turn_path_decision.path == "weather_lookup":
+        if turn_path_decision.path == "weather_lookup" and _weather_provider_configured():
             tool_current_weather = _load_attr(
                 "app.engine.tools.utility_tools",
                 "tool_current_weather",

--- a/maritime-ai-service/app/engine/multi_agent/turn_path_governor.py
+++ b/maritime-ai-service/app/engine/multi_agent/turn_path_governor.py
@@ -55,6 +55,20 @@ CHARACTER_MEMORY_TOOL_NAMES: frozenset[str] = frozenset(
         "tool_character_log_experience",
     }
 )
+LIVE_LOOKUP_READ_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "tool_current_datetime",
+        "tool_web_search",
+        "tool_fetch_url",
+    }
+)
+WEB_SEARCH_TOOL_NAMES: frozenset[str] = LIVE_LOOKUP_READ_TOOL_NAMES | frozenset(
+    {
+        "tool_search_news",
+        "tool_search_legal",
+        "tool_search_maritime",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -275,7 +289,7 @@ def resolve_turn_path_decision(signals: TurnPathSignals) -> TurnPathDecision:
             reason="weather_current_conditions_request",
             force_tools=True,
             allow_all_tools=False,
-            allowed_tool_names=WEATHER_TOOL_NAMES,
+            allowed_tool_names=WEATHER_TOOL_NAMES | LIVE_LOOKUP_READ_TOOL_NAMES,
             forbidden_tool_prefixes=POINTY_TOOL_PREFIXES,
             allow_agent_handoff=False,
         )
@@ -285,16 +299,26 @@ def resolve_turn_path_decision(signals: TurnPathSignals) -> TurnPathDecision:
             path="maritime_search",
             reason="maritime_domain_lookup",
             force_tools=True,
+            allow_all_tools=False,
+            allowed_tool_names=WEB_SEARCH_TOOL_NAMES,
             allow_rag_delegation=True,
             forbidden_tool_prefixes=POINTY_TOOL_PREFIXES,
             allow_agent_handoff=False,
         )
 
-    if signals.web_search_forced or signals.needs_web_search or signals.needs_news_search or signals.needs_legal_search:
+    if (
+        signals.web_search_forced
+        or signals.routing_intent == "web_search"
+        or signals.needs_web_search
+        or signals.needs_news_search
+        or signals.needs_legal_search
+    ):
         return TurnPathDecision(
             path="web_search",
             reason="explicit_or_detected_web_search",
             force_tools=True,
+            allow_all_tools=False,
+            allowed_tool_names=WEB_SEARCH_TOOL_NAMES,
             forbidden_tool_prefixes=POINTY_TOOL_PREFIXES
             if signals.suppress_pointy_for_output
             else (),
@@ -306,6 +330,8 @@ def resolve_turn_path_decision(signals: TurnPathSignals) -> TurnPathDecision:
             path="datetime_lookup",
             reason="datetime_request",
             force_tools=True,
+            allow_all_tools=False,
+            allowed_tool_names=frozenset({"tool_current_datetime"}),
             forbidden_tool_prefixes=POINTY_TOOL_PREFIXES,
             allow_agent_handoff=False,
         )
@@ -491,6 +517,7 @@ def _has_tool_or_output_signal(signals: TurnPathSignals) -> bool:
     return any(
         (
             signals.web_search_forced,
+            signals.routing_intent == "web_search",
             signals.pointy_forced,
             signals.host_ui_navigation,
             signals.looks_document_preview,

--- a/maritime-ai-service/app/engine/multi_agent/turn_path_governor.py
+++ b/maritime-ai-service/app/engine/multi_agent/turn_path_governor.py
@@ -62,6 +62,11 @@ LIVE_LOOKUP_READ_TOOL_NAMES: frozenset[str] = frozenset(
         "tool_fetch_url",
     }
 )
+# Weather turns should not fetch arbitrary URLs; keep URL reads on the explicit
+# web/url lane until fetch_url has stronger SSRF guardrails.
+WEATHER_LIVE_LOOKUP_TOOL_NAMES: frozenset[str] = WEATHER_TOOL_NAMES | (
+    LIVE_LOOKUP_READ_TOOL_NAMES - frozenset({"tool_fetch_url"})
+)
 WEB_SEARCH_TOOL_NAMES: frozenset[str] = LIVE_LOOKUP_READ_TOOL_NAMES | frozenset(
     {
         "tool_search_news",
@@ -289,7 +294,7 @@ def resolve_turn_path_decision(signals: TurnPathSignals) -> TurnPathDecision:
             reason="weather_current_conditions_request",
             force_tools=True,
             allow_all_tools=False,
-            allowed_tool_names=WEATHER_TOOL_NAMES | LIVE_LOOKUP_READ_TOOL_NAMES,
+            allowed_tool_names=WEATHER_LIVE_LOOKUP_TOOL_NAMES,
             forbidden_tool_prefixes=POINTY_TOOL_PREFIXES,
             allow_agent_handoff=False,
         )

--- a/maritime-ai-service/app/engine/multi_agent/visual_events.py
+++ b/maritime-ai-service/app/engine/multi_agent/visual_events.py
@@ -11,12 +11,16 @@ from app.engine.context.host_action_result_bridge import (
     parse_host_action_request_result,
 )
 from app.engine.multi_agent.direct_reasoning import _DIRECT_HOST_ACTION_PREFIX
+from app.engine.multi_agent.direct_tool_sources import (
+    extract_source_infos_from_tool_result,
+)
 from app.engine.multi_agent.state import AgentState
 from app.engine.runtime.event_payload_sanitizer import sanitize_runtime_payload
 from typing import Any, Optional
 import asyncio
 import json
 import logging
+import unicodedata
 import uuid
 
 logger = logging.getLogger(__name__)
@@ -27,6 +31,58 @@ def _log_visual_telemetry(event_name: str, **fields: object) -> None:
         logger.info("[VISUAL_TELEMETRY] %s %s", event_name, json.dumps(fields, ensure_ascii=False, sort_keys=True))
     else:
         logger.info("[VISUAL_TELEMETRY] %s", event_name)
+
+
+def _fold_for_stream_compare(value: str) -> str:
+    normalized = value.replace("đ", "d").replace("Đ", "D")
+    return (
+        unicodedata.normalize("NFD", normalized)
+        .encode("ascii", "ignore")
+        .decode("ascii")
+        .lower()
+    )
+
+
+def _is_weather_tool_for_stream(tool_name: str) -> bool:
+    normalized = str(tool_name or "").strip().lower().replace("-", "_").replace(" ", "_")
+    return (
+        normalized in {"tool_current_weather", "current_weather"}
+        or "current_weather" in normalized
+        or normalized.endswith("_weather")
+    )
+
+
+def _truncate_stream_summary(value: str, limit: int = 180) -> str:
+    if len(value) <= limit:
+        return value
+    sliced = value[:limit]
+    last_space = sliced.rfind(" ")
+    if last_space > 80:
+        sliced = sliced[:last_space]
+    return f"{sliced.strip()}..."
+
+
+def _summarize_weather_result_for_stream(result: object) -> str:
+    compact = " ".join(str(result or "").split())
+    if not compact:
+        return "Chưa có dữ liệu thời tiết từ tool."
+
+    folded = _fold_for_stream_compare(compact)
+    if "chua co ket noi thoi tiet truc tiep" in folded:
+        return "Chưa có kết nối thời tiết trực tiếp."
+    if (
+        "ban muon xem nhiet do" in folded
+        or "thanh pho nao" in folded
+        or "can them dia diem" in folded
+    ):
+        return "Cần thêm địa điểm để tra thời tiết."
+    if (
+        "chua lay duoc thoi tiet" in folded
+        or "khong co du lieu thoi tiet" in folded
+    ):
+        return "Chưa lấy được thời tiết hiện tại."
+
+    return _truncate_stream_summary(compact)
 
 
 def _summarize_tool_result_for_stream(tool_name: str, result: object) -> str:
@@ -53,28 +109,28 @@ def _summarize_tool_result_for_stream(tool_name: str, result: object) -> str:
     except Exception:
         pass
     lowered_tool = str(tool_name or "").strip().lower()
+    if _is_weather_tool_for_stream(lowered_tool):
+        return _summarize_weather_result_for_stream(result)
     if any(token in lowered_tool for token in ("web_search", "search_news", "search_legal", "search_maritime")):
-        # Phase 35 — show actual source count + top domain (Perplexity/Claude pattern).
-        # Format from _format_results: "**Title** ... URL: https://domain.com/...",
-        # separated by "---". Count "URL:" markers for source count, extract domains.
-        import re as _re
         result_str = str(result or "")
-        urls = _re.findall(r"URL:\s*(https?://[^\s\n]+)", result_str)
+        sources = extract_source_infos_from_tool_result(lowered_tool, result)
         domains: list[str] = []
-        seen_domains: set[str] = set()
-        for u in urls:
+        for source in sources:
+            url = str(source.get("url") or "")
+            if not url:
+                continue
             try:
                 from urllib.parse import urlparse
-                d = urlparse(u).netloc.replace("www.", "")
-                if d and d not in seen_domains:
-                    domains.append(d)
-                    seen_domains.add(d)
+
+                domain = urlparse(url).netloc.replace("www.", "")
             except Exception:  # noqa: BLE001
                 continue
-        if urls:
+            if domain and domain not in domains:
+                domains.append(domain)
+        if sources:
             top = ", ".join(domains[:3])
             extra = f" +{len(domains) - 3}" if len(domains) > 3 else ""
-            return f"Tìm được {len(urls)} nguồn: {top}{extra}"
+            return f"Tìm được {len(sources)} nguồn: {top}{extra}"
         # No URLs detected → check for "Không tìm thấy" or empty
         if "không tìm thấy" in result_str.lower():
             return "Chưa tìm được kết quả phù hợp — sẽ thử cách khác."

--- a/maritime-ai-service/app/engine/tools/web_search_tools.py
+++ b/maritime-ai-service/app/engine/tools/web_search_tools.py
@@ -150,6 +150,29 @@ def _is_finance_query(query: str) -> bool:
     return any(kw in q for kw in _FINANCE_KEYWORDS)
 
 
+def _fold_search_text(value: str) -> str:
+    import unicodedata
+
+    normalized = unicodedata.normalize("NFKD", str(value or "").lower())
+    stripped = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    return " ".join(stripped.replace("đ", "d").split())
+
+
+def _is_weather_search_query(query: str) -> bool:
+    folded = _fold_search_text(query)
+    return any(
+        marker in folded
+        for marker in (
+            "thoi tiet",
+            "nhiet do",
+            "du bao thoi tiet",
+            "weather",
+            "forecast",
+            "temperature",
+        )
+    )
+
+
 # =============================================================================
 # Circuit breaker helpers
 # =============================================================================
@@ -774,12 +797,9 @@ def _searxng_search_sync(
     try:
         from app.core.config import settings
         # Default to internal docker network address; override via env if external.
-        base_url = (
-            getattr(settings, "searxng_url", None)
-            or "http://searxng:8080"
-        )
+        configured_url = getattr(settings, "searxng_url", None)
     except Exception:  # noqa: BLE001
-        base_url = "http://searxng:8080"
+        configured_url = None
 
     try:
         import httpx
@@ -793,31 +813,67 @@ def _searxng_search_sync(
         }
         if time_range:
             params["time_range"] = time_range  # day | week | month | year
-        resp = httpx.get(
-            f"{base_url.rstrip('/')}/search",
-            params=params,
-            timeout=8.0,
-            follow_redirects=True,
-        )
-        if resp.status_code != 200:
-            logger.debug("[SEARXNG] HTTP %d for: %s", resp.status_code, query[:60])
-            return []
-        data = resp.json() or {}
-        results = data.get("results") or []
-        return [
-            {
-                "title": str(r.get("title", ""))[:200],
-                "body": r.get("content") or r.get("description", ""),
-                "href": r.get("url", ""),
-                "date": r.get("publishedDate", ""),
-                "source": r.get("engine", "searxng"),
-            }
-            for r in results[:max_results]
-            if r.get("url")
-        ]
+        for index, base_url in enumerate(_searxng_base_url_candidates(configured_url)):
+            try:
+                resp = httpx.get(
+                    f"{base_url.rstrip('/')}/search",
+                    params=params,
+                    timeout=8.0 if index == 0 else 3.0,
+                    follow_redirects=True,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[SEARXNG] %s failed: %s", base_url, exc)
+                continue
+            if resp.status_code != 200:
+                logger.debug(
+                    "[SEARXNG] HTTP %d via %s for: %s",
+                    resp.status_code,
+                    base_url,
+                    query[:60],
+                )
+                continue
+            data = resp.json() or {}
+            results = data.get("results") or []
+            normalized = [
+                {
+                    "title": str(r.get("title", ""))[:200],
+                    "body": r.get("content") or r.get("description", ""),
+                    "href": r.get("url", ""),
+                    "date": r.get("publishedDate", ""),
+                    "source": r.get("engine", "searxng"),
+                }
+                for r in results[:max_results]
+                if r.get("url")
+            ]
+            if normalized:
+                logger.info(
+                    "[SEARXNG] %s returned %d results for: %s",
+                    base_url,
+                    len(normalized),
+                    query[:60],
+                )
+                return normalized
+        return []
     except Exception as exc:  # noqa: BLE001
         logger.debug("[SEARXNG] failed: %s", exc)
         return []
+
+
+def _searxng_base_url_candidates(configured_url: str | None) -> list[str]:
+    base_url = (configured_url or "http://searxng:8080").strip().rstrip("/")
+    candidates = [base_url]
+    if base_url == "http://searxng:8080":
+        candidates.extend(
+            [
+                "http://host.docker.internal:8080",
+                "http://127.0.0.1:8080",
+            ]
+        )
+    deduped: list[str] = []
+    for candidate in candidates:
+        if candidate and candidate not in deduped:
+            deduped.append(candidate)
+    return deduped
 
 
 _FINANCE_QUERY_TO_EN: tuple[tuple[str, str], ...] = (
@@ -1503,7 +1559,7 @@ def tool_web_search(query: str) -> str:
         # If the user explicitly asks for an official source and search already
         # found that host, keep the official result set instead of spending
         # 10-20s merging generic news wrappers above it.
-        if not _requests_official_source(query):
+        if not _requests_official_source(query) and not _is_weather_search_query(query):
             results = _merge_news_into_search(results, query)
         results = _augment_top_result_with_deep_fetch(results[:5], query)
         return _format_results(results, "WEB_SEARCH")

--- a/maritime-ai-service/app/models/schemas.py
+++ b/maritime-ai-service/app/models/schemas.py
@@ -195,6 +195,8 @@ class SourceInfo(BaseModel):
     """Source citation info for LMS response"""
     title: str = Field(..., description="Tiêu đề nguồn tài liệu")
     content: str = Field(..., description="Nội dung trích dẫn")
+    url: Optional[str] = Field(default=None, description="Public URL for web sources")
+    source_type: Optional[str] = Field(default=None, description="Source type, e.g. web or document")
     image_url: Optional[str] = Field(default=None, description="URL ảnh trang tài liệu (CHỈ THỊ 26)")
     page_number: Optional[int] = Field(default=None, description="Page number in PDF (Feature: source-highlight-citation)")
     document_id: Optional[str] = Field(default=None, description="Document ID for PDF reference (Feature: source-highlight-citation)")

--- a/maritime-ai-service/tests/unit/test_direct_node_provider_errors.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_provider_errors.py
@@ -1003,7 +1003,7 @@ async def test_direct_response_node_emergency_searches_when_provider_busy_before
 
 
 @pytest.mark.asyncio
-async def test_direct_response_node_force_binds_web_search_intent_without_keyword_heuristic():
+async def test_direct_response_node_forces_web_search_intent_without_mutating_force_skills():
     class FakeSearchTool:
         name = "tool_web_search"
 
@@ -1068,7 +1068,7 @@ async def test_direct_response_node_force_binds_web_search_intent_without_keywor
             **kwargs,
         )
 
-    assert "web-search" in captured["state_force_skills"]
+    assert captured["state_force_skills"] == []
     assert captured["forced_tool_choice"] == "any"
     assert result["final_response"] == "Source-backed web answer"
     assert result["tool_call_events"][0]["name"] == "tool_web_search"

--- a/maritime-ai-service/tests/unit/test_direct_node_response_cleanup.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_response_cleanup.py
@@ -6,6 +6,7 @@ from typing import Any
 from app.engine.multi_agent.direct_node_response_cleanup import (
     apply_source_backed_empty_response_fallback,
     clean_direct_node_llm_response,
+    strip_live_lookup_inferred_personal_context,
 )
 
 
@@ -64,6 +65,140 @@ def test_clean_direct_node_llm_response_compacts_identity_after_sanitize() -> No
     )
 
     assert result.response == "identity::Wiii clean"
+
+
+def test_strip_live_lookup_inferred_personal_context_removes_memory_bleed() -> None:
+    events = [{"type": "result", "name": "tool_web_search"}]
+
+    cleaned = strip_live_lookup_inferred_personal_context(
+        (
+            "Hai Phong hom nay nang nong 37C. "
+            "Minh biet cau dang buon, nen dung ra ngoai lau nha. "
+            "Co gi can minh goi y cach chong nong khong?"
+        ),
+        query="thoi tiet Hai Phong hom nay",
+        tool_call_events=events,
+    )
+
+    assert "37C" in cleaned
+    assert "dang buon" not in cleaned
+    assert "goi y" not in cleaned
+
+
+def test_strip_live_lookup_inferred_personal_context_removes_story_bleed_and_replay() -> None:
+    events = [{"type": "result", "name": "tool_web_search"}]
+
+    cleaned = strip_live_lookup_inferred_personal_context(
+        (
+            "Minh vua tra ne: thoi tiet Hai Phong 29C.\n\n"
+            "Minh vua tra ne: thoi tiet Hai Phong 29C. Do am 81%, co kha nang mua. "
+            "Cau nho mang ao mua neu ra ngoai. "
+            "Bong ao cua minh cung dang cuon tron trong chan ne."
+        ),
+        query="thoi tiet Hai Phong hom nay",
+        tool_call_events=events,
+    )
+
+    assert cleaned.count("Minh vua tra ne") == 1
+    assert "Do am 81%" in cleaned
+    assert "mang ao mua" in cleaned
+    assert "Bong" not in cleaned
+    assert "cuon tron" not in cleaned
+
+
+def test_strip_live_lookup_inferred_personal_context_removes_bong_bedtime_aside() -> None:
+    events = [{"type": "result", "name": "tool_web_search"}]
+
+    cleaned = strip_live_lookup_inferred_personal_context(
+        (
+            "Minh vua tra xong thoi tiet Hai Phong: nhiet do cao nhat 37C, "
+            "do am 84%, co mua dong rai rac. "
+            "Neu di ra ngoai, nho mang ao mua va tranh cay cao khi co sam set. "
+            "Dung thuc khuya qua, minh ke chuyen meo Bong bi uot vi quen mang o."
+        ),
+        query="thoi tiet Hai Phong hom nay",
+        tool_call_events=events,
+    )
+
+    assert "37C" in cleaned
+    assert "mang ao mua" in cleaned
+    assert "Bong" not in cleaned
+    assert "thuc khuya" not in cleaned
+    assert "ke chuyen" not in cleaned
+
+
+def test_strip_live_lookup_inferred_personal_context_removes_unsolicited_creation_followup() -> None:
+    events = [{"type": "result", "name": "tool_web_search"}]
+
+    cleaned = strip_live_lookup_inferred_personal_context(
+        (
+            "Hai Phong luc 22h nhiet do 30C, nhieu may, do am 85%. "
+            "Ngay mai co mua rao va dong, nen mang o neu ra ngoai. "
+            "Minh co the tao bieu do de nhin luon."
+        ),
+        query="thoi tiet Hai Phong hom nay",
+        tool_call_events=events,
+    )
+
+    assert "30C" in cleaned
+    assert "mang o" in cleaned
+    assert "tao bieu do" not in cleaned
+
+
+def test_strip_live_lookup_inferred_personal_context_removes_study_late_inference() -> None:
+    events = [{"type": "result", "name": "tool_web_search"}]
+
+    cleaned = strip_live_lookup_inferred_personal_context(
+        (
+            "Hai Phong hien 29C, nhieu may, do am 82%, kha nang mua 75%. "
+            "Du bao den 23h van am u va am uot. "
+            "Cau dang hoc khuya ma troi nhu the nay thi de buon ngu va met lam."
+        ),
+        query="thoi tiet Hai Phong hom nay",
+        tool_call_events=events,
+    )
+
+    assert "29C" in cleaned
+    assert "am uot" in cleaned
+    assert "hoc khuya" not in cleaned
+    assert "buon ngu" not in cleaned
+
+
+def test_strip_live_lookup_inferred_personal_context_removes_whereabouts_followup() -> None:
+    events = [{"type": "result", "name": "tool_web_search"}]
+
+    cleaned = strip_live_lookup_inferred_personal_context(
+        (
+            "Hai Phong luc 22h la 29C, troi quang, do am 80%. "
+            "Tu 23h co mua rao nhe keo dai den sang mai. "
+            "Cau dang o nha hay di dau khuya vay? "
+            "Neu ra ngoai, nho mang ao mua nho nha. Dung de uot, minh lo lam. "
+            "Con neu dang hoc bai thi nghi som mot chut."
+        ),
+        query="thoi tiet Hai Phong hom nay",
+        tool_call_events=events,
+    )
+
+    assert "29C" in cleaned
+    assert "mua rao" in cleaned
+    assert "dang o nha" not in cleaned
+    assert "di dau" not in cleaned
+    assert "minh lo" not in cleaned
+    assert "hoc bai" not in cleaned
+
+
+def test_strip_live_lookup_inferred_personal_context_keeps_requested_context() -> None:
+    events = [{"type": "result", "name": "tool_web_search"}]
+    response = "Minh biet cau dang buon, nen minh se noi ngan: troi nong 37C."
+
+    assert (
+        strip_live_lookup_inferred_personal_context(
+            response,
+            query="minh dang buon, thoi tiet Hai Phong hom nay the nao",
+            tool_call_events=events,
+        )
+        == response
+    )
 
 
 def test_apply_source_backed_empty_response_fallback_uses_tool_events() -> None:

--- a/maritime-ai-service/tests/unit/test_direct_node_tool_selection.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_tool_selection.py
@@ -149,8 +149,8 @@ def test_select_direct_node_tools_forces_web_search_and_must_include(monkeypatch
 
     assert result.tools == tools
     assert result.force_tools is True
-    assert state["force_skills"] == ["web-search"]
-    assert ctx["force_skills"] == ["web-search"]
+    assert "force_skills" not in state
+    assert "force_skills" not in ctx
     assert "tool_web_search" in captured["must_include"]
     assert captured["user_role"] == "teacher"
 

--- a/maritime-ai-service/tests/unit/test_direct_node_turn_start.py
+++ b/maritime-ai-service/tests/unit/test_direct_node_turn_start.py
@@ -1,6 +1,27 @@
 from app.engine.multi_agent.direct_node_turn_start import start_direct_node_turn
 
 
+def test_routing_web_search_intent_is_not_user_explicit_web_search():
+    from app.engine.multi_agent.direct_node_operational_fast_paths import (
+        _is_explicit_web_search_turn_for_direct,
+    )
+
+    assert (
+        _is_explicit_web_search_turn_for_direct(
+            "hom nay co gi hot",
+            {"routing_metadata": {"intent": "web_search"}},
+        )
+        is False
+    )
+    assert (
+        _is_explicit_web_search_turn_for_direct(
+            "tim tren web hom nay co gi hot",
+            {"routing_metadata": {"intent": "web_search"}},
+        )
+        is True
+    )
+
+
 def test_start_direct_node_turn_resolves_greeting_when_natural_conversation_disabled():
     state = {"domain_id": "maritime"}
     result = start_direct_node_turn(

--- a/maritime-ai-service/tests/unit/test_direct_response_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_response_runtime.py
@@ -119,3 +119,40 @@ def test_extract_direct_response_impl_derives_analytical_thinking_from_answer_fo
     assert thinking.startswith("Hien tai gia dau dang giang co giua ba luc chinh")
     assert "bao cao eia" in thinking.lower()
     assert tools_used == [{"name": "tool_web_search"}]
+
+
+def test_extract_direct_response_impl_uses_user_query_not_trailing_tool_result_for_thinking():
+    llm_response = SimpleNamespace(
+        content=(
+            "Thoi tiet Hai Phong hom nay nhieu may, co mua rao rai rac vao chieu toi va do am cao. "
+            "Nhiet do dao dong quanh 27 den 35 do C, nen cam giac ngoai troi kha oi va am. "
+            "Neu phai di chuyen gan khu vuc cang bien, nen theo doi them canh bao mua dong ngan han."
+        ),
+        response_metadata={},
+        additional_kwargs={},
+    )
+
+    response, thinking, tools_used = extract_direct_response_impl(
+        llm_response,
+        messages=[
+            {"role": "user", "content": "thoi tiet Hai Phong hom nay cho minh nhe"},
+            SimpleNamespace(
+                type="ai",
+                content="",
+                tool_calls=[{"name": "tool_web_search"}],
+            ),
+            {
+                "role": "tool",
+                "content": (
+                    "Additional weather web search was not executed because the previous "
+                    "source-backed web search already contains enough live weather evidence."
+                ),
+            },
+        ],
+    )
+
+    assert response.startswith("Thoi tiet Hai Phong hom nay")
+    assert "file/schema" not in thinking.lower()
+    assert "source-backed" not in thinking.lower()
+    assert thinking.startswith("Thoi tiet Hai Phong hom nay")
+    assert tools_used == [{"name": "tool_web_search"}]

--- a/maritime-ai-service/tests/unit/test_direct_tool_dispatch_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_dispatch_runtime.py
@@ -99,6 +99,60 @@ async def test_dispatch_direct_tool_call_emits_stable_call_and_result_events():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_direct_tool_call_emits_sources_for_web_search_results():
+    class FakeTool:
+        name = "tool_web_search"
+
+    events: list[dict] = []
+    tool_call_events: list[dict] = []
+
+    async def push_event(event):
+        events.append(event)
+
+    async def invoke_tool_with_runtime(_tool, _args, **_kwargs):
+        return (
+            "**Weather Hải Phòng today**\n"
+            "Cloudy and warm.\n"
+            "URL: https://weather.example/hai-phong"
+        )
+
+    result = await dispatch_direct_tool_call(
+        tool_call={
+            "id": "call_sources",
+            "name": "tool_web_search",
+            "args": {"query": "thời tiết Hải Phòng hôm nay"},
+        },
+        tool_round=0,
+        tools=[FakeTool()],
+        query="thời tiết Hải Phòng hôm nay",
+        push_event=push_event,
+        tool_call_events=tool_call_events,
+        get_tool_by_name=lambda tools, name: tools[0] if name == "tool_web_search" else None,
+        invoke_tool_with_runtime=invoke_tool_with_runtime,
+        runtime_context_base=None,
+        is_search_tool_name=lambda name: name == "tool_web_search",
+        prefer_official_query_for_known_docs=lambda args, _query: args,
+        summarize_tool_result_for_stream=lambda _name, value: "Tìm được 1 nguồn",
+        logger_obj=SimpleNamespace(warning=lambda *args, **kwargs: None),
+    )
+
+    assert result.matched is True
+    assert [event["type"] for event in events] == [
+        "tool_call",
+        "tool_result",
+        "sources",
+    ]
+    assert events[2]["content"] == [
+        {
+            "title": "Weather Hải Phòng today",
+            "content": "Cloudy and warm.",
+            "url": "https://weather.example/hai-phong",
+            "source_type": "web",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_dispatch_direct_tool_call_returns_structured_unknown_tool_error():
     events: list[dict] = []
     tool_call_events: list[dict] = []

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -47,9 +47,15 @@ def test_build_direct_final_synthesis_instruction_blocks_live_lookup_memory_blee
     assert "cam xuc" in instruction
     assert "hang hai" in instruction
     assert "ui da co the nguon" in instruction
-    guard = build_direct_live_lookup_system_guard(["tool_web_search"])
-    assert "Do not use stored memory" in guard
-    assert "interested in ports" in guard
+    for tool_name in [
+        "tool_web_search",
+        "TOOL_SEARCH_LEGAL",
+        "search_maritime",
+        "tool_search_news",
+    ]:
+        guard = build_direct_live_lookup_system_guard([tool_name])
+        assert "Do not use stored memory" in guard
+        assert "interested in ports" in guard
     assert build_direct_live_lookup_system_guard(["tool_generate_visual"]) == ""
 
 

--- a/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
+++ b/maritime-ai-service/tests/unit/test_direct_tool_rounds_runtime.py
@@ -30,6 +30,29 @@ def test_build_direct_final_synthesis_instruction_is_mode_aware_for_market_turn(
     assert "opec+" in instruction or "ton kho" in instruction
 
 
+def test_build_direct_final_synthesis_instruction_blocks_live_lookup_memory_bleed():
+    from app.engine.multi_agent.direct_final_synthesis_runtime import (
+        build_direct_live_lookup_system_guard,
+        build_direct_final_synthesis_instruction as _build_direct_final_synthesis_instruction,
+    )
+
+    instruction = _build_direct_final_synthesis_instruction(
+        "thoi tiet Hai Phong hom nay",
+        {},
+        ["tool_web_search", "tool_current_datetime", "tool_fetch_url"],
+    ).lower()
+
+    assert "chi tra loi tu bang chung cong cu" in instruction
+    assert "khong chen ky uc" in instruction
+    assert "cam xuc" in instruction
+    assert "hang hai" in instruction
+    assert "ui da co the nguon" in instruction
+    guard = build_direct_live_lookup_system_guard(["tool_web_search"])
+    assert "Do not use stored memory" in guard
+    assert "interested in ports" in guard
+    assert build_direct_live_lookup_system_guard(["tool_generate_visual"]) == ""
+
+
 def test_explicit_web_search_returns_template_after_fetch_evidence():
     from app.engine.multi_agent.direct_web_search_policy import (
         _prefer_official_query_for_known_docs,
@@ -108,6 +131,79 @@ def test_explicit_web_search_returns_template_after_fetch_evidence():
     ) is False
 
 
+def test_auto_routed_web_search_does_not_use_explicit_search_template():
+    from app.engine.multi_agent.direct_web_search_policy import (
+        _should_return_search_template_after_tool_round,
+        _should_use_search_template_for_empty_response,
+    )
+
+    events = [
+        {
+            "type": "result",
+            "name": "tool_web_search",
+            "result": ("URL: https://example.test/news\nCurrent event evidence.\n") * 80,
+            "id": "search_1",
+        },
+    ]
+
+    assert (
+        _should_return_search_template_after_tool_round(
+            query="hom nay co gi hot",
+            state={"routing_metadata": {"intent": "web_search"}},
+            tool_call_events=events,
+            tool_round=1,
+        )
+        is False
+    )
+    assert (
+        _should_use_search_template_for_empty_response(
+            query="hom nay co gi hot",
+            state={"routing_metadata": {"intent": "web_search"}},
+            tool_call_events=events,
+        )
+        is False
+    )
+
+
+def test_weather_web_search_does_not_return_raw_search_template_after_tool_round():
+    from app.engine.multi_agent.direct_web_search_policy import (
+        _should_return_search_template_after_tool_round,
+        _should_use_search_template_for_empty_response,
+    )
+
+    events = [
+        {
+            "type": "result",
+            "name": "tool_web_search",
+            "result": (
+                "**AccuWeather Hai Phong**\n"
+                "RealFeel 39C, humidity 64%, cloudy.\n"
+                "URL: https://example.test/weather\n"
+            )
+            * 80,
+            "id": "search_1",
+        },
+    ]
+
+    assert (
+        _should_return_search_template_after_tool_round(
+            query="thời tiết Hải Phòng hôm nay cho mình nhé",
+            state={"routing_metadata": {"intent": "web_search"}},
+            tool_call_events=events,
+            tool_round=0,
+        )
+        is False
+    )
+    assert (
+        _should_use_search_template_for_empty_response(
+            query="thời tiết Hải Phòng hôm nay cho mình nhé",
+            state={"routing_metadata": {"intent": "web_search"}},
+            tool_call_events=events,
+        )
+        is False
+    )
+
+
 def test_clean_forced_web_search_query_strips_vietnamese_discourse_marker():
     from app.engine.multi_agent.direct_web_search_policy import (
         _clean_forced_web_search_query,
@@ -121,6 +217,58 @@ def test_clean_forced_web_search_query_strips_vietnamese_discourse_marker():
     assert not cleaned.lower().startswith("ý là")
 
 
+def test_clean_forced_web_search_query_strips_polite_search_suffix():
+    from app.engine.multi_agent.direct_web_search_policy import (
+        _clean_forced_web_search_query,
+    )
+
+    assert (
+        _clean_forced_web_search_query("thời tiết Hải Phòng hôm nay cho mình")
+        == "thời tiết Hải Phòng hôm nay"
+    )
+    assert (
+        _clean_forced_web_search_query("@web-search giá vàng hôm nay giúp mình nhé")
+        == "giá vàng hôm nay"
+    )
+
+
+def test_weather_lookup_limits_duplicate_web_search_fanout():
+    from app.engine.multi_agent.direct_tool_round_execution_runtime import (
+        _should_skip_weather_search_fanout,
+    )
+
+    state = {"_turn_path_decision": {"path": "web_search"}}
+    query = "thời tiết Hải Phòng hôm nay"
+
+    assert (
+        _should_skip_weather_search_fanout(
+            tool_call={"name": "tool_web_search"},
+            query=query,
+            state=state,
+            executed_web_search_count=0,
+        )
+        is False
+    )
+    assert (
+        _should_skip_weather_search_fanout(
+            tool_call={"name": "tool_web_search"},
+            query=query,
+            state=state,
+            executed_web_search_count=1,
+        )
+        is True
+    )
+    assert (
+        _should_skip_weather_search_fanout(
+            tool_call={"name": "tool_current_datetime"},
+            query=query,
+            state=state,
+            executed_web_search_count=1,
+        )
+        is False
+    )
+
+
 def test_build_direct_post_tool_search_template_response_for_forced_web(monkeypatch):
     from app.engine.multi_agent import direct_search_template_runtime as runtime
 
@@ -130,9 +278,15 @@ def test_build_direct_post_tool_search_template_response_for_forced_web(monkeypa
         lambda **_kwargs: "Tổng hợp từ web có nguồn.",
     )
 
+    monkeypatch.setattr(
+        runtime,
+        "_force_skills_for_turn",
+        lambda _state: {"web-search"},
+    )
+
     response = runtime.build_direct_post_tool_search_template_response(
         query="giá dầu hôm nay",
-        state={"force_skills": ["web-search"]},
+        state={"routing_metadata": {"intent": "web_search"}},
         tool_call_events=[
             {
                 "type": "result",
@@ -146,6 +300,34 @@ def test_build_direct_post_tool_search_template_response_for_forced_web(monkeypa
 
     assert response is not None
     assert response.content == "Tổng hợp từ web có nguồn."
+
+
+def test_build_direct_post_tool_search_template_response_skips_weather_even_when_forced(
+    monkeypatch,
+):
+    from app.engine.multi_agent import direct_search_template_runtime as runtime
+
+    monkeypatch.setattr(
+        runtime,
+        "build_search_template_fallback",
+        lambda **_kwargs: "Không nên trả template cho weather tự nhiên.",
+    )
+
+    response = runtime.build_direct_post_tool_search_template_response(
+        query="thời tiết Hải Phòng hôm nay cho mình nhé",
+        state={"force_skills": ["web-search"]},
+        tool_call_events=[
+            {
+                "type": "result",
+                "name": "tool_web_search",
+                "result": "URL: https://example.test/weather\nRealFeel 39C.",
+            }
+        ],
+        tool_round=0,
+        native_tool_messages=False,
+    )
+
+    assert response is None
 
 
 def test_build_direct_post_tool_search_template_response_for_explicit_round(
@@ -252,10 +434,12 @@ async def test_execute_forced_web_search_shortcut_emits_events(monkeypatch):
     assert [event["type"] for event in emitted] == [
         "tool_call",
         "tool_result",
+        "sources",
         "thinking_start",
         "thinking_delta",
         "thinking_end",
     ]
+    assert emitted[2]["content"][0]["url"] == "https://example.test"
     thinking_text = " ".join(
         str(event.get("content", ""))
         for event in emitted
@@ -277,6 +461,36 @@ async def test_execute_forced_web_search_shortcut_emits_events(monkeypatch):
     assert invoke_call["tool_call_id"] == "forced_web_search_0"
     assert invoke_call["prefer_async"] is False
     assert invoke_call["run_sync_in_thread"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_forced_web_search_shortcut_skips_natural_weather_auto_route():
+    from app.engine.multi_agent import direct_forced_web_search_runtime as runtime
+
+    emitted: list[dict] = []
+
+    async def push_event(event):
+        emitted.append(event)
+
+    async def invoke_tool_with_runtime(*_args, **_kwargs):
+        raise AssertionError("Natural weather routing should use the planner loop")
+
+    response = await runtime.execute_forced_web_search_shortcut(
+        query="thời tiết Hải Phòng hôm nay cho mình nhé",
+        state={"routing_metadata": {"intent": "web_search"}},
+        tools=[object()],
+        messages=[],
+        tool_call_events=[],
+        push_event=push_event,
+        native_tool_messages=False,
+        runtime_context_base={},
+        get_tool_by_name=lambda _tools, _name: object(),
+        invoke_tool_with_runtime=invoke_tool_with_runtime,
+        summarize_tool_result_for_stream=lambda _name, result: result,
+    )
+
+    assert response is None
+    assert emitted == []
 
 
 @pytest.mark.asyncio
@@ -428,7 +642,9 @@ async def test_run_direct_final_synthesis_uses_no_tool_binding_and_moderate_time
 
     assert result.llm_response is final_response
     assert result.resolved_provider == "qwen"
-    assert len(result.messages) == 1
+    assert len(result.messages) == 2
+    assert result.messages[0].role == "system"
+    assert "Do not use stored memory" in result.messages[0].content
     assert "Khong goi them cong cu" in result.messages[-1].content
     assert calls[0]["llm"] is llm_base
     assert "tools" not in calls[0]["kwargs"]

--- a/maritime-ai-service/tests/unit/test_event_bus.py
+++ b/maritime-ai-service/tests/unit/test_event_bus.py
@@ -131,6 +131,26 @@ class TestConvertBusEvent:
         assert event.content["result"] == "found docs"
 
     @pytest.mark.asyncio
+    async def test_sources(self):
+        sources = [
+            {
+                "title": "Weather Hai Phong",
+                "content": "Cloudy and warm.",
+                "url": "https://weather.example/hai-phong",
+                "source_type": "web",
+            }
+        ]
+
+        event = await _convert_bus_event({
+            "type": "sources",
+            "content": sources,
+            "node": "direct",
+        })
+
+        assert event.type == StreamEventType.SOURCES
+        assert event.content == sources
+
+    @pytest.mark.asyncio
     async def test_visual(self):
         event = await _convert_bus_event({
             "type": "visual",

--- a/maritime-ai-service/tests/unit/test_graph_routing.py
+++ b/maritime-ai-service/tests/unit/test_graph_routing.py
@@ -1745,7 +1745,7 @@ class TestVisibleProgressCopy:
             "giá dầu hôm nay https://example.com Brent 98.74 WTI 95.92",
         )
 
-        assert result == "Đã kéo thêm vài nguồn để kiểm chéo."
+        assert result == "Tìm được 1 nguồn: example.com"
 
 
 class TestProviderFlowIntegrity:

--- a/maritime-ai-service/tests/unit/test_sprint99_forced_tool_calling.py
+++ b/maritime-ai-service/tests/unit/test_sprint99_forced_tool_calling.py
@@ -423,9 +423,10 @@ class TestForcedToolChoice:
             assert mock_llm.bind_tools.call_count == 2
             calls = mock_llm.bind_tools.call_args_list
             has_forced = any(
-                c.kwargs.get("tool_choice") == "any" for c in calls
+                c.kwargs.get("tool_choice") in {"any", "tool_current_datetime"}
+                for c in calls
             )
-            assert has_forced, "One bind_tools call should have tool_choice='any'"
+            assert has_forced, "One bind_tools call should force the datetime tool"
 
     @pytest.mark.asyncio
     async def test_follow_up_call_uses_auto_not_forced(self):

--- a/maritime-ai-service/tests/unit/test_tool_policy_session.py
+++ b/maritime-ai-service/tests/unit/test_tool_policy_session.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import pytest
 
 
-def test_tool_policy_session_records_visible_weather_tool_only():
+def test_tool_policy_session_records_visible_weather_with_live_lookup():
     from app.engine.multi_agent.tool_policy_session import (
         build_tool_policy_session,
         filter_tools_for_policy_session,
@@ -51,14 +51,19 @@ def test_tool_policy_session_records_visible_weather_tool_only():
     )
     final_session = tool_policy_session_from_state(state)
 
-    assert [tool.name for tool in filtered] == ["tool_current_weather"]
+    assert [tool.name for tool in filtered] == [
+        "tool_current_weather",
+        "tool_web_search",
+    ]
     assert final_session is not None
     assert final_session.path == "weather_lookup"
-    assert final_session.visible_tool_names == frozenset({"tool_current_weather"})
+    assert final_session.visible_tool_names == frozenset(
+        {"tool_current_weather", "tool_web_search"}
+    )
     assert final_session.tool_capabilities is not None
     assert final_session.tool_capabilities["tool_current_weather"]["group"] == "weather"
     assert final_session.decision_for("tool_current_weather").allowed is True
-    assert final_session.decision_for("tool_web_search").allowed is False
+    assert final_session.decision_for("tool_web_search").allowed is True
 
 
 def test_tool_policy_session_denies_lms_authoring_without_connection():

--- a/maritime-ai-service/tests/unit/test_turn_path_governor.py
+++ b/maritime-ai-service/tests/unit/test_turn_path_governor.py
@@ -206,7 +206,28 @@ def test_turn_path_governor_web_search_force_beats_visual_drift():
     assert decision.path == "web_search"
     assert decision.force_tools is True
     assert decision.should_keep_tool_name("tool_web_search") is True
-    assert decision.should_keep_tool_name("tool_generate_visual") is True
+    assert decision.should_keep_tool_name("tool_fetch_url") is True
+    assert decision.should_keep_tool_name("tool_generate_visual") is False
+
+
+def test_turn_path_governor_treats_supervisor_web_intent_as_tool_signal():
+    from app.engine.multi_agent.turn_path_governor import (
+        TurnPathSignals,
+        resolve_turn_path_decision,
+    )
+
+    decision = resolve_turn_path_decision(
+        TurnPathSignals(
+            normalized_query="topic that keyword detectors missed",
+            routing_intent="web_search",
+        )
+    )
+
+    assert decision.path == "web_search"
+    assert decision.force_tools is True
+    assert decision.should_keep_tool_name("tool_web_search") is True
+    assert decision.should_keep_tool_name("tool_fetch_url") is True
+    assert decision.should_keep_tool_name("tool_pointy_show") is False
 
 
 def test_turn_path_governor_code_execution_beats_visual_drift():
@@ -256,7 +277,7 @@ def test_collect_direct_tools_routes_code_studio_app_to_visual_lane():
     )
 
 
-def test_turn_path_governor_routes_weather_to_weather_tool_only():
+def test_turn_path_governor_routes_weather_to_weather_with_live_lookup_fallback():
     from app.engine.multi_agent.turn_path_governor import (
         TurnPathSignals,
         resolve_turn_path_decision,
@@ -276,7 +297,9 @@ def test_turn_path_governor_routes_weather_to_weather_tool_only():
     assert decision.force_tools is True
     assert decision.allow_all_tools is False
     assert decision.should_keep_tool_name("tool_current_weather") is True
-    assert decision.should_keep_tool_name("tool_web_search") is False
+    assert decision.should_keep_tool_name("tool_web_search") is True
+    assert decision.should_keep_tool_name("tool_fetch_url") is True
+    assert decision.should_keep_tool_name("tool_current_datetime") is True
     assert decision.should_keep_tool_name("tool_pointy_show") is False
 
 
@@ -573,6 +596,24 @@ def test_collect_direct_tools_keeps_explicit_web_search_path():
     assert "tool_current_weather" not in names
 
 
+def test_collect_direct_tools_honors_supervisor_web_search_intent():
+    from app.engine.multi_agent import tool_collection as module
+
+    state = {"context": {}, "routing_metadata": {"intent": "web_search"}}
+    tools, force_tools = module._collect_direct_tools(
+        "topic that local intent detectors missed",
+        user_role="student",
+        state=state,
+    )
+    names = {getattr(tool, "name", getattr(tool, "__name__", "")) for tool in tools}
+
+    assert force_tools is True
+    assert state["_turn_path_decision"]["path"] == "web_search"
+    assert "tool_web_search" in names
+    assert "tool_fetch_url" in names
+    assert "tool_current_weather" not in names
+
+
 def test_collect_direct_tools_scopes_personal_fact_to_character_tools():
     from app.engine.multi_agent import tool_collection as module
 
@@ -591,8 +632,12 @@ def test_collect_direct_tools_scopes_personal_fact_to_character_tools():
     assert "tool_web_search" not in names
 
 
-def test_collect_direct_tools_routes_weather_followup_to_weather_tool():
+def test_collect_direct_tools_routes_weather_followup_to_weather_tool(monkeypatch):
+    from app.core.config import settings
     from app.engine.multi_agent import tool_collection as module
+
+    monkeypatch.setattr(settings, "living_agent_enable_weather", True)
+    monkeypatch.setattr(settings, "living_agent_weather_api_key", "test-weather-key")
 
     state = {"context": {}}
     tools, force_tools = module._collect_direct_tools(
@@ -604,7 +649,31 @@ def test_collect_direct_tools_routes_weather_followup_to_weather_tool():
 
     assert force_tools is True
     assert state["_turn_path_decision"]["path"] == "weather_lookup"
-    assert names == {"tool_current_weather"}
+    assert "tool_current_weather" in names
+    assert "tool_web_search" in names
+    assert "tool_fetch_url" in names
+    assert "tool_current_datetime" in names
+
+
+def test_collect_direct_tools_routes_weather_to_web_search_when_provider_missing(monkeypatch):
+    from app.core.config import settings
+    from app.engine.multi_agent import tool_collection as module
+
+    monkeypatch.setattr(settings, "living_agent_enable_weather", False)
+    monkeypatch.setattr(settings, "living_agent_weather_api_key", None)
+
+    state = {"context": {}}
+    tools, force_tools = module._collect_direct_tools(
+        "thời tiết Hải Phòng hôm nay thế nào",
+        user_role="student",
+        state=state,
+    )
+    names = {getattr(tool, "name", getattr(tool, "__name__", "")) for tool in tools}
+
+    assert force_tools is True
+    assert state["_turn_path_decision"]["path"] == "web_search"
+    assert "tool_web_search" in names
+    assert "tool_current_weather" not in names
 
 
 @pytest.mark.parametrize(
@@ -616,8 +685,12 @@ def test_collect_direct_tools_routes_weather_followup_to_weather_tool():
         "troi co mua khong",
     ],
 )
-def test_collect_direct_tools_routes_weather_turns_to_weather_tool(query):
+def test_collect_direct_tools_routes_weather_turns_to_weather_tool(query, monkeypatch):
+    from app.core.config import settings
     from app.engine.multi_agent import tool_collection as module
+
+    monkeypatch.setattr(settings, "living_agent_enable_weather", True)
+    monkeypatch.setattr(settings, "living_agent_weather_api_key", "test-weather-key")
 
     state = {"context": {}}
     tools, force_tools = module._collect_direct_tools(
@@ -629,7 +702,9 @@ def test_collect_direct_tools_routes_weather_turns_to_weather_tool(query):
 
     assert force_tools is True
     assert state["_turn_path_decision"]["path"] == "weather_lookup"
-    assert names == {"tool_current_weather"}
+    assert "tool_current_weather" in names
+    assert "tool_web_search" in names
+    assert "tool_fetch_url" in names
 
 
 def test_collect_direct_tools_keeps_maritime_tool_on_maritime_path():
@@ -649,8 +724,12 @@ def test_collect_direct_tools_keeps_maritime_tool_on_maritime_path():
     assert "tool_current_weather" not in names
 
 
-def test_direct_required_tool_names_weather_prefers_weather_over_web():
+def test_direct_required_tool_names_weather_prefers_weather_over_web(monkeypatch):
+    from app.core.config import settings
     from app.engine.multi_agent.tool_collection import _direct_required_tool_names
+
+    monkeypatch.setattr(settings, "living_agent_enable_weather", True)
+    monkeypatch.setattr(settings, "living_agent_weather_api_key", "test-weather-key")
 
     required = _direct_required_tool_names(
         "ý là thời tiết nóng đó. Bạn biết nay bao độ không",
@@ -658,18 +737,44 @@ def test_direct_required_tool_names_weather_prefers_weather_over_web():
     )
 
     assert "tool_current_weather" in required
-    assert "tool_web_search" not in required
+    assert "tool_web_search" in required
+    assert "tool_fetch_url" in required
+    assert "tool_current_datetime" in required
 
 
-def test_direct_required_tool_names_temperature_question_prefers_weather_over_web():
+def test_direct_required_tool_names_temperature_question_prefers_weather_over_web(monkeypatch):
+    from app.core.config import settings
     from app.engine.multi_agent.tool_collection import _direct_required_tool_names
+
+    monkeypatch.setattr(settings, "living_agent_enable_weather", True)
+    monkeypatch.setattr(settings, "living_agent_weather_api_key", "test-weather-key")
 
     required = _direct_required_tool_names(
         "hom nay bao nhieu do",
         user_role="student",
     )
 
-    assert required == ["tool_current_weather"]
+    assert required == [
+        "tool_current_weather",
+        "tool_web_search",
+        "tool_fetch_url",
+        "tool_current_datetime",
+    ]
+
+
+def test_direct_required_tool_names_weather_falls_back_to_web_search(monkeypatch):
+    from app.core.config import settings
+    from app.engine.multi_agent.tool_collection import _direct_required_tool_names
+
+    monkeypatch.setattr(settings, "living_agent_enable_weather", False)
+    monkeypatch.setattr(settings, "living_agent_weather_api_key", None)
+
+    required = _direct_required_tool_names(
+        "hom nay bao nhieu do",
+        user_role="student",
+    )
+
+    assert required == ["tool_web_search"]
 
 
 def test_direct_required_tool_names_includes_wiii_connect_facebook_direct_apply():

--- a/maritime-ai-service/tests/unit/test_turn_path_governor.py
+++ b/maritime-ai-service/tests/unit/test_turn_path_governor.py
@@ -298,7 +298,7 @@ def test_turn_path_governor_routes_weather_to_weather_with_live_lookup_fallback(
     assert decision.allow_all_tools is False
     assert decision.should_keep_tool_name("tool_current_weather") is True
     assert decision.should_keep_tool_name("tool_web_search") is True
-    assert decision.should_keep_tool_name("tool_fetch_url") is True
+    assert decision.should_keep_tool_name("tool_fetch_url") is False
     assert decision.should_keep_tool_name("tool_current_datetime") is True
     assert decision.should_keep_tool_name("tool_pointy_show") is False
 
@@ -651,7 +651,7 @@ def test_collect_direct_tools_routes_weather_followup_to_weather_tool(monkeypatc
     assert state["_turn_path_decision"]["path"] == "weather_lookup"
     assert "tool_current_weather" in names
     assert "tool_web_search" in names
-    assert "tool_fetch_url" in names
+    assert "tool_fetch_url" not in names
     assert "tool_current_datetime" in names
 
 
@@ -704,7 +704,7 @@ def test_collect_direct_tools_routes_weather_turns_to_weather_tool(query, monkey
     assert state["_turn_path_decision"]["path"] == "weather_lookup"
     assert "tool_current_weather" in names
     assert "tool_web_search" in names
-    assert "tool_fetch_url" in names
+    assert "tool_fetch_url" not in names
 
 
 def test_collect_direct_tools_keeps_maritime_tool_on_maritime_path():
@@ -738,7 +738,7 @@ def test_direct_required_tool_names_weather_prefers_weather_over_web(monkeypatch
 
     assert "tool_current_weather" in required
     assert "tool_web_search" in required
-    assert "tool_fetch_url" in required
+    assert "tool_fetch_url" not in required
     assert "tool_current_datetime" in required
 
 
@@ -757,7 +757,6 @@ def test_direct_required_tool_names_temperature_question_prefers_weather_over_we
     assert required == [
         "tool_current_weather",
         "tool_web_search",
-        "tool_fetch_url",
         "tool_current_datetime",
     ]
 

--- a/maritime-ai-service/tests/unit/test_turn_path_governor.py
+++ b/maritime-ai-service/tests/unit/test_turn_path_governor.py
@@ -655,7 +655,7 @@ def test_collect_direct_tools_routes_weather_followup_to_weather_tool(monkeypatc
     assert "tool_current_datetime" in names
 
 
-def test_collect_direct_tools_routes_weather_to_web_search_when_provider_missing(monkeypatch):
+def test_collect_direct_tools_keeps_weather_path_with_web_search_when_provider_missing(monkeypatch):
     from app.core.config import settings
     from app.engine.multi_agent import tool_collection as module
 
@@ -671,7 +671,7 @@ def test_collect_direct_tools_routes_weather_to_web_search_when_provider_missing
     names = {getattr(tool, "name", getattr(tool, "__name__", "")) for tool in tools}
 
     assert force_tools is True
-    assert state["_turn_path_decision"]["path"] == "web_search"
+    assert state["_turn_path_decision"]["path"] == "weather_lookup"
     assert "tool_web_search" in names
     assert "tool_current_weather" not in names
 

--- a/maritime-ai-service/tests/unit/test_visual_event_summaries.py
+++ b/maritime-ai-service/tests/unit/test_visual_event_summaries.py
@@ -1,0 +1,52 @@
+from app.engine.multi_agent.visual_events import _summarize_tool_result_for_stream
+from app.engine.multi_agent.direct_tool_sources import (
+    extract_source_infos_from_tool_result,
+)
+
+
+def test_weather_tool_result_summary_keeps_unconfigured_status():
+    result = _summarize_tool_result_for_stream(
+        "current_weather",
+        "Mình hiện chưa có kết nối thời tiết trực tiếp cho Hải Phòng, nên không nên đoán nhiệt độ.",
+    )
+
+    assert result == "Chưa có kết nối thời tiết trực tiếp."
+
+
+def test_weather_tool_result_summary_requests_location_when_missing():
+    result = _summarize_tool_result_for_stream(
+        "tool_current_weather",
+        "Bạn muốn xem nhiệt độ ở thành phố nào?",
+    )
+
+    assert result == "Cần thêm địa điểm để tra thời tiết."
+
+
+def test_web_search_result_summary_uses_structured_source_count():
+    result = _summarize_tool_result_for_stream(
+        "tool_web_search",
+        "\n\n---\n\n".join(
+            [
+                "**Weather Hải Phòng today**\nCloudy and warm.\nURL: https://weather.example/hai-phong",
+                "**Local forecast**\nRain chance later.\nURL: https://meteo.example/forecast",
+            ]
+        ),
+    )
+
+    assert result == "Tìm được 2 nguồn: weather.example, meteo.example"
+
+
+def test_extract_source_infos_from_web_search_markdown():
+    sources = extract_source_infos_from_tool_result(
+        "tool_web_search",
+        "**Weather Hải Phòng today**\nCloudy and warm.\nURL: https://weather.example/hai-phong",
+    )
+
+    assert sources == [
+        {
+            "title": "Weather Hải Phòng today",
+            "content": "Cloudy and warm.",
+            "url": "https://weather.example/hai-phong",
+            "source_type": "web",
+        }
+    ]

--- a/maritime-ai-service/tests/unit/test_web_search_tools.py
+++ b/maritime-ai-service/tests/unit/test_web_search_tools.py
@@ -142,6 +142,41 @@ class TestWebSearchTool:
 
         assert ranked[0]["title"] == "Introducing GPT-5.5 - OpenAI"
 
+    def test_searxng_default_candidates_include_local_docker_host(self):
+        from app.engine.tools import web_search_tools as ws
+
+        assert ws._searxng_base_url_candidates(None) == [
+            "http://searxng:8080",
+            "http://host.docker.internal:8080",
+            "http://127.0.0.1:8080",
+        ]
+
+    def test_searxng_explicit_url_does_not_add_local_fallbacks(self):
+        from app.engine.tools import web_search_tools as ws
+
+        assert ws._searxng_base_url_candidates("http://search.internal:8888/") == [
+            "http://search.internal:8888",
+        ]
+
+    def test_weather_search_keeps_organic_results_without_news_merge(self):
+        from app.engine.tools import web_search_tools as ws
+
+        weather_results = [
+            {
+                "title": "Thời tiết Hải Phòng hôm nay - AccuWeather",
+                "body": "Hải Phòng hiện nhiều mây, nhiệt độ 30°C.",
+                "href": "https://www.accuweather.com/vi/vn/haiphong/353511/weather-forecast/353511",
+            }
+        ]
+
+        with patch.object(ws, "_searxng_search_sync", return_value=weather_results), patch.object(
+            ws, "_merge_news_into_search", side_effect=AssertionError("weather search should not merge news")
+        ):
+            result = ws.tool_web_search.invoke({"query": "thời tiết Hải Phòng hôm nay"})
+
+        assert "AccuWeather" in result
+        assert "30°C" in result
+
 
 class TestWebSearchRegistration:
     """Test tool registration."""

--- a/wiii-desktop/src/__tests__/chat-store.test.ts
+++ b/wiii-desktop/src/__tests__/chat-store.test.ts
@@ -235,6 +235,103 @@ describe("Chat Store — Streaming", () => {
     expect(useChatStore.getState().streamingSources).toEqual(sources);
   });
 
+  it("should merge streaming sources from repeated source events", () => {
+    useChatStore.getState().startStreaming();
+
+    useChatStore.getState().setStreamingSources([
+      {
+        title: "Weather Hải Phòng",
+        content: "Cloudy.",
+        url: "https://weather.example/hai-phong",
+        source_type: "web",
+      },
+    ]);
+    useChatStore.getState().setStreamingSources([
+      {
+        title: "Weather Hải Phòng duplicate",
+        content: "Cloudy duplicate.",
+        url: "https://weather.example/hai-phong",
+        source_type: "web",
+      },
+      {
+        title: "Forecast",
+        content: "Rain chance.",
+        url: "https://meteo.example/forecast",
+        source_type: "web",
+      },
+    ]);
+
+    expect(useChatStore.getState().streamingSources).toEqual([
+      {
+        title: "Weather Hải Phòng",
+        content: "Cloudy.",
+        url: "https://weather.example/hai-phong",
+        source_type: "web",
+      },
+      {
+        title: "Forecast",
+        content: "Rain chance.",
+        url: "https://meteo.example/forecast",
+        source_type: "web",
+      },
+    ]);
+  });
+
+  it("should attach late source events to the finalized assistant message", () => {
+    const store = useChatStore.getState();
+    store.createConversation("maritime");
+    store.addUserMessage("weather");
+    store.startStreaming();
+    store.appendStreamingContent("Weather answer.");
+
+    useChatStore.getState().finalizeStream({
+      processing_time: 2.4,
+      model: "qwen",
+      agent_type: "direct",
+      request_id: "req-weather",
+    } as any);
+
+    useChatStore.getState().setStreamingSources([
+      {
+        title: "Hai Phong forecast",
+        content: "Rain.",
+        url: "https://weather.example/hai-phong",
+        source_type: "web",
+      },
+    ]);
+    useChatStore.getState().setStreamingSources([
+      {
+        title: "Hai Phong forecast duplicate",
+        content: "Rain duplicate.",
+        url: "https://weather.example/hai-phong",
+        source_type: "web",
+      },
+      {
+        title: "AccuWeather",
+        content: "Cloudy.",
+        url: "https://accuweather.example/hai-phong",
+        source_type: "web",
+      },
+    ]);
+
+    const conv = useChatStore.getState().conversations[0];
+    expect(conv.messages[1].sources).toEqual([
+      {
+        title: "Hai Phong forecast",
+        content: "Rain.",
+        url: "https://weather.example/hai-phong",
+        source_type: "web",
+      },
+      {
+        title: "AccuWeather",
+        content: "Cloudy.",
+        url: "https://accuweather.example/hai-phong",
+        source_type: "web",
+      },
+    ]);
+    expect(useChatStore.getState().streamingSources).toEqual([]);
+  });
+
   it("should finalize stream into an assistant message", () => {
     const store = useChatStore.getState();
     store.createConversation("maritime");

--- a/wiii-desktop/src/__tests__/chat-store.test.ts
+++ b/wiii-desktop/src/__tests__/chat-store.test.ts
@@ -19,6 +19,8 @@ beforeEach(() => {
     streamingBlocks: [],
     streamingStartTime: null,
     streamingSteps: [],
+    streamCompletedAt: null,
+    lastCompletedConversationId: null,
   });
 });
 
@@ -330,6 +332,49 @@ describe("Chat Store — Streaming", () => {
       },
     ]);
     expect(useChatStore.getState().streamingSources).toEqual([]);
+  });
+
+  it("attaches late source events to the finalized conversation after switching chats", () => {
+    const store = useChatStore.getState();
+    const firstId = store.createConversation("maritime");
+    store.addUserMessage("weather");
+    store.startStreaming();
+    store.appendStreamingContent("Weather answer.");
+
+    useChatStore.getState().finalizeStream({
+      processing_time: 2.4,
+      model: "qwen",
+      agent_type: "direct",
+      request_id: "req-weather",
+    } as any);
+
+    const secondId = useChatStore.getState().createConversation("maritime");
+    expect(useChatStore.getState().activeConversationId).toBe(secondId);
+
+    useChatStore.getState().setStreamingSources([
+      {
+        title: "Hai Phong forecast",
+        content: "Rain.",
+        url: "https://weather.example/hai-phong",
+        source_type: "web",
+      },
+    ]);
+
+    const state = useChatStore.getState();
+    const first = state.conversations.find((item) => item.id === firstId);
+    const second = state.conversations.find((item) => item.id === secondId);
+
+    expect(first?.messages[1].sources).toEqual([
+      {
+        title: "Hai Phong forecast",
+        content: "Rain.",
+        url: "https://weather.example/hai-phong",
+        source_type: "web",
+      },
+    ]);
+    expect(
+      second?.messages.some((message) => Boolean(message.sources?.length)),
+    ).toBe(false);
   });
 
   it("should finalize stream into an assistant message", () => {

--- a/wiii-desktop/src/__tests__/reasoning-interval.test.tsx
+++ b/wiii-desktop/src/__tests__/reasoning-interval.test.tsx
@@ -128,6 +128,8 @@ describe("ReasoningInterval", () => {
       },
     });
     expect(document.querySelector(".code-studio-card")).toBeNull();
+    expect(screen.getByText("Wiii đang xử lý")).toBeTruthy();
+    expect(screen.queryByText("Code Studio")).toBeNull();
     expect(screen.getByText("Minh dang khau lai app tuong tac nay cho that muot.")).toBeTruthy();
     expect(screen.queryByText("Pendulum App")).toBeNull();
   });

--- a/wiii-desktop/src/__tests__/reasoning-interval.test.tsx
+++ b/wiii-desktop/src/__tests__/reasoning-interval.test.tsx
@@ -216,7 +216,7 @@ describe("ReasoningInterval", () => {
     );
 
     expect(screen.getAllByText("Minh dang gom lai vai moc dang tin roi moi dung phan nhin.").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Wiii da nghi xong~").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Wiii đã xử lý xong").length).toBeGreaterThan(0);
     expect(container.querySelector(".sr-only")).toBeNull();
     expect(container.querySelector(".reasoning-interval__thinking-body")?.hasAttribute("hidden")).toBe(true);
   });
@@ -252,7 +252,7 @@ describe("ReasoningInterval", () => {
       />,
     );
 
-    expect(screen.getAllByText("Wiii da nghi xong~").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Wiii đã xử lý xong").length).toBeGreaterThan(0);
     expect(
       screen.queryByText("Minh dang gom vai moc dang tin truoc khi chot cau tra loi."),
     ).toBeNull();

--- a/wiii-desktop/src/__tests__/source-citation.test.tsx
+++ b/wiii-desktop/src/__tests__/source-citation.test.tsx
@@ -36,4 +36,50 @@ describe("SourceCitation", () => {
     expect(screen.getByRole("link", { name: /Weather Hải Phòng today/i }))
       .toHaveProperty("href", "https://weather.example/hai-phong");
   });
+
+  it("keeps mixed web and uploaded document sources in the normal citation list", () => {
+    render(
+      <SourceCitation
+        sources={[
+          {
+            title: "Weather source",
+            content: "Cloudy and warm.",
+            url: "https://weather.example/hai-phong",
+            source_type: "web",
+          },
+          {
+            title: "Uploaded forecast PDF",
+            content: "Local forecast excerpt.",
+            page_number: 4,
+            source_type: "document",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByTestId("web-source-citation")).toBeNull();
+    expect(screen.getByText("Uploaded forecast PDF")).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Weather source/i }))
+      .toHaveProperty("href", "https://weather.example/hai-phong");
+  });
+
+  it("does not render unsafe source URLs as links", () => {
+    render(
+      <SourceCitation
+        sources={[
+          {
+            title: "Unsafe web source",
+            content: "Do not navigate.",
+            url: "javascript:alert(1)",
+            source_type: "web",
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("web-source-citation-summary"));
+
+    expect(screen.getByText("Unsafe web source")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: /Unsafe web source/i })).toBeNull();
+  });
 });

--- a/wiii-desktop/src/__tests__/source-citation.test.tsx
+++ b/wiii-desktop/src/__tests__/source-citation.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SourceCitation } from "@/components/chat/SourceCitation";
+
+describe("SourceCitation", () => {
+  it("renders web sources as a compact collapsed source box", () => {
+    render(
+      <SourceCitation
+        sources={[
+          {
+            title: "Weather Hải Phòng today",
+            content: "Cloudy and warm.",
+            url: "https://weather.example/hai-phong",
+            source_type: "web",
+          },
+          {
+            title: "Local forecast",
+            content: "Rain chance later.",
+            url: "https://meteo.example/forecast",
+            source_type: "web",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("2 nguồn web")).toBeTruthy();
+    expect(screen.getByTestId("web-source-citation")).toBeTruthy();
+    expect(screen.getByTestId("web-source-citation-summary")).toBeTruthy();
+    expect(screen.getByText("weather.example, meteo.example")).toBeTruthy();
+    expect(screen.queryByText("Weather Hải Phòng today")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /2 nguồn web/i }));
+
+    expect(screen.getByText("Weather Hải Phòng today")).toBeTruthy();
+    expect(screen.getByText("Local forecast")).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Weather Hải Phòng today/i }))
+      .toHaveProperty("href", "https://weather.example/hai-phong");
+  });
+});

--- a/wiii-desktop/src/__tests__/streaming-blocks.test.ts
+++ b/wiii-desktop/src/__tests__/streaming-blocks.test.ts
@@ -39,6 +39,10 @@ function getBlocks(): ContentBlock[] {
   return useChatStore.getState().streamingBlocks;
 }
 
+function stateToolCalls() {
+  return useChatStore.getState().streamingToolCalls;
+}
+
 function thinkingAt(blocks: ContentBlock[], index: number): ThinkingBlockData {
   const block = blocks[index];
   expect(block.type).toBe("thinking");
@@ -218,6 +222,52 @@ describe("streaming blocks", () => {
     expect(blocks).toHaveLength(1);
     expect(blocks[0].type).toBe("tool_execution");
     expect(toolAt(blocks, 0).tool.id).toBe("tc-orphan");
+  });
+
+  it("deduplicates replayed tool calls by id", () => {
+    const store = useChatStore.getState();
+    store.startStreaming();
+    store.setStreamingThinking("Need a search.");
+    store.appendToolCall({
+      id: "tc-replay",
+      name: "tool_web_search",
+      args: { query: "first query" },
+    });
+    store.appendToolCall({
+      id: "tc-replay",
+      name: "tool_web_search",
+      args: { query: "replayed query" },
+    });
+
+    const blocks = getBlocks();
+    expect(stateToolCalls()).toHaveLength(1);
+    expect(
+      blocks.filter((block) => block.type === "tool_execution"),
+    ).toHaveLength(1);
+    expect(toolAt(blocks, 1).tool.args?.query).toBe("replayed query");
+    expect(thinkingAt(blocks, 0).toolCalls).toHaveLength(1);
+  });
+
+  it("keeps completed tool calls completed when a duplicate call is replayed", () => {
+    const store = useChatStore.getState();
+    store.startStreaming();
+    store.appendToolCall({
+      id: "tc-complete-replay",
+      name: "tool_web_search",
+      args: { query: "weather" },
+    });
+    store.updateToolCallResult("tc-complete-replay", "Found sources");
+    store.appendToolCall({
+      id: "tc-complete-replay",
+      name: "tool_web_search",
+      args: { query: "weather" },
+    });
+
+    const blocks = getBlocks();
+    expect(stateToolCalls()).toHaveLength(1);
+    expect(blocks).toHaveLength(1);
+    expect(toolAt(blocks, 0).status).toBe("completed");
+    expect(toolAt(blocks, 0).tool.result).toBe("Found sources");
   });
 
   it("places a late tool_execution block after an answer when no new thinking step exists", () => {

--- a/wiii-desktop/src/__tests__/tool-execution-strip.test.tsx
+++ b/wiii-desktop/src/__tests__/tool-execution-strip.test.tsx
@@ -312,6 +312,31 @@ describe("ToolExecutionStrip", () => {
     ).toBeTruthy();
   });
 
+  it("uses structured weather status before falling back to text matching", () => {
+    const block: ToolExecutionBlockData = {
+      type: "tool_execution",
+      id: "tool-weather-json",
+      status: "completed",
+      tool: {
+        id: "tool-weather-json",
+        name: "current_weather",
+        args: {
+          city: "Hải Phòng",
+        },
+        result: JSON.stringify({
+          status: "error",
+          reason_code: "no_data",
+          message: "Provider returned an empty response.",
+        }),
+      },
+    };
+
+    render(<ToolExecutionStrip block={block} />);
+    fireEvent.click(screen.getByRole("button", { name: /Tra thời tiết/i }));
+
+    expect(screen.getByText("Chưa lấy được thời tiết hiện tại.")).toBeTruthy();
+  });
+
   it("marks pending tool calls as busy without inventing output", () => {
     const block: ToolExecutionBlockData = {
       type: "tool_execution",

--- a/wiii-desktop/src/__tests__/tool-execution-strip.test.tsx
+++ b/wiii-desktop/src/__tests__/tool-execution-strip.test.tsx
@@ -240,4 +240,100 @@ describe("ToolExecutionStrip", () => {
       screen.getByText("Đã chèn minh họa ngay trong câu trả lời"),
     ).toBeTruthy();
   });
+
+  it("shows a professional web-search trace while keeping results collapsed", () => {
+    const block: ToolExecutionBlockData = {
+      type: "tool_execution",
+      id: "tool-search-1",
+      status: "completed",
+      tool: {
+        id: "tool-search-1",
+        name: "tool_web_search",
+        args: {
+          query: "thời tiết Hải Phòng hôm nay",
+        },
+        result: JSON.stringify([
+          {
+            title: "Dự báo thời tiết Hải Phòng",
+            url: "https://weather.gov.vn/hai-phong",
+            snippet: "Thông tin dự báo trong ngày.",
+          },
+        ]),
+      },
+    };
+
+    render(<ToolExecutionStrip block={block} />);
+
+    const strip = screen.getByTestId("tool-execution-strip");
+    expect(strip.getAttribute("data-tool-kind")).toBe("search");
+    expect(screen.getByText("Tìm kiếm web")).toBeTruthy();
+    expect(screen.getByText("Đã xong")).toBeTruthy();
+    expect(screen.getByText("Truy vấn")).toBeTruthy();
+    expect(screen.getByText("thời tiết Hải Phòng hôm nay")).toBeTruthy();
+    expect(screen.queryByText("Dự báo thời tiết Hải Phòng")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Tìm kiếm web/i }));
+
+    expect(screen.getByText("Nguồn tìm được")).toBeTruthy();
+    expect(screen.getByText("Dự báo thời tiết Hải Phòng")).toBeTruthy();
+    expect(screen.getByText("weather.gov.vn")).toBeTruthy();
+    expect(strip.textContent || "").not.toContain('"snippet"');
+  });
+
+  it("shows weather tool traces as location-aware status instead of a generic tool", () => {
+    const block: ToolExecutionBlockData = {
+      type: "tool_execution",
+      id: "tool-weather-1",
+      status: "completed",
+      tool: {
+        id: "tool-weather-1",
+        name: "current_weather",
+        args: {
+          city: "Hải Phòng",
+        },
+        result: "Chưa có kết nối thời tiết trực tiếp.",
+      },
+    };
+
+    render(<ToolExecutionStrip block={block} />);
+
+    const strip = screen.getByTestId("tool-execution-strip");
+    expect(strip.getAttribute("data-tool-kind")).toBe("weather");
+    expect(screen.getByText("Tra thời tiết")).toBeTruthy();
+    expect(screen.getByText("Địa điểm")).toBeTruthy();
+    expect(screen.getByText("Hải Phòng")).toBeTruthy();
+    expect(screen.queryByText("Tình trạng")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Tra thời tiết/i }));
+
+    expect(screen.getByText("Tình trạng")).toBeTruthy();
+    expect(
+      screen.getByText("Chưa có kết nối thời tiết trực tiếp."),
+    ).toBeTruthy();
+  });
+
+  it("marks pending tool calls as busy without inventing output", () => {
+    const block: ToolExecutionBlockData = {
+      type: "tool_execution",
+      id: "tool-search-pending",
+      status: "pending",
+      tool: {
+        id: "tool-search-pending",
+        name: "tool_web_search",
+        args: {
+          query: "NVIDIA models API",
+        },
+      },
+    };
+
+    render(<ToolExecutionStrip block={block} />);
+
+    const strip = screen.getByTestId("tool-execution-strip");
+    const button = screen.getByRole("button", { name: /Tìm kiếm web/i });
+    expect(strip.getAttribute("aria-busy")).toBe("true");
+    expect(button).toHaveProperty("disabled", true);
+    expect(screen.getByText("Đang gọi")).toBeTruthy();
+    expect(screen.getByText("NVIDIA models API")).toBeTruthy();
+    expect(screen.queryByText("Nguồn tìm được")).toBeNull();
+  });
 });

--- a/wiii-desktop/src/api/types.ts
+++ b/wiii-desktop/src/api/types.ts
@@ -156,6 +156,8 @@ export interface ChatRequest {
 export interface SourceInfo {
   title: string;
   content: string;
+  url?: string;
+  source_type?: string;
   image_url?: string;
   page_number?: number;
   document_id?: string;
@@ -355,6 +357,7 @@ export interface SSEAnswerEvent {
 
 export interface SSESourcesEvent {
   sources: SourceInfo[];
+  content?: SourceInfo[];
   display_role?: DisplayRole;
   sequence_id?: number;
   step_id?: string;

--- a/wiii-desktop/src/api/types.ts
+++ b/wiii-desktop/src/api/types.ts
@@ -356,7 +356,7 @@ export interface SSEAnswerEvent {
 }
 
 export interface SSESourcesEvent {
-  sources: SourceInfo[];
+  sources?: SourceInfo[];
   content?: SourceInfo[];
   display_role?: DisplayRole;
   sequence_id?: number;

--- a/wiii-desktop/src/components/chat/ReasoningInterval.tsx
+++ b/wiii-desktop/src/components/chat/ReasoningInterval.tsx
@@ -86,25 +86,11 @@ function getNodeLabel(node?: string) {
 const WIII_FALLBACK_LABEL_LIVE = "Wiii đang xử lý";
 const WIII_FALLBACK_LABEL_DONE = "Wiii đã xử lý xong";
 
-// Reasoning/tool headers should stay operational. Cute persona labels belong in
-// the assistant answer, not in the tool timeline.
-const PLAYFUL_REASONING_LABEL_MARKER =
-  /[~≽˶╥⊙¬ᕙ•̀ᴗ•́و\u{1F600}-\u{1F64F}\u{2728}\u{1F31F}]|Wiii\s+(?:đang\s+suy|đã\s+nghĩ|da\s+nghi|suy\s+nghĩ)/iu;
-
 /**
- * Header label: ONLY Wiii persona labels from tool_think's persona_label field.
- * Everything else (phase names, node names, technical text) → fallback.
- *
- * Rule: If it doesn't SOUND like Wiii, it doesn't go on the header.
+ * Header labels stay operational. Persona text and internal phase labels belong
+ * in the expanded body or the final answer, not in the timeline chrome.
  */
 function getIntervalHeaderLabel(interval: ReasoningIntervalViewModel) {
-  if (interval.label?.trim()) {
-    const label = interval.label.trim();
-    if (!PLAYFUL_REASONING_LABEL_MARKER.test(label)) {
-      return label;
-    }
-  }
-
   if (interval.isLive) return WIII_FALLBACK_LABEL_LIVE;
   return WIII_FALLBACK_LABEL_DONE;
 }

--- a/wiii-desktop/src/components/chat/ReasoningInterval.tsx
+++ b/wiii-desktop/src/components/chat/ReasoningInterval.tsx
@@ -83,19 +83,13 @@ function getNodeLabel(node?: string) {
   return NODE_LABELS[normalizeNode(node)] || node || "Đang suy luận";
 }
 
-// Wiii-voice fallback labels (Tier 2) — used when no persona_label received.
-// Wiii is a Living Agent (Soul AGI, Sprints 170-210) — her cute personality is
-// core identity, not cosmetic. Keep the aliveness.
-const WIII_FALLBACK_LABELS_LIVE = "Wiii đang suy nghĩ~ (˶˃ ᵕ ˂˶)";
-const WIII_FALLBACK_LABELS_DONE = [
-  "Wiii đã nghĩ xong~ (˶˃ ᵕ ˂˶)",
-  "Hmm Wiii suy nghĩ rồi nè~",
-  "Wiii đã xem xong ≽^•⩊•^≼",
-];
+const WIII_FALLBACK_LABEL_LIVE = "Wiii đang xử lý";
+const WIII_FALLBACK_LABEL_DONE = "Wiii đã xử lý xong";
 
-// Detect genuine Wiii persona labels (contain kaomoji, ~, Wiii, emoji patterns)
-const PERSONA_MARKER =
-  /[~≽˶╥⊙¬ᕙ•̀ᴗ•́و\u{1F600}-\u{1F64F}\u{2728}\u{1F31F}]|Wiii/u;
+// Reasoning/tool headers should stay operational. Cute persona labels belong in
+// the assistant answer, not in the tool timeline.
+const PLAYFUL_REASONING_LABEL_MARKER =
+  /[~≽˶╥⊙¬ᕙ•̀ᴗ•́و\u{1F600}-\u{1F64F}\u{2728}\u{1F31F}]|Wiii\s+(?:đang\s+suy|đã\s+nghĩ|da\s+nghi|suy\s+nghĩ)/iu;
 
 /**
  * Header label: ONLY Wiii persona labels from tool_think's persona_label field.
@@ -104,19 +98,15 @@ const PERSONA_MARKER =
  * Rule: If it doesn't SOUND like Wiii, it doesn't go on the header.
  */
 function getIntervalHeaderLabel(interval: ReasoningIntervalViewModel) {
-  // Tier 1: Only accept labels that are genuine persona labels from tool_think
   if (interval.label?.trim()) {
     const label = interval.label.trim();
-    if (PERSONA_MARKER.test(label)) {
+    if (!PLAYFUL_REASONING_LABEL_MARKER.test(label)) {
       return label;
     }
   }
 
-  // Tier 2: Wiii-voice fallback (ALWAYS cute, never technical)
-  if (interval.isLive) return WIII_FALLBACK_LABELS_LIVE;
-  return WIII_FALLBACK_LABELS_DONE[
-    Math.floor(Math.random() * WIII_FALLBACK_LABELS_DONE.length)
-  ];
+  if (interval.isLive) return WIII_FALLBACK_LABEL_LIVE;
+  return WIII_FALLBACK_LABEL_DONE;
 }
 
 /** Full summary for the expanded body preview. */

--- a/wiii-desktop/src/components/chat/SourceCitation.tsx
+++ b/wiii-desktop/src/components/chat/SourceCitation.tsx
@@ -10,6 +10,7 @@ import type { SourceInfo } from "@/api/types";
 import { useUIStore } from "@/stores/ui-store";
 
 const MAX_VISIBLE = 3;
+const SAFE_URL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
 
 interface SourceCitationProps {
   sources: SourceInfo[];
@@ -21,10 +22,8 @@ export function SourceCitation({ sources }: SourceCitationProps) {
 
   if (!sources || sources.length === 0) return null;
 
-  const hasWebSources = sources.some(
-    (source) => source.url || source.source_type === "web",
-  );
-  if (hasWebSources) {
+  const allWebSources = sources.every(isWebSource);
+  if (allWebSources) {
     return <WebSourceCitation sources={sources} />;
   }
 
@@ -44,22 +43,45 @@ export function SourceCitation({ sources }: SourceCitationProps) {
         Nguồn tham khảo
       </div>
       <div className="source-citation__list">
-        {visibleSources.map((source, i) => (
-          <button
-            key={i}
-            onClick={() => handleClick(i)}
-            className="source-citation__item"
-            title={source.title}
-          >
-            <span className="source-citation__index">[{i + 1}]</span>
-            <span className="source-citation__title">{source.title}</span>
-            {source.page_number && (
-              <span className="source-citation__page">
-                tr. {source.page_number}
-              </span>
-            )}
-          </button>
-        ))}
+        {visibleSources.map((source, i) => {
+          const safeUrl = safeSourceUrl(source.url);
+          const body = (
+            <>
+              <span className="source-citation__index">[{i + 1}]</span>
+              <span className="source-citation__title">{source.title}</span>
+              {source.page_number && (
+                <span className="source-citation__page">
+                  tr. {source.page_number}
+                </span>
+              )}
+              {safeUrl && <ExternalLink size={12} aria-hidden="true" />}
+            </>
+          );
+          if (safeUrl) {
+            return (
+              <a
+                key={`${safeUrl}-${i}`}
+                href={safeUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="source-citation__item"
+                title={source.title}
+              >
+                {body}
+              </a>
+            );
+          }
+          return (
+            <button
+              key={i}
+              onClick={() => handleClick(i)}
+              className="source-citation__item"
+              title={source.title}
+            >
+              {body}
+            </button>
+          );
+        })}
       </div>
       {!showAll && hiddenCount > 0 && (
         <button
@@ -87,7 +109,7 @@ function WebSourceCitation({ sources }: SourceCitationProps) {
   const [expanded, setExpanded] = useState(false);
   const visibleSources = expanded ? sources : sources.slice(0, 3);
   const domains = sources
-    .map((source) => domainLabel(source.url || ""))
+    .map((source) => domainLabel(safeSourceUrl(source.url)))
     .filter(Boolean)
     .slice(0, 3);
 
@@ -118,17 +140,10 @@ function WebSourceCitation({ sources }: SourceCitationProps) {
       {expanded && (
         <div className="web-source-citation__list">
           {visibleSources.map((source, index) => {
-            const url = source.url || "";
+            const url = safeSourceUrl(source.url);
             const domain = domainLabel(url);
-            return (
-              <a
-                key={`${url || source.title}-${index}`}
-                href={url || undefined}
-                target="_blank"
-                rel="noreferrer noopener"
-                className="web-source-citation__item"
-                aria-disabled={!url}
-              >
+            const body = (
+              <>
                 <span className="web-source-citation__index">
                   {index + 1}
                 </span>
@@ -141,6 +156,27 @@ function WebSourceCitation({ sources }: SourceCitationProps) {
                   </span>
                 </span>
                 {url && <ExternalLink size={12} />}
+              </>
+            );
+            if (!url) {
+              return (
+                <div
+                  key={`${source.title}-${index}`}
+                  className="web-source-citation__item"
+                >
+                  {body}
+                </div>
+              );
+            }
+            return (
+              <a
+                key={`${url || source.title}-${index}`}
+                href={url}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="web-source-citation__item"
+              >
+                {body}
               </a>
             );
           })}
@@ -148,6 +184,20 @@ function WebSourceCitation({ sources }: SourceCitationProps) {
       )}
     </div>
   );
+}
+
+function isWebSource(source: SourceInfo): boolean {
+  return source.source_type === "web" || Boolean(safeSourceUrl(source.url));
+}
+
+function safeSourceUrl(url: string | undefined): string {
+  if (!url) return "";
+  try {
+    const parsed = new URL(url);
+    return SAFE_URL_PROTOCOLS.has(parsed.protocol) ? parsed.href : "";
+  } catch {
+    return "";
+  }
 }
 
 function domainLabel(url: string): string {

--- a/wiii-desktop/src/components/chat/SourceCitation.tsx
+++ b/wiii-desktop/src/components/chat/SourceCitation.tsx
@@ -5,6 +5,7 @@
  * Sprint 233: Compact list layout, 3 visible by default, "+N" expandable.
  */
 import { useState } from "react";
+import { ChevronDown, ExternalLink, Globe } from "lucide-react";
 import type { SourceInfo } from "@/api/types";
 import { useUIStore } from "@/stores/ui-store";
 
@@ -19,6 +20,13 @@ export function SourceCitation({ sources }: SourceCitationProps) {
   const [showAll, setShowAll] = useState(false);
 
   if (!sources || sources.length === 0) return null;
+
+  const hasWebSources = sources.some(
+    (source) => source.url || source.source_type === "web",
+  );
+  if (hasWebSources) {
+    return <WebSourceCitation sources={sources} />;
+  }
 
   const handleClick = (index: number) => {
     selectSource(index);
@@ -73,4 +81,80 @@ export function SourceCitation({ sources }: SourceCitationProps) {
       )}
     </div>
   );
+}
+
+function WebSourceCitation({ sources }: SourceCitationProps) {
+  const [expanded, setExpanded] = useState(false);
+  const visibleSources = expanded ? sources : sources.slice(0, 3);
+  const domains = sources
+    .map((source) => domainLabel(source.url || ""))
+    .filter(Boolean)
+    .slice(0, 3);
+
+  return (
+    <div className="web-source-citation" data-testid="web-source-citation">
+      <button
+        type="button"
+        className="web-source-citation__summary"
+        data-testid="web-source-citation-summary"
+        onClick={() => setExpanded((value) => !value)}
+        aria-expanded={expanded}
+      >
+        <span className="web-source-citation__title">
+          <Globe size={14} />
+          {sources.length} nguồn web
+        </span>
+        {domains.length > 0 && (
+          <span className="web-source-citation__domains">
+            {domains.join(", ")}
+          </span>
+        )}
+        <ChevronDown
+          size={14}
+          className={`web-source-citation__chevron ${expanded ? "web-source-citation__chevron--open" : ""}`}
+        />
+      </button>
+
+      {expanded && (
+        <div className="web-source-citation__list">
+          {visibleSources.map((source, index) => {
+            const url = source.url || "";
+            const domain = domainLabel(url);
+            return (
+              <a
+                key={`${url || source.title}-${index}`}
+                href={url || undefined}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="web-source-citation__item"
+                aria-disabled={!url}
+              >
+                <span className="web-source-citation__index">
+                  {index + 1}
+                </span>
+                <span className="web-source-citation__body">
+                  <span className="web-source-citation__item-title">
+                    {source.title}
+                  </span>
+                  <span className="web-source-citation__item-meta">
+                    {domain || source.content}
+                  </span>
+                </span>
+                {url && <ExternalLink size={12} />}
+              </a>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function domainLabel(url: string): string {
+  if (!url) return "";
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return "";
+  }
 }

--- a/wiii-desktop/src/components/chat/ToolExecutionStrip.tsx
+++ b/wiii-desktop/src/components/chat/ToolExecutionStrip.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import {
   CheckCircle2,
   ChevronDown,
+  CloudSun,
   Clock3,
   ExternalLink,
   FileSearch,
@@ -49,13 +50,35 @@ const SEARCH_TOOL_NAMES = new Set([
   "tool_search_shopping",
 ]);
 
+const WEATHER_TOOL_NAMES = new Set(["tool_current_weather", "current_weather"]);
+
+function normalizeToolName(name: string): string {
+  return name.trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function isWeatherTool(name: string): boolean {
+  const normalized = normalizeToolName(name);
+  return (
+    WEATHER_TOOL_NAMES.has(normalized) ||
+    normalized.includes("current_weather") ||
+    normalized.endsWith("_weather")
+  );
+}
+
 export function resolveToolExecutionIcon(name: string) {
-  if (name === "tool_create_visual_code") return Palette;
-  if (name.includes("browser") || name.includes("web")) return Globe2;
-  if (name.includes("search")) return Search;
-  if (name.includes("python") || name.includes("exec") || name.includes("code"))
+  const lowered = normalizeToolName(name);
+  if (lowered === "tool_create_visual_code") return Palette;
+  if (isWeatherTool(lowered)) return CloudSun;
+  if (lowered.includes("browser") || lowered.includes("web")) return Globe2;
+  if (lowered.includes("search")) return Search;
+  if (
+    lowered.includes("python") ||
+    lowered.includes("exec") ||
+    lowered.includes("code")
+  )
     return TerminalSquare;
-  if (name.includes("generate") || name.includes("file")) return FileSearch;
+  if (lowered.includes("generate") || lowered.includes("file"))
+    return FileSearch;
   return Wrench;
 }
 
@@ -184,7 +207,20 @@ function summarizeArgs(
     return "Script Python đang được chuẩn bị";
   }
 
+  if (isWeatherTool(toolName)) {
+    const locationKeys = ["city", "location", "place", "query", "q"];
+    for (const key of locationKeys) {
+      const value = args[key];
+      if (typeof value === "string" && value.trim()) {
+        return clampNaturalText(sanitizeInlineText(value.trim()), 120);
+      }
+    }
+  }
+
   const preferredKeys = [
+    "city",
+    "location",
+    "place",
     "query",
     "q",
     "url",
@@ -207,6 +243,59 @@ function summarizeArgs(
   }
 
   return "";
+}
+
+function getToolKindLabel(toolName: string): string {
+  if (VISUAL_TOOL_NAMES.has(toolName)) return "VISUAL";
+  if (isWeatherTool(toolName)) return "WEATHER";
+  if (SEARCH_TOOL_NAMES.has(toolName) || toolName.includes("search")) {
+    return "SEARCH";
+  }
+  if (toolName.includes("browser") || toolName.includes("web")) return "WEB";
+  if (
+    toolName.includes("python") ||
+    toolName.includes("exec") ||
+    toolName.includes("code")
+  ) {
+    return "CODE";
+  }
+  if (toolName.includes("generate") || toolName.includes("file")) return "FILE";
+  return "TOOL";
+}
+
+function getToolInputLabel(
+  toolName: string,
+  args?: Record<string, unknown>,
+): string {
+  if (isWeatherTool(toolName)) return "Địa điểm";
+  if (toolName === "tool_execute_python") return "Tác vụ";
+  if (
+    toolName === "tool_generate_visual" ||
+    toolName === "tool_generate_rich_visual" ||
+    toolName === "tool_create_visual_code"
+  ) {
+    return "Mục tiêu";
+  }
+  if (typeof args?.url === "string" && args.url.trim()) return "URL";
+  if (
+    (typeof args?.query === "string" && args.query.trim()) ||
+    (typeof args?.q === "string" && args.q.trim())
+  ) {
+    return "Truy vấn";
+  }
+  if (typeof args?.prompt === "string" && args.prompt.trim()) return "Prompt";
+  return "Đầu vào";
+}
+
+function getToolResultLabel(toolName: string): string {
+  if (isWeatherTool(toolName)) return "Tình trạng";
+  if (SEARCH_TOOL_NAMES.has(toolName) || toolName.includes("search")) {
+    return "Nguồn tìm được";
+  }
+  if (toolName.includes("browser") || toolName.includes("web")) {
+    return "Kết quả web";
+  }
+  return "Kết quả";
 }
 
 function extractArtifactNames(result: string): string[] {
@@ -247,6 +336,43 @@ function buildPythonTechnicalDetail(
   return parts.join("\n\n").trim();
 }
 
+function stripVietnameseMarks(value: string): string {
+  return value
+    .replace(/đ/g, "d")
+    .replace(/Đ/g, "D")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}
+
+function summarizeWeatherResult(result: string): string {
+  const sanitized = sanitizeInlineText(result);
+  const folded = stripVietnameseMarks(sanitized);
+  if (
+    folded.includes("da co them ket qua de chat loc") ||
+    folded.includes("da co them ket qua de chon loc")
+  ) {
+    return "Tool thời tiết chưa trả về dữ liệu cụ thể.";
+  }
+  if (folded.includes("chua co ket noi thoi tiet truc tiep")) {
+    return "Chưa có kết nối thời tiết trực tiếp.";
+  }
+  if (
+    folded.includes("can them dia diem") ||
+    folded.includes("thanh pho nao") ||
+    folded.includes("ban muon xem nhiet do")
+  ) {
+    return "Cần thêm địa điểm để tra thời tiết.";
+  }
+  if (
+    folded.includes("chua lay duoc thoi tiet") ||
+    folded.includes("khong co du lieu thoi tiet")
+  ) {
+    return "Chưa lấy được thời tiết hiện tại.";
+  }
+  return clampNaturalText(sanitized.replace(/[{}[\]"]/g, ""), 180);
+}
+
 function summarizeResult(
   toolName: string,
   result?: string,
@@ -278,6 +404,20 @@ function summarizeResult(
       line: clampNaturalText(line, 160),
       technicalDetail: technicalDetail || undefined,
       detailLabel: "Chi tiết script",
+    };
+  }
+
+  if (isWeatherTool(toolName)) {
+    const line = summarizeWeatherResult(result);
+    const technicalDetail = sanitizeTechnicalDetail(result) || undefined;
+    return {
+      line,
+      technicalDetail:
+        technicalDetail &&
+        normalizeForCompare(technicalDetail) !== normalizeForCompare(line)
+          ? technicalDetail
+          : undefined,
+      detailLabel: "Chi tiết thời tiết",
     };
   }
 
@@ -476,19 +616,21 @@ function VisualToolStrip({ block }: ToolExecutionStripProps) {
 
 /** Generic tool strip — separated to avoid hooks-after-return violation. */
 function GenericToolStrip({ block }: ToolExecutionStripProps) {
-  // Phase 35 — SOTA collapse pattern (Claude.ai / Perplexity 2026):
-  // - Always show: label + state + args line  (1-2 visual rows)
-  // - Hide by default: result line + search cards + technical detail
-  // - User clicks the strip header / "Xem nguồn" link to expand
-  // This cuts vertical footprint ~70% for multi-tool turns.
   const [expanded, setExpanded] = useState(false);
   const toolName = block.tool.name;
   const Icon = resolveToolExecutionIcon(toolName);
   const label =
     TOOL_LABELS[toolName] || toolName.replace(/^tool_/, "").replace(/_/g, " ");
   const isPending = block.status === "pending";
+  const kindLabel = getToolKindLabel(toolName);
+  const stateLabel = isPending ? "Đang gọi" : "Đã xong";
+  const resultLabel = getToolResultLabel(toolName);
   const argsLine = useMemo(
     () => summarizeArgs(toolName, block.tool.args),
+    [toolName, block.tool.args],
+  );
+  const inputLabel = useMemo(
+    () => getToolInputLabel(toolName, block.tool.args),
     [toolName, block.tool.args],
   );
   const {
@@ -512,18 +654,25 @@ function GenericToolStrip({ block }: ToolExecutionStripProps) {
     () => (isSearchTool ? parseSearchResults(block.tool.result) : []),
     [isSearchTool, block.tool.result],
   );
+  const shouldShowTechnicalDetail = Boolean(
+    technicalDetail && searchItems.length === 0,
+  );
 
-  // Show body content (result/cards) only when user expands. The summary
-  // line in the header already conveys what happened (e.g. "Tìm được 4
-  // nguồn: cnbc.com, ..."), so the cards/details are progressive disclosure.
   const hasBodyContent = searchItems.length > 0 || Boolean(resultLine);
-  const canExpand = hasBodyContent || showDetailsToggle;
+  const canExpand =
+    hasBodyContent || (showDetailsToggle && shouldShowTechnicalDetail);
+  const expandedLabel = expanded ? "Thu gọn" : "Mở chi tiết";
 
   return (
     <div
       className={`tool-strip ${isPending ? "tool-strip--pending" : "tool-strip--complete"}`}
+      data-status={isPending ? "pending" : "complete"}
+      data-tool-kind={kindLabel.toLowerCase()}
+      data-testid="tool-execution-strip"
+      aria-busy={isPending || undefined}
     >
       <div className="tool-strip__rail" aria-hidden="true">
+        <span className="tool-strip__rail-line" />
         <span className="tool-strip__dot">
           <Icon size={12} />
         </span>
@@ -536,35 +685,61 @@ function GenericToolStrip({ block }: ToolExecutionStripProps) {
           onClick={() => canExpand && setExpanded((v) => !v)}
           aria-expanded={canExpand ? expanded : undefined}
           aria-disabled={!canExpand}
+          aria-label={`${label}: ${stateLabel}${
+            argsLine ? `. ${inputLabel}: ${argsLine}` : ""
+          }`}
           disabled={!canExpand}
         >
-          <span className="tool-strip__label">{label}</span>
-          <span className="tool-strip__state">
-            {isPending ? <Clock3 size={12} /> : <CheckCircle2 size={12} />}
-            {isPending ? "Đang chạy" : "Đã xong"}
+          <span className="tool-strip__title">
+            <span className="tool-strip__kind">{kindLabel}</span>
+            <span className="tool-strip__label">{label}</span>
           </span>
-          {canExpand && !isPending && (
-            <ChevronDown
-              size={11}
-              className={`tool-strip__expand-chevron ${expanded ? "tool-strip__expand-chevron--open" : ""}`}
-            />
-          )}
+          <span className="tool-strip__header-meta">
+            <span className="tool-strip__state">
+              {isPending ? <Clock3 size={12} /> : <CheckCircle2 size={12} />}
+              {stateLabel}
+            </span>
+            {canExpand && !isPending && (
+              <span className="tool-strip__expand">
+                <span className="tool-strip__expand-label">
+                  {expandedLabel}
+                </span>
+                <ChevronDown
+                  size={12}
+                  className={`tool-strip__expand-chevron ${expanded ? "tool-strip__expand-chevron--open" : ""}`}
+                />
+              </span>
+            )}
+          </span>
         </button>
 
-        {argsLine && <div className="tool-strip__query">{argsLine}</div>}
+        {argsLine && (
+          <div className="tool-strip__query">
+            <span className="tool-strip__query-label">{inputLabel}</span>
+            <span className="tool-strip__query-text">{argsLine}</span>
+          </div>
+        )}
 
-        {/* Rich search results when available — only when expanded */}
+        {isPending && (
+          <div className="tool-strip__progress" aria-hidden="true">
+            <span />
+          </div>
+        )}
+
         {expanded && searchItems.length > 0 ? (
-          <SearchResultWidget items={searchItems} />
+          <div className="tool-strip__expanded">
+            <div className="tool-strip__section-label">{resultLabel}</div>
+            <SearchResultWidget items={searchItems} />
+          </div>
         ) : null}
         {expanded && searchItems.length === 0 && resultLine ? (
-          <div className="tool-strip__result">{resultLine}</div>
+          <div className="tool-strip__result">
+            <span className="tool-strip__section-label">{resultLabel}</span>
+            <span className="tool-strip__result-text">{resultLine}</span>
+          </div>
         ) : null}
 
-        {/* Phase 35 — inner toggle button removed; header itself toggles
-            `expanded` (clickable). technicalDetail renders inline when
-            expanded for tools that have raw output (e.g. python script). */}
-        {expanded && technicalDetail && (
+        {expanded && shouldShowTechnicalDetail && technicalDetail && (
           <div
             className="tool-strip__detail"
             role="region"

--- a/wiii-desktop/src/components/chat/ToolExecutionStrip.tsx
+++ b/wiii-desktop/src/components/chat/ToolExecutionStrip.tsx
@@ -345,7 +345,72 @@ function stripVietnameseMarks(value: string): string {
     .toLowerCase();
 }
 
+function getStringField(
+  payload: Record<string, unknown>,
+  keys: string[],
+): string {
+  for (const key of keys) {
+    const value = payload[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "";
+}
+
+function parseStructuredWeatherStatus(result: string): string | null {
+  const trimmed = result.trim();
+  if (!trimmed.startsWith("{")) return null;
+
+  try {
+    const payload = JSON.parse(trimmed) as unknown;
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      return null;
+    }
+
+    const fields = payload as Record<string, unknown>;
+    const status = stripVietnameseMarks(getStringField(fields, ["status"]));
+    const reason = stripVietnameseMarks(
+      getStringField(fields, ["reason_code", "reason", "error_code"]),
+    );
+    const code = `${status} ${reason}`;
+
+    if (
+      code.includes("provider_unconfigured") ||
+      code.includes("not_configured") ||
+      code.includes("missing_api_key")
+    ) {
+      return "Chưa có kết nối thời tiết trực tiếp.";
+    }
+    if (
+      code.includes("missing_location") ||
+      code.includes("needs_location") ||
+      code.includes("location_required")
+    ) {
+      return "Cần thêm địa điểm để tra thời tiết.";
+    }
+    if (
+      code.includes("no_data") ||
+      code.includes("unavailable") ||
+      code.includes("error")
+    ) {
+      return "Chưa lấy được thời tiết hiện tại.";
+    }
+
+    const summary = getStringField(fields, [
+      "summary",
+      "message",
+      "description",
+      "condition",
+    ]);
+    return summary ? clampNaturalText(sanitizeInlineText(summary), 180) : null;
+  } catch {
+    return null;
+  }
+}
+
 function summarizeWeatherResult(result: string): string {
+  const structured = parseStructuredWeatherStatus(result);
+  if (structured) return structured;
+
   const sanitized = sanitizeInlineText(result);
   const folded = stripVietnameseMarks(sanitized);
   if (

--- a/wiii-desktop/src/components/layout/SourcesPanel.tsx
+++ b/wiii-desktop/src/components/layout/SourcesPanel.tsx
@@ -36,6 +36,13 @@ function inferSourceType(source: SourceInfo): {
       bg: "var(--accent)",
     };
   }
+  if (source.url || source.source_type === "web") {
+    return {
+      label: "WEB",
+      color: "var(--accent-blue, #2563eb)",
+      bg: "var(--accent-blue, #2563eb)",
+    };
+  }
   return {
     label: "VĂN BẢN",
     color: "var(--accent-green, #16a34a)",
@@ -159,6 +166,17 @@ export function SourcesPanel() {
                       <div className="text-sm text-text">
                         <MarkdownRenderer content={selected.content} />
                       </div>
+                      {selected.url && (
+                        <a
+                          href={selected.url}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                          className="mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-[var(--accent)] hover:underline"
+                        >
+                          Mở nguồn web
+                          <ExternalLink size={12} />
+                        </a>
+                      )}
                     </div>
                   </div>
                 </motion.div>

--- a/wiii-desktop/src/hooks/useSSEStream.ts
+++ b/wiii-desktop/src/hooks/useSSEStream.ts
@@ -1205,8 +1205,9 @@ export function useSSEStream() {
         tryStreamingDispatch(fullAnswerTextRef.current);
       },
       onSources: (data) => {
-        traceEvent("sources", { count: data.sources?.length || 0 });
-        useChatStore.getState().setStreamingSources(data.sources || []);
+        const sources = data.sources || data.content || [];
+        traceEvent("sources", { count: sources.length });
+        useChatStore.getState().setStreamingSources(sources);
       },
       onMetadata: (data) => {
         traceEvent("metadata", { session_id: data.session_id, model: data.model });

--- a/wiii-desktop/src/hooks/useSSEStream.ts
+++ b/wiii-desktop/src/hooks/useSSEStream.ts
@@ -1205,7 +1205,11 @@ export function useSSEStream() {
         tryStreamingDispatch(fullAnswerTextRef.current);
       },
       onSources: (data) => {
-        const sources = data.sources || data.content || [];
+        const sources = Array.isArray(data.sources)
+          ? data.sources
+          : Array.isArray(data.content)
+            ? data.content
+            : [];
         traceEvent("sources", { count: sources.length });
         useChatStore.getState().setStreamingSources(sources);
       },

--- a/wiii-desktop/src/lib/reasoning-labels.ts
+++ b/wiii-desktop/src/lib/reasoning-labels.ts
@@ -14,6 +14,8 @@ export const TOOL_LABELS: Record<string, string> = {
   tool_search_legal: "Tra cứu pháp luật",
   tool_search_maritime: "Tìm kiếm hàng hải",
   tool_fetch_url: "Đọc chi tiết URL",
+  tool_current_weather: "Tra thời tiết",
+  current_weather: "Tra thời tiết",
   tool_current_datetime: "Thời gian hiện tại",
   tool_calculator: "Máy tính",
   tool_think: "Suy nghĩ",

--- a/wiii-desktop/src/stores/chat-store.ts
+++ b/wiii-desktop/src/stores/chat-store.ts
@@ -80,6 +80,55 @@ function normalizeThinkingSnapshot(value: string | undefined): string {
   return (value || "").replace(/\s+/g, " ").trim();
 }
 
+function sourceDedupKey(source: SourceInfo): string {
+  const url = String(source.url || "").trim().toLowerCase();
+  if (url) return `url:${url}`;
+  return [
+    "text",
+    String(source.title || "").trim().toLowerCase(),
+    String(source.content || "").slice(0, 160).trim().toLowerCase(),
+  ].join(":");
+}
+
+function mergeSourceInfos(
+  existing: SourceInfo[],
+  incoming: SourceInfo[],
+): SourceInfo[] {
+  const merged: SourceInfo[] = [];
+  const seen = new Set<string>();
+  for (const source of [...existing, ...incoming]) {
+    const key = sourceDedupKey(source);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    merged.push(source);
+  }
+  return merged;
+}
+
+function attachSourcesToLastAssistantDraft(
+  state: ChatState,
+  sources: SourceInfo[],
+): boolean {
+  if (sources.length === 0 || !state.activeConversationId) return false;
+  const recentlyCompleted =
+    typeof state.streamCompletedAt === "number" &&
+    Date.now() - state.streamCompletedAt < 60_000;
+  if (!recentlyCompleted) return false;
+
+  const conversation = state.conversations.find(
+    (item) => item.id === state.activeConversationId,
+  );
+  if (!conversation) return false;
+
+  for (let i = conversation.messages.length - 1; i >= 0; i -= 1) {
+    const message = conversation.messages[i];
+    if (message.role !== "assistant") continue;
+    message.sources = mergeSourceInfos(message.sources || [], sources);
+    return true;
+  }
+  return false;
+}
+
 function getLastNarrativeLine(value: string | undefined): string {
   const segments = (value || "")
     .split("\n")
@@ -561,6 +610,50 @@ function findLastThinkingBlock(
     if (!stepId && !node) return block;
   }
   return undefined;
+}
+
+function mergeToolCallInfoDraft(
+  target: ToolCallInfo,
+  incoming: ToolCallInfo,
+): ToolCallInfo {
+  target.name = incoming.name || target.name;
+  if (incoming.args) {
+    target.args = {
+      ...(target.args || {}),
+      ...incoming.args,
+    };
+  }
+  if (incoming.result !== undefined) {
+    target.result = incoming.result;
+  }
+  if (incoming.node) {
+    target.node = incoming.node;
+  }
+  return target;
+}
+
+function upsertToolCallInfoDraft(
+  toolCalls: ToolCallInfo[],
+  incoming: ToolCallInfo,
+): ToolCallInfo {
+  const existing = toolCalls.find((tc) => tc.id === incoming.id);
+  if (existing) return mergeToolCallInfoDraft(existing, incoming);
+  const next = {
+    ...incoming,
+    args: incoming.args ? { ...incoming.args } : undefined,
+  };
+  toolCalls.push(next);
+  return next;
+}
+
+function findToolExecutionBlockDraft(
+  blocks: ContentBlock[],
+  toolCallId: string,
+): ToolExecutionBlockData | undefined {
+  return blocks.find(
+    (block): block is ToolExecutionBlockData =>
+      block.type === "tool_execution" && block.tool.id === toolCallId,
+  );
 }
 
 function findActiveThinkingPhaseIndex(
@@ -1567,9 +1660,25 @@ export const useChatStore = create<ChatState>()(
     },
 
     setStreamingSources: (sources) => {
+      let attachedToFinalMessage = false;
       set((state) => {
-        state.streamingSources = sources;
+        if (state.isStreaming) {
+          state.streamingSources =
+            sources.length === 0
+              ? []
+              : mergeSourceInfos(state.streamingSources, sources);
+          return;
+        }
+        if (sources.length > 0) {
+          attachedToFinalMessage = attachSourcesToLastAssistantDraft(
+            state,
+            sources,
+          );
+        }
       });
+      if (attachedToFinalMessage) {
+        persistConversationsImmediate(get().conversations);
+      }
     },
 
     addStreamingStep: (label, node) => {
@@ -2288,7 +2397,7 @@ export const useChatStore = create<ChatState>()(
           tc.node,
         );
         if (idx >= 0) {
-          state.streamingPhases[idx].toolCalls.push(tc);
+          upsertToolCallInfoDraft(state.streamingPhases[idx].toolCalls, tc);
         }
       });
     },
@@ -2320,27 +2429,63 @@ export const useChatStore = create<ChatState>()(
 
     appendToolCall: (tc, meta) => {
       set((state) => {
-        // Flat field - backward compat
-        state.streamingToolCalls.push(tc);
+        // Flat field - backward compat. Treat tool_call as idempotent because
+        // some provider streams can replay the same native call chunk by id.
+        const normalizedToolCall = upsertToolCallInfoDraft(
+          state.streamingToolCalls,
+          tc,
+        );
 
         // Keep tool call mirrored on current thinking block for backward compat
+        let mirroredOnThinkingBlock = false;
+        for (const block of state.streamingBlocks) {
+          if (block.type !== "thinking") continue;
+          const existing = block.toolCalls.find(
+            (toolCall) => toolCall.id === normalizedToolCall.id,
+          );
+          if (existing) {
+            mergeToolCallInfoDraft(existing, normalizedToolCall);
+            mirroredOnThinkingBlock = true;
+          }
+        }
+
         const openBlock = findLastOpenThinkingBlock(
           state.streamingBlocks,
           meta?.stepId,
-          tc.node,
+          normalizedToolCall.node,
         );
-        if (openBlock) {
-          openBlock.toolCalls.push(tc);
+        if (openBlock && !mirroredOnThinkingBlock) {
+          upsertToolCallInfoDraft(openBlock.toolCalls, normalizedToolCall);
+        }
+
+        const existingToolBlock = findToolExecutionBlockDraft(
+          state.streamingBlocks,
+          normalizedToolCall.id,
+        );
+        if (existingToolBlock) {
+          mergeToolCallInfoDraft(existingToolBlock.tool, normalizedToolCall);
+          existingToolBlock.node =
+            normalizedToolCall.node || existingToolBlock.node;
+          existingToolBlock.status = existingToolBlock.tool.result
+            ? "completed"
+            : "pending";
+          applyDisplayMeta(existingToolBlock, meta);
+          return;
         }
 
         state.streamingBlocks.push(
           applyDisplayMeta(
             {
               type: "tool_execution",
-              id: tc.id,
-              tool: { ...tc },
-              node: tc.node,
-              status: tc.result ? "completed" : "pending",
+              id: normalizedToolCall.id,
+              tool: {
+                ...normalizedToolCall,
+                args: normalizedToolCall.args
+                  ? { ...normalizedToolCall.args }
+                  : undefined,
+              },
+              node: normalizedToolCall.node,
+              status: normalizedToolCall.result ? "completed" : "pending",
             } as ToolExecutionBlockData,
             {
               displayRole: "tool",

--- a/wiii-desktop/src/stores/chat-store.ts
+++ b/wiii-desktop/src/stores/chat-store.ts
@@ -108,15 +108,16 @@ function mergeSourceInfos(
 function attachSourcesToLastAssistantDraft(
   state: ChatState,
   sources: SourceInfo[],
+  conversationId: string | null,
 ): boolean {
-  if (sources.length === 0 || !state.activeConversationId) return false;
+  if (sources.length === 0 || !conversationId) return false;
   const recentlyCompleted =
     typeof state.streamCompletedAt === "number" &&
     Date.now() - state.streamCompletedAt < 60_000;
   if (!recentlyCompleted) return false;
 
   const conversation = state.conversations.find(
-    (item) => item.id === state.activeConversationId,
+    (item) => item.id === conversationId,
   );
   if (!conversation) return false;
 
@@ -243,6 +244,7 @@ interface ChatState {
   // Sprint 145: Transient avatar state fields
   streamError: string;
   streamCompletedAt: number | null;
+  lastCompletedConversationId: string | null;
 
   // Computed
   activeConversation: () => Conversation | undefined;
@@ -1327,6 +1329,7 @@ export const useChatStore = create<ChatState>()(
     _activeSubagentGroupId: null,
     streamError: "",
     streamCompletedAt: null,
+    lastCompletedConversationId: null,
 
     loadConversations: async () => {
       try {
@@ -1531,6 +1534,7 @@ export const useChatStore = create<ChatState>()(
         state.streamingStartTime = Date.now();
         state.streamError = "";
         state.streamCompletedAt = null;
+        state.lastCompletedConversationId = null;
         state.lastCompletedLifecycleEvents = [];
       });
     },
@@ -1673,6 +1677,7 @@ export const useChatStore = create<ChatState>()(
           attachedToFinalMessage = attachSourcesToLastAssistantDraft(
             state,
             sources,
+            state.lastCompletedConversationId,
           );
         }
       });
@@ -2677,6 +2682,7 @@ export const useChatStore = create<ChatState>()(
         resetStreamingDraft(state);
         state.streamError = "";
         state.streamCompletedAt = Date.now();
+        state.lastCompletedConversationId = activeConversationId;
         state.lastCompletedLifecycleEvents = lifecycleSnapshot;
 
         const conv = state.conversations.find(
@@ -2722,6 +2728,7 @@ export const useChatStore = create<ChatState>()(
         resetStreamingDraft(state);
         state.streamError = error;
         state.streamCompletedAt = null;
+        state.lastCompletedConversationId = null;
         state.lastCompletedLifecycleEvents = lifecycleSnapshot;
 
         const conv = state.conversations.find(
@@ -2755,6 +2762,7 @@ export const useChatStore = create<ChatState>()(
         resetStreamingDraft(state);
         state.streamError = "";
         state.streamCompletedAt = null;
+        state.lastCompletedConversationId = null;
         state.lastCompletedLifecycleEvents = [];
       });
     },
@@ -2870,6 +2878,7 @@ export const useChatStore = create<ChatState>()(
         state.isLoaded = true;
         state.visualSessions = {};
         resetStreamingDraft(state);
+        state.lastCompletedConversationId = null;
         state.lastCompletedLifecycleEvents = [];
       });
     },
@@ -2890,6 +2899,7 @@ export const useChatStore = create<ChatState>()(
           state.isLoaded = true;
           state.visualSessions = {};
           resetStreamingDraft(state);
+          state.lastCompletedConversationId = null;
           state.lastCompletedLifecycleEvents = [];
         });
       } catch (err) {
@@ -2903,6 +2913,7 @@ export const useChatStore = create<ChatState>()(
           state.isLoaded = true;
           state.visualSessions = {};
           resetStreamingDraft(state);
+          state.lastCompletedConversationId = null;
           state.lastCompletedLifecycleEvents = [];
         });
       }

--- a/wiii-desktop/src/styles/globals.css
+++ b/wiii-desktop/src/styles/globals.css
@@ -1248,13 +1248,35 @@ html.dark .shiki span {
    row to vertical stack so titles aren't truncated to nothing. */
 @media (max-width: 767px) {
   .tool-strip {
-    margin-left: 0.6rem;
+    margin-left: 0;
     gap: 0.5rem;
+  }
+  .tool-strip__body {
+    padding: 0.56rem 0.6rem 0.6rem;
+  }
+  .tool-strip__header {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+  .tool-strip__title {
+    width: 100%;
+  }
+  .tool-strip__header-meta {
+    width: 100%;
+    justify-content: space-between;
+    margin-left: 0;
+    gap: 0.36rem;
   }
   .tool-strip__query,
   .tool-strip__result {
+    grid-template-columns: 1fr;
+    gap: 0.18rem;
     max-width: 100%;
     font-size: 0.74rem;
+  }
+  .tool-strip__expand-label {
+    display: none;
   }
   .search-result-widget__item {
     padding: 8px 10px;
@@ -2774,13 +2796,10 @@ html.dark .shiki span {
   position: relative;
   display: flex;
   align-items: flex-start;
-  gap: 0.72rem;
-  /* Phase 35 — tighten vertical spacing between tool strips. Previously
-     0.7rem bottom margin made 5 stacked tools take half the screen. SOTA
-     reference (Claude.ai, Perplexity) uses ~0.25rem between consecutive
-     tool entries. */
-  margin: 0.12rem 0 0.32rem 1.42rem;
-  padding: 0.08rem 0 0;
+  gap: 0.62rem;
+  margin: 0.16rem 0 0.42rem 1.2rem;
+  padding: 0;
+  max-width: min(100%, 64rem);
 }
 
 .tool-strip__rail {
@@ -2790,6 +2809,23 @@ html.dark .shiki span {
   justify-content: center;
   width: 1rem;
   min-width: 1rem;
+  min-height: 100%;
+  padding-top: 0.72rem;
+}
+
+.tool-strip__rail-line {
+  position: absolute;
+  top: 0;
+  bottom: -0.42rem;
+  left: 50%;
+  width: 1px;
+  transform: translateX(-50%);
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    color-mix(in srgb, var(--border) 72%, transparent) 18%,
+    color-mix(in srgb, var(--border) 48%, transparent) 100%
+  );
 }
 
 .tool-strip__dot {
@@ -2801,22 +2837,29 @@ html.dark .shiki span {
   width: 1rem;
   height: 1rem;
   border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--border) 72%, white);
-  background: color-mix(in srgb, var(--surface-secondary) 90%, white);
+  border: 1px solid color-mix(in srgb, var(--border) 76%, white);
+  background: color-mix(in srgb, var(--surface) 92%, white);
   color: var(--text-secondary);
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--surface-white, white) 42%, transparent);
 }
 
 .tool-strip__body {
   min-width: 0;
   flex: 1;
-  padding: 0 0 0.15rem;
+  padding: 0.62rem 0.72rem 0.66rem;
+  border: 1px solid color-mix(in srgb, var(--border) 64%, transparent);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--surface-white, white) 52%, transparent) 0%, transparent 100%),
+    color-mix(in srgb, var(--surface-secondary) 42%, transparent);
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--surface-white, white) 26%, transparent);
 }
 
 .tool-strip__header {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 0.45rem 0.7rem;
+  justify-content: space-between;
+  gap: 0.7rem;
 }
 
 .tool-strip__header--clickable {
@@ -2828,20 +2871,52 @@ html.dark .shiki span {
   width: 100%;
   text-align: left;
   cursor: pointer;
-  border-radius: 4px;
-  transition: background 0.12s ease;
+  border-radius: 6px;
+  transition: color 0.12s ease;
 }
 
 .tool-strip__header--clickable:not(:disabled):hover {
-  background: color-mix(in srgb, var(--surface-tertiary) 60%, transparent);
+  color: var(--text);
 }
 
 .tool-strip__header--clickable:disabled {
   cursor: default;
 }
 
-.tool-strip__expand-chevron {
+.tool-strip__title {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+  min-width: 0;
+}
+
+.tool-strip__kind {
+  display: inline-flex;
+  align-items: center;
+  height: 1.18rem;
+  padding: 0 0.42rem;
+  border: 1px solid color-mix(in srgb, var(--border) 68%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface) 72%, transparent);
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.tool-strip__header-meta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.52rem;
   margin-left: auto;
+  white-space: nowrap;
+}
+
+.tool-strip__expand-chevron {
   color: var(--text-tertiary);
   transition: transform 0.15s ease;
 }
@@ -2850,11 +2925,26 @@ html.dark .shiki span {
   transform: rotate(180deg);
 }
 
+.tool-strip__expand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  color: var(--text-tertiary);
+  font-size: 0.66rem;
+  line-height: 1;
+}
+
+.tool-strip__expand-label {
+  display: inline;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .tool-strip__expand-chevron,
   .citation-chip,
-  .tool-strip__header--clickable {
+  .tool-strip__header--clickable,
+  .tool-strip__progress span {
     transition: none !important;
+    animation: none !important;
   }
   .streaming-timer__dot {
     animation: none !important;
@@ -2866,36 +2956,106 @@ html.dark .shiki span {
 }
 
 .tool-strip__label {
-  color: var(--text-secondary);
-  font-size: 0.78rem;
-  font-weight: 650;
+  color: color-mix(in srgb, var(--text) 82%, var(--text-secondary));
+  font-size: 0.8rem;
+  font-weight: 680;
   line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .tool-strip__state {
   display: inline-flex;
   align-items: center;
   gap: 0.3rem;
+  min-height: 1.18rem;
+  padding: 0 0.42rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface) 64%, transparent);
   color: var(--text-tertiary);
-  font-size: 0.68rem;
+  font-size: 0.66rem;
+  font-weight: 650;
   line-height: 1;
 }
 
 .tool-strip__query {
-  margin-top: 0.22rem;
-  color: color-mix(in srgb, var(--text) 74%, var(--text-tertiary));
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 0.52rem;
+  margin-top: 0.48rem;
+  padding: 0.48rem 0.56rem;
+  border: 1px solid color-mix(in srgb, var(--border) 54%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--surface) 54%, transparent);
+  color: color-mix(in srgb, var(--text) 78%, var(--text-tertiary));
   font-size: 0.76rem;
-  line-height: 1.6;
+  line-height: 1.55;
   word-break: break-word;
-  max-width: 64ch;
+  max-width: 74ch;
+}
+
+.tool-strip__query-label,
+.tool-strip__section-label {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.55;
+  text-transform: uppercase;
+}
+
+.tool-strip__query-text,
+.tool-strip__result-text {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.tool-strip__progress {
+  position: relative;
+  height: 2px;
+  margin-top: 0.56rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--border) 38%, transparent);
+}
+
+.tool-strip__progress span {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -35%;
+  width: 35%;
+  border-radius: inherit;
+  background: color-mix(in srgb, var(--accent-orange) 82%, white);
+  animation: tool-strip-progress 1.25s ease-in-out infinite;
+}
+
+@keyframes tool-strip-progress {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(390%);
+  }
+}
+
+.tool-strip__expanded {
+  margin-top: 0.56rem;
+  display: grid;
+  gap: 0.4rem;
 }
 
 .tool-strip__result {
-  margin-top: 0.28rem;
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 0.52rem;
+  margin-top: 0.56rem;
+  padding-top: 0.52rem;
+  border-top: 1px solid color-mix(in srgb, var(--border) 52%, transparent);
   color: var(--text-secondary);
   font-size: 0.76rem;
   line-height: 1.62;
-  max-width: 68ch;
+  max-width: 74ch;
 }
 
 .tool-strip__toggle {
@@ -2926,11 +3086,11 @@ html.dark .shiki span {
 }
 
 .tool-strip__detail {
-  margin-top: 0.48rem;
-  max-width: 70ch;
+  margin-top: 0.56rem;
+  max-width: 74ch;
   border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
   border-radius: 8px;
-  background: color-mix(in srgb, var(--surface-secondary) 60%, transparent);
+  background: color-mix(in srgb, var(--surface) 62%, transparent);
   overflow: hidden;
 }
 
@@ -2952,10 +3112,26 @@ html.dark .shiki span {
   background: color-mix(in srgb, var(--accent-orange) 8%, white);
 }
 
+.tool-strip--pending .tool-strip__state,
+.tool-strip--pending .tool-strip__kind {
+  color: color-mix(in srgb, var(--accent-orange) 82%, var(--text));
+  border-color: color-mix(in srgb, var(--accent-orange) 30%, var(--border));
+  background: color-mix(in srgb, var(--accent-orange) 8%, transparent);
+}
+
+.tool-strip--pending .tool-strip__body {
+  border-color: color-mix(in srgb, var(--accent-orange) 18%, var(--border));
+}
+
 .tool-strip--complete .tool-strip__dot {
   color: var(--accent-teal);
   border-color: color-mix(in srgb, var(--accent-teal) 20%, var(--border));
   background: color-mix(in srgb, var(--accent-teal) 7%, white);
+}
+
+.tool-strip--complete .tool-strip__state {
+  color: color-mix(in srgb, var(--accent-teal) 76%, var(--text));
+  background: color-mix(in srgb, var(--accent-teal) 8%, transparent);
 }
 
 .assistant-response {
@@ -3804,4 +3980,134 @@ html.dark .shiki span {
 
 .source-citation__expand:hover {
   color: var(--accent-hover);
+}
+
+.web-source-citation {
+  margin-top: 12px;
+  max-width: min(720px, 100%);
+}
+
+.web-source-citation__summary {
+  width: 100%;
+  min-height: 40px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 88%, var(--accent) 12%);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.16s var(--ease-default),
+    background 0.16s var(--ease-default);
+}
+
+.web-source-citation__summary:hover {
+  border-color: color-mix(in srgb, var(--accent) 48%, var(--border));
+  background: color-mix(in srgb, var(--surface) 82%, var(--accent) 18%);
+}
+
+.web-source-citation__summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.web-source-citation__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  font-weight: 650;
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.web-source-citation__title svg {
+  color: var(--accent);
+}
+
+.web-source-citation__domains {
+  min-width: 0;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.web-source-citation__chevron {
+  color: var(--text-tertiary);
+  transition: transform 0.16s var(--ease-default);
+}
+
+.web-source-citation__chevron--open {
+  transform: rotate(180deg);
+}
+
+.web-source-citation__list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.web-source-citation__item {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 7px 9px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  text-decoration: none;
+}
+
+.web-source-citation__item:hover {
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
+  background: var(--surface-secondary);
+}
+
+.web-source-citation__index {
+  display: inline-flex;
+  width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.web-source-citation__body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.web-source-citation__item-title,
+.web-source-citation__item-meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.web-source-citation__item-title {
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.web-source-citation__item-meta {
+  color: var(--text-tertiary);
+  font-size: 12px;
 }

--- a/wiii-desktop/src/styles/globals.css
+++ b/wiii-desktop/src/styles/globals.css
@@ -2989,7 +2989,6 @@ html.dark .shiki span {
   color: color-mix(in srgb, var(--text) 78%, var(--text-tertiary));
   font-size: 0.76rem;
   line-height: 1.55;
-  word-break: break-word;
   max-width: 74ch;
 }
 


### PR DESCRIPTION
﻿## Summary
- Aligns Wiii's live lookup/tool UX with the Odysseus pattern: the tool loop owns tool selection and source events, while the model keeps the final answer natural instead of being driven by patched prompt phrases.
- Hardens backend live-lookup routing: legal/maritime/news aliases now trigger the evidence-only guard, weather turns no longer expose `tool_fetch_url`, and domain keywords like maritime/campus/ports no longer bypass memory-bleed cleanup.
- Improves source/event contracts in the desktop client: `sources` SSE payloads are type-guarded, late source events attach to the conversation that just finalized, mixed web+document sources stay visible, and rendered URLs are validated before linking.
- Keeps the tool timeline more professional: reasoning headers use neutral operational labels, weather strips prefer structured status payloads, and deprecated `word-break: break-word` was removed from the touched strip style.

## Odysseus comparison
- Odysseus separates Chat mode from Agent mode: Chat calls the model without tools, Agent mode runs `stream_agent_loop` with selected tools and typed events (`tool_start`, `tool_progress`, `tool_output`, `web_sources`).
- Odysseus selects a compact relevant tool set through tool descriptions/keyword hints plus a small always-available set, instead of forcing broad tools through ad hoc prompt text.
- Odysseus persists web sources as tool metadata and renders them separately from the assistant answer. This PR moves Wiii in that direction by making source events structured, typed, deduped, and attached to the correct finalized message.

## Verification
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_tool_rounds_runtime.py::test_build_direct_final_synthesis_instruction_blocks_live_lookup_memory_bleed tests/unit/test_turn_path_governor.py::test_turn_path_governor_routes_weather_to_weather_with_live_lookup_fallback tests/unit/test_turn_path_governor.py::test_collect_direct_tools_routes_weather_followup_to_weather_tool tests/unit/test_turn_path_governor.py::test_collect_direct_tools_keeps_weather_path_with_web_search_when_provider_missing tests/unit/test_turn_path_governor.py::test_collect_direct_tools_routes_weather_turns_to_weather_tool tests/unit/test_turn_path_governor.py::test_direct_required_tool_names_weather_prefers_weather_over_web tests/unit/test_turn_path_governor.py::test_direct_required_tool_names_temperature_question_prefers_weather_over_web -q` -> 10 passed
- `cd maritime-ai-service && .\.venv\Scripts\python.exe -m pytest tests/unit/test_direct_node_response_cleanup.py tests/unit/test_direct_node_tool_selection.py tests/unit/test_direct_node_turn_start.py tests/unit/test_direct_response_runtime.py tests/unit/test_direct_tool_dispatch_runtime.py tests/unit/test_direct_tool_rounds_runtime.py tests/unit/test_event_bus.py tests/unit/test_turn_path_governor.py tests/unit/test_web_search_tools.py tests/unit/test_visual_event_summaries.py tests/unit/test_direct_node_provider_errors.py tests/unit/test_graph_routing.py tests/unit/test_supervisor_agent.py -q` -> 387 passed
- `cd maritime-ai-service && .\.venv\Scripts\ruff.exe check app/ --select=E9,F63,F7` -> passed
- `cd wiii-desktop && npx vitest run src/__tests__/chat-store.test.ts src/__tests__/source-citation.test.tsx src/__tests__/sse.test.ts src/__tests__/tool-execution-strip.test.tsx src/__tests__/reasoning-interval.test.tsx` -> 83 passed
- `cd wiii-desktop && npx tsc --noEmit` -> passed
- `cd wiii-desktop && npm run build:embed` -> passed; Vite reported existing chunk-size/dynamic-import warnings
- `git diff --check` -> passed; Git reported an existing CRLF normalization warning for `wiii-desktop/src/__tests__/chat-store.test.ts`

## Local test notes
- Full local `cd wiii-desktop && npx vitest run` still has 3 isolated failures outside this patch surface: `assistant-markdown-rendering.test.tsx` renders plain markdown instead of a table, `auth-store.test.ts` logout timeout, and `sprint153b-desktop-hardening.test.ts` aborted-fetch timeout. The focused tests for all touched chat/tool/source paths pass, and CI is the source of truth for the standard desktop environment.

## Visual evidence
- Earlier local Chrome smoke on `http://127.0.0.1:1420` compared Wiii with Odysseus on `http://127.0.0.1:7005` for weather/tool-source UX. The visible follow-up changes in this commit are edge-state hardening for mixed sources, unsafe URLs, neutral timeline labels, and structured weather status, all covered by focused component/store tests above. No screenshot artifact is committed because repository guidance forbids committing temporary screenshots/build output.

## Risk and rollback
- Risk: touches high-risk tool routing, memory/tool boundaries, SSE source contracts, and persisted Zustand chat state.
- Mitigation: backend route/source tests, frontend source/tool/SSE/store tests, TypeScript, embed build, and repository diff check all pass for the touched paths.
- Rollback: revert this PR/commit to restore previous tool routing, source rendering, and reasoning label behavior. No migrations or persistent schema changes are included.

## Notes
- Local-only artifacts remain untracked and intentionally excluded: `research/` and `maritime-ai-service/uv.lock`.
