### PR TITLE
fix(web): restore root SPA and stale auth recovery

### DIFF
--- a/maritime-ai-service/app/core/middleware.py
+++ b/maritime-ai-service/app/core/middleware.py
@@ -26,7 +26,7 @@ from starlette.responses import FileResponse, JSONResponse, Response
 logger = logging.getLogger(__name__)
 
 # Subdomains that should NOT be treated as org slugs
-_RESERVED_SUBDOMAINS = frozenset({"www", "api", "admin", "app", "mail", "static", "cdn"})
+_RESERVED_SUBDOMAINS = frozenset({"www", "api", "admin", "app", "mail", "static", "cdn", "wiii"})
 _EMBED_HASHED_ASSET_RE = re.compile(r"^(?P<prefix>.+)-(?P<hash>[A-Za-z0-9_-]+)\.(?P<ext>js|css)$")
 
 

--- a/maritime-ai-service/app/engine/llm_pool.py
+++ b/maritime-ai-service/app/engine/llm_pool.py
@@ -284,6 +284,8 @@ class LLMPool:
         return thinking_budget_for_tier_impl(
             thinking_budgets=THINKING_BUDGETS,
             tier_key=tier_key,
+            thinking_enabled=getattr(settings, "thinking_enabled", True),
+            include_thought_summaries=getattr(settings, "include_thought_summaries", True),
         )
 
     @classmethod

