### PR TITLE
fix(runtime): default NVIDIA provider to Nemotron 3 Ultra

### DIFF
--- a/maritime-ai-service/.env.example
+++ b/maritime-ai-service/.env.example
@@ -95,11 +95,11 @@ LLM_FAILOVER_CHAIN=["openrouter","ollama","google"]
 
 # NVIDIA NIM (Issue #110) — OpenAI-compatible endpoint with free tier
 # Get an NGC API key at https://build.nvidia.com/explore/discover
-# Default models: Qwen instruct (light/moderate), Qwen thinking (deep)
+# Default model: Nemotron 3 Ultra for both normal and deep turns
 # NVIDIA_API_KEY=nvapi-...
 # NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
-# NVIDIA_MODEL=qwen/qwen3-next-80b-a3b-instruct
-# NVIDIA_MODEL_ADVANCED=qwen/qwen3-next-80b-a3b-thinking
+# NVIDIA_MODEL=nvidia/nemotron-3-ultra-550b-a55b
+# NVIDIA_MODEL_ADVANCED=nvidia/nemotron-3-ultra-550b-a55b
 # NVIDIA_VISION_MODEL=meta/llama-3.2-11b-vision-instruct
 
 # Google Gemini

--- a/maritime-ai-service/app/engine/model_catalog.py
+++ b/maritime-ai-service/app/engine/model_catalog.py
@@ -81,18 +81,18 @@ ZHIPU_DEFAULT_BASE_URL = "https://open.bigmodel.cn/api/paas/v4"
 # NVIDIA NIM — OpenAI-compatible endpoint (Issue #110)
 # Free tier available with NGC API key from build.nvidia.com.
 NVIDIA_DEFAULT_BASE_URL = "https://integrate.api.nvidia.com/v1"
+NVIDIA_NEMOTRON_ULTRA_MODEL = "nvidia/nemotron-3-ultra-550b-a55b"
 NVIDIA_QWEN_INSTRUCT_MODEL = "qwen/qwen3-next-80b-a3b-instruct"
 NVIDIA_QWEN_THINKING_MODEL = "qwen/qwen3-next-80b-a3b-thinking"
 NVIDIA_DEEPSEEK_FLASH_MODEL = "deepseek-ai/deepseek-v4-flash"
 NVIDIA_DEEPSEEK_PRO_MODEL = "deepseek-ai/deepseek-v4-pro"
-NVIDIA_DEFAULT_MODEL = NVIDIA_QWEN_INSTRUCT_MODEL
-NVIDIA_DEFAULT_MODEL_ADVANCED = NVIDIA_QWEN_THINKING_MODEL
+NVIDIA_DEFAULT_MODEL = NVIDIA_NEMOTRON_ULTRA_MODEL
+NVIDIA_DEFAULT_MODEL_ADVANCED = NVIDIA_NEMOTRON_ULTRA_MODEL
 NVIDIA_DEFAULT_VISION_MODEL = "meta/llama-3.2-11b-vision-instruct"