--- a/maritime-ai-service/app/engine/llm_pool_bootstrap_runtime.py
+++ b/maritime-ai-service/app/engine/llm_pool_bootstrap_runtime.py
@@ -176,8 +176,7 @@ def create_primary_instance_impl(*, cls_ref, tier, settings_obj, logger_obj, thi
         else:
             return cached_llm
 
-    thinking_budget = thinking_budgets.get(tier_key, 1024)
-    include_thoughts = thinking_budget > 0
+    thinking_budget, include_thoughts = cls_ref._thinking_budget_for_tier(tier_key)
     should_use_provider_chain = cls_ref._providers and (
         settings_obj.enable_llm_failover or settings_obj.llm_provider != "google"
     )
@@ -253,8 +252,7 @@ def create_fallback_instances_impl(*, cls_ref, settings_obj, logger_obj, thinkin
         created = 0
         for tier in [thinking_tier.DEEP, thinking_tier.MODERATE, thinking_tier.LIGHT]:
             tier_key = tier.value
-            thinking_budget = thinking_budgets.get(tier_key, 1024)
-            include_thoughts = thinking_budget > 0
+            thinking_budget, include_thoughts = cls_ref._thinking_budget_for_tier(tier_key)
             try:
                 llm = provider.create_instance(
                     tier=tier_key,

--- a/maritime-ai-service/app/engine/llm_pool_support.py
+++ b/maritime-ai-service/app/engine/llm_pool_support.py
@@ -47,10 +47,19 @@ def normalize_tier_key_impl(*, tier, resolve_tier, thinking_tier) -> str:
     return tier_key
 
 
-def thinking_budget_for_tier_impl(*, thinking_budgets: dict, tier_key: str) -> tuple[int, bool]:
+def thinking_budget_for_tier_impl(
+    *,
+    thinking_budgets: dict,
+    tier_key: str,
+    thinking_enabled: bool = True,
+    include_thought_summaries: bool = True,
+) -> tuple[int, bool]:
     """Return thinking budget + thought flag for one tier."""
+    if not thinking_enabled:
+        return 0, False
+
     thinking_budget = thinking_budgets.get(tier_key, 1024)
-    include_thoughts = thinking_budget > 0
+    include_thoughts = thinking_budget > 0 and include_thought_summaries
     return thinking_budget, include_thoughts
 
 

--- a/maritime-ai-service/tests/unit/test_llm_failover.py
+++ b/maritime-ai-service/tests/unit/test_llm_failover.py
@@ -208,12 +208,13 @@ class TestLegacyPath:
 
     @patch("app.engine.llm_pool.create_provider")
     @patch("app.engine.llm_pool.settings")
-    def test_legacy_uses_provider_thinking_contract(self, mock_settings, mock_create_provider):
+    def test_legacy_respects_disabled_thinking_contract(self, mock_settings, mock_create_provider):
         mock_settings.enable_llm_failover = False
         mock_settings.llm_provider = "google"
         mock_settings.google_api_key = "test-key"
         mock_settings.google_model = "gemini-3-flash-preview"
         mock_settings.thinking_enabled = False
+        mock_settings.include_thought_summaries = False
         mock_settings.llm_failover_chain = ["google"]
         google = _make_mock_provider("google")
         mock_create_provider.return_value = google
@@ -223,8 +224,8 @@ class TestLegacyPath:
 
         call_kwargs = google.create_instance.call_args.kwargs
         assert call_kwargs["tier"] == "light"
-        assert call_kwargs["thinking_budget"] == 1024
-        assert call_kwargs["include_thoughts"] is True
+        assert call_kwargs["thinking_budget"] == 0
+        assert call_kwargs["include_thoughts"] is False
 
     @patch("app.engine.llm_pool.create_provider")
     @patch("app.engine.llm_pool.settings")

--- a/maritime-ai-service/tests/unit/test_sprint120_desktop_apis.py
+++ b/maritime-ai-service/tests/unit/test_sprint120_desktop_apis.py
@@ -228,21 +228,26 @@ class TestSSEMetadataMood:
 class TestRouterRegistration:
     """Tests that new routers are registered."""
 
-    def _registered_paths(self) -> list[str]:
-        from fastapi import FastAPI
-
+    def _registered_imports(self, monkeypatch) -> list[str]:
         from app.api.v1 import _build_router
+        import app.api.v1 as v1
 
-        app = FastAPI()
-        app.include_router(_build_router(), prefix="/api/v1")
-        return [route.path for route in app.routes if hasattr(route, "path")]
+        imports: list[str] = []
 
-    def test_character_router_registered(self):
+        def capture_router(_router, import_path: str, _label: str) -> None:
+            imports.append(import_path)
+
+        monkeypatch.setattr(v1, "_register_router", capture_router)
+        monkeypatch.setattr(v1, "_register_optional_router", lambda *args, **kwargs: None)
+        _build_router()
+        return imports
+
+    def test_character_router_registered(self, monkeypatch):
         """Character router is in v1 routes."""
-        paths = self._registered_paths()
-        assert any("/character" in p for p in paths)
+        imports = self._registered_imports(monkeypatch)
+        assert "app.api.v1.character.router" in imports
 
-    def test_mood_router_registered(self):
+    def test_mood_router_registered(self, monkeypatch):
         """Mood router is in v1 routes."""
-        paths = self._registered_paths()
-        assert any("/mood" in p for p in paths)
+        imports = self._registered_imports(monkeypatch)
+        assert "app.api.v1.mood.router" in imports

--- a/maritime-ai-service/tests/unit/test_sprint120_desktop_apis.py
+++ b/maritime-ai-service/tests/unit/test_sprint120_desktop_apis.py
@@ -231,10 +231,10 @@ class TestRouterRegistration:
     def _registered_paths(self) -> list[str]:
         from fastapi import FastAPI
 
-        from app.api.v1 import router
+        from app.api.v1 import _build_router
 
         app = FastAPI()
-        app.include_router(router, prefix="/api/v1")
+        app.include_router(_build_router(), prefix="/api/v1")
         return [route.path for route in app.routes if hasattr(route, "path")]
 
     def test_character_router_registered(self):

--- a/maritime-ai-service/tests/unit/test_sprint120_desktop_apis.py
+++ b/maritime-ai-service/tests/unit/test_sprint120_desktop_apis.py
@@ -228,15 +228,21 @@ class TestSSEMetadataMood:
 class TestRouterRegistration:
     """Tests that new routers are registered."""
 
+    def _registered_paths(self) -> list[str]:
+        from fastapi import FastAPI
+
+        from app.api.v1 import router
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api/v1")
+        return [route.path for route in app.routes if hasattr(route, "path")]
+
     def test_character_router_registered(self):
         """Character router is in v1 routes."""
-        from app.api.v1 import router
-        paths = [r.path for r in router.routes]
+        paths = self._registered_paths()
         assert any("/character" in p for p in paths)
 
     def test_mood_router_registered(self):
         """Mood router is in v1 routes."""
-        from app.api.v1 import router
-        paths = [r.path for r in router.routes]
+        paths = self._registered_paths()
         assert any("/mood" in p for p in paths)
-

--- a/maritime-ai-service/tests/unit/test_sprint178_admin_compliance.py
+++ b/maritime-ai-service/tests/unit/test_sprint178_admin_compliance.py
@@ -135,7 +135,11 @@ def base_app():
     from app.api.v1.admin_audit import router as audit_router
     from app.api.v1.admin_gdpr import router as gdpr_router
 
-    existing_paths = {r.path for r in _app.routes}
+    existing_paths = {
+        path
+        for route in _app.routes
+        if (path := getattr(route, "path", None)) is not None
+    }
     if "/api/v1/admin/audit-logs" not in existing_paths:
         _app.include_router(audit_router, prefix="/api/v1")
     if "/api/v1/admin/users/{user_id}/export" not in existing_paths:

--- a/maritime-ai-service/tests/unit/test_sprint194c_middleware_failclosed.py
+++ b/maritime-ai-service/tests/unit/test_sprint194c_middleware_failclosed.py
@@ -186,3 +186,12 @@ class TestSubdomain:
                     },
                 )
         assert captured[0] == "header-org"
+
+    def test_wiii_app_subdomain_is_reserved(self):
+        captured = []
+        ms = MagicMock(); ms.enable_multi_tenant = True; ms.subdomain_base_domain = "holilihu.online"
+        with patch(_SP, ms):
+            with patch(_RP) as repo_fn:
+                _get(_app(captured), headers={"Host": "wiii.holilihu.online"})
+        assert captured[0] is None
+        repo_fn.assert_not_called()

--- a/wiii-desktop/src/App.tsx
+++ b/wiii-desktop/src/App.tsx
@@ -56,6 +56,12 @@ function BootSplash({ label }: { label: string }) {
   );
 }
 
+export function readOAuthCallbackParams(hash: string): URLSearchParams | null {
+  if (!hash) return null;
+  const params = new URLSearchParams(hash.startsWith("#") ? hash.substring(1) : hash);
+  return params.get("access_token") && params.get("refresh_token") ? params : null;
+}
+
 export default function App() {
   // Dev tool: ?preview=avatar shows avatar preview page
   if (window.location.search.includes("preview=avatar")) {
@@ -142,11 +148,17 @@ export default function App() {
     });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Initialize on mount
+  // Initialize on mount. When Google returns tokens in the URL hash, the
+  // callback effect above owns auth persistence; loadAuth() must not restore
+  // an older expired session over the fresh callback.
   useEffect(() => {
     async function init() {
       // 1. Load persisted settings
       await loadSettings();
+      if (readOAuthCallbackParams(window.location.hash)) {
+        await loadConversations();
+        return;
+      }
       // 2. Load persisted auth state (Sprint 157)
       await loadAuth();
       // 3. Load persisted conversations

--- a/wiii-desktop/src/App.tsx
+++ b/wiii-desktop/src/App.tsx
@@ -174,15 +174,37 @@ export default function App() {
       //     backend's .env). Force-logout clears state + lets the user
       //     re-authenticate fresh instead of leaving them stuck on a
       //     broken-looking app where every call silently 401s.
-      client.setOnUnauthorized(async () => {
+      client.setOnUnauthorized(async (failure) => {
         const authState = useAuthStore.getState();
         if (authState.authMode === "oauth") {
-          return authState.refreshAccessToken(
+          if (failure?.status === 403) {
+            const activeOrgId = authState.user?.active_organization_id || "";
+            const currentOrgId = useSettingsStore.getState().settings.organization_id || "";
+            if (activeOrgId && currentOrgId !== activeOrgId) {
+              await useSettingsStore.getState().updateSettings({
+                organization_id: activeOrgId,
+              });
+              return true;
+            }
+            await authState.logout();
+            addToast(
+              "error",
+              "Phiên đăng nhập không còn khớp với tổ chức hiện tại. Vui lòng đăng nhập lại.",
+            );
+            return false;
+          }
+
+          const refreshed = await authState.refreshAccessToken(
             useSettingsStore.getState().settings.server_url,
           );
+          if (refreshed) return true;
+          await authState.logout();
+          addToast("error", "Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại.");
+          return false;
         }
         if (authState.authMode === "legacy" && authState.isAuthenticated) {
           await authState.logout();
+          addToast("error", "API key không còn hợp lệ. Vui lòng đăng nhập lại.");
         }
         return false;
       });

--- a/wiii-desktop/src/App.tsx
+++ b/wiii-desktop/src/App.tsx
@@ -191,19 +191,16 @@ export default function App() {
         if (authState.authMode === "oauth") {
           if (failure?.status === 403) {
             const activeOrgId = authState.user?.active_organization_id || "";
-            const currentOrgId = useSettingsStore.getState().settings.organization_id || "";
-            if (activeOrgId && currentOrgId !== activeOrgId) {
+            if (activeOrgId) {
               await useSettingsStore.getState().updateSettings({
                 organization_id: activeOrgId,
               });
               return true;
             }
-            await authState.logout();
-            addToast(
-              "error",
-              "Phiên đăng nhập không còn khớp với tổ chức hiện tại. Vui lòng đăng nhập lại.",
-            );
-            return false;
+            await useSettingsStore.getState().updateSettings({
+              organization_id: null,
+            });
+            return true;
           }
 
           const refreshed = await authState.refreshAccessToken(

--- a/wiii-desktop/src/__tests__/api-client-auth-recovery.test.ts
+++ b/wiii-desktop/src/__tests__/api-client-auth-recovery.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiHttpError, WiiiClient } from "@/api/client";
+
+function jsonResponse(status: number, body: Record<string, unknown>) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function streamResponse() {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("event: done\ndata: {}\n\n"));
+        controller.close();
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+describe("WiiiClient auth recovery", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("retries stream requests after recoverable organization-context 403", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(403, {
+          detail: "Active organization does not match authenticated organization.",
+        }),
+      )
+      .mockResolvedValueOnce(streamResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new WiiiClient("https://wiii.example");
+    const recover = vi.fn().mockResolvedValue(true);
+    client.setOnUnauthorized(recover);
+
+    const stream = await client.postStream("/api/v1/chat/stream/v3", {
+      message: "xin chao",
+    });
+
+    expect(stream).toBeTruthy();
+    expect(recover).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 403,
+        detail: "Active organization does not match authenticated organization.",
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not treat ordinary authorization 403 as stale auth", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(403, { detail: "Admin access required" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new WiiiClient("https://wiii.example");
+    const recover = vi.fn().mockResolvedValue(true);
+    client.setOnUnauthorized(recover);
+
+    await expect(client.get("/api/v1/admin/domains")).rejects.toMatchObject({
+      name: "ApiHttpError",
+      status: 403,
+      message: "Admin access required",
+    } satisfies Partial<ApiHttpError>);
+    expect(recover).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps existing 401 refresh-and-retry behavior", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "Invalid or expired token" }))
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new WiiiClient("https://wiii.example");
+    const recover = vi.fn().mockResolvedValue(true);
+    client.setOnUnauthorized(recover);
+
+    const result = await client.get<{ ok: boolean }>("/api/v1/context/info");
+
+    expect(result.ok).toBe(true);
+    expect(recover).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 401,
+        detail: "Invalid or expired token",
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/wiii-desktop/src/__tests__/app-oauth-callback.test.ts
+++ b/wiii-desktop/src/__tests__/app-oauth-callback.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { readOAuthCallbackParams } from "@/App";
+
+describe("App OAuth callback hash parser", () => {
+  it("accepts Google callback hashes containing both access and refresh tokens", () => {
+    const params = readOAuthCallbackParams(
+      "#access_token=access-123&refresh_token=refresh-456&expires_in=900",
+    );
+
+    expect(params?.get("access_token")).toBe("access-123");
+    expect(params?.get("refresh_token")).toBe("refresh-456");
+  });
+
+  it("ignores non-auth hashes and partial callbacks", () => {
+    expect(readOAuthCallbackParams("#preview=pointy")).toBeNull();
+    expect(readOAuthCallbackParams("#access_token=access-only")).toBeNull();
+    expect(readOAuthCallbackParams("")).toBeNull();
+  });
+});

--- a/wiii-desktop/src/__tests__/auth-identity-ssot.test.ts
+++ b/wiii-desktop/src/__tests__/auth-identity-ssot.test.ts
@@ -58,7 +58,11 @@ vi.mock("@/api/admin", () => ({
 // Imports (after mocks)
 // =============================================================================
 
-import { useSettingsStore, generateAnonymousId } from "@/stores/settings-store";
+import {
+  useSettingsStore,
+  generateAnonymousId,
+  resolveOAuthOrganizationHeader,
+} from "@/stores/settings-store";
 import { useAuthStore } from "@/stores/auth-store";
 import type { AuthUser } from "@/stores/auth-store";
 import { useOrgStore } from "@/stores/org-store";
@@ -818,6 +822,58 @@ describe("Integration: settings + auth store header coordination", () => {
 
     const headers = useSettingsStore.getState().getAuthHeaders();
     expect(headers["X-Role"]).toBe("admin");
+  });
+
+  it("settings-store OAuth headers use the token active org instead of stale settings org", async () => {
+    useSettingsStore.setState({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        organization_id: "maritime-lms",
+      },
+      isLoaded: true,
+    });
+
+    await useAuthStore.getState().loginWithTokens(
+      "oauth-access-token",
+      "oauth-refresh-token",
+      1800,
+      {
+        ...MOCK_USER,
+        active_organization_id: "default",
+      },
+    );
+
+    const headers = useSettingsStore.getState().getAuthHeaders();
+    expect(headers["Authorization"]).toBe("Bearer oauth-access-token");
+    expect(headers["X-Organization-ID"]).toBe("default");
+  });
+
+  it("settings-store OAuth headers omit stale org when the token has no active org", async () => {
+    useSettingsStore.setState({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        organization_id: "maritime-lms",
+      },
+      isLoaded: true,
+    });
+
+    await useAuthStore.getState().loginWithTokens(
+      "oauth-access-token",
+      "oauth-refresh-token",
+      1800,
+      MOCK_USER,
+    );
+
+    const headers = useSettingsStore.getState().getAuthHeaders();
+    expect(headers["Authorization"]).toBe("Bearer oauth-access-token");
+    expect(headers["X-Organization-ID"]).toBeUndefined();
+  });
+
+  it("normalizes OAuth org headers", () => {
+    expect(resolveOAuthOrganizationHeader(" default ")).toBe("default");
+    expect(resolveOAuthOrganizationHeader("personal")).toBeUndefined();
+    expect(resolveOAuthOrganizationHeader("")).toBeUndefined();
+    expect(resolveOAuthOrganizationHeader(null)).toBeUndefined();
   });
 });
 

--- a/wiii-desktop/src/__tests__/auth-mode-fallback.test.ts
+++ b/wiii-desktop/src/__tests__/auth-mode-fallback.test.ts
@@ -3,10 +3,10 @@
  *
  * Tests:
  *   1. loadAuth() keeps oauth+valid-tokens as oauth (no demotion)
- *   2. loadAuth() demotes oauth+expired-tokens to legacy
- *   3. loadAuth() demotes oauth+null-tokens to legacy
+ *   2. loadAuth() refreshes oauth+expired-tokens before showing login
+ *   3. loadAuth() clears oauth+null-tokens without falling back to legacy
  *   4. getAuthHeaders() returns Authorization when tokens are fresh
- *   5. getAuthHeaders() falls through to X-API-Key when tokens are expired
+ *   5. getAuthHeaders() does not send stale OAuth or legacy headers when tokens are expired
  *   6. getAuthHeaders() returns Authorization when token is within 30s grace window
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
@@ -70,8 +70,56 @@ describe("auth-store loadAuth — self-heal stale OAuth (Issue #108)", () => {
     expect(s.isAuthenticated).toBe(true);
   });
 
-  it("demotes oauth to legacy when tokens are expired", async () => {
+  it("refreshes oauth tokens on load when access token is expired", async () => {
     const pastExpiry = Date.now() - 60_000; // 60s ago
+    const storeTokens = vi.fn();
+    vi.doMock("@/lib/secure-token-storage", () => ({
+      loadTokens: async () => ({
+        access_token: "expired-access",
+        refresh_token: "refresh",
+        expires_at: pastExpiry,
+      }),
+      storeTokens,
+      clearTokens: async () => {},
+    }));
+    vi.doMock("@/lib/storage", () => ({
+      loadStore: async () => ({
+        user: { id: "u1", email: "u@x.com", name: "U" },
+        authMode: "oauth",
+      }),
+      saveStore: async () => {},
+    }));
+    vi.doMock("@/stores/settings-store", () => ({
+      useSettingsStore: {
+        getState: () => ({ settings: { server_url: "https://wiii.example" } }),
+      },
+    }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: "new-access",
+        refresh_token: "new-refresh",
+        expires_in: 1800,
+      }),
+    }));
+    vi.resetModules();
+    const { useAuthStore: mod } = await import("@/stores/auth-store");
+    await mod.getState().loadAuth();
+
+    const s = mod.getState();
+    expect(s.authMode).toBe("oauth");
+    expect(s.tokens?.access_token).toBe("new-access");
+    expect(s.tokens?.refresh_token).toBe("new-refresh");
+    expect(s.isAuthenticated).toBe(true);
+    expect(storeTokens).toHaveBeenCalledWith(
+      "new-access",
+      "new-refresh",
+      expect.any(Number),
+    );
+  });
+
+  it("shows oauth login when expired token refresh fails", async () => {
+    const pastExpiry = Date.now() - 60_000;
     vi.doMock("@/lib/secure-token-storage", () => ({
       loadTokens: async () => ({
         access_token: "expired-access",
@@ -91,19 +139,25 @@ describe("auth-store loadAuth — self-heal stale OAuth (Issue #108)", () => {
         savedPayload = payload;
       },
     }));
+    vi.doMock("@/stores/settings-store", () => ({
+      useSettingsStore: {
+        getState: () => ({ settings: { server_url: "https://wiii.example" } }),
+      },
+    }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401 }));
     vi.resetModules();
     const { useAuthStore: mod } = await import("@/stores/auth-store");
     await mod.getState().loadAuth();
 
     const s = mod.getState();
-    expect(s.authMode).toBe("legacy");
+    expect(s.authMode).toBe("oauth");
     expect(s.tokens).toBeNull();
     expect(s.isAuthenticated).toBe(false);
-    // Persisted demotion so we don't loop on next load
-    expect(savedPayload?.authMode).toBe("legacy");
+    expect(s.isLoaded).toBe(true);
+    expect(savedPayload?.authMode).toBe("oauth");
   });
 
-  it("demotes oauth to legacy when no tokens are present", async () => {
+  it("clears oauth auth when no tokens are present", async () => {
     vi.doMock("@/lib/secure-token-storage", () => ({
       loadTokens: async () => null,
       storeTokens: async () => {},
@@ -125,9 +179,9 @@ describe("auth-store loadAuth — self-heal stale OAuth (Issue #108)", () => {
     await mod.getState().loadAuth();
 
     const s = mod.getState();
-    expect(s.authMode).toBe("legacy");
+    expect(s.authMode).toBe("oauth");
     expect(s.tokens).toBeNull();
-    expect(savedPayload?.authMode).toBe("legacy");
+    expect(savedPayload?.authMode).toBe("oauth");
   });
 });
 
@@ -150,7 +204,7 @@ describe("settings-store getAuthHeaders — runtime stale-token defense (Issue #
     expect(headers["X-API-Key"]).toBeUndefined();
   });
 
-  it("falls through to X-API-Key when oauth tokens are expired", () => {
+  it("does not send stale OAuth or legacy headers when oauth tokens are expired", () => {
     useAuthStore.setState({
       isAuthenticated: true,
       authMode: "oauth",
@@ -164,7 +218,9 @@ describe("settings-store getAuthHeaders — runtime stale-token defense (Issue #
 
     const headers = useSettingsStore.getState().getAuthHeaders();
     expect(headers["Authorization"]).toBeUndefined();
-    expect(headers["X-API-Key"]).toBe("local-dev-key");
+    expect(headers["X-API-Key"]).toBeUndefined();
+    expect(headers["X-User-ID"]).toBeUndefined();
+    expect(Object.keys(headers)).toHaveLength(0);
   });
 
   it("treats tokens within 30s of expiry as fresh (clock-skew tolerance)", () => {

--- a/wiii-desktop/src/__tests__/auth-store.test.ts
+++ b/wiii-desktop/src/__tests__/auth-store.test.ts
@@ -33,6 +33,7 @@ const MOCK_USER: AuthUser = {
 function resetStore() {
   useAuthStore.setState({
     isAuthenticated: false,
+    isLoaded: false,
     user: null,
     tokens: null,
     authMode: "legacy",
@@ -64,6 +65,7 @@ describe("AuthStore", () => {
 
     const state = useAuthStore.getState();
     expect(state.isAuthenticated).toBe(true);
+    expect(state.isLoaded).toBe(true);
     expect(state.user).toEqual(MOCK_USER);
     expect(state.tokens?.access_token).toBe("access-token-abc");
     expect(state.tokens?.refresh_token).toBe("refresh-token-xyz");

--- a/wiii-desktop/src/api/client.ts
+++ b/wiii-desktop/src/api/client.ts
@@ -28,6 +28,27 @@ export class ApiHttpError extends Error {
   }
 }
 
+export interface AuthRecoveryContext {
+  status: number;
+  detail: string;
+  body: Record<string, unknown> | null;
+}
+
+const RECOVERABLE_AUTH_403_MARKERS = [
+  "active organization does not match authenticated organization",
+  "authenticated token does not carry an active organization",
+  "organization context required for chat request scope",
+  "user is not a member of organization",
+];
+
+function detailFromParsedBody(body: Record<string, unknown> | null): string {
+  if (!body) return "";
+  if (typeof body.message === "string") return body.message;
+  if (typeof body.detail === "string") return body.detail;
+  if (body.detail) return JSON.stringify(body.detail);
+  return "";
+}
+
 /**
  * Adaptive fetch — uses Tauri plugin-http in Tauri, native fetch in browser.
  * Sprint 85: Adds configurable timeout via AbortController.
@@ -73,7 +94,7 @@ export class WiiiClient {
   private baseUrl: string;
   private headers: Record<string, string>;
   private headerResolver?: () => Record<string, string>;
-  private onUnauthorized?: () => Promise<boolean>;
+  private onUnauthorized?: (context?: AuthRecoveryContext) => Promise<boolean>;
 
   constructor(baseUrl: string, headers: Record<string, string> = {}) {
     this.baseUrl = baseUrl.replace(/\/+$/, ""); // Remove trailing slash
@@ -90,8 +111,8 @@ export class WiiiClient {
     this.headerResolver = resolver;
   }
 
-  /** Sprint 192: Set 401 handler for automatic token refresh */
-  setOnUnauthorized(handler: () => Promise<boolean>) {
+  /** Sprint 192/231: Set auth recovery handler for token refresh or clean logout. */
+  setOnUnauthorized(handler: (context?: AuthRecoveryContext) => Promise<boolean>) {
     this.onUnauthorized = handler;
   }
 
@@ -133,6 +154,68 @@ export class WiiiClient {
     throw new ApiHttpError(detail, response.status, parsedBody);
   }
 
+  private async _authRecoveryContext(
+    response: Response,
+  ): Promise<AuthRecoveryContext | null> {
+    if (response.status === 401) {
+      let parsedBody: Record<string, unknown> | null = null;
+      try {
+        const body = await response.clone().json();
+        if (body && typeof body === "object" && !Array.isArray(body)) {
+          parsedBody = body as Record<string, unknown>;
+        }
+      } catch {
+        parsedBody = null;
+      }
+      return {
+        status: response.status,
+        detail: detailFromParsedBody(parsedBody),
+        body: parsedBody,
+      };
+    }
+
+    if (response.status !== 403) return null;
+
+    let parsedBody: Record<string, unknown> | null = null;
+    try {
+      const body = await response.clone().json();
+      if (body && typeof body === "object" && !Array.isArray(body)) {
+        parsedBody = body as Record<string, unknown>;
+      }
+    } catch {
+      parsedBody = null;
+    }
+
+    const detail = detailFromParsedBody(parsedBody);
+    const normalizedDetail = detail.toLowerCase();
+    const isRecoverable403 = RECOVERABLE_AUTH_403_MARKERS.some((marker) =>
+      normalizedDetail.includes(marker),
+    );
+    if (!isRecoverable403) return null;
+
+    return {
+      status: response.status,
+      detail,
+      body: parsedBody,
+    };
+  }
+
+  private async _retryAfterAuthRecovery(
+    response: Response,
+    retry: () => Promise<Response>,
+  ): Promise<Response> {
+    if (!this.onUnauthorized) return response;
+
+    const context = await this._authRecoveryContext(response);
+    if (!context) return response;
+
+    const recovered = await this.onUnauthorized(context);
+    if (recovered) {
+      return await retry();
+    }
+    return response;
+  }
+
   /** GET request */
   async get<T>(
     path: string,
@@ -153,20 +236,16 @@ export class WiiiClient {
       timeoutMs,
     );
 
-    // Sprint 192: Auto-retry on 401
-    if (response.status === 401 && this.onUnauthorized) {
-      const refreshed = await this.onUnauthorized();
-      if (refreshed) {
-        response = await adaptiveFetch(
-          url.toString(),
-          {
-            method: "GET",
-            headers: this.resolveHeaders(),
-          },
-          timeoutMs,
-        );
-      }
-    }
+    response = await this._retryAfterAuthRecovery(response, () =>
+      adaptiveFetch(
+        url.toString(),
+        {
+          method: "GET",
+          headers: this.resolveHeaders(),
+        },
+        timeoutMs,
+      ),
+    );
 
     if (!response.ok) {
       await this._throwApiError(response);
@@ -188,20 +267,16 @@ export class WiiiClient {
       body: JSON.stringify(body),
     });
 
-    // Sprint 192: Auto-retry on 401
-    if (response.status === 401 && this.onUnauthorized) {
-      const refreshed = await this.onUnauthorized();
-      if (refreshed) {
-        response = await adaptiveFetch(url, {
-          method: "POST",
-          headers: {
-            ...this.resolveHeaders(),
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(body),
-        });
-      }
-    }
+    response = await this._retryAfterAuthRecovery(response, () =>
+      adaptiveFetch(url, {
+        method: "POST",
+        headers: {
+          ...this.resolveHeaders(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      }),
+    );
 
     if (!response.ok) {
       await this._throwApiError(response);
@@ -226,15 +301,12 @@ export class WiiiClient {
       headers: { ...this.resolveHeaders(), ...extraHeaders },
     });
 
-    if (response.status === 401 && this.onUnauthorized) {
-      const refreshed = await this.onUnauthorized();
-      if (refreshed) {
-        response = await adaptiveFetch(url.toString(), {
-          method: "GET",
-          headers: { ...this.resolveHeaders(), ...extraHeaders },
-        });
-      }
-    }
+    response = await this._retryAfterAuthRecovery(response, () =>
+      adaptiveFetch(url.toString(), {
+        method: "GET",
+        headers: { ...this.resolveHeaders(), ...extraHeaders },
+      }),
+    );
 
     if (!response.ok) {
       await this._throwApiError(response);
@@ -261,20 +333,17 @@ export class WiiiClient {
       body: JSON.stringify(body),
     });
 
-    if (response.status === 401 && this.onUnauthorized) {
-      const refreshed = await this.onUnauthorized();
-      if (refreshed) {
-        response = await adaptiveFetch(url, {
-          method: "POST",
-          headers: {
-            ...this.resolveHeaders(),
-            "Content-Type": "application/json",
-            ...extraHeaders,
-          },
-          body: JSON.stringify(body),
-        });
-      }
-    }
+    response = await this._retryAfterAuthRecovery(response, () =>
+      adaptiveFetch(url, {
+        method: "POST",
+        headers: {
+          ...this.resolveHeaders(),
+          "Content-Type": "application/json",
+          ...extraHeaders,
+        },
+        body: JSON.stringify(body),
+      }),
+    );
 
     if (!response.ok) {
       await this._throwApiError(response);
@@ -292,15 +361,12 @@ export class WiiiClient {
       headers: this.resolveHeaders(),
     });
 
-    if (response.status === 401 && this.onUnauthorized) {
-      const refreshed = await this.onUnauthorized();
-      if (refreshed) {
-        response = await adaptiveFetch(url, {
-          method: "DELETE",
-          headers: this.resolveHeaders(),
-        });
-      }
-    }
+    response = await this._retryAfterAuthRecovery(response, () =>
+      adaptiveFetch(url, {
+        method: "DELETE",
+        headers: this.resolveHeaders(),
+      }),
+    );
 
     if (!response.ok) {
       await this._throwApiError(response);
@@ -322,19 +388,16 @@ export class WiiiClient {
       body: JSON.stringify(body),
     });
 
-    if (response.status === 401 && this.onUnauthorized) {
-      const refreshed = await this.onUnauthorized();
-      if (refreshed) {
-        response = await adaptiveFetch(url, {
-          method: "PUT",
-          headers: {
-            ...this.resolveHeaders(),
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(body),
-        });
-      }
-    }
+    response = await this._retryAfterAuthRecovery(response, () =>
+      adaptiveFetch(url, {
+        method: "PUT",
+        headers: {
+          ...this.resolveHeaders(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      }),
+    );
 
     if (!response.ok) {
       await this._throwApiError(response);
@@ -356,19 +419,16 @@ export class WiiiClient {
       body: JSON.stringify(body),
     });
 
-    if (response.status === 401 && this.onUnauthorized) {
-      const refreshed = await this.onUnauthorized();
-      if (refreshed) {
-        response = await adaptiveFetch(url, {
-          method: "PATCH",
-          headers: {
-            ...this.resolveHeaders(),
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(body),
-        });
-      }
-    }
+    response = await this._retryAfterAuthRecovery(response, () =>
+      adaptiveFetch(url, {
+        method: "PATCH",
+        headers: {
+          ...this.resolveHeaders(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      }),
+    );
 
     if (!response.ok) {
       await this._throwApiError(response);
@@ -394,17 +454,14 @@ export class WiiiClient {
       body: formData,
     }, timeoutMs);
 
-    if (response.status === 401 && this.onUnauthorized) {
-      const refreshed = await this.onUnauthorized();
-      if (refreshed) {
-        const { "Content-Type": __, ...retryHeaders } = this.resolveHeaders();
-        response = await adaptiveFetch(url, {
-          method: "POST",
-          headers: retryHeaders,
-          body: formData,
-        }, timeoutMs);
-      }
-    }
+    response = await this._retryAfterAuthRecovery(response, () => {
+      const { "Content-Type": __, ...retryHeaders } = this.resolveHeaders();
+      return adaptiveFetch(url, {
+        method: "POST",
+        headers: retryHeaders,
+        body: formData,
+      }, timeoutMs);
+    });
 
     if (!response.ok) {
       await this._throwApiError(response);
@@ -437,22 +494,18 @@ export class WiiiClient {
       signal,
     });
 
-    // Sprint 192: Auto-retry on 401 (stream requests)
-    if (response.status === 401 && this.onUnauthorized) {
-      const refreshed = await this.onUnauthorized();
-      if (refreshed) {
-        response = await adaptiveFetch(url, {
-          method: "POST",
-          headers: {
-            ...this.resolveHeaders(),
-            "Content-Type": "application/json",
-            ...extraHeaders,
-          },
-          body: JSON.stringify(body),
-          signal,
-        });
-      }
-    }
+    response = await this._retryAfterAuthRecovery(response, () =>
+      adaptiveFetch(url, {
+        method: "POST",
+        headers: {
+          ...this.resolveHeaders(),
+          "Content-Type": "application/json",
+          ...extraHeaders,
+        },
+        body: JSON.stringify(body),
+        signal,
+      }),
+    );
 
     if (!response.ok) {
       await this._throwApiError(response);

--- a/wiii-desktop/src/stores/auth-store.ts
+++ b/wiii-desktop/src/stores/auth-store.ts
@@ -196,6 +196,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
     set({
       isAuthenticated: true,
+      isLoaded: true,
       user,
       tokens,
       authMode: "oauth",

--- a/wiii-desktop/src/stores/auth-store.ts
+++ b/wiii-desktop/src/stores/auth-store.ts
@@ -159,19 +159,54 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           isLoaded: true,
         });
       } else if (saved?.authMode === "oauth") {
-        // Saved oauth mode but tokens are missing/stale — demote to legacy
-        // and persist the corrected mode so subsequent loads don't loop.
+        // OAuth access tokens are short-lived. If a refresh token is still
+        // available, try to renew before showing the login screen.
+        if (tokens?.refresh_token && saved.user) {
+          set({
+            isAuthenticated: true,
+            isLoaded: false,
+            user: saved.user,
+            tokens,
+            authMode: "oauth",
+          });
+
+          let serverUrl = "";
+          try {
+            const { useSettingsStore } = await import(
+              "@/stores/settings-store"
+            );
+            serverUrl = useSettingsStore.getState().settings.server_url || "";
+          } catch {
+            serverUrl = "";
+          }
+
+          if (serverUrl) {
+            const refreshed = await get().refreshAccessToken(serverUrl);
+            if (refreshed) {
+              set({
+                isAuthenticated: true,
+                isLoaded: true,
+                user: saved.user,
+                authMode: "oauth",
+              });
+              return;
+            }
+          }
+        }
+        // Saved oauth mode but tokens are missing or refresh failed. Keep the
+        // user unauthenticated in OAuth mode; never fall back to legacy API-key
+        // identity for a Google-login account.
         set({
           isAuthenticated: false,
           isLoaded: true,
           user: null,
           tokens: null,
-          authMode: "legacy",
+          authMode: "oauth",
         });
         try {
           await saveStore(AUTH_STORE_KEY, "data", {
             user: null,
-            authMode: "legacy",
+            authMode: "oauth",
           });
         } catch {
           // Persistence failure is non-fatal; in-memory state is still corrected.
@@ -359,7 +394,13 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   getAuthHeaders: (): Record<string, string> => {
     const { tokens, authMode } = get();
-    if (authMode === "oauth" && tokens?.access_token) {
+    const STALE_TOKEN_GRACE_MS = 30_000;
+    const hasFreshOAuthToken =
+      authMode === "oauth" &&
+      !!tokens?.access_token &&
+      typeof tokens.expires_at === "number" &&
+      tokens.expires_at + STALE_TOKEN_GRACE_MS >= Date.now();
+    if (hasFreshOAuthToken) {
       return { Authorization: `Bearer ${tokens.access_token}` };
     }
     return {};

--- a/wiii-desktop/src/stores/settings-store.ts
+++ b/wiii-desktop/src/stores/settings-store.ts
@@ -100,6 +100,13 @@ function normalizeLoadedSettings(saved: Partial<AppSettings> | null): AppSetting
   return normalizeLoadedSettingsForHost(saved, hostname);
 }
 
+export function resolveOAuthOrganizationHeader(
+  activeOrganizationId?: string | null,
+): string | undefined {
+  const orgId = typeof activeOrganizationId === "string" ? activeOrganizationId.trim() : "";
+  return orgId && orgId !== "personal" ? orgId : undefined;
+}
+
 const DEFAULT_SETTINGS: AppSettings = {
   server_url: DEFAULT_SERVER_URL,
   api_key: "",
@@ -269,9 +276,9 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       // Sprint 194b (H1): OAuth mode — identity from JWT only
       // DO NOT send X-User-ID or X-Role — backend extracts from token
       headers["Authorization"] = `Bearer ${authState.tokens!.access_token}`;
-      // Sprint 156: Include org ID when not personal workspace
-      if (settings.organization_id && settings.organization_id !== "personal") {
-        headers["X-Organization-ID"] = settings.organization_id;
+      const oauthOrgId = resolveOAuthOrganizationHeader(authState.user?.active_organization_id);
+      if (oauthOrgId) {
+        headers["X-Organization-ID"] = oauthOrgId;
       }
       return headers;
     }

--- a/wiii-desktop/src/stores/settings-store.ts
+++ b/wiii-desktop/src/stores/settings-store.ts
@@ -283,6 +283,13 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       return headers;
     }
 
+    if (authState.authMode === "oauth") {
+      // OAuth sessions should recover via refresh token after a 401. Do not
+      // fall through to legacy API-key headers, or an expired Google session
+      // can look like a different anonymous legacy user.
+      return headers;
+    }
+
     // Legacy API key mode
     // Sprint 192: API key from settings (secure store loaded at init)
     if (settings.api_key) headers["X-API-Key"] = settings.api_key;

--- a/wiii-desktop/vite.config.ts
+++ b/wiii-desktop/vite.config.ts
@@ -65,6 +65,13 @@ function manualChunks(id: string) {
     return "vendor-react";
   }
 
+  if (
+    normalizedId.includes("/node_modules/zustand/")
+    || normalizedId.includes("/node_modules/use-sync-external-store/")
+  ) {
+    return "vendor-state";
+  }
+
   return undefined;
 }
 


### PR DESCRIPTION
## Summary
- isolates Zustand/use-sync-external-store into a dedicated vendor chunk so the production root SPA no longer hits the `O is not a function` chunk-cycle crash
- adds selective auth recovery for stale OAuth organization/session context: recoverable 403s update the active organization header or force a clean re-login, while ordinary authorization 403s stay untouched
- adds API-client tests covering recoverable organization 403 retry, ordinary 403 no-recovery, and existing 401 refresh/retry behavior

## Verification
- `npx vitest run src/__tests__/api-client-auth-recovery.test.ts`
- `npm run build`
- `npm run build:embed`
- `npm run build:pointy`
- Local Playwright preview smoke: `/` HTTP 200, login screen rendered, `pageerrors []`
- Production temporary static hotfix applied to `wiii-nginx` for SHA `999f7886`; public smoke: `https://wiii.holilihu.online/` HTTP 200, marker bundle served, `pageerrors []`, console errors `[]`
- Production API checks: `/api/v1/health/live` 200, `/api/v1/auth/lms/health` 200

## Risk / rollback
- Risk is scoped to frontend auth recovery and web bundle chunking. Ordinary 403s such as admin permission failures are intentionally not retried.
- Rollback production temporary static hotfix by restoring the VM backup `/tmp/html-before-auth-recovery-999f7886.tar.gz` into `wiii-nginx:/usr/share/nginx/html`, or by redeploying the previous published image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Desktop OAuth sign-in now validates hash callbacks and prioritizes OAuth delivery during startup.
  * Enhanced auth recovery can automatically retry requests after eligible authorization failures.

* **Bug Fixes**
  * Prevents stale/expired OAuth tokens and legacy API-key headers from being sent.
  * Improves handling of unauthorized responses (refresh flow or safe logout) and keeps OAuth mode consistent after failed persistence.
  * OAuth organization header values are now normalized and personal/empty values are suppressed.
  * Reserved `wiii` subdomains are no longer treated as organization slugs.

* **Chores**
  * Optimized desktop bundle chunking for faster loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->