-# Phase 32a (#207): Qwen3 thinking model emits ``reasoning_content`` deltas
-# that Wiii's existing thinking-stream extractor already understands.
-# The default NVIDIA profile stays on Qwen for both normal and deep turns so
-# Wiii does not silently fall back to DeepSeek when env overrides are absent.
-NVIDIA_THINKING_MODEL = NVIDIA_QWEN_THINKING_MODEL
+# Keep the NVIDIA profile pinned to the product-design model for both normal
+# and deep turns so env-free startup, admin presets, and direct chatter do not
+# drift back to older Qwen/DeepSeek defaults.
+NVIDIA_THINKING_MODEL = NVIDIA_NEMOTRON_ULTRA_MODEL
 
 GOOGLE_CHAT_MODELS: dict[str, ChatModelMetadata] = {
     GOOGLE_DEFAULT_MODEL: ChatModelMetadata(
@@ -434,20 +434,31 @@ OLLAMA_KNOWN_MODELS: dict[str, ChatModelMetadata] = {
 }
 
 NVIDIA_CHAT_MODELS: dict[str, ChatModelMetadata] = {
-    NVIDIA_DEFAULT_MODEL: ChatModelMetadata(
+    NVIDIA_NEMOTRON_ULTRA_MODEL: ChatModelMetadata(
         provider="nvidia",
-        model_name=NVIDIA_DEFAULT_MODEL,
-        display_name="Qwen3 Next 80B Instruct (NVIDIA NIM)",
+        model_name=NVIDIA_NEMOTRON_ULTRA_MODEL,
+        display_name="Nemotron 3 Ultra 550B-A55B (NVIDIA NIM)",
         status="current",
+        supports_tool_calling=True,
+        supports_streaming=True,
+        supports_structured_output=False,
+        context_window_tokens=262_144,
+        capability_source="static",
+    ),
+    NVIDIA_QWEN_INSTRUCT_MODEL: ChatModelMetadata(
+        provider="nvidia",
+        model_name=NVIDIA_QWEN_INSTRUCT_MODEL,
+        display_name="Qwen3 Next 80B Instruct (NVIDIA NIM)",
+        status="available",
         supports_streaming=True,
         supports_structured_output=False,
         capability_source="static",
     ),
-    NVIDIA_DEFAULT_MODEL_ADVANCED: ChatModelMetadata(
+    NVIDIA_QWEN_THINKING_MODEL: ChatModelMetadata(
         provider="nvidia",
-        model_name=NVIDIA_DEFAULT_MODEL_ADVANCED,
+        model_name=NVIDIA_QWEN_THINKING_MODEL,
         display_name="Qwen3 80B Thinking (NVIDIA NIM)",
-        status="current",
+        status="available",
         supports_streaming=True,
         supports_structured_output=False,
         capability_source="static",

--- a/maritime-ai-service/tests/unit/test_llm_runtime_profiles.py
+++ b/maritime-ai-service/tests/unit/test_llm_runtime_profiles.py
@@ -37,6 +37,14 @@ def test_get_runtime_provider_preset_for_google_exposes_advanced_model():
     assert preset.google_model_advanced == "gemini-3.1-pro-preview"
 
 
+def test_get_runtime_provider_preset_for_nvidia_uses_nemotron_design_default():
+    preset = get_runtime_provider_preset("nvidia")
+    assert preset.provider == "nvidia"
+    assert preset.failover_chain == ("nvidia",)
+    assert preset.nvidia_model == "nvidia/nemotron-3-ultra-550b-a55b"
+    assert preset.nvidia_model_advanced == "nvidia/nemotron-3-ultra-550b-a55b"
+
+
 def test_get_runtime_provider_preset_for_ollama_matches_verified_local_default():
     preset = get_runtime_provider_preset("ollama")
     assert preset.provider == "ollama"

--- a/maritime-ai-service/tests/unit/test_model_catalog.py
+++ b/maritime-ai-service/tests/unit/test_model_catalog.py
@@ -22,21 +22,25 @@ def test_google_default_model_is_current():
     assert metadata.status == "current"
 
 
-def test_nvidia_defaults_are_qwen_models():
+def test_nvidia_defaults_are_nemotron_model():
     default_metadata = get_provider_chat_model_metadata("nvidia", NVIDIA_DEFAULT_MODEL)
     advanced_metadata = get_provider_chat_model_metadata(
         "nvidia",
         NVIDIA_DEFAULT_MODEL_ADVANCED,
     )
 
-    assert NVIDIA_DEFAULT_MODEL == "qwen/qwen3-next-80b-a3b-instruct"
-    assert NVIDIA_DEFAULT_MODEL_ADVANCED == "qwen/qwen3-next-80b-a3b-thinking"
+    assert NVIDIA_DEFAULT_MODEL == "nvidia/nemotron-3-ultra-550b-a55b"
+    assert NVIDIA_DEFAULT_MODEL_ADVANCED == "nvidia/nemotron-3-ultra-550b-a55b"
     assert default_metadata is not None
     assert default_metadata.status == "current"
-    assert "Qwen" in default_metadata.display_name
+    assert "Nemotron 3 Ultra" in default_metadata.display_name
+    assert default_metadata.supports_tool_calling is True
+    assert default_metadata.context_window_tokens == 262_144
     assert advanced_metadata is not None
     assert advanced_metadata.status == "current"
-    assert "Qwen" in advanced_metadata.display_name
+    assert "Nemotron 3 Ultra" in advanced_metadata.display_name
+    assert advanced_metadata.supports_tool_calling is True
+    assert advanced_metadata.context_window_tokens == 262_144
 
 
 def test_legacy_google_model_is_marked_legacy():

--- a/maritime-ai-service/tests/unit/test_nvidia_provider.py
+++ b/maritime-ai-service/tests/unit/test_nvidia_provider.py
@@ -39,15 +39,15 @@ class TestNvidiaRegistry:
 # ---------------------------------------------------------------------------
 
 class TestNvidiaResolvers:
-    def test_default_models_are_current_qwen_targets(self):
+    def test_default_models_are_current_nemotron_target(self):
         from app.engine.model_catalog import (
             NVIDIA_DEFAULT_MODEL,
             NVIDIA_DEFAULT_MODEL_ADVANCED,
             get_all_static_chat_models,
         )
 
-        assert NVIDIA_DEFAULT_MODEL == "qwen/qwen3-next-80b-a3b-instruct"
-        assert NVIDIA_DEFAULT_MODEL_ADVANCED == "qwen/qwen3-next-80b-a3b-thinking"
+        assert NVIDIA_DEFAULT_MODEL == "nvidia/nemotron-3-ultra-550b-a55b"
+        assert NVIDIA_DEFAULT_MODEL_ADVANCED == "nvidia/nemotron-3-ultra-550b-a55b"
         assert NVIDIA_DEFAULT_MODEL in get_all_static_chat_models()["nvidia"]
         assert NVIDIA_DEFAULT_MODEL_ADVANCED in get_all_static_chat_models()["nvidia"]
 

--- a/maritime-ai-service/tests/unit/test_sprint120_desktop_apis.py
+++ b/maritime-ai-service/tests/unit/test_sprint120_desktop_apis.py
@@ -228,15 +228,26 @@ class TestSSEMetadataMood:
 class TestRouterRegistration:
     """Tests that new routers are registered."""
 
+    @staticmethod
+    def _registered_import_paths():
+        import app.api.v1 as api_v1
+
+        captured = []
+
+        def capture_register(_router, import_path, _label):
+            captured.append(import_path)
+
+        with patch.object(api_v1, "_register_router", side_effect=capture_register), \
+                patch.object(api_v1, "_register_optional_router", return_value=None):
+            api_v1._build_router()
+        return captured
+
     def test_character_router_registered(self):
         """Character router is in v1 routes."""
-        from app.api.v1 import router
-        paths = [r.path for r in router.routes]
-        assert any("/character" in p for p in paths)
+        paths = self._registered_import_paths()
+        assert "app.api.v1.character.router" in paths
 
     def test_mood_router_registered(self):
         """Mood router is in v1 routes."""
-        from app.api.v1 import router
-        paths = [r.path for r in router.routes]
-        assert any("/mood" in p for p in paths)
-
+        paths = self._registered_import_paths()
+        assert "app.api.v1.mood.router" in paths

--- a/maritime-ai-service/tests/unit/test_sprint175_lms_integration.py
+++ b/maritime-ai-service/tests/unit/test_sprint175_lms_integration.py
@@ -867,7 +867,7 @@ class TestRouterRegistration:
 
     def test_lms_data_endpoints_exist(self):
         from app.api.v1.lms_data import router
-        paths = [route.path for route in router.routes]
+        paths = [getattr(route, "path", "") for route in router.routes]
         assert "/lms/students/{student_id}/profile" in paths
         assert "/lms/students/{student_id}/grades" in paths
         assert "/lms/students/{student_id}/enrollments" in paths
@@ -876,7 +876,7 @@ class TestRouterRegistration:
 
     def test_lms_dashboard_endpoints_exist(self):
         from app.api.v1.lms_dashboard import router
-        paths = [route.path for route in router.routes]
+        paths = [getattr(route, "path", "") for route in router.routes]
         assert "/lms/dashboard/courses/{course_id}/overview" in paths
         assert "/lms/dashboard/courses/{course_id}/at-risk" in paths
         assert "/lms/dashboard/courses/{course_id}/grade-distribution" in paths

--- a/maritime-ai-service/tests/unit/test_sprint178_admin_compliance.py
+++ b/maritime-ai-service/tests/unit/test_sprint178_admin_compliance.py
@@ -135,7 +135,9 @@ def base_app():
     from app.api.v1.admin_audit import router as audit_router
     from app.api.v1.admin_gdpr import router as gdpr_router
 
-    existing_paths = {r.path for r in _app.routes}
+    existing_paths = {
+        path for r in _app.routes if (path := getattr(r, "path", None))
+    }
     if "/api/v1/admin/audit-logs" not in existing_paths:
         _app.include_router(audit_router, prefix="/api/v1")
     if "/api/v1/admin/users/{user_id}/export" not in existing_paths:

--- a/maritime-ai-service/tests/unit/test_sprint224_magic_link.py
+++ b/maritime-ai-service/tests/unit/test_sprint224_magic_link.py
@@ -661,17 +661,17 @@ class TestMagicLinkRouter:
 
     def test_router_has_request_endpoint(self):
         from app.auth.magic_link_router import router
-        paths = [r.path for r in router.routes]
+        paths = [getattr(r, "path", "") for r in router.routes]
         assert any("request" in p for p in paths)
 
     def test_router_has_verify_endpoint(self):
         from app.auth.magic_link_router import router
-        paths = [r.path for r in router.routes]
+        paths = [getattr(r, "path", "") for r in router.routes]
         assert any("verify" in p and "token" in p for p in paths)
 
     def test_router_has_websocket_endpoint(self):
         from app.auth.magic_link_router import router
-        paths = [r.path for r in router.routes]
+        paths = [getattr(r, "path", "") for r in router.routes]
         assert any("/ws/" in p for p in paths)
 
 

--- a/maritime-ai-service/tests/unit/test_sprint225_conversation_sync.py
+++ b/maritime-ai-service/tests/unit/test_sprint225_conversation_sync.py
@@ -554,7 +554,7 @@ class TestEndpointRegistration:
         """GET /threads/{thread_id}/messages route is registered."""
         from app.api.v1.threads import router
 
-        routes = [r.path for r in router.routes]
+        routes = [getattr(r, "path", "") for r in router.routes]
         assert "/threads/{thread_id}/messages" in routes
 
     def test_messages_route_is_get(self):


### PR DESCRIPTION
## Summary
- Pin NVIDIA normal and advanced defaults to `nvidia/nemotron-3-ultra-550b-a55b`.
- Keep previous Qwen NVIDIA models in the static catalog as selectable `available` options instead of source defaults.
- Update `.env.example` and regression tests so provider presets/direct chatter cannot drift back to Qwen/DeepSeek silently.
- Make router-path unit tests avoid FastAPI's private `_IncludedRouter.path` assumption, fixing CI failures seen on this branch without changing runtime routing.

Refs #283

## Risk / rollback
- Provider/model routing is a high-risk runtime surface. Rollback is to set production `NVIDIA_MODEL` / `NVIDIA_MODEL_ADVANCED` back to the previous known-good values or revert the runtime commit.
- Production live probe evidence on 2026-06-18: `/models` lists `nvidia/nemotron-3-ultra-550b-a55b`, so the key can see the model, but streaming chat timed out after 180s. Do not treat this PR alone as proof that the serverless endpoint is production-ready for the demo; deploy should wait for a passing provider smoke or a deliberate fallback decision.
- The router test changes are test-only; rollback is reverting `test(api): tolerate included routers in v1 registration checks` if the v1/FastAPI route enumeration contract changes.

## Verification
- `cd maritime-ai-service && python -m pytest tests/unit/test_sprint175_lms_integration.py::TestRouterRegistration::test_lms_data_endpoints_exist tests/unit/test_sprint175_lms_integration.py::TestRouterRegistration::test_lms_dashboard_endpoints_exist tests/unit/test_sprint178_admin_compliance.py::TestAuditLogViewer::test_no_filters_returns_entries tests/unit/test_sprint224_magic_link.py::TestMagicLinkRouter::test_router_has_request_endpoint tests/unit/test_sprint224_magic_link.py::TestMagicLinkRouter::test_router_has_verify_endpoint tests/unit/test_sprint224_magic_link.py::TestMagicLinkRouter::test_router_has_websocket_endpoint tests/unit/test_sprint225_conversation_sync.py::TestEndpointRegistration::test_messages_route_exists tests/unit/test_sprint120_desktop_apis.py::TestRouterRegistration::test_character_router_registered tests/unit/test_sprint120_desktop_apis.py::TestRouterRegistration::test_mood_router_registered tests/unit/test_nvidia_provider.py tests/unit/test_model_catalog.py tests/unit/test_llm_runtime_profiles.py tests/unit/test_agent_config.py::TestAgentConfigRegistry::test_direct_chatter_uses_nvidia_default_model_when_nvidia_selected -q --tb=short` -> 50 passed
- `cd maritime-ai-service && python -m ruff check app/ tests/unit/test_nvidia_provider.py tests/unit/test_model_catalog.py tests/unit/test_llm_runtime_profiles.py tests/unit/test_sprint120_desktop_apis.py tests/unit/test_sprint175_lms_integration.py tests/unit/test_sprint178_admin_compliance.py tests/unit/test_sprint224_magic_link.py tests/unit/test_sprint225_conversation_sync.py --select=E9,F63,F7` -> All checks passed
- `git diff --check HEAD~2..HEAD` -> passed
- Production NVIDIA `/models` probe -> `target_present: true` for `nvidia/nemotron-3-ultra-550b-a55b`
- Production NVIDIA streaming probe -> `TimeoutError` after ~180s, no auth/model-not-found error